### PR TITLE
Pass producer/consumer properties as per-binding properties

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
@@ -274,10 +274,20 @@ public class StreamDeploymentController {
 		for (Map.Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
 			if (entry.getKey().startsWith(modulePrefix)) {
 				if (entry.getKey().startsWith(producerPropertyPrefix)) {
+					// Set per-binding properties
+					moduleDeploymentProperties.put(BindingProperties.OUTPUT_BINDING_KEY_PREFIX +
+							entry.getKey().substring(producerPropertyPrefix.length()), entry.getValue());
+					// Set ChannelBindingServiceProperties' producer properties
+					// todo: Once the producer/consumer properties are moved to per-binding properties, following step
+					// 		isn't needed: https://github.com/spring-cloud/spring-cloud-stream/issues/256
 					moduleDeploymentProperties.put(CHANNEL_BINDING_PRODUCER_PROPERTIES_PREFIX +
 							entry.getKey().substring(producerPropertyPrefix.length()), entry.getValue());
 				}
 				else if (entry.getKey().startsWith(consumerPropertyPrefix)) {
+					// Set per-binding properties
+					moduleDeploymentProperties.put(BindingProperties.INPUT_BINDING_KEY_PREFIX +
+							entry.getKey().substring(consumerPropertyPrefix.length()), entry.getValue());
+					// Set ChannelBindingServiceProperties' consumer properties
 					moduleDeploymentProperties.put(CHANNEL_BINDING_CONSUMER_PROPERTIES_PREFIX +
 							entry.getKey().substring(consumerPropertyPrefix.length()), entry.getValue());
 				}


### PR DESCRIPTION
 - This will make `trackHistory` property as a per-binding property
This is in contrast to how XD DSL supports `trackHistory`. In XD, this property is set as `module.<label>.trackHistory`.
But, we want this to be a `per-binding` property in SCS. Hence, syntax for passing `trackHistory` property would be
module.<label>.producer/consumer.trackHistory
 - This PR change also enables any producer/consumer property can be passed as output/input binding property.

- Add test

This fixes #209