### PR TITLE
XD-3618: Add 'runtime modules' command

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -92,6 +93,11 @@ public class AdminConfiguration {
 				// the REST API produces JSON only; adding this converter
 				// prevents the registration of the default converters
 				converters.add(new MappingJackson2HttpMessageConverter());
+			}
+
+			@Override
+			public void configurePathMatch(PathMatchConfigurer configurer) {
+				configurer.setUseSuffixPatternMatch(false);
 			}
 		};
 	}

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/AdminController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/AdminController.java
@@ -19,7 +19,9 @@ package org.springframework.cloud.dataflow.admin.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.resource.CompletionProposalsResource;
 import org.springframework.cloud.dataflow.rest.resource.CounterResource;
+import org.springframework.cloud.dataflow.rest.resource.ModuleInstanceStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.ModuleRegistrationResource;
+import org.springframework.cloud.dataflow.rest.resource.ModuleStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.hateoas.EntityLinks;
@@ -27,6 +29,7 @@ import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponents;
 
 /**
  * Controller for the root resource of the admin server.
@@ -65,11 +68,19 @@ public class AdminController {
 		resourceSupport.add(entityLinks.linkToCollectionResource(StreamDefinitionResource.class).withRel("streams"));
 		resourceSupport.add(entityLinks.linkToCollectionResource(TaskDefinitionResource.class).withRel("tasks"));
 		resourceSupport.add(entityLinks.linkToCollectionResource(CounterResource.class).withRel("counters"));
-		resourceSupport.add(new Link(entityLinks.linkToCollectionResource(CounterResource.class).getHref() + "/{name}").withRel("counters/counter"));
+		resourceSupport.add(unescapeTemplateVariables(entityLinks.linkToSingleResource(CounterResource.class, "{name}").withRel("counters/counter")));
 		resourceSupport.add(entityLinks.linkToCollectionResource(ModuleRegistrationResource.class).withRel("modules"));
+		resourceSupport.add(entityLinks.linkToCollectionResource(ModuleStatusResource.class).withRel("runtime/modules"));
+		resourceSupport.add(unescapeTemplateVariables(entityLinks.linkForSingleResource(ModuleStatusResource.class, "{moduleId}").withRel("runtime/module")));
+		resourceSupport.add(unescapeTemplateVariables(entityLinks.linkFor(ModuleInstanceStatusResource.class, UriComponents.UriTemplateVariables.SKIP_VALUE).withRel("runtime/modules/instances")));
 		String templated = entityLinks.linkFor(CompletionProposalsResource.class).withSelfRel().getHref() + ("/stream{?start,detailLevel}");
 		resourceSupport.add(new Link(templated).withRel("completions/stream"));
 		return resourceSupport;
+	}
+
+	// Workaround https://github.com/spring-projects/spring-hateoas/issues/234
+	private Link unescapeTemplateVariables(Link raw) {
+		return new Link(raw.getHref().replace("%7B", "{").replace("%7D", "}"), raw.getRel());
 	}
 
 }

--- a/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/controller/RuntimeModulesController.java
+++ b/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/controller/RuntimeModulesController.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.admin.controller;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
+import org.springframework.cloud.dataflow.module.ModuleInstanceStatus;
+import org.springframework.cloud.dataflow.module.ModuleStatus;
+import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
+import org.springframework.cloud.dataflow.rest.resource.ModuleInstanceStatusResource;
+import org.springframework.cloud.dataflow.rest.resource.ModuleStatusResource;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceAssembler;
+import org.springframework.hateoas.Resources;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes runtime status of deployed modules.
+ *
+ * @author Eric Bottard
+ */
+@RestController
+@RequestMapping("/runtime/modules")
+@ExposesResourceFor(ModuleStatusResource.class)
+public class RuntimeModulesController {
+
+	private static final Comparator<? super ModuleInstanceStatus> INSTANCE_SORTER = new Comparator<ModuleInstanceStatus>() {
+		@Override
+		public int compare(ModuleInstanceStatus i1, ModuleInstanceStatus i2) {
+			return i1.getId().compareTo(i2.getId());
+		}
+	};
+
+	private final Collection<ModuleDeployer> moduleDeployers;
+
+	private final ResourceAssembler<ModuleStatus, ModuleStatusResource> statusAssembler = new Assembler();
+
+	@Autowired
+	public RuntimeModulesController(Collection<ModuleDeployer> moduleDeployers) {
+		this.moduleDeployers = new HashSet<>(moduleDeployers);
+	}
+
+	@RequestMapping
+	public PagedResources<ModuleStatusResource> list(PagedResourcesAssembler<ModuleStatus> assembler) {
+		List<ModuleStatus> values = new ArrayList<>();
+		for (ModuleDeployer moduleDeployer : moduleDeployers) {
+			values.addAll(moduleDeployer.status().values());
+		}
+		Collections.sort(values, new Comparator<ModuleStatus>() {
+			@Override
+			public int compare(ModuleStatus o1, ModuleStatus o2) {
+				return o1.getModuleDeploymentId().toString().compareTo(o2.getModuleDeploymentId().toString());
+			}
+		});
+		return assembler.toResource(new PageImpl<>(values), statusAssembler);
+	}
+
+	@RequestMapping("/{id}")
+	public ModuleStatusResource display(@PathVariable String id) {
+		ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId.parse(id);
+		for (ModuleDeployer moduleDeployer : moduleDeployers) {
+			ModuleStatus status = moduleDeployer.status(moduleDeploymentId);
+			if (status != null) {
+				return statusAssembler.toResource(status);
+			}
+		}
+		throw new ResourceNotFoundException();
+	}
+
+	private class Assembler extends ResourceAssemblerSupport<ModuleStatus, ModuleStatusResource> {
+
+		public Assembler() {
+			super(RuntimeModulesController.class, ModuleStatusResource.class);
+		}
+
+		@Override
+		public ModuleStatusResource toResource(ModuleStatus entity) {
+			return createResourceWithId(entity.getModuleDeploymentId(), entity);
+		}
+
+		@Override
+		protected ModuleStatusResource instantiateResource(ModuleStatus entity) {
+			ModuleStatusResource resource = new ModuleStatusResource(entity.getModuleDeploymentId().toString(), entity.getState().name());
+			List<ModuleInstanceStatusResource> instanceStatusResources = new ArrayList<>();
+			InstanceAssembler instanceAssembler = new InstanceAssembler(entity);
+			List<ModuleInstanceStatus> instanceStatuses = new ArrayList<>(entity.getInstances().values());
+			Collections.sort(instanceStatuses, INSTANCE_SORTER);
+			for (ModuleInstanceStatus moduleInstanceStatus : instanceStatuses) {
+				instanceStatusResources.add(instanceAssembler.toResource(moduleInstanceStatus));
+			}
+			resource.setInstances(new Resources<>(instanceStatusResources));
+			return resource;
+		}
+	}
+
+	@RestController
+	@RequestMapping("/runtime/modules/{moduleId}/instances")
+	@ExposesResourceFor(ModuleInstanceStatusResource.class)
+	public static class InstanceController {
+
+		private final Collection<ModuleDeployer> moduleDeployers;
+
+		@Autowired
+		public InstanceController(Collection<ModuleDeployer> moduleDeployers) {
+			this.moduleDeployers = new HashSet<>(moduleDeployers);
+		}
+
+		@RequestMapping
+		public PagedResources<ModuleInstanceStatusResource> list(@PathVariable String moduleId,
+				PagedResourcesAssembler<ModuleInstanceStatus> assembler) {
+			ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId.parse(moduleId);
+			for (ModuleDeployer moduleDeployer : moduleDeployers) {
+				ModuleStatus status = moduleDeployer.status(moduleDeploymentId);
+				if (status != null) {
+					List<ModuleInstanceStatus> moduleInstanceStatuses = new ArrayList<>(status.getInstances().values());
+					Collections.sort(moduleInstanceStatuses, INSTANCE_SORTER);
+					return assembler.toResource(new PageImpl<>(moduleInstanceStatuses), new InstanceAssembler(status));
+				}
+			}
+			throw new ResourceNotFoundException();
+		}
+
+		@RequestMapping("/{instanceId}")
+		public ModuleInstanceStatusResource display(@PathVariable String moduleId, @PathVariable String instanceId) {
+			ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId.parse(moduleId);
+			for (ModuleDeployer moduleDeployer : moduleDeployers) {
+				ModuleStatus status = moduleDeployer.status(moduleDeploymentId);
+				if (status != null) {
+					ModuleInstanceStatus moduleInstanceStatus = status.getInstances().get(instanceId);
+					if (moduleInstanceStatus == null) {
+						throw new ResourceNotFoundException();
+					}
+					return new InstanceAssembler(status).toResource(moduleInstanceStatus);
+				}
+			}
+			throw new ResourceNotFoundException();
+		}
+
+	}
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	private static class ResourceNotFoundException extends RuntimeException {
+
+	}
+
+	private static class InstanceAssembler extends ResourceAssemblerSupport<ModuleInstanceStatus, ModuleInstanceStatusResource> {
+
+		private final ModuleStatus owningModule;
+
+		public InstanceAssembler(ModuleStatus owningModule) {
+			super(InstanceController.class, ModuleInstanceStatusResource.class);
+			this.owningModule = owningModule;
+		}
+
+		@Override
+		public ModuleInstanceStatusResource toResource(ModuleInstanceStatus entity) {
+			return createResourceWithId("/" + entity.getId(), entity, owningModule.getModuleDeploymentId().toString());
+		}
+
+		@Override
+		protected ModuleInstanceStatusResource instantiateResource(ModuleInstanceStatus entity) {
+			return new ModuleInstanceStatusResource(entity.getId(), entity.getState().name(), entity.getAttributes());
+		}
+	}
+}

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
@@ -72,7 +72,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 	/**
 	 * REST Client for runtime operations.
 	 */
-	private final RuntimeOperations runtimeTemplate;
+	private final RuntimeOperations runtimeOperations;
 
 
 	public DataFlowTemplate(URI baseURI, RestTemplate restTemplate) {
@@ -90,7 +90,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 		this.taskOperations = new TaskTemplate(restTemplate, resources);
 		this.moduleOperations = new ModuleTemplate(restTemplate, resourceSupport);
 		this.completionOperations = new CompletionTemplate(restTemplate, resourceSupport.getLink("completions/stream"));
-		this.runtimeTemplate = new RuntimeTemplate(restTemplate, resourceSupport);
+		this.runtimeOperations = new RuntimeTemplate(restTemplate, resourceSupport);
 	}
 
 	public Link getLink(ResourceSupport resourceSupport, String rel) {
@@ -129,6 +129,6 @@ public class DataFlowTemplate implements DataFlowOperations {
 
 	@Override
 	public RuntimeOperations runtimeOperations() {
-		return runtimeTemplate;
+		return runtimeOperations;
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
@@ -69,6 +69,11 @@ public class DataFlowTemplate implements DataFlowOperations {
 	 */
 	private final CompletionOperations completionOperations;
 
+	/**
+	 * REST Client for runtime operations.
+	 */
+	private final RuntimeOperations runtimeTemplate;
+
 
 	public DataFlowTemplate(URI baseURI, RestTemplate restTemplate) {
 		this.restTemplate = restTemplate;
@@ -85,6 +90,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 		this.taskOperations = new TaskTemplate(restTemplate, resources);
 		this.moduleOperations = new ModuleTemplate(restTemplate, resourceSupport);
 		this.completionOperations = new CompletionTemplate(restTemplate, resourceSupport.getLink("completions/stream"));
+		this.runtimeTemplate = new RuntimeTemplate(restTemplate, resourceSupport);
 	}
 
 	public Link getLink(ResourceSupport resourceSupport, String rel) {
@@ -119,5 +125,10 @@ public class DataFlowTemplate implements DataFlowOperations {
 	@Override
 	public CompletionOperations completionOperations() {
 		return completionOperations;
+	}
+
+	@Override
+	public RuntimeOperations runtimeOperations() {
+		return runtimeTemplate;
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeOperations.java
@@ -16,40 +16,23 @@
 
 package org.springframework.cloud.dataflow.rest.client;
 
+import org.springframework.cloud.dataflow.rest.resource.ModuleStatusResource;
+import org.springframework.hateoas.PagedResources;
+
 /**
- * Interface the REST clients implement to interact with spring-cloud-dataflow REST API.
+ * Defines operations available for obtaining information about deployed modules.
  *
- * @author Ilayaperumal Gopinathan
+ * @author Eric Bottard
  */
-public interface DataFlowOperations {
+public interface RuntimeOperations {
 
 	/**
-	 * Stream related operations.
+	 * Return runtime information about all deployed modules.
 	 */
-	StreamOperations streamOperations();
+	PagedResources<ModuleStatusResource> status();
 
 	/**
-	 * Counter related operations.
+	 * Return runtime information about a single module deployment.
 	 */
-	CounterOperations counterOperations();
-
-	/**
-	 * Task related operations.
-	 */
-	TaskOperations taskOperations();
-
-	/**
-	 * Module related operations.
-	 */
-	ModuleOperations moduleOperations();
-
-	/**
-	 * DSL Completion related operations.
-	 */
-	CompletionOperations completionOperations();
-
-	/**
-	 * Runtime related opertations.
-	 */
-	RuntimeOperations runtimeOperations();
+	ModuleStatusResource status(String moduleDeploymentId);
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeTemplate.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.client;
+
+import org.springframework.cloud.dataflow.rest.resource.ModuleStatusResource;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Implementation for {@link RuntimeOperations}.
+ *
+ * @author Eric Bottard
+ */
+public class RuntimeTemplate implements RuntimeOperations {
+
+	private final RestTemplate restTemplate;
+
+	/**
+	 * Uri template for accessing status of all modules.
+	 */
+	private final Link moduleStatusesUriTemplate;
+
+	/**
+	 * Uri template for accessing status of a single module.
+	 */
+	private final Link moduleStatusUriTemplate;
+
+	RuntimeTemplate(RestTemplate restTemplate, ResourceSupport resources) {
+		this.restTemplate = restTemplate;
+		this.moduleStatusesUriTemplate = resources.getLink("runtime/modules");
+		this.moduleStatusUriTemplate = resources.getLink("runtime/module");
+	}
+
+	@Override
+	public PagedResources<ModuleStatusResource> status() {
+		return restTemplate.getForObject(moduleStatusesUriTemplate.expand().getHref(), ModuleStatusResource.Page.class);
+	}
+
+	@Override
+	public ModuleStatusResource status(String moduleDeploymentId) {
+		return restTemplate.getForObject(moduleStatusUriTemplate.expand(moduleDeploymentId).getHref(), ModuleStatusResource.class);
+	}
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/ModuleInstanceStatusResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/ModuleInstanceStatusResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource;
+
+import java.util.Map;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * REST representation for a ModuleInstanceStatus.
+ *
+ * @author Eric Bottard
+ */
+public class ModuleInstanceStatusResource extends ResourceSupport {
+
+	private String instanceId;
+
+	private String state;
+
+	private Map<String, String> attributes;
+
+	private ModuleInstanceStatusResource() {
+		// noarg constructor for serialization
+	}
+
+	public ModuleInstanceStatusResource(String instanceId, String state, Map<String, String> attributes) {
+		this.instanceId = instanceId;
+		this.state = state;
+		this.attributes = attributes;
+	}
+
+	public String getInstanceId() {
+		return instanceId;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public Map<String, String> getAttributes() {
+		return attributes;
+	}
+
+	public void setInstanceId(String instanceId) {
+		this.instanceId = instanceId;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public void setAttributes(Map<String, String> attributes) {
+		this.attributes = attributes;
+	}
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/ModuleStatusResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/ModuleStatusResource.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource;
+
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.Resources;
+
+/**
+ * REST representation of a ModuleStatus.
+ *
+ * @author Eric Bottard
+ */
+public class ModuleStatusResource extends ResourceSupport {
+
+	private String moduleDeploymentId;
+
+	private String state;
+
+	private Resources<ModuleInstanceStatusResource> instances;
+
+	private ModuleStatusResource() {
+		// Noarg constructor for serialization;
+	}
+
+	public ModuleStatusResource(String moduleDeploymentId, String state) {
+		this.moduleDeploymentId = moduleDeploymentId;
+		this.state = state;
+	}
+
+	public String getModuleDeploymentId() {
+		return moduleDeploymentId;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public Resources<ModuleInstanceStatusResource> getInstances() {
+		return instances;
+	}
+
+	public void setInstances(Resources<ModuleInstanceStatusResource> instances) {
+		this.instances = instances;
+	}
+
+	public static class Page extends PagedResources<ModuleStatusResource> {
+
+	}
+
+	public void setModuleDeploymentId(String moduleDeploymentId) {
+		this.moduleDeploymentId = moduleDeploymentId;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+}

--- a/spring-cloud-dataflow-shell/pom.xml
+++ b/spring-cloud-dataflow-shell/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>org.springframework.shell</groupId>
 			<artifactId>spring-shell</artifactId>
-			<version>1.1.0.RELEASE</version>
+			<version>1.2.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
@@ -83,13 +83,13 @@ public class RuntimeCommands implements CommandMarker {
 			modelBuilder.addRow()
 					.addValue("Module Id / Instance Id")
 					.addValue("Unit Status")
-					.addValue("Nb of Instances / Attributes");
+					.addValue("No. of Instances / Attributes");
 		}
 		else {
 			modelBuilder.addRow()
 					.addValue("Module Id")
 					.addValue("Unit Status")
-					.addValue("Nb of Instances");
+					.addValue("No. of Instances");
 		}
 
 		// In detailed mode, keep track of module vs instance lines, to use

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell.command;
+
+import static org.springframework.shell.table.CellMatchers.*;
+import static org.springframework.shell.table.SimpleHorizontalAligner.*;
+import static org.springframework.shell.table.SimpleVerticalAligner.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.dataflow.rest.client.RuntimeOperations;
+import org.springframework.cloud.dataflow.rest.resource.ModuleInstanceStatusResource;
+import org.springframework.cloud.dataflow.rest.resource.ModuleStatusResource;
+import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.table.BorderFactory;
+import org.springframework.shell.table.BorderSpecification;
+import org.springframework.shell.table.BorderStyle;
+import org.springframework.shell.table.Table;
+import org.springframework.shell.table.TableModel;
+import org.springframework.shell.table.TableModelBuilder;
+import org.springframework.shell.table.Tables;
+import org.springframework.stereotype.Component;
+
+/**
+ * Commands for displaying the runtime state of deployed modules.
+ *
+ * @author Eric Bottard
+ */
+@Component
+public class RuntimeCommands implements CommandMarker {
+
+	private static final String LIST_MODULES = "runtime modules";
+
+	@Autowired
+	private DataFlowShell dataFlowShell;
+
+	@CliAvailabilityIndicator({LIST_MODULES})
+	public boolean available() {
+		return dataFlowShell.getDataFlowOperations() != null;
+	}
+
+	@CliCommand(value = LIST_MODULES, help = "List runtime modules")
+	public Table list(
+			@CliOption(key = "summary", help = "whether to hide module instances details",
+					unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean summary,
+			@CliOption(key = {"moduleId", "moduleIds"}, help = "module id(s) to display, also supports '<group>.*' pattern") String[] moduleIds) {
+
+		Set<String> filter = null;
+		if (moduleIds != null) {
+			filter = new HashSet<>(Arrays.asList(moduleIds));
+		}
+
+		TableModelBuilder<Object> builder = new TableModelBuilder<>();
+		if (!summary) {
+			builder.addRow()
+					.addValue("Module Id / Instance Id")
+					.addValue("Unit Status")
+					.addValue("Nb of Instances / Attributes");
+		}
+		else {
+			builder.addRow()
+					.addValue("Module Id")
+					.addValue("Unit Status")
+					.addValue("Nb of Instances");
+		}
+
+		// In detailed mode, keep track of module vs instance lines, to use
+		// a different border style later.
+		List<Integer> splits = new ArrayList<>();
+		int line = 1;
+		// Optimise for the 1 module case, which is likely less resource intensive on the server
+		// than client side filtering
+		Iterable<ModuleStatusResource> statuses;
+		if (filter != null && filter.size() == 1 && !filter.iterator().next().endsWith(".*")) {
+			statuses = Collections.singleton(runtimeOperations().status(filter.iterator().next()));
+		}
+		else {
+			statuses = runtimeOperations().status();
+		}
+		for (ModuleStatusResource moduleStatusResource : statuses) {
+			if (filter != null && !shouldRetain(filter, moduleStatusResource)) {
+				continue;
+			}
+			builder.addRow()
+					.addValue(moduleStatusResource.getModuleDeploymentId())
+					.addValue(moduleStatusResource.getState())
+					.addValue(moduleStatusResource.getInstances().getContent().size());
+			splits.add(line);
+			line++;
+			if (!summary) {
+				for (ModuleInstanceStatusResource moduleInstanceStatusResource : moduleStatusResource.getInstances()) {
+					builder.addRow()
+							.addValue(moduleInstanceStatusResource.getInstanceId())
+							.addValue(moduleInstanceStatusResource.getState())
+							.addValue(moduleInstanceStatusResource.getAttributes());
+					line++;
+				}
+			}
+		}
+
+		TableModel model = builder.build();
+		final Table table = new Table(model);
+		BorderFactory.header(table, BorderStyle.fancy_double);
+		BorderFactory.inner(table, BorderStyle.fancy_light);
+		Tables.configureKeyValueRendering(table, " = ");
+
+		table.align(column(0), middle);
+		table.align(column(1), middle);
+		table.align(column(1), center);
+		table.align(row(0), center);
+
+		// This will match the "number of instances" cells only
+		table.align(ofType(Integer.class), center);
+
+		for (int i = 2; i < model.getRowCount(); i++) {
+			if (splits.contains(i)) {
+				table.withBorder(i, 0, i + 1, model.getColumnCount(), BorderSpecification.TOP, BorderStyle.fancy_light);
+			}
+			else {
+				table.withBorder(i, 0, i + 1, model.getColumnCount(), BorderSpecification.TOP, BorderStyle.fancy_light_quadruple_dash);
+			}
+		}
+
+		return table;
+	}
+
+	private boolean shouldRetain(Set<String> filter, ModuleStatusResource moduleStatusResource) {
+		String moduleDeploymentId = moduleStatusResource.getModuleDeploymentId();
+		boolean directMatch = filter.contains(moduleDeploymentId);
+		if (directMatch) {
+			return true;
+		}
+		for (String candidate : filter) {
+			if (candidate.endsWith(".*")) {
+				String pattern = candidate.substring(0, candidate.length() - "*".length());
+				if (moduleDeploymentId.startsWith(pattern)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private RuntimeOperations runtimeOperations() {
+		return dataFlowShell.getDataFlowOperations().runtimeOperations();
+	}
+}


### PR DESCRIPTION
This requires https://github.com/spring-projects/spring-shell/pull/86

This is best tested with the non-local deployer (which is not very interesting as it exposes no attributes).

This is what you'd get for example with the CF deployer for `time | log x3`:

```
╔════════════════════╤═════════╤═════════════════════════════════════════════╗
║Module Id / Instance│  Unit   │        Nb of Instances / Attributes         ║
║         Id         │ Status  │                                             ║
╟────────────────────┼─────────┼─────────────────────────────────────────────╢
║foobarbar.log       │deployed │                      3                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                    │         │  usage.time = 2015-11-05 14:13:34           ║
║                    │         │   uris = foobarbar-log.cfapps.pez.pivotal.io║
║                    │         │   mem_quota = 1073741824                    ║
║                    │         │        port = 63832                         ║
║                    │         │   usage.cpu = 4.3499719577721606E-4         ║
║foobarbar-log:0     │deployed │        name = foobarbar-log                 ║
║                    │         │        host = 192.168.8.95                  ║
║                    │         │  usage.disk = 182968320                     ║
║                    │         │  disk_quota = 1073741824                    ║
║                    │         │   fds_quota = 16384                         ║
║                    │         │usage.memory = 664776704                     ║
║                    │         │      uptime = 171098.0                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                    │         │  usage.time = 2015-11-05 14:13:34           ║
║                    │         │   uris = foobarbar-log.cfapps.pez.pivotal.io║
║                    │         │   mem_quota = 1073741824                    ║
║                    │         │        port = 64186                         ║
║                    │         │   usage.cpu = 5.036031948609361E-4          ║
║foobarbar-log:1     │deployed │        name = foobarbar-log                 ║
║                    │         │        host = 192.168.9.21                  ║
║                    │         │  usage.disk = 182968320                     ║
║                    │         │  disk_quota = 1073741824                    ║
║                    │         │   fds_quota = 16384                         ║
║                    │         │usage.memory = 626724864                     ║
║                    │         │      uptime = 171098.0                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                    │         │  usage.time = 2015-11-05 14:13:34           ║
║                    │         │   uris = foobarbar-log.cfapps.pez.pivotal.io║
║                    │         │   mem_quota = 1073741824                    ║
║                    │         │        port = 64949                         ║
║                    │         │   usage.cpu = 6.484337514418791E-4          ║
║foobarbar-log:2     │deployed │        name = foobarbar-log                 ║
║                    │         │        host = 192.168.8.101                 ║
║                    │         │  usage.disk = 182972416                     ║
║                    │         │  disk_quota = 1073741824                    ║
║                    │         │   fds_quota = 16384                         ║
║                    │         │usage.memory = 635297792                     ║
║                    │         │      uptime = 171098.0                      ║
╟────────────────────┼─────────┼─────────────────────────────────────────────╢
║foobarbar.time      │deployed │                      1                      ║
╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
║                    │         │  usage.time = 2015-11-05 14:13:38           ║
║                    │         │  uris = foobarbar-time.cfapps.pez.pivotal.io║
║                    │         │   mem_quota = 1073741824                    ║
║                    │         │        port = 61980                         ║
║                    │         │   usage.cpu = 7.549136888851503E-4          ║
║foobarbar-time:0    │deployed │        name = foobarbar-time                ║
║                    │         │        host = 192.168.8.61                  ║
║                    │         │  usage.disk = 188022784                     ║
║                    │         │  disk_quota = 1073741824                    ║
║                    │         │   fds_quota = 16384                         ║
║                    │         │usage.memory = 678387712                     ║
║                    │         │      uptime = 171071.0                      ║
╚════════════════════╧═════════╧═════════════════════════════════════════════╝

```

This resolves spring-cloud/spring-cloud-dataflow#162