### PR TITLE
ModuleStatus undeployed when no state exists

### DIFF
--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/ModuleStatus.java
@@ -78,6 +78,9 @@ public class ModuleStatus {
 			states.add(entry.getValue().getState());
 		}
 
+		if (states.size() == 0) {
+			return DeploymentState.undeployed;
+		}
 		if (states.size() == 1) {
 			return states.iterator().next();
 		}

--- a/spring-cloud-dataflow-module-deployer-spi/src/test/java/org/springframework/cloud/dataflow/module/ModuleStatusTests.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/test/java/org/springframework/cloud/dataflow/module/ModuleStatusTests.java
@@ -16,6 +16,14 @@
 
 package org.springframework.cloud.dataflow.module;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.module.DeploymentState.deployed;
+import static org.springframework.cloud.dataflow.module.DeploymentState.failed;
+import static org.springframework.cloud.dataflow.module.DeploymentState.partial;
+import static org.springframework.cloud.dataflow.module.DeploymentState.undeployed;
+import static org.springframework.cloud.dataflow.module.DeploymentState.unknown;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -23,10 +31,6 @@ import java.util.UUID;
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.springframework.cloud.dataflow.module.DeploymentState.*;
 
 /**
  * Tests for {@link ModuleStatus}.
@@ -42,6 +46,7 @@ public class ModuleStatusTests {
 		assertThat(moduleStatus(deployed, undeployed).getState(), is(partial));
 		assertThat(moduleStatus(deployed, unknown).getState(), is(partial));
 		assertThat(moduleStatus(undeployed, unknown).getState(), is(partial));
+		assertThat(moduleStatus(new DeploymentState[0]).getState(), is(undeployed));
 	}
 
 	static ModuleStatus moduleStatus(DeploymentState... states) {


### PR DESCRIPTION
 - WHen there is no ModuleDeploymentStates, then set stream deployment status to be 'undeployed`
 - This fixes #259