### PR TITLE
Don't show banner for local module deployer

### DIFF
--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-local/src/main/java/org/springframework/cloud/dataflow/module/deployer/local/LocalModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-local/src/main/java/org/springframework/cloud/dataflow/module/deployer/local/LocalModuleDeployer.java
@@ -85,6 +85,7 @@ public class LocalModuleDeployer implements ModuleDeployer {
 			throw new IllegalStateException("failed to determine URL for module: " + module, e);
 		}
 		args.put("endpoints.shutdown.enabled", "true");
+		args.put("spring.main.show_banner", "false");
 
 		ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(module, args);
 		launcher.launch(Collections.singletonList(moduleLaunchRequest));


### PR DESCRIPTION
 - The spring-cloud-dataflow banner gets displayed when the local module deployer deploys the modules. We need to disable showing the dataflow banner for the modules.