### PR TITLE
Do not shut down Admin on test completion

### DIFF
--- a/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractShellIntegrationTest {
 	 *
 	 * @see #SHUTDOWN_AFTER_RUN
 	 */
-	private static boolean shutdownAfterRun = true;
+	private static boolean shutdownAfterRun = false;
 
 	/**
 	 * Application context for admin application.


### PR DESCRIPTION
The shell tests have the option of shutting down the Admin server after test execution. This change makes the default setting `false` because shutting down the admin inside of the test may lead to the following test failure:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test (default-test)
on project spring-cloud-dataflow-shell: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test failed: The forked VM terminated without properly saying goodbye. VM crash or
System.exit called?
```
This failure occurred with the following environment:
```
$ mvn --version
Apache Maven 3.3.3 (7994120775791599e205a5524ec3e0dfe41d4a06;
2015-04-22T07:57:37-04:00)
Maven home: /usr/local/Cellar/maven/3.3.3/libexec
Java version: 1.8.0_60, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_60.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.10.5", arch: "x86_64", family: "mac"
```