### PR TITLE
Bump Boot and spring-cloud-build Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.1.0.M1</version>
+		<version>1.1.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<scm>
@@ -23,8 +23,8 @@
 	</scm>
 	<properties>
 		<java.version>1.7</java.version>
-		<spring-framework.version>4.2.0.RELEASE</spring-framework.version>
-		<spring-boot.version>1.3.0.M5</spring-boot.version>
+		<spring-framework.version>4.2.3.BUILD-SNAPSHOT</spring-framework.version>
+		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
 		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
 		<spring-xd.version>1.0.2.RELEASE</spring-xd.version>
 		<spring-data.version>1.9.1.RELEASE</spring-data.version>

--- a/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/CloudConfiguration.java
+++ b/spring-cloud-dataflow-admin/src/main/java/org/springframework/cloud/dataflow/admin/config/CloudConfiguration.java
@@ -17,9 +17,10 @@
 package org.springframework.cloud.dataflow.admin.config;
 
 import org.cloudfoundry.receptor.client.ReceptorClient;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.cloud.Cloud;
 import org.springframework.cloud.CloudConnector;
 import org.springframework.cloud.CloudFactory;
@@ -32,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Configuration used when running <i>in a cloud</i>, triggered by cloud profiles (cloud, lattice).

--- a/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-module-deployers/spring-cloud-dataflow-module-deployer-cloudfoundry/pom.xml
@@ -26,6 +26,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                        <optional>true</optional>
+                </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -19,5 +19,9 @@
 			<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.plugin</groupId>
+			<artifactId>spring-plugin-core</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.UriTemplate;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -69,10 +68,8 @@ public class DataFlowTemplate implements DataFlowOperations {
 	private final CompletionOperations completionOperations;
 
 
-	public DataFlowTemplate(URI baseURI) {
-		this.restTemplate = new RestTemplate();
-		restTemplate.getMessageConverters().add(new MappingJackson2HttpMessageConverter());
-		restTemplate.setErrorHandler(new VndErrorResponseErrorHandler(restTemplate.getMessageConverters()));
+	public DataFlowTemplate(URI baseURI, RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
 		ResourceSupport resourceSupport = restTemplate.getForObject(baseURI, ResourceSupport.class);
 		resources.put("streams/definitions", new UriTemplate(resourceSupport.getLink("streams").getHref() + "/definitions"));
 		resources.put("streams/deployments", new UriTemplate(resourceSupport.getLink("streams").getHref() + "/deployments"));


### PR DESCRIPTION
Boot 1.3.0.BUILD-SNAPSHOT
s-c-b 1.1.0.BUILD-SNAPSHOT
SF 4.2.3.BUILD-SNAPSHOT

Fix Hateoas

Needs `@EnableHypermediaSupport` so that the `ObjectMapper` in the
`RestTemplate` can handle `_links`.