### PR TITLE
Destroy Failed Deploys

### DIFF
--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/ModuleStatusBuilder.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/ModuleStatusBuilder.java
@@ -64,6 +64,7 @@ class ModuleStatusBuilder {
 				return ModuleStatus.State.deploying;
 			case "CRASHED":
 			case "CRASHING":
+			case "DOWN":
 				return ModuleStatus.State.failed;
 			case "RUNNING":
 				return ModuleStatus.State.deployed;


### PR DESCRIPTION
If a deployment fails on CloudFoundry the resulting apps may be in the
"DOWN" state. This state was not allowed for in the calculation of
module status, which meant that the module status was classed as 'unknown'.
Modules in that status are not undeployed, hence the apps were orphaned
on CF. This change adds the missing state, allowing such modules to be
deleted as expected.