### PR TITLE
GH-275 Allow redeployment for the local out of process deployer

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.PostConstruct;
@@ -54,6 +55,7 @@ import org.springframework.web.client.RestTemplate;
  * A ModuleDeployer implementation that spins off a new JVM process per
  * module instance.
  * @author Eric Bottard
+ * @author Marius Bogoevici
  */
 public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
@@ -93,7 +95,16 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 
 		try {
-			Path workDir = Files.createDirectory(Paths.get(logPathRoot.toFile().getAbsolutePath(),
+			String moduleDeploymentGroupId = request.getDeploymentProperties().get(MODULE_DEPLOYMENT_GROUP_ID);
+			if (moduleDeploymentGroupId == null) {
+				moduleDeploymentGroupId = UUID.randomUUID().toString();
+			}
+			Path moduleDeploymentGroupDir = Paths.get(logPathRoot.toFile().getAbsolutePath(), moduleDeploymentGroupId);
+			if (!Files.exists(moduleDeploymentGroupDir)) {
+				Files.createDirectory(moduleDeploymentGroupDir);
+				moduleDeploymentGroupDir.toFile().deleteOnExit();
+			}
+			Path workDir = Files.createDirectory(Paths.get(moduleDeploymentGroupDir.toFile().getAbsolutePath(),
 					moduleDeploymentId.toString()));
 			if (properties.isDeleteFilesOnExit()) {
 				workDir.toFile().deleteOnExit();

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployer.java
@@ -95,11 +95,11 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 
 		try {
-			String moduleDeploymentGroupId = request.getDeploymentProperties().get(MODULE_DEPLOYMENT_GROUP_ID);
-			if (moduleDeploymentGroupId == null) {
-				moduleDeploymentGroupId = UUID.randomUUID().toString();
+			String groupDeploymentId = request.getDeploymentProperties().get(GROUP_DEPLOYMENT_ID);
+			if (groupDeploymentId == null) {
+				groupDeploymentId = request.getDefinition().getGroup() + "-" + System.currentTimeMillis();
 			}
-			Path moduleDeploymentGroupDir = Paths.get(logPathRoot.toFile().getAbsolutePath(), moduleDeploymentGroupId);
+			Path moduleDeploymentGroupDir = Paths.get(logPathRoot.toFile().getAbsolutePath(), groupDeploymentId);
 			if (!Files.exists(moduleDeploymentGroupDir)) {
 				Files.createDirectory(moduleDeploymentGroupDir);
 				moduleDeploymentGroupDir.toFile().deleteOnExit();

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
@@ -165,7 +165,7 @@ public class StreamDeploymentController {
 			}
 			ArtifactCoordinates coordinates = registration.getCoordinates();
 			Map<String, String> moduleDeploymentProperties = extractModuleDeploymentProperties(currentModule, streamDeploymentProperties);
-			moduleDeploymentProperties.put(ModuleDeployer.MODULE_DEPLOYMENT_GROUP_ID, currentModule.getGroup() + "-" + timestamp);
+			moduleDeploymentProperties.put(ModuleDeployer.GROUP_DEPLOYMENT_ID, currentModule.getGroup() + "-" + timestamp);
 			boolean upstreamModuleSupportsPartition = upstreamModuleHasPartitionInfo(stream, currentModule, streamDeploymentProperties);
 			// consumer module partition properties
 			if (upstreamModuleSupportsPartition) {

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Mark Fisher
  * @author Patrick Peralta
  * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
  */
 @RestController
 @RequestMapping("/streams/deployments")
@@ -153,6 +154,7 @@ public class StreamDeploymentController {
 		Iterator<ModuleDefinition> iterator = stream.getDeploymentOrderIterator();
 		int nextModuleCount = 0;
 		boolean isDownStreamModulePartitioned = false;
+		long timestamp = System.currentTimeMillis();
 		while (iterator.hasNext()) {
 			ModuleDefinition currentModule = iterator.next();
 			ArtifactType type = determineModuleType(currentModule);
@@ -163,6 +165,7 @@ public class StreamDeploymentController {
 			}
 			ArtifactCoordinates coordinates = registration.getCoordinates();
 			Map<String, String> moduleDeploymentProperties = extractModuleDeploymentProperties(currentModule, streamDeploymentProperties);
+			moduleDeploymentProperties.put(ModuleDeployer.MODULE_DEPLOYMENT_GROUP_ID, currentModule.getGroup() + "-" + timestamp);
 			boolean upstreamModuleSupportsPartition = upstreamModuleHasPartitionInfo(stream, currentModule, streamDeploymentProperties);
 			// consumer module partition properties
 			if (upstreamModuleSupportsPartition) {

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -52,6 +52,7 @@ import org.springframework.web.bind.annotation.RestController;
  * operations.
  *
  * @author Michael Minella
+ * @author Marius Bogoevici
  */
 @RestController
 @RequestMapping("/tasks")
@@ -157,6 +158,8 @@ public class TaskController {
 		Map<String, String> deploymentProperties = new HashMap<>();
 		deploymentProperties.put("spring.cloud.task.name", taskDefinition.getName());
 		deploymentProperties.putAll(DeploymentPropertiesUtils.parse(properties));
+		deploymentProperties.put(ModuleDeployer.MODULE_DEPLOYMENT_GROUP_ID, taskDefinition.getName()
+				+ "-" + System.currentTimeMillis());
 
 		this.moduleDeployer.deploy(
 				new ModuleDeploymentRequest(module, coordinates, deploymentProperties));

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -158,7 +158,7 @@ public class TaskController {
 		Map<String, String> deploymentProperties = new HashMap<>();
 		deploymentProperties.put("spring.cloud.task.name", taskDefinition.getName());
 		deploymentProperties.putAll(DeploymentPropertiesUtils.parse(properties));
-		deploymentProperties.put(ModuleDeployer.MODULE_DEPLOYMENT_GROUP_ID, taskDefinition.getName()
+		deploymentProperties.put(ModuleDeployer.GROUP_DEPLOYMENT_ID, taskDefinition.getName()
 				+ "-" + System.currentTimeMillis());
 
 		this.moduleDeployer.deploy(

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
@@ -39,7 +39,7 @@ public interface ModuleDeployer {
 
 	public static final String JMX_DEFAULT_DOMAIN_KEY  = "spring.jmx.default-domain";
 
-	public static final String MODULE_DEPLOYMENT_GROUP_ID = "spring_cloud_dataflow.module_deployment_group_id";
+	public static final String GROUP_DEPLOYMENT_ID = "dataflow.group-deployment-id";
 
 	/**
 	 * Handle the given {@code ModuleDeploymentRequest}. Implementations

--- a/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
+++ b/spring-cloud-dataflow-module-deployer-spi/src/main/java/org/springframework/cloud/dataflow/module/deployer/ModuleDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.cloud.dataflow.module.ModuleStatus;
  *
  * @author Mark Fisher
  * @author Patrick Peralta
+ * @author Marius Bogoevici
  */
 public interface ModuleDeployer {
 
@@ -37,6 +38,8 @@ public interface ModuleDeployer {
 	public static final int DEFAULT_SERVER_PORT = 8080;
 
 	public static final String JMX_DEFAULT_DOMAIN_KEY  = "spring.jmx.default-domain";
+
+	public static final String MODULE_DEPLOYMENT_GROUP_ID = "spring_cloud_dataflow.module_deployment_group_id";
 
 	/**
 	 * Handle the given {@code ModuleDeploymentRequest}. Implementations


### PR DESCRIPTION
Resolves #275.

* Introduces a 'module group deployment id', set for each stream/task deployment, and shared among the modules.
* Set up module output/error directories to be use the deployment id as part of their path, thus avoiding clashes at deployment time.