### PR TITLE
Add type conversion support

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
@@ -44,6 +44,8 @@ public class BindingProperties {
 
 	public static final String OUTPUT_BINDING_KEY_PREFIX = BINDING_KEY_PREFIX + "output.";
 
+	public static final String CONTENT_TYPE_KEY = "contentType";
+
 	/**
 	 * Default property key for input channel binding.
 	 */
@@ -65,5 +67,12 @@ public class BindingProperties {
 	public static final String OUTPUT_PARTITION_SELECTOR_EXPRESSION = OUTPUT_BINDING_KEY_PREFIX + PARTITION_SELECTOR_EXPRESSION;
 
 	public static final String OUTPUT_PARTITION_COUNT = OUTPUT_BINDING_KEY_PREFIX + "partitionCount";
+
+	/**
+	 * Type conversion for channel binding
+	 */
+	public static final String INPUT_TYPE_KEY = INPUT_BINDING_KEY_PREFIX + CONTENT_TYPE_KEY;
+
+	public static final String OUTPUT_TYPE_KEY = OUTPUT_BINDING_KEY_PREFIX + CONTENT_TYPE_KEY;
 
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -71,7 +71,15 @@ class ModuleDefinitionBuilder {
 			if (moduleNode.hasArguments()) {
 				ArgumentNode[] arguments = moduleNode.getArguments();
 				for (ArgumentNode argument : arguments) {
-					builder.setParameter(argument.getName(), argument.getValue());
+					if (argument.getName().equalsIgnoreCase("inputType")) {
+						builder.setParameter(BindingProperties.INPUT_TYPE_KEY, argument.getValue());
+					}
+					else if (argument.getName().equalsIgnoreCase("outputType")) {
+						builder.setParameter(BindingProperties.OUTPUT_TYPE_KEY, argument.getValue());
+					}
+					else {
+						builder.setParameter(argument.getName(), argument.getValue());
+					}
 				}
 			}
 			if (m > 0) {


### PR DESCRIPTION
 - Support inputType/outputType for the module (same support that Spring XD has)
 - Set the module parameters as s-c-s binding properties based on the inputType/outputType specified in DSL