### PR TITLE
XD-3680: Consistent Stream.undeployed state

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalModuleInstanceStatus.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.dataflow.module.DeploymentState;
 import org.springframework.cloud.dataflow.module.ModuleInstanceStatus;
-import org.springframework.cloud.dataflow.module.ModuleStatus;
 
 /**
  * @author Mark Fisher
@@ -35,7 +35,7 @@ public class LocalModuleInstanceStatus implements ModuleInstanceStatus {
 
 	private final String id;
 
-	private final ModuleStatus.State state;
+	private final DeploymentState state;
 
 	private final Map<String, String> attributes = new HashMap<String, String>();
 
@@ -43,7 +43,7 @@ public class LocalModuleInstanceStatus implements ModuleInstanceStatus {
 	public LocalModuleInstanceStatus(String id, boolean deployed, Map<String, String> attributes) {
 		logger.trace("Local Module {}, deployed {}, attributes: {}", id, deployed, attributes);
 		this.id = id;
-		this.state = deployed ? ModuleStatus.State.deployed : ModuleStatus.State.unknown;
+		this.state = deployed ? DeploymentState.deployed : DeploymentState.unknown;
 		if (attributes != null) {
 			this.attributes.putAll(attributes);
 		}
@@ -53,7 +53,7 @@ public class LocalModuleInstanceStatus implements ModuleInstanceStatus {
 		return id;
 	}
 
-	public ModuleStatus.State getState() {
+	public DeploymentState getState() {
 		return state;
 	}
 

--- a/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/module/DeploymentStateTests.java
+++ b/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/module/DeploymentStateTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.module.DeploymentState.deployed;
+import static org.springframework.cloud.dataflow.module.DeploymentState.error;
+import static org.springframework.cloud.dataflow.module.DeploymentState.failed;
+import static org.springframework.cloud.dataflow.module.DeploymentState.incomplete;
+import static org.springframework.cloud.dataflow.module.DeploymentState.reduce;
+import static org.springframework.cloud.dataflow.module.DeploymentState.undeployed;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Tests for DeploymentState.
+ *
+ * @author Eric Bottard
+ */
+public class DeploymentStateTests {
+
+	@Test
+	public void testReduce() {
+		for (DeploymentState value : DeploymentState.values()) {
+			assertThat(reduce(setOf(value)), is(value));
+		}
+
+		assertThat(reduce(setOf(deployed, undeployed)), is(incomplete));
+		assertThat(reduce(setOf(deployed, failed)), is(incomplete));
+		assertThat(reduce(setOf(deployed, failed, error)), is(error));
+
+
+	}
+
+	private static Set<DeploymentState> setOf(DeploymentState... states) {
+		Set<DeploymentState> result = new HashSet<>();
+		for (DeploymentState state : states) {
+			result.add(state);
+		}
+		return result;
+	}
+
+}

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -49,6 +49,7 @@ import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.module.DeploymentState;
 import org.springframework.cloud.dataflow.module.ModuleStatus;
 import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
 import org.springframework.http.MediaType;
@@ -296,7 +297,7 @@ public class StreamControllerTests {
 		repository.save(new StreamDefinition("myStream", "time | log"));
 		assertEquals(1, repository.count());
 		ModuleStatus status = mock(ModuleStatus.class);
-		when(status.getState()).thenReturn(ModuleStatus.State.unknown);
+		when(status.getState()).thenReturn(DeploymentState.unknown);
 		when(moduleDeployer.status(ModuleDeploymentId.parse("myStream.time"))).thenReturn(status);
 		when(moduleDeployer.status(ModuleDeploymentId.parse("myStream.log"))).thenReturn(status);
 		mockMvc.perform(

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/DeploymentState.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/DeploymentState.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Deployment states for modules and streams. Unless indicated, these states
+ * may represent the state of<ul>
+ * <li>an entire stream</li>
+ * <li>the global state of a deployed module as part of a stream</li>
+ * <li>the state of a particular instance of a module, in cases where {@literal module.count > 1}</li>
+ * </ul>
+ * @author Patrick Peralta
+ * @author Eric Bottard
+ */
+public enum DeploymentState {
+
+	/**
+	 * The stream or module is being deployed. If there are multiple modules or module instances,
+	 * at least one of them is still being deployed.
+	 */
+	deploying,
+
+	/**
+	 * All modules have been correctly deployed.
+	 */
+	deployed,
+
+	/**
+	 * The stream or module is known to the system, but is not currently deployed.
+	 */
+	undeployed,
+
+	/**
+	 * The module exited normally.
+	 */
+	complete,
+
+	/**
+	 * In the case of multiple modules, some have successfully deployed, some haven't.
+	 * This state does not apply for individual modules instances.
+	 */
+	incomplete,
+
+	/**
+	 * Reported when all components of the considered unit have failed deployment.
+	 */
+	failed,
+
+	/**
+	 * Used when some error occurred trying to determine deployment status.
+	 */
+	error,
+
+	/**
+	 * Returned when the queried stream or module deployment is not known to the system.
+	 */
+	unknown;
+
+	public static DeploymentState reduce(Set<DeploymentState> states) {
+		if (states.size() == 1) {
+			return states.iterator().next();
+		}
+		if (states.contains(error)) {
+			return error;
+		}
+		else if (states.contains(deploying)) {
+			return deploying;
+		}
+		else if (states.contains(incomplete)) {
+			return incomplete;
+		}
+
+		// deployed + any of (failed|undeployed) => incomplete
+		HashSet<DeploymentState> copy = new HashSet<>(states);
+		copy.retainAll(Arrays.asList(deployed, failed, undeployed));
+		if (copy.equals(states)) {
+			return incomplete;
+		}
+
+		throw new IllegalStateException("Could not decide how to aggregate " + states);
+	}
+}

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
@@ -18,8 +18,10 @@ package org.springframework.cloud.dataflow.module;
 
 import java.util.Map;
 
+import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
+
 /**
- * Status for an individual instance of a {@link org.springframework.xd.module.ModuleDescriptor}
+ * Status for an individual instance of a {@link ModuleDeploymentRequest}
  * deployment. The underlying instance may be backed by an application context in
  * the JVM, or by a remote process managed by a distributed runtime.
  *
@@ -35,14 +37,14 @@ public interface ModuleInstanceStatus {
 	String getId();
 
 	/**
-	 * Return the state of the deployed module.
+	 * Return the state of the deployed module instance.
 	 *
-	 * @return state of the deployed module
+	 * @return state of the deployed module instance
 	 */
-	ModuleStatus.State getState();
+	DeploymentState getState();
 
 	/**
-	 * Return a map of attributes for the deployed module. The specific
+	 * Return a map of attributes for the deployed module instance. The specific
 	 * keys/values returned are dependent on the runtime executing the module.
 	 * This may include extra information such as deployment location
 	 * or specific error messages in the case of failure.

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
@@ -33,60 +33,10 @@ import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
  * {@link org.springframework.cloud.dataflow.module.deployer.ModuleDeployer#status},
  * whereas SPI implementations create instances of this class via
  * {@link ModuleStatus.Builder}.
- *
- * @see ModuleInstanceStatus
- *
  * @author Patrick Peralta
+ * @see ModuleInstanceStatus
  */
 public class ModuleStatus {
-
-	/**
-	 * Module deployment states. Unless indicated, these states
-	 * may represent the state of an individual module deployment
-	 * or the aggregate state of all module instances for a given
-	 * module.
-	 */
-	public enum State {
-
-		/**
-		 * The module is being deployed. If there are multiple modules,
-		 * at least one module is being deployed.
-		 */
-		deploying,
-
-		/**
-		 * All modules have been deployed.
-		 */
-		deployed,
-
-		/**
-		 * The unit is known to the system, but is not currently deployed.
-		 */
-		undeployed,
-
-		/**
-		 * The module exited normally.
-		 */
-		complete,
-
-		/**
-		 * In the case of multiple modules, some have successfully deployed.
-		 * This state does not apply for individual modules.
-		 */
-		incomplete,
-
-		/**
-		 * The module has failed to deploy. If there are multiple modules,
-		 * all instances have failed deployment.
-		 */
-		failed,
-
-		/**
-		 * Module deployment state could not be calculated. This may be
-		 * caused by an error in the SPI implementation.
-		 */
-		unknown // some error occured
-	}
 
 	/**
 	 * The key of the module this status is for.
@@ -101,7 +51,6 @@ public class ModuleStatus {
 
 	/**
 	 * Construct a new {@code ModuleStatus}.
-	 *
 	 * @param moduleDeploymentId key of the module this status is for
 	 */
 	protected ModuleStatus(ModuleDeploymentId moduleDeploymentId) {
@@ -120,31 +69,19 @@ public class ModuleStatus {
 	 * Return the deployment state for the the module. If the descriptor
 	 * indicates multiple instances, this state represents an aggregate
 	 * of all individual instances.
-	 *
 	 * @return deployment state for the module
 	 */
-	public State getState() {
-		Set<State> instanceStates = new HashSet<State>();
+	public DeploymentState getState() {
+		Set<DeploymentState> instanceStates = new HashSet<DeploymentState>();
 		for (Map.Entry<String, ModuleInstanceStatus> entry : instances.entrySet()) {
 			instanceStates.add(entry.getValue().getState());
 		}
-		State state = State.unknown;
-		if (instanceStates.size() == 1 && instanceStates.contains(State.deployed)) {
-			state = State.deployed;
-		}
-		if (instanceStates.contains(State.deploying)) {
-			state = State.deploying;
-		}
-		if (instanceStates.contains(State.failed)) {
-			state = (instanceStates.size() == 1 ? State.failed : State.incomplete);
-		}
-		return state;
+		return DeploymentState.reduce(instanceStates);
 	}
 
 	/**
 	 * Return a map of {@code ModuleInstanceStatus} keyed by a unique identifier
 	 * for each module deployment instance.
-	 *
 	 * @return map of {@code ModuleInstanceStatus}
 	 */
 	public Map<String, ModuleInstanceStatus> getInstances() {
@@ -157,9 +94,7 @@ public class ModuleStatus {
 
 	/**
 	 * Return a {@code Builder} for {@code ModuleStatus}.
-	 *
 	 * @param key of the module this status is for
-	 *
 	 * @return {@code Builder} for {@code ModuleStatus}
 	 */
 	public static Builder of(ModuleDeploymentId key) {
@@ -179,9 +114,7 @@ public class ModuleStatus {
 		 * Add an instance of {@code ModuleInstanceStatus} to build
 		 * the status for the module. This will
 		 * be invoked once per individual module instance.
-		 *
 		 * @param instance status of individual module deployment
-		 *
 		 * @return this {@code Builder}
 		 */
 		public Builder with(ModuleInstanceStatus instance) {
@@ -193,7 +126,6 @@ public class ModuleStatus {
 		 * Return a new instance of {@code ModuleStatus} based on
 		 * the provided individual module instances via
 		 * {@link #with(ModuleInstanceStatus)}.
-		 *
 		 * @return new instance of {@code ModuleStatus}
 		 */
 		public ModuleStatus build() {

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
@@ -60,6 +60,11 @@ public class ModuleStatus {
 		deployed,
 
 		/**
+		 * The unit is known to the system, but is not currently deployed.
+		 */
+		undeployed,
+
+		/**
 		 * The module exited normally.
 		 */
 		complete,
@@ -80,7 +85,7 @@ public class ModuleStatus {
 		 * Module deployment state could not be calculated. This may be
 		 * caused by an error in the SPI implementation.
 		 */
-		unknown
+		unknown // some error occured
 	}
 
 	/**

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
@@ -69,7 +69,7 @@ public interface ModuleDeployer {
 	 *
 	 * @param id id for the module this status is for
 	 *
-	 * @return module deployment status
+	 * @return module deployment status or {@literal null} if this deployer knows nothing about the given deployment
 	 */
 	ModuleStatus status(ModuleDeploymentId id);
 


### PR DESCRIPTION
fixes spring-cloud/spring-cloud-dataflow#152 

This is a first step of things discussed with @markfisher and @pperalta.
The task `complete` enum value is not taken care of in this PR. Primarily looking for feedback on: 
* javadoc and API contract expressed in the new top level enum. 
* logic implemented in `reduce()`