### PR TITLE
XD-3680: Consistent state calculation

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/InProcessModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/InProcessModuleInstanceStatus.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.dataflow.module.DeploymentState;
 import org.springframework.cloud.dataflow.module.ModuleInstanceStatus;
-import org.springframework.cloud.dataflow.module.ModuleStatus;
 
 /**
  * @author Mark Fisher
@@ -35,7 +35,7 @@ public class InProcessModuleInstanceStatus implements ModuleInstanceStatus {
 
 	private final String id;
 
-	private final ModuleStatus.State state;
+	private final DeploymentState state;
 
 	private final Map<String, String> attributes = new HashMap<String, String>();
 
@@ -43,7 +43,7 @@ public class InProcessModuleInstanceStatus implements ModuleInstanceStatus {
 	public InProcessModuleInstanceStatus(String id, boolean deployed, Map<String, String> attributes) {
 		logger.trace("Local Module {}, deployed {}, attributes: {}", id, deployed, attributes);
 		this.id = id;
-		this.state = deployed ? ModuleStatus.State.deployed : ModuleStatus.State.unknown;
+		this.state = deployed ? DeploymentState.deployed : DeploymentState.unknown;
 		if (attributes != null) {
 			this.attributes.putAll(attributes);
 		}
@@ -53,7 +53,7 @@ public class InProcessModuleInstanceStatus implements ModuleInstanceStatus {
 		return id;
 	}
 
-	public ModuleStatus.State getState() {
+	public DeploymentState getState() {
 		return state;
 	}
 

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
+import org.springframework.cloud.dataflow.module.DeploymentState;
 import org.springframework.cloud.dataflow.module.ModuleInstanceStatus;
 import org.springframework.cloud.dataflow.module.ModuleStatus;
 import org.springframework.cloud.dataflow.module.deployer.ModuleArgumentQualifier;
@@ -208,8 +209,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 		}
 
 		@Override
-		public ModuleStatus.State getState() {
-			return isAlive(process) ? ModuleStatus.State.deployed : ModuleStatus.State.failed;
+		public DeploymentState getState() {
+			return isAlive(process) ? DeploymentState.deployed : DeploymentState.failed;
 		}
 
 		@Override
@@ -222,8 +223,7 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 			return result;
 		}
 	}
-
-	// Copy-pasting of JDK8+ isAlive method to retain JDK7 compat
+	// Copy-pasting of JDK8+ isAlive method to retain JDK7 compatibility
 	private static boolean isAlive(Process process) {
 		try {
 			process.exitValue();

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -28,7 +28,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.cloud.dataflow.module.DeploymentState.*;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.junit.After;
@@ -49,6 +51,7 @@ import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.module.DeploymentState;
 import org.springframework.cloud.dataflow.module.ModuleStatus;
 import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
 import org.springframework.http.MediaType;
@@ -296,7 +299,7 @@ public class StreamControllerTests {
 		repository.save(new StreamDefinition("myStream", "time | log"));
 		assertEquals(1, repository.count());
 		ModuleStatus status = mock(ModuleStatus.class);
-		when(status.getState()).thenReturn(ModuleStatus.State.unknown);
+		when(status.getState()).thenReturn(DeploymentState.unknown);
 		when(moduleDeployer.status(ModuleDeploymentId.parse("myStream.time"))).thenReturn(status);
 		when(moduleDeployer.status(ModuleDeploymentId.parse("myStream.log"))).thenReturn(status);
 		mockMvc.perform(
@@ -328,4 +331,16 @@ public class StreamControllerTests {
 		ModuleDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
 	}
+
+	@Test
+	public void testAggregateState() {
+		assertThat(StreamController.aggregateState(EnumSet.of(deployed, failed)), is(failed));
+		assertThat(StreamController.aggregateState(EnumSet.of(unknown, failed)), is(failed));
+		assertThat(StreamController.aggregateState(EnumSet.of(deployed, failed, error)), is(error));
+		assertThat(StreamController.aggregateState(EnumSet.of(deployed, undeployed)), is(partial));
+		assertThat(StreamController.aggregateState(EnumSet.of(deployed, unknown)), is(partial));
+		assertThat(StreamController.aggregateState(EnumSet.of(undeployed, unknown)), is(partial));
+		assertThat(StreamController.aggregateState(EnumSet.of(unknown)), is(undeployed));
+	}
+
 }

--- a/spring-cloud-dataflow-module-deployer-spi/pom.xml
+++ b/spring-cloud-dataflow-module-deployer-spi/pom.xml
@@ -15,6 +15,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/DeploymentState.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/DeploymentState.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module;
+
+/**
+ * Deployment states for modules and streams. These may represent the
+ * state of:
+ * <ul>
+ *   <li>an entire stream</li>
+ *   <li>the global state of a deployed module as part of a stream</li>
+ *   <li>the state of a particular instance of a module, in cases where
+ *   {@code module.count > 1}</li>
+ * </ul>
+ *
+ * @author Patrick Peralta
+ * @author Eric Bottard
+ */
+public enum DeploymentState {
+
+	/**
+	 * The stream or module is being deployed. If there are multiple modules or
+	 * module instances, at least one of them is still being deployed.
+	 */
+	deploying,
+
+	/**
+	 * All modules have been successfully deployed.
+	 */
+	deployed,
+
+	/**
+	 * The stream or module is known to the system, but is not currently deployed.
+	 */
+	undeployed,
+
+	/**
+	 * The module completed execution. Currently used for tasks only.
+	 */
+	complete,
+
+	/**
+	 * In the case of multiple modules, some have successfully deployed, while
+	 * others have not. This state does not apply for individual modules instances.
+	 */
+	partial,
+
+	/**
+	 * All modules have failed deployment.
+	 */
+	failed,
+
+	/**
+	 * A system error occurred trying to determine deployment status.
+	 */
+	error,
+
+	/**
+	 * The stream or module deployment is not known to the system.
+	 */
+	unknown;
+
+}

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleInstanceStatus.java
@@ -35,14 +35,14 @@ public interface ModuleInstanceStatus {
 	String getId();
 
 	/**
-	 * Return the state of the deployed module.
+	 * Return the state of the deployed module instance.
 	 *
-	 * @return state of the deployed module
+	 * @return state of the deployed module instance
 	 */
-	ModuleStatus.State getState();
+	DeploymentState getState();
 
 	/**
-	 * Return a map of attributes for the deployed module. The specific
+	 * Return a map of attributes for the deployed module instance. The specific
 	 * keys/values returned are dependent on the runtime executing the module.
 	 * This may include extra information such as deployment location
 	 * or specific error messages in the case of failure.

--- a/spring-cloud-dataflow-module-deployer-spi/src/test/java/org/springframework/cloud/dataflow/module/ModuleStatusTests.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/test/java/org/springframework/cloud/dataflow/module/ModuleStatusTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.module;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.module.DeploymentState.*;
+
+/**
+ * Tests for {@link ModuleStatus}.
+ *
+ * @author Patrick Peralta
+ */
+public class ModuleStatusTests {
+
+	@Test
+	public void testState() {
+		assertThat(moduleStatus(deployed, failed).getState(), is(partial));
+		assertThat(moduleStatus(failed, unknown).getState(), is(failed));
+		assertThat(moduleStatus(deployed, undeployed).getState(), is(partial));
+		assertThat(moduleStatus(deployed, unknown).getState(), is(partial));
+		assertThat(moduleStatus(undeployed, unknown).getState(), is(partial));
+	}
+
+	static ModuleStatus moduleStatus(DeploymentState... states) {
+		ModuleStatus.Builder builder = ModuleStatus.of(new ModuleDeploymentId("group", "label"));
+		for (DeploymentState state: states) {
+			builder.with(new Status(state));
+		}
+		return builder.build();
+	}
+
+
+	static class Status implements ModuleInstanceStatus {
+
+		private final String id = UUID.randomUUID().toString();
+
+		private final DeploymentState state;
+
+		public Status(DeploymentState state) {
+			this.state = state;
+		}
+
+		@Override
+		public String getId() {
+			return id;
+		}
+
+		@Override
+		public DeploymentState getState() {
+			return state;
+		}
+
+		@Override
+		public Map<String, String> getAttributes() {
+			return Collections.emptyMap();
+		}
+	}
+
+}


### PR DESCRIPTION
Replacement for https://github.com/spring-cloud/spring-cloud-dataflow/pull/194 by @ericbottard.

This includes the following changes:
* Rebased with merge conflicts resolved (based on top of master)
* State `incomplete` renamed to `partial`.
* Stream and module state calculation split

After discussion with @markfisher we decided to split the state calculation. There are some subtle differences between stream and module state calculation. For instance, if module states include `deployed` and `failed`, the resulting state is `partial`. However if a stream includes modules in `deployed` and `failed` states, the stream should be `failed` since it cannot function with a failed module.

This resolves spring-cloud/spring-cloud-dataflow#152