### PR TITLE
Move "About the documentation" and "Getting help" sections to separat…

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -38,6 +38,7 @@ Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinat
 :ant-manual: http://ant.apache.org/manual
 // ======================================================================================
 
+include::preface.adoc[]
 include::spring-cloud-dataflow-overview.adoc[]
 include::getting-started.adoc[]
 include::using-spring-cloud-stream-modules.adoc[]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/preface.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/preface.adoc
@@ -1,0 +1,25 @@
+[[preface]]
+= Preface
+
+[[dataflow-documentation-about]]
+== About the documentation
+The Spring Cloud Data Flow reference guide is available as {spring-cloud-dataflow-docs}/html[html],
+{spring-cloud-dataflow-docs}/pdf/spring-cloud-dataflow-reference.pdf[pdf]
+and {spring-cloud-dataflow-docs}/epub/spring-cloud-dataflow-reference.epub[epub] documents. The latest copy
+is available at {spring-cloud-dataflow-docs-current}.
+
+Copies of this document may be made for your own use and for
+distribution to others, provided that you do not charge any fee for such copies and
+further provided that each copy contains this Copyright Notice, whether distributed in
+print or electronically.
+
+[[dataflow-documentation-getting-help]]
+== Getting help
+Having trouble with Spring Cloud Data Flow, We'd like to help!
+
+* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
+  tagged with http://stackoverflow.com/tags/spring-cloud[`spring-cloud`].
+* Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
+
+NOTE: All of Spring Cloud Data Flow is open source, including the documentation! If you find problems
+with the docs; or if you just want to improve them, please {github-code}[get involved].

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
@@ -8,30 +8,6 @@ it as map for the rest of the document. You can read this reference guide in a l
 fashion, or you can skip sections if something doesn't interest you.
 --
 
-[[dataflow-documentation-about]]
-== About the documentation
-The Spring Cloud Data Flow reference guide is available as {spring-cloud-dataflow-docs}/html[html],
-{spring-cloud-dataflow-docs}/pdf/spring-cloud-dataflow-reference.pdf[pdf]
-and {spring-cloud-dataflow-docs}/epub/spring-cloud-dataflow-reference.epub[epub] documents. The latest copy
-is available at {spring-cloud-dataflow-docs-current}.
-
-Copies of this document may be made for your own use and for
-distribution to others, provided that you do not charge any fee for such copies and
-further provided that each copy contains this Copyright Notice, whether distributed in
-print or electronically.
-
-
-[[dataflow-documentation-getting-help]]
-== Getting help
-Having trouble with Spring Cloud Data Flow, We'd like to help!
-
-* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud[`spring-cloud`].
-* Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
-
-NOTE: All of Spring Cloud Data Flow is open source, including the documentation! If you find problems
-with the docs; or if you just want to improve them, please {github-code}[get involved].
-
 [[dataflow-documentation-intro]]
 == Introducing Spring Cloud Data Flow
 A cloud native programming and operating model for composable data microservices on a structured platform. 


### PR DESCRIPTION
…e preface doc

- This makes it easier to include spring-cloud-dataflow-overview.adoc in other SPI docs