### PR TITLE
Associates the task being executed with the name of the task definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<spring-shell.version>1.2.0.M1</spring-shell.version>
 		<spring-cloud.version>Brixton.M4</spring-cloud.version>
 		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
+		<spring-cloud-task.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-task.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-artifact-registry</module>

--- a/spring-cloud-dataflow-admin-starter/pom.xml
+++ b/spring-cloud-dataflow-admin-starter/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<version>${spring-cloud-task.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.skyscreamer</groupId>

--- a/spring-cloud-dataflow-admin-starter/pom.xml
+++ b/spring-cloud-dataflow-admin-starter/pom.xml
@@ -87,6 +87,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-task-core</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.admin.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.dataflow.admin.repository.TaskDefinitionRepository;
@@ -29,6 +32,7 @@ import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
 import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
 import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -149,8 +153,13 @@ public class TaskController {
 					"Module %s of type %s not found in registry", module.getName(), ArtifactType.task));
 		}
 		ArtifactCoordinates coordinates = registration.getCoordinates();
-		// todo: pass deployment properties
-		this.moduleDeployer.deploy(new ModuleDeploymentRequest(module, coordinates));
+
+		Map<String, String> deploymentProperties = new HashMap<>();
+		deploymentProperties.put("spring.cloud.task.name", taskDefinition.getName());
+		deploymentProperties.putAll(DeploymentPropertiesUtils.parse(properties));
+
+		this.moduleDeployer.deploy(
+				new ModuleDeploymentRequest(module, coordinates, deploymentProperties));
 	}
 
 	/**

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit now passes the spring.cloud.task.name parameter to the task
being executed, allowing the execution within the repository to map back
to the definition that is being run.

resolves spring-cloud/spring-cloud-dataflow#290