### PR TITLE
Bump Boot and spring-cloud-build Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.1.0.M1</version>
+		<version>1.1.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<scm>
@@ -24,7 +24,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 		<spring-framework.version>4.2.0.RELEASE</spring-framework.version>
-		<spring-boot.version>1.3.0.M5</spring-boot.version>
+		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
 		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
 		<spring-xd.version>1.0.2.RELEASE</spring-xd.version>
 		<spring-data.version>1.9.1.RELEASE</spring-data.version>

--- a/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/CloudConfiguration.java
+++ b/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/CloudConfiguration.java
@@ -17,9 +17,10 @@
 package org.springframework.cloud.dataflow.admin.config;
 
 import org.cloudfoundry.receptor.client.ReceptorClient;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudConnector;
 import org.springframework.cloud.CloudFactory;
@@ -32,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Configuration used when running <i>in a cloud</i>, triggered by cloud profiles (cloud, lattice).

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/pom.xml
@@ -26,6 +26,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                        <optional>true</optional>
+                </dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
Boot 1.3.0.BUILD-SNAPSHOT
s-c-s 1.1.0.BUILD-SNAPSHOT

Needed to support deployment consumer properties.