### PR TITLE
GH-203 Fix SecurityInfo REST endpoint

### DIFF
--- a/spring-cloud-dataflow-admin-starter/pom.xml
+++ b/spring-cloud-dataflow-admin-starter/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
 	<packaging>jar</packaging>
@@ -45,6 +46,14 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-web</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/SecurityController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/SecurityController.java
@@ -35,8 +35,12 @@ import org.springframework.web.bind.annotation.RestController;
 @EnableConfigurationProperties(SecurityProperties.class)
 public class SecurityController {
 
+	private final SecurityProperties securityProperties;
+
 	@Autowired
-	SecurityProperties securityProperties;
+	public SecurityController(SecurityProperties securityProperties) {
+		this.securityProperties = securityProperties;
+	}
 
 	/**
 	 * Return security information.

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/SecurityController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/SecurityController.java
@@ -17,7 +17,8 @@
 package org.springframework.cloud.dataflow.admin.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -31,10 +32,11 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/security/info")
+@EnableConfigurationProperties(SecurityProperties.class)
 public class SecurityController {
 
 	@Autowired
-	private Environment environment;
+	SecurityProperties securityProperties;
 
 	/**
 	 * Return security information.
@@ -43,7 +45,7 @@ public class SecurityController {
 	@ResponseStatus(HttpStatus.OK)
 	public boolean getSecurityInfo() {
 		//todo: Add SecurityResource with authentication information
-		return environment.getRequiredProperty("security.basic.enabled", boolean.class);
+		return securityProperties.getBasic().isEnabled();
 	}
 
 }


### PR DESCRIPTION
 - Use `SecurityProperties` instead of infering from environment
 - Thanks to @jvalkeal for the suggestion

This resolves spring-cloud/spring-cloud-dataflow/issues/203