### PR TITLE
Fix parser handling of dots in option names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ spring-*/src/main/java/META-INF/MANIFEST.MF
 *.ipr
 *.iws
 .idea/*
+hs_err_*.log

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/ModuleParser.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/ModuleParser.java
@@ -205,7 +205,11 @@ public class ModuleParser {
 	protected String toData(Iterable<Token> iterable) {
 		StringBuilder result = new StringBuilder();
 		for (Token t : iterable) {
-			result.append(t.getKind().hasPayload() ? t.data : t.getKind().tokenChars);
+			if (t.getKind().hasPayload()) {
+				result.append(t.data);
+			} else {
+				result.append(t.getKind().tokenChars);
+			}
 		}
 		return result.toString();
 	}


### PR DESCRIPTION
Subtle bug related to method overloading (evil) and the fact that
`x ? a : b ` resolves to the common super type (more evil)