### PR TITLE
GH-213 Fixes bug where shell omits first row of module list.

### DIFF
--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/ModuleCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/ModuleCommands.java
@@ -194,8 +194,9 @@ public class ModuleCommands implements CommandMarker {
 				if (row == 0) {
 					return key;
 				}
-				if (mappings.get(key).size() > row) {
-					return mappings.get(key).get(row);
+				int currentRow = row - 1;
+				if (mappings.get(key).size() > currentRow) {
+					return mappings.get(key).get(currentRow);
 				} else {
 					return null;
 				}


### PR DESCRIPTION
Steps to reproduce
1) Execute Module List
2) look for file source or timestamp task and you will note that they are missing.

This resolves spring-cloud/spring-cloud-dataflow#213