### PR TITLE
Fix closed set value code completion

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/BooleanValueHintProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/BooleanValueHintProvider.java
@@ -49,4 +49,9 @@ public class BooleanValueHintProvider implements ValueHintProvider {
 			return Collections.emptyList();
 		}
 	}
+
+	@Override
+	public boolean isExclusive(ConfigurationMetadataProperty property) {
+		return true;
+	}
 }

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DefaultValueHintProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DefaultValueHintProvider.java
@@ -20,16 +20,27 @@ import java.util.List;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.configurationmetadata.ValueHint;
+import org.springframework.boot.configurationmetadata.ValueProvider;
 
 /**
  * A default ValueHint provider that returns hints explicitly defined by a property.
  *
  * @author Eric Bottard
  */
-public class DefaultValueHintProvider implements ValueHintProvider{
+public class DefaultValueHintProvider implements ValueHintProvider {
 
 	@Override
 	public List<ValueHint> guessValueHints(ConfigurationMetadataProperty property, ClassLoader classLoader) {
 		return property.getValueHints();
+	}
+
+	@Override
+	public boolean isExclusive(ConfigurationMetadataProperty property) {
+		for (ValueProvider valueProvider : property.getValueProviders()) {
+			if ("any".equals(valueProvider.getName())) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EnumValueHintProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EnumValueHintProvider.java
@@ -24,7 +24,10 @@ import org.springframework.boot.configurationmetadata.ValueHint;
 import org.springframework.util.ClassUtils;
 
 /**
- * Created by ericbottard on 07/10/15.
+ * A ValueHintProvider that returns possible values when the property
+ * is some kind of {@link Enum}.
+ *
+ * @author Eric Bottard
  */
 public class EnumValueHintProvider implements ValueHintProvider {
 
@@ -42,5 +45,10 @@ public class EnumValueHintProvider implements ValueHintProvider {
 			}
 		}
 		return result;
+	}
+
+	@Override
+	public boolean isExclusive(ConfigurationMetadataProperty property) {
+		return true;
 	}
 }

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ValueHintProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ValueHintProvider.java
@@ -29,4 +29,12 @@ import org.springframework.boot.configurationmetadata.ValueHint;
 public interface ValueHintProvider {
 
 	List<ValueHint> guessValueHints(ConfigurationMetadataProperty property, ClassLoader classLoader);
+
+	/**
+	 * Return {@literal true} if the values returned by this provider, if any, are the only values
+	 * that make sense as completion proposals. If this is true, then no other kind of completion
+	 * makes sense until one of the returned values has been typed in full.
+	 * @param property
+	 */
+	boolean isExclusive(ConfigurationMetadataProperty property);
 }

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -231,6 +231,17 @@ public class StreamCompletionProviderTests {
 		assertThat(completionProvider.complete("http | filter --expression=something --expresso=not-a-valid-prefix", 1), empty());
 	}
 
+	/*
+	 * http --use.ssl=tr<TAB> => must be true or false, no need to present "...=tr --other.prop"
+	 */
+	@Test
+	public void testClosedSetValuesShouldBeExclusive() {
+		assertThat(completionProvider.complete("http --use.ssl=tr", 1), not(hasItems(
+				proposalThat(startsWith("http --use.ssl=tr "))
+		)));
+
+	}
+
 
 	private static org.hamcrest.Matcher<CompletionProposal> proposalThat(org.hamcrest.Matcher<String> matcher) {
 		return new FeatureMatcher<CompletionProposal, String>(matcher, "a proposal whose text", "text") {


### PR DESCRIPTION
When trying to complete `http --use.ssl=tr<TAB>`, we know that `true`
is the only possible value. `tr` is not a possible value, and hence no
other completion strategy shall be used until `true` has been typed in full.