### PR TITLE
Interpret more application states

### DIFF
--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryApplicationTemplate.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryApplicationTemplate.java
@@ -112,13 +112,8 @@ class CloudFoundryApplicationTemplate implements CloudFoundryApplicationOperatio
 		for (ResourceResponse<ApplicationEntity> application : applications) {
 			String applicationId = application.getMetadata().getId();
 			String applicationName = application.getEntity().getName();
-			String applicationState = application.getEntity().getState();
 
-			// TODO: decide what to do here
-			if (!"STARTED".equals(applicationState)) {
-				response.withApplication(applicationName, new ApplicationStatus());
-			}
-			else {
+			try {
 				GetApplicationStatisticsRequest statsRequest = new GetApplicationStatisticsRequest()
 						.withId(applicationId);
 
@@ -126,6 +121,10 @@ class CloudFoundryApplicationTemplate implements CloudFoundryApplicationOperatio
 				response.withApplication(applicationName, new ApplicationStatus()
 						.withId(applicationId)
 						.withInstances(statsResponse));
+			}
+			catch (RestClientException rce) {
+				// TODO: Log the error?
+				response.withApplication(applicationName, new ApplicationStatus());
 			}
 		}
 

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/ModuleStatusBuilder.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/ModuleStatusBuilder.java
@@ -56,9 +56,15 @@ class ModuleStatusBuilder {
 		return this;
 	}
 
-	// TODO: Find out what the application state candidates are
 	private static ModuleStatus.State convertState(String state) {
 		switch (state) {
+			case "STARTED":
+			case "STARTING":
+			case "STOPPED":
+				return ModuleStatus.State.deploying;
+			case "CRASHED":
+			case "CRASHING":
+				return ModuleStatus.State.failed;
 			case "RUNNING":
 				return ModuleStatus.State.deployed;
 			default:


### PR DESCRIPTION
Currently only STARTED is recognized and interpreted as module state
`deployed`. This commit recognizes all the application instance states
we are aware of, and interprets them as various module instance states.

It also attempts to obtain application instance status irrespective of
the reported state of the application, and ignores the exception that
might be thrown.