### PR TITLE
Out of process deployer improvements: module shutdown and directories

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -97,14 +97,14 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 				workDir.toFile().deleteOnExit();
 			}
 			for (int i = 0; i < request.getCount(); i++) {
-				int port = SocketUtils.findAvailableTcpPort(DEFAULT_SERVER_PORT);
-				args.put(SERVER_PORT_KEY, String.valueOf(port));
+				int managementPort = SocketUtils.findAvailableTcpPort(DEFAULT_MANAGEMENT_PORT);
+				args.put(MANAGEMENT_PORT_KEY, String.valueOf(managementPort));
 
 				ProcessBuilder builder = new ProcessBuilder(properties.getJavaCmd(), "-jar", moduleLauncherPath);
 				builder.environment().clear();
 				builder.environment().putAll(args);
 
-				Instance instance = new Instance(moduleDeploymentId, i, builder, workDir);
+				Instance instance = new Instance(moduleDeploymentId, i, builder, workDir, managementPort);
 				processes.add(instance);
 				if (properties.isDeleteFilesOnExit()) {
 					instance.stdout.deleteOnExit();
@@ -206,7 +206,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 		private final URL moduleUrl;
 
-		private Instance(ModuleDeploymentId moduleDeploymentId, int instanceNumber, ProcessBuilder builder, Path workDir) throws IOException {
+		private Instance(ModuleDeploymentId moduleDeploymentId, int instanceNumber, ProcessBuilder builder,
+		                 Path workDir, int managementPort) throws IOException {
 			this.moduleDeploymentId = moduleDeploymentId;
 			this.instanceNumber = instanceNumber;
 			builder.directory(workDir.toFile());
@@ -218,8 +219,7 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 			builder.environment().put("INSTANCE_INDEX", Integer.toString(instanceNumber));
 			this.process = builder.start();
 			this.workDir = workDir.toFile();
-			int port = Integer.parseInt(builder.environment().get("server.port"));
-			moduleUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), port, "");
+			moduleUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), managementPort, "");
 
 		}
 

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -24,11 +24,13 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -61,7 +63,7 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 	private static final Logger logger = LoggerFactory.getLogger(OutOfProcessModuleDeployer.class);
 
-	private Map<ModuleDeploymentId, List<Instance>> running = new HashMap<>();
+	private Map<ModuleDeploymentId, List<Instance>> running = new ConcurrentHashMap<>();
 
 	@Autowired
 	private OutOfProcessModuleDeployerProperties properties;
@@ -211,10 +213,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 			this.instanceNumber = instanceNumber;
 			builder.directory(workDir.toFile());
 			String workDirPath = workDir.toFile().getAbsolutePath();
-			this.stdout =
-					Files.createFile(FileSystems.getDefault().getPath(workDirPath, "stdout_" + instanceNumber + ".log")).toFile();
-			this.stderr =
-					Files.createFile(FileSystems.getDefault().getPath(workDirPath, "stderr_" + instanceNumber + ".log")).toFile();
+			this.stdout = Files.createFile(Paths.get(workDirPath, "stdout_" + instanceNumber + ".log")).toFile();
+			this.stderr = Files.createFile(Paths.get(workDirPath, "stderr_" + instanceNumber + ".log")).toFile();
 			builder.redirectOutput(this.stdout);
 			builder.redirectError(this.stderr);
 			builder.environment().put("INSTANCE_INDEX", Integer.toString(instanceNumber));

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -21,7 +21,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.URL;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -92,9 +91,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 
 		try {
-			Path workDir = Files.createDirectory(
-					FileSystems.getDefault().getPath(logPathRoot.toFile().getAbsolutePath(),
-							moduleDeploymentId.toString()));
+			Path workDir = Files.createDirectory(Paths.get(logPathRoot.toFile().getAbsolutePath(),
+					moduleDeploymentId.toString()));
 			if (properties.isDeleteFilesOnExit()) {
 				workDir.toFile().deleteOnExit();
 			}

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
@@ -34,7 +34,11 @@ public interface ModuleDeployer {
 
 	public static final String SERVER_PORT_KEY = "server.port";
 
+	public static final String MANAGEMENT_PORT_KEY = "management.port";
+
 	public static final int DEFAULT_SERVER_PORT = 8080;
+
+	public static final int DEFAULT_MANAGEMENT_PORT = 8080;
 
 	public static final String JMX_DEFAULT_DOMAIN_KEY  = "spring.jmx.default-domain";
 


### PR DESCRIPTION
This resolves spring-cloud/spring-cloud-dataflow#207.

- handling the shutdown of the children processes in the shutdown hook of the admin;
- reworking the paths for the out of process modules - a single temporary root is created for the admin, and module log files are created underneath