### PR TITLE
Fix module-deployers-spi parent

### DIFF
--- a/spring-cloud-dataflow-module-deployer-spi/pom.xml
+++ b/spring-cloud-dataflow-module-deployer-spi/pom.xml
@@ -14,7 +14,7 @@
 	</dependencies>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-dataflow-module-deployers-parent</artifactId>
+		<artifactId>spring-cloud-dataflow-parent</artifactId>
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 </project>


### PR DESCRIPTION
 - use `dataflow-parent` instead of `deployers-parent` which no longer exists.