### PR TITLE
Add incremental TAB completion of configuration properties

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddModuleOptionsExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddModuleOptionsExpansionStrategy.java
@@ -16,25 +16,26 @@
 
 package org.springframework.cloud.dataflow.completion;
 
-import static org.springframework.cloud.dataflow.completion.CompletionProposal.*;
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataGroup;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
+import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
+import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 import org.springframework.cloud.dataflow.core.ArtifactType;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
-import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
-import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 import org.springframework.cloud.stream.configuration.metadata.ModuleConfigurationMetadataResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
 import org.springframework.core.io.Resource;
 
 /**
  * Adds missing module configuration properties at the end of a well formed stream definition.
- *
  * @author Eric Bottard
  */
 class AddModuleOptionsExpansionStrategy implements ExpansionStrategy {
@@ -46,8 +47,8 @@ class AddModuleOptionsExpansionStrategy implements ExpansionStrategy {
 	private final ModuleResolver moduleResolver;
 
 	public AddModuleOptionsExpansionStrategy(ArtifactRegistry artifactRegistry,
-			ModuleConfigurationMetadataResolver moduleConfigurationMetadataResolver,
-			ModuleResolver moduleResolver) {
+	                                         ModuleConfigurationMetadataResolver moduleConfigurationMetadataResolver,
+	                                         ModuleResolver moduleResolver) {
 		this.artifactRegistry = artifactRegistry;
 		this.moduleConfigurationMetadataResolver = moduleConfigurationMetadataResolver;
 		this.moduleResolver = moduleResolver;
@@ -55,7 +56,7 @@ class AddModuleOptionsExpansionStrategy implements ExpansionStrategy {
 
 	@Override
 	public boolean addProposals(String text, StreamDefinition streamDefinition, int detailLevel,
-			List<CompletionProposal> collector) {
+	                            List<CompletionProposal> collector) {
 		ModuleDefinition lastModule = streamDefinition.getDeploymentOrderIterator().next();
 
 		String lastModuleName = lastModule.getName();
@@ -76,9 +77,35 @@ class AddModuleOptionsExpansionStrategy implements ExpansionStrategy {
 
 		CompletionProposal.Factory proposals = expanding(text);
 
-		for (ConfigurationMetadataProperty property : moduleConfigurationMetadataResolver.listProperties(jarFile)) {
-			if (!alreadyPresentOptions.contains(property.getId())) {
-				collector.add(proposals.withSeparateTokens("--" + property.getId() + "=", property.getShortDescription()));
+		Set<String> prefixes = new HashSet<>();
+		for (ConfigurationMetadataGroup group : moduleConfigurationMetadataResolver.listPropertyGroups(jarFile)) {
+			String groupId = ConfigurationMetadataRepository.ROOT_GROUP.equals(group.getId()) ? "" : group.getId();
+			if ("".equals(groupId)) {
+				// For props that don't have a group id, add their bare names as proposals.
+				// Caveat: props can themselves have dots in their names. In that case, treat that as a prefix
+				for (ConfigurationMetadataProperty property : group.getProperties().values()) {
+					int dot = property.getId().indexOf('.', 0);
+					if (dot > 0) {
+						String prefix = property.getId().substring(0, dot);
+						if (!prefixes.contains(prefix)) {
+							prefixes.add(prefix);
+							collector.add(proposals.withSeparateTokens("--" + prefix + ".", "Properties starting with '" + prefix + ".'"));
+						}
+					}
+					else if (!alreadyPresentOptions.contains(property.getId())) {
+						collector.add(proposals.withSeparateTokens("--" + property.getId()
+								+ "=", property.getShortDescription()));
+					}
+				}
+			}
+			else {
+				// Present group ids up to the first dot
+				int dot = groupId.indexOf('.', 0);
+				String prefix = dot > 0 ? groupId.substring(0, dot) : groupId;
+				if (!prefixes.contains(prefix)) {
+					prefixes.add(prefix);
+					collector.add(proposals.withSeparateTokens("--" + prefix + ".", "Properties starting with '" + prefix + ".'"));
+				}
 			}
 		}
 		return false;

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -242,6 +242,28 @@ public class StreamCompletionProviderTests {
 
 	}
 
+	/*
+	 *
+	 */
+	@Test
+	public void testCompletionStopsAtDots() {
+		assertThat(completionProvider.complete("hdfs --", 1), hasItems(
+				proposalThat(is("hdfs --directory=")),
+				proposalThat(is("hdfs --some."))
+		));
+		assertThat(completionProvider.complete("hdfs --", 1), not(hasItems(
+				proposalThat(startsWith("hdfs --some.l"))
+		)));
+		assertThat(completionProvider.complete("hdfs --some.long.prefix", 1), hasItems(
+				proposalThat(is("hdfs --some.long.prefix."))
+		));
+		assertThat(completionProvider.complete("hdfs --some.long.prefix.", 1), hasItems(
+				proposalThat(is("hdfs --some.long.prefix.option1=")),
+				proposalThat(is("hdfs --some.long.prefix.option2=")),
+				proposalThat(startsWith("hdfs --some.long.prefix.nested."))
+		));
+	}
+
 
 	private static org.hamcrest.Matcher<CompletionProposal> proposalThat(org.hamcrest.Matcher<String> matcher) {
 		return new FeatureMatcher<CompletionProposal, String>(matcher, "a proposal whose text", "text") {

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/modules/hdfs-source/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/modules/hdfs-source/META-INF/spring-configuration-metadata.json
@@ -1,11 +1,44 @@
 {
+  "groups": [
+    {
+      "name": "some.long.prefix",
+      "type": "foo.bar.HdfsProperties",
+      "sourceType": "foo.bar.HdfsProperties"
+    },
+    {
+      "name": "some.long.prefix.nested",
+      "type": "foo.bar.OtherHdfsProperties",
+      "sourceType": "foo.bar.HdfsProperties"
+    }
+  ],
   "properties": [
     {
       "name": "directory",
       "type": "java.lang.String",
       "description": "A path",
-      "sourceType": "com.foo.HdfsProperties",
+      "sourceType": "com.foo.DifferentHdfsProperties",
       "defaultValue": "/tmp"
+    },
+    {
+      "name": "some.long.prefix.option1",
+      "type": "java.lang.String",
+      "description": "An option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "foo"
+    },
+    {
+      "name": "some.long.prefix.option2",
+      "type": "java.lang.String",
+      "description": "Another option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "bar"
+    },
+    {
+      "name": "some.long.prefix.nested.itworks",
+      "type": "java.lang.String",
+      "description": "Nested option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "wizz"
     }
   ],
   "hints": []


### PR DESCRIPTION
Instead of showing the 100s of configuration properties that are
currently visible though boot metadata, stop at each dot.

This resolves spring-cloud/spring-cloud-dataflow#187.