### PR TITLE
Implemented view for TaskExecutions

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskExecutionController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
  * This includes obtaining task execution information from the task explorer.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 @RestController
 @RequestMapping("/tasks/executions")
@@ -83,13 +84,25 @@ public class TaskExecutionController {
 	 * @param pageable  page-able collection of {@code TaskExecution}s.
 	 * @param assembler for the {@link TaskExecution}s
 	 */
-	@RequestMapping(value = "/{taskName}", method = RequestMethod.GET)
+	@RequestMapping(value = "/name/{taskName}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public PagedResources<TaskExecutionResource> retrieveTasksByName(
 			@PathVariable("taskName") String taskName, Pageable pageable,
 				PagedResourcesAssembler<TaskExecution> assembler) {
 		Page<TaskExecution> result = explorer.findTaskExecutionsByName(taskName, pageable);
 		return assembler.toResource(result, taskAssembler);
+	}
+
+	/**
+	 * View the details of a single task execution, specified by id.
+	 *
+	 * @param id the id of the requested {@link TaskExecution}
+	 * @return the {@link TaskExecution}
+	 */
+	@RequestMapping(value = "/id/{id}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public TaskExecutionResource view(@PathVariable("id") long id) {
+		return taskAssembler.toResource(this.explorer.getTaskExecution(id));
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,38 +26,47 @@ import org.springframework.hateoas.PagedResources;
  * Interface defining operations available against tasks.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 public interface TaskOperations {
 
 	/**
 	 * List tasks known to the system.
 	 */
-	public PagedResources<TaskDefinitionResource> list();
+	PagedResources<TaskDefinitionResource> list();
 
 	/**
 	 * Create a new task.
 	 */
-	public TaskDefinitionResource create(String name, String definition);
+	TaskDefinitionResource create(String name, String definition);
 
 	/**
 	 * Launch an already created task.
 	 */
-	public void launch(String name, Map<String, String> properties);
+	void launch(String name, Map<String, String> properties);
 	
 	/**
 	 * Destroy an existing task.
 	 */
-	public void destroy(String name);
+	void destroy(String name);
 
 	/**
 	 * List task executions known to the system.
 	 */
-	public PagedResources<TaskExecutionResource> executionList();
+	PagedResources<TaskExecutionResource> executionList();
 
 	/**
 	 * List task executions known to the system filtered by task name.
 	 * @param taskName of the executions.
 	 */
-	public PagedResources<TaskExecutionResource> executionListByTaskName(String taskName);
+	PagedResources<TaskExecutionResource> executionListByTaskName(String taskName);
+
+	/**
+	 * Return the {@link TaskExecutionResource} for the id specified.
+	 *
+	 * @param id identifier of the task execution
+	 * @return {@link TaskExecutionResource}
+	 */
+	TaskExecutionResource view(long id);
 
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.web.client.RestTemplate;
  * Implementation for {@link org.springframework.cloud.dataflow.rest.client.TaskOperations}.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 public class TaskTemplate implements TaskOperations {
 
@@ -103,9 +104,18 @@ public class TaskTemplate implements TaskOperations {
 	@Override
 	public TaskExecutionResource.Page executionListByTaskName(String taskName) {
 		String uriTemplate = executionsPath.toString();
-		uriTemplate = uriTemplate + "/{taskName}";
+		uriTemplate = uriTemplate + "/name/{taskName}";
 		return restTemplate.getForObject(uriTemplate, TaskExecutionResource.Page.class,
 				Collections.singletonMap("taskName", taskName));
+	}
+
+	@Override
+	public TaskExecutionResource view(long id) {
+		String uriTemplate = executionsPath.toString();
+		uriTemplate = uriTemplate + "/id/{id}";
+
+		return restTemplate.getForObject(uriTemplate, TaskExecutionResource.class,
+			Collections.singletonMap("id", id));
 	}
 
 }

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,14 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.shell.table.BeanListTableModel;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableBuilder;
+import org.springframework.shell.table.TableModelBuilder;
 import org.springframework.stereotype.Component;
 
 /**
  * Task commands.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 @Component
 // todo: reenable optionContext attributes
@@ -58,6 +60,8 @@ public class TaskCommands implements CommandMarker {
 	private static final String STATUS = "task status";
 
 	private static final String DESTROY = "task destroy";
+
+	private static final String VIEW = "task view";
 
 	private static final String PROPERTIES_OPTION = "properties";
 
@@ -157,6 +161,34 @@ public class TaskCommands implements CommandMarker {
 		headers.put("exitCode", "Exit Code");
 		final TableBuilder builder = new TableBuilder(new BeanListTableModel<>(tasks, headers));
 		return DataFlowTables.applyStyle(builder).build();
+	}
+
+	@CliCommand(value = VIEW, help = "View the details of a specific task execution")
+	public Table view(
+			@CliOption(key = { "id" },
+					help = "the task execution id",
+					mandatory = true) long id) {
+
+		TaskExecutionResource taskExecutionResource = taskOperations().view(id);
+
+		TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
+
+		modelBuilder.addRow().addValue("Key ").addValue("Value ");
+		modelBuilder.addRow().addValue("Id ").addValue(taskExecutionResource.getExecutionId());
+		modelBuilder.addRow().addValue("Name ").addValue(taskExecutionResource.getTaskName());
+		modelBuilder.addRow().addValue("Parameters ").addValue(taskExecutionResource.getParameters());
+		modelBuilder.addRow().addValue("External Execution Id ").addValue(taskExecutionResource.getExternalExecutionID());
+		modelBuilder.addRow().addValue("Start Time ").addValue(taskExecutionResource.getStartTime());
+		modelBuilder.addRow().addValue("Status Code ").addValue(taskExecutionResource.getStatusCode());
+		modelBuilder.addRow().addValue("End Time ").addValue(taskExecutionResource.getEndTime());
+		modelBuilder.addRow().addValue("Exit Code ").addValue(taskExecutionResource.getExitCode());
+		modelBuilder.addRow().addValue("Exit Message ").addValue(taskExecutionResource.getExitMessage());
+
+		TableBuilder builder = new TableBuilder(modelBuilder.build());
+
+		DataFlowTables.applyStyle(builder);
+
+		return builder.build();
 	}
 
 	private TaskOperations taskOperations() {

--- a/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public abstract class AbstractShellIntegrationTest {
 	/**
 	 * Application context for admin application.
 	 */
-	private static ApplicationContext applicationContext;
+	protected static ApplicationContext applicationContext;
 
 	/**
 	 * Instance of shell to execute commands for testing.

--- a/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
+++ b/spring-cloud-dataflow-shell/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.shell.table.TableModel;
  * It should mimic the client side API of TaskOperations as much as possible.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 public class TaskCommandTemplate {
 
@@ -141,6 +142,18 @@ public class TaskCommandTemplate {
 			}
 		}
 		fail("Task named " + taskName + " was not created");
+	}
+
+	/**
+	 * Return the results of executing the shell command:
+	 * <code>dataflow: task view --id FOO</code> where FOO is the id for the task
+	 * execution requested.
+	 *
+	 * @param id the identifier for the task execution
+	 * @return the results of the shell command.
+	 */
+	public CommandResult view(long id) {
+		return shell.executeCommand("task view --id " + id);
 	}
 
 }


### PR DESCRIPTION
This commit adds the ability to view the details of a task execution via
either the REST endpoint or the shell command task view --id

Resolves spring-cloud/spring-cloud-dataflow#183