### PR TITLE
Handle partitioning properties for deployment

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.core;
+
+/**
+ * Spring Cloud Stream property names mostly used for binding.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class BindingProperties {
+
+	public static final String COUNT_PROPERTY = "count";
+
+	public static final String PARTITIONED_PROPERTY = "partitioned";
+
+	public static final String PARTITION_KEY_EXPRESSION = "partitionKeyExpression";
+
+	public static final String PARTITION_KEY_EXTRACTOR_CLASS = "partitionKeyExtractorClass";
+
+	public static final String PARTITION_SELECTOR_CLASS = "partitionSelectorClass";
+
+	public static final String PARTITION_SELECTOR_EXPRESSION = "partitionSelectorExpression";
+
+	public static final String ROOT_PREFIX = "spring.cloud.stream.";
+
+	public static final String INSTANCE_COUNT = ROOT_PREFIX + "instanceCount";
+
+	public static final String BINDING_KEY_PREFIX = ROOT_PREFIX + "bindings.";
+
+	public static final String INPUT_BINDING_KEY_PREFIX = BINDING_KEY_PREFIX + "input.";
+
+	public static final String OUTPUT_BINDING_KEY_PREFIX = BINDING_KEY_PREFIX + "output.";
+
+	/**
+	 * Default property key for input channel binding.
+	 */
+	public static final String INPUT_BINDING_KEY = INPUT_BINDING_KEY_PREFIX + "destination";
+
+	public static final String INPUT_PARTITIONED = INPUT_BINDING_KEY_PREFIX + PARTITIONED_PROPERTY;
+
+	/**
+	 * Default property key for output channel binding.
+	 */
+	public static final String OUTPUT_BINDING_KEY = OUTPUT_BINDING_KEY_PREFIX + "destination";
+
+	public static final String OUTPUT_PARTITION_KEY_EXPRESSION = OUTPUT_BINDING_KEY_PREFIX + PARTITION_KEY_EXPRESSION;
+
+	public static final String OUTPUT_PARTITION_KEY_EXTRACTOR_CLASS = OUTPUT_BINDING_KEY_PREFIX + PARTITION_KEY_EXTRACTOR_CLASS;
+
+	public static final String OUTPUT_PARTITION_SELECTOR_CLASS = OUTPUT_BINDING_KEY_PREFIX + PARTITION_SELECTOR_CLASS;
+
+	public static final String OUTPUT_PARTITION_SELECTOR_EXPRESSION = OUTPUT_BINDING_KEY_PREFIX + PARTITION_SELECTOR_EXPRESSION;
+
+	public static final String OUTPUT_PARTITION_COUNT = OUTPUT_BINDING_KEY_PREFIX + "partitionCount";
+
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -38,16 +38,6 @@ import org.springframework.util.Assert;
  */
 class ModuleDefinitionBuilder {
 
-	/**
-	 * Default property key for input channel binding.
-	 */
-	private static final String INPUT_BINDING_KEY = "spring.cloud.stream.bindings.input";
-
-	/**
-	 * Default property key for output channel binding.
-	 */
-	private static final String OUTPUT_BINDING_KEY = "spring.cloud.stream.bindings.output";
-
 	private final String streamName;
 
 	private final StreamNode streamNode;
@@ -85,20 +75,24 @@ class ModuleDefinitionBuilder {
 				}
 			}
 			if (m > 0) {
-				builder.setParameter(INPUT_BINDING_KEY, String.format("%s.%d", streamName, m - 1));
+				builder.setParameter(BindingProperties.INPUT_BINDING_KEY,
+						String.format("%s.%d", streamName, m - 1));
 			}
 			if (m < moduleNodes.size() - 1) {
-				builder.setParameter(OUTPUT_BINDING_KEY, String.format("%s.%d", streamName, m));
+				builder.setParameter(BindingProperties.OUTPUT_BINDING_KEY,
+						String.format("%s.%d", streamName, m));
 			}
 			builders.add(builder);
 		}
 		SourceChannelNode sourceChannel = streamNode.getSourceChannelNode();
 		if (sourceChannel != null) {
-			builders.getLast().setParameter(INPUT_BINDING_KEY, sourceChannel.getChannelName());
+			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY,
+					sourceChannel.getChannelName());
 		}
 		SinkChannelNode sinkChannel = streamNode.getSinkChannelNode();
 		if (sinkChannel != null) {
-			builders.getFirst().setParameter(OUTPUT_BINDING_KEY, sinkChannel.getChannelName());
+			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY,
+					sinkChannel.getChannelName());
 		}
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(builders.size());
 		for (ModuleDefinition.Builder builder : builders) {

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -37,10 +37,6 @@ import org.springframework.cloud.dataflow.core.dsl.ParseException;
  */
 public class StreamDefinitionTests {
 
-	private static final String INPUT_BINDING_KEY = "spring.cloud.stream.bindings.input";
-
-	private static final String OUTPUT_BINDING_KEY = "spring.cloud.stream.bindings.output";
-
 	@Test
 	public void testStreamCreation() {
 		StreamDefinition stream = new StreamDefinition("ticktock", "time | log");
@@ -48,14 +44,14 @@ public class StreamDefinitionTests {
 		ModuleDefinition time = stream.getModuleDefinitions().get(0);
 		assertEquals("time", time.getName());
 		assertEquals("time", time.getLabel());
-		assertEquals("ticktock.0", time.getParameters().get(OUTPUT_BINDING_KEY));
-		assertFalse(time.getParameters().containsKey(INPUT_BINDING_KEY));
+		assertEquals("ticktock.0", time.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertFalse(time.getParameters().containsKey(BindingProperties.INPUT_BINDING_KEY));
 
 		ModuleDefinition log = stream.getModuleDefinitions().get(1);
 		assertEquals("log", log.getName());
 		assertEquals("log", log.getLabel());
-		assertEquals("ticktock.0", log.getParameters().get(INPUT_BINDING_KEY));
-		assertFalse(log.getParameters().containsKey(OUTPUT_BINDING_KEY));
+		assertEquals("ticktock.0", log.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertFalse(log.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -69,11 +65,11 @@ public class StreamDefinitionTests {
 		assertEquals("test", source.getGroup());
 
 		assertEquals(1, source.getParameters().size());
-		assertEquals("test.0", source.getParameters().get(OUTPUT_BINDING_KEY));
+		assertEquals("test.0", source.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 		assertEquals("bar", sink.getName());
 		assertEquals("test", sink.getGroup());
 		assertEquals(1, sink.getParameters().size());
-		assertEquals("test.0", sink.getParameters().get(INPUT_BINDING_KEY));
+		assertEquals("test.0", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -128,7 +124,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "topic:foo > goo | blah | file");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
-		assertEquals("topic:foo", requests.get(0).getParameters().get(INPUT_BINDING_KEY));
+		assertEquals("topic:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -136,7 +132,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "boo | blah | aaak > queue:foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
-		assertEquals("queue:foo", requests.get(2).getParameters().get(OUTPUT_BINDING_KEY));
+		assertEquals("queue:foo", requests.get(2).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -144,7 +140,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "bart > queue:foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
-		assertEquals("queue:foo", requests.get(0).getParameters().get(OUTPUT_BINDING_KEY));
+		assertEquals("queue:foo", requests.get(0).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -167,7 +163,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "queue:foo > boot");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
-		assertEquals("queue:foo", requests.get(0).getParameters().get(INPUT_BINDING_KEY));
+		assertEquals("queue:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -197,11 +193,11 @@ public class StreamDefinitionTests {
 		ModuleDefinition source = modules.get(0);
 		ModuleDefinition sink = modules.get(1);
 		assertEquals("time", source.getLabel());
-		assertEquals("ticktock.0", source.getParameters().get(OUTPUT_BINDING_KEY));
-		assertFalse(source.getParameters().containsKey(INPUT_BINDING_KEY));
+		assertEquals("ticktock.0", source.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertFalse(source.getParameters().containsKey(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("log", sink.getLabel());
-		assertEquals("ticktock.0", sink.getParameters().get(INPUT_BINDING_KEY));
-		assertFalse(sink.getParameters().containsKey(OUTPUT_BINDING_KEY));
+		assertEquals("ticktock.0", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertFalse(sink.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -214,16 +210,16 @@ public class StreamDefinitionTests {
 		ModuleDefinition sink = modules.get(2);
 
 		assertEquals("time", source.getLabel());
-		assertEquals("ticktock.0", source.getParameters().get(OUTPUT_BINDING_KEY));
-		assertFalse(source.getParameters().containsKey(INPUT_BINDING_KEY));
+		assertEquals("ticktock.0", source.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertFalse(source.getParameters().containsKey(BindingProperties.INPUT_BINDING_KEY));
 
 		assertEquals("filter", processor.getLabel());
-		assertEquals("ticktock.0", processor.getParameters().get(INPUT_BINDING_KEY));
-		assertEquals("ticktock.1", processor.getParameters().get(OUTPUT_BINDING_KEY));
+		assertEquals("ticktock.0", processor.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("ticktock.1", processor.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 
 		assertEquals("log", sink.getLabel());
-		assertEquals("ticktock.1", sink.getParameters().get(INPUT_BINDING_KEY));
-		assertFalse(sink.getParameters().containsKey(OUTPUT_BINDING_KEY));
+		assertEquals("ticktock.1", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertFalse(sink.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 }

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.cloud.dataflow.module.deployer;
 
 


### PR DESCRIPTION
 - When deploying stream, if the stream modules are partitioned, then set appropriate binding properties to handle the producer/consumer modules' partitioning properties.
 - Use the binding key `spring.cloud.stream.bindings.input/output.destination` for input/output binding keys so that partitioning is always supported with `Map` object as binding properties
 - For the consumer module:
   - Set `s.c.s.instanceCount`, `s.c.s.bindings.input.partitioned` with the assumption on `INSTANCE_INDEX`/`CF_INSTANCE_INDEX` would always be set for the module at run time for the target lattice/CF.
 - For the producer module:
   - Set `s.c.s.bindings.output.partitionCount` from the down stream module's count value (nextModuleCount)
   - Set `s.c.s.bindings.output.partitionKeyExpression`, `s.c.s.bindings.output.partitionKeyExtractorClass`, `s.c.s.bindings.output.partitionSelectorClass` and `s.c.s.bindings.output.partitionSelectorExpression` when required.