### PR TITLE
[Not Ready for Merge] Add a Mesos/Marathon Deployer

### DIFF
--- a/spring-cloud-dataflow-admin/pom.xml
+++ b/spring-cloud-dataflow-admin/pom.xml
@@ -42,6 +42,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-module-deployer-marathon</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-module-deployer-yarn</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
@@ -106,6 +111,24 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
 		</dependency>
+
+		<!--Force Feign versions -->
+		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-core</artifactId>
+			<version>6.1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-gson</artifactId>
+			<version>6.1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.3</version>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/LocalConfiguration.java
+++ b/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/LocalConfiguration.java
@@ -72,7 +72,12 @@ public class LocalConfiguration {
 		}
 
 		@ConditionalOnProperty("cloudfoundry.apiEndpoint")
-		static class TragetingCloudFoundry {
+		static class TargetingCloudFoundry {
+		}
+
+		@ConditionalOnProperty("marathon.apiEndpoint")
+		static class TargetingMarathon {
+
 		}
 	}
 

--- a/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/MarathonConfiguration.java
+++ b/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/MarathonConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.admin.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
+import org.springframework.cloud.dataflow.module.deployer.marathon.MarathonModuleDeployer;
+import org.springframework.cloud.dataflow.module.deployer.marathon.MarathonProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration which creates deployers that deploy on Marathon.
+ * Can be used either when running <i>in</i> Marathon, or <i>targeting</i> Marathon.
+ *
+ * @author Eric Bottard
+ */
+@Configuration
+@ConditionalOnProperty("marathon.apiEndpoint")
+public class MarathonConfiguration {
+
+	@Bean
+	public MarathonProperties marathonProperties() {
+		return new MarathonProperties();
+	}
+
+	@Bean
+	public ModuleDeployer processModuleDeployer() {
+		return new MarathonModuleDeployer(marathonProperties());
+	}
+
+	@Bean
+	public ModuleDeployer taskModuleDeployer() {
+		return processModuleDeployer();
+	}
+
+}

--- a/spring-cloud-dataflow-module-deployers/pom.xml
+++ b/spring-cloud-dataflow-module-deployers/pom.xml
@@ -15,6 +15,7 @@
 		<module>spring-cloud-dataflow-module-deployer-spi</module>
 		<module>spring-cloud-dataflow-module-deployer-local</module>
 		<module>spring-cloud-dataflow-module-deployer-lattice</module>
+		<module>spring-cloud-dataflow-module-deployer-marathon</module>
 		<module>spring-cloud-dataflow-module-deployer-cloudfoundry</module>
 		<module>spring-cloud-dataflow-module-deployer-yarn</module>
 	</modules>

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/README.adoc
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/README.adoc
@@ -1,0 +1,2 @@
+SPI implementation for deploying https://github.com/spring-cloud/spring-cloud-stream[Spring Cloud Stream] modules to
+ https://mesosphere.github.io/marathon[Marathon].

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/pom.xml
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-dataflow-module-deployer-marathon</artifactId>
+	<packaging>jar</packaging>
+	<name>spring-cloud-dataflow-module-deployer-marathon</name>
+	<description>module deployer SPI implementation for Mesos/Marathon</description>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-module-deployers-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-module-deployer-spi</artifactId>
+		</dependency>
+		<!--
+		<dependency>
+			<groupId>com.github.mohitsoni</groupId>
+			<artifactId>marathon-client</artifactId>
+			<version>0.4.2</version>
+		</dependency>
+		-->
+		<!--Force Feign versions -->
+		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-core</artifactId>
+			<version>6.1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-gson</artifactId>
+			<version>6.1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.cloudbees.marathon</groupId>
+			<artifactId>marathon-client</artifactId>
+			<version>0.4.11</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonModuleDeployer.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module.deployer.marathon;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import mesosphere.marathon.client.Marathon;
+import mesosphere.marathon.client.MarathonClient;
+import mesosphere.marathon.client.model.v2.App;
+import mesosphere.marathon.client.model.v2.Container;
+import mesosphere.marathon.client.model.v2.Docker;
+import mesosphere.marathon.client.model.v2.Port;
+import mesosphere.marathon.client.model.v2.Task;
+import mesosphere.marathon.client.utils.MarathonException;
+
+import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
+import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
+import org.springframework.cloud.dataflow.module.ModuleStatus;
+import org.springframework.cloud.dataflow.module.deployer.ModuleArgumentQualifier;
+import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
+
+/**
+ * A ModuleDeployer implementation for deploying modules as applications on Marathon, using the
+ * ModuleLauncher Docker image.
+ *
+ * @author Eric Bottard
+ */
+public class MarathonModuleDeployer implements ModuleDeployer {
+
+	/**
+	 * The name of the ENV variable that is added to apps to identify Spring Cloud Data Flow modules.
+	 */
+	private static final String SPRING_CLOUD_DATAFLOW_MODULE = "SPRING_CLOUD_DATAFLOW_MODULE";
+
+	public static final String CONNECTOR_DEPENDENCY = "org.springframework.cloud:spring-cloud-marathon-connector:1.0.0.BUILD-SNAPSHOT";
+
+	private final MarathonProperties properties;
+
+	private final Marathon marathon;
+
+	public MarathonModuleDeployer(MarathonProperties properties) {
+		this.properties = properties;
+		marathon = MarathonClient.getInstance(properties.getApiEndpoint());
+	}
+
+	@Override
+	public ModuleDeploymentId deploy(ModuleDeploymentRequest request) {
+		App app = new App();
+		Container container = new Container();
+		Docker docker = new Docker();
+		docker.setImage(properties.getImage());
+		Port port = new Port(8080);
+		port.setHostPort(0);
+		docker.setPortMappings(Arrays.asList(port));
+		docker.setNetwork("BRIDGE");
+		container.setDocker(docker);
+		app.setContainer(container);
+
+		app.setId(deduceAppId(request));
+
+		Map<String, String> args = new HashMap<>();
+		args.putAll(request.getDeploymentProperties());
+		args.putAll(request.getDefinition().getParameters());
+		String includes = args.get("includes");
+		if (includes != null) {
+			includes += "," + CONNECTOR_DEPENDENCY;
+		} else {
+			includes = CONNECTOR_DEPENDENCY;
+		}
+		args.put("includes", includes);
+		Map<String, String> qualifiedArgs = ModuleArgumentQualifier.qualifyArgs(0, args);
+		Map<String, String> env = new HashMap<>();
+		env.putAll(qualifiedArgs);
+		env.putAll(properties.getLauncherProperties());
+		env.put("MODULES", request.getCoordinates().toString());
+		env.put("spring.profiles.active", "cloud");
+		env.put(SPRING_CLOUD_DATAFLOW_MODULE, request.getDefinition().getGroup() + ":" + request.getDefinition().getLabel());
+
+		app.setEnv(env);
+
+		Double cpus = deduceCpus(request);
+		Double memory = deduceMemory(request);
+
+		app.setCpus(cpus);
+		app.setMem(memory);
+		app.setInstances(request.getCount());
+
+		try {
+			marathon.createApp(app);
+		}
+		catch (MarathonException e) {
+			throw new RuntimeException(e);
+		}
+		return ModuleDeploymentId.fromModuleDefinition(request.getDefinition());
+	}
+	@Override
+	public void undeploy(ModuleDeploymentId id) {
+		String appId = deduceAppId(id);
+		try {
+			marathon.deleteApp(appId);
+		}
+		catch (MarathonException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private String deduceAppId(ModuleDeploymentId id) {
+		return id.getGroup() + "-" + id.getLabel();
+	}
+
+	@Override
+	public ModuleStatus status(ModuleDeploymentId id) {
+		String appName = deduceAppId(id);
+		try {
+			App app = marathon.getApp(appName).getApp();
+			return buildStatus(id, app);
+		}
+		catch (MarathonException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public Map<ModuleDeploymentId, ModuleStatus> status() {
+		Map<ModuleDeploymentId, ModuleStatus> result = new HashMap<>();
+		for (App app : marathon.getApps().getApps()) {
+			String moduleMarker = app.getEnv().get("SPRING_CLOUD_DATAFLOW_MODULE");
+			if (moduleMarker != null) {
+				int colon = moduleMarker.indexOf(':');
+				String group = moduleMarker.substring(0, colon);
+				String label = moduleMarker.substring(colon + 1);
+				ModuleDeploymentId id = new ModuleDeploymentId(group, label);
+				ModuleStatus status = buildStatus(id, app);
+				result.put(id, status);
+			}
+		}
+		return result;
+	}
+
+	private ModuleStatus buildStatus(ModuleDeploymentId id, App app) {
+		ModuleStatus.Builder result = ModuleStatus.of(id);
+		int requestedInstances = app.getInstances();
+		int actualInstances = 0;
+		for (Task task : app.getTasks()) {
+			result.with(MarathonModuleInstanceStatus.up(app, task));
+			actualInstances++;
+		}
+		for (int i = actualInstances; i < requestedInstances; i++) {
+			result.with(MarathonModuleInstanceStatus.down(app));
+		}
+		return result.build();
+	}
+
+	private Double deduceMemory(ModuleDeploymentRequest request) {
+		String override = request.getDeploymentProperties().get("marathon.memory");
+		return override != null ? Double.valueOf(override) : properties.getMemory();
+	}
+
+	private Double deduceCpus(ModuleDeploymentRequest request) {
+		String override = request.getDeploymentProperties().get("marathon.cpu");
+		return override != null ? Double.valueOf(override) : properties.getCpu();
+	}
+
+	private String deduceAppId(ModuleDeploymentRequest request) {
+		return request.getDefinition().getGroup() + "-" + request.getDefinition().getLabel();
+	}
+
+
+
+}

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonModuleInstanceStatus.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module.deployer.marathon;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import mesosphere.marathon.client.model.v2.App;
+import mesosphere.marathon.client.model.v2.Task;
+
+import org.springframework.cloud.dataflow.module.ModuleInstanceStatus;
+import org.springframework.cloud.dataflow.module.ModuleStatus;
+import org.springframework.util.StringUtils;
+
+/**
+ * Adapts from the Marathon task API to ModuleInstanceStatus. An instance of this class
+ * can also represent a missing application instance.
+ *
+ * @author Eric Bottard
+ */
+public class MarathonModuleInstanceStatus implements ModuleInstanceStatus {
+
+	private final App app;
+
+	private final Task task;
+
+	private MarathonModuleInstanceStatus(App app, Task task) {
+		this.app = app;
+		this.task = task;
+	}
+
+	/**
+	 * Construct a status from a running app task.
+	 */
+	static MarathonModuleInstanceStatus up(App app, Task task) {
+		return new MarathonModuleInstanceStatus(app, task);
+	}
+
+	/**
+	 * Construct a status from a missing app task (maybe it crashed, maybe Mesos could not offer enough resources, etc.)
+	 */
+	static MarathonModuleInstanceStatus down(App app) {
+		return new MarathonModuleInstanceStatus(app, null);
+	}
+
+	@Override
+	public String getId() {
+		return task != null ? task.getId() : (app.getId() + "-failed-" + new Random().nextInt());
+	}
+
+	@Override
+	public ModuleStatus.State getState() {
+		return task != null ? ModuleStatus.State.deployed : ModuleStatus.State.failed;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		HashMap<String, String> result = new HashMap<>();
+		if (task != null) {
+			result.put("staged_at", task.getStagedAt());
+			result.put("started_at", task.getStartedAt());
+			result.put("host", task.getHost());
+			result.put("ports", StringUtils.collectionToCommaDelimitedString(task.getPorts()));
+		}
+		return result;
+	}
+}

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonProperties.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-marathon/src/main/java/org/springframework/cloud/dataflow/module/deployer/marathon/MarathonProperties.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module.deployer.marathon;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for connecting to a Marathon installation.
+ *
+ * @author Eric Bottard
+ */
+@ConfigurationProperties("marathon")
+public class MarathonProperties {
+
+	/**
+	 * The location of the Marathon REST endpoint.
+	 */
+	private String apiEndpoint = "http://10.141.141.10:8080";
+
+	/**
+	 * The docker image to use for launching modules.
+	 */
+	private String image = "springcloud/stream-module-launcher";
+
+	/**
+	 * Additional arguments to pass to the module launcher.
+	 */
+	private Map<String, String> launcherProperties = new HashMap<>();
+
+	/**
+	 * How much memory to allocate per module, can be overridden at deployment time.
+	 */
+	private double memory = 128.0D;
+
+	/**
+	 * How manu CPUs to allocate per module, can be overridden at deployment time.
+	 */
+	private double cpu = 0.5D;
+
+	public double getMemory() {
+		return memory;
+	}
+
+	public void setMemory(double memory) {
+		this.memory = memory;
+	}
+
+	public double getCpu() {
+		return cpu;
+	}
+
+	public void setCpu(double cpu) {
+		this.cpu = cpu;
+	}
+
+	public String getApiEndpoint() {
+		return apiEndpoint;
+	}
+
+	public void setApiEndpoint(String apiEndpoint) {
+		this.apiEndpoint = apiEndpoint;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+
+	public Map<String, String> getLauncherProperties() {
+		return launcherProperties;
+	}
+
+	public void setLauncherProperties(Map<String, String> launcherProperties) {
+		this.launcherProperties = launcherProperties;
+	}
+}


### PR DESCRIPTION
This adds a Deployer implementation for Mesos/Marathon.

A couple of caveats:
* same as the current CF deployer, the `task` deployer is actually not able to deploy tasks
* this requires https://github.com/ericbottard/spring-cloud-marathon-connector
* of particular interest is the way the connector above is added to modules at runtime, using `includes`. This could be applied to the Lattice and CF deployers as well IMO

An easy way to test this is to use https://github.com/mesosphere/playa-mesos
Can also use `marathon.launcherProperties.remoteRepositories=xxxx` to target your local maven repo