### PR TITLE
SCDF-307 Dev needs access to h2 db from other apps

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
+++ b/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
@@ -17,6 +17,14 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
+  datasource:
+    url: jdbc:h2:tcp://localhost:9092/mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  task:
+    repo:
+      initialize: true
 
 # If you prefer to use Eureka to locate the Config Server, you can do that by setting
 # spring.cloud.config.discovery.enabled=true (default "false"). The net result of that is

--- a/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
+++ b/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
@@ -18,10 +18,10 @@ spring:
     config:
       uri: http://localhost:8888
   datasource:
-    url: jdbc:h2:tcp://localhost:9092/mem:testdb
+    url: jdbc:h2:tcp://localhost:9092/mem:dataflow
     username: sa
     password:
-    driver-class-name: org.h2.Driver
+    driverClassName: org.h2.Driver
   task:
     repo:
       initialize: true

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -61,11 +61,9 @@ import org.springframework.web.bind.annotation.RestController;
 @ExposesResourceFor(TaskDefinitionResource.class)
 public class TaskController {
 
-	private final String DEFAULT_TASK_DATASOURCE_URL = "jdbc:h2:tcp://localhost:9092/mem:testdb";
+	private final String DEFAULT_TASK_DATASOURCE_URL = "jdbc:h2:tcp://localhost:9092/mem:dataflow";
 
 	private final String DEFAULT_TASK_DATASOURCE_USER_NAME = "sa";
-
-	private final String DEFAULT_TASK_DATASOURCE_PASSWORD = "";
 
 	private final String DEFAULT_TASK_DATASOURCE_DRIVER_CLASS_NAME = "org.h2.Driver";
 
@@ -87,7 +85,7 @@ public class TaskController {
 	@Value("${spring.datasource.password:#{null}}")
 	private String dataSourcePassword;
 
-	@Value("${spring.datasource.driver-class-name:#{null}}")
+	@Value("${spring.datasource.driverClassName:#{null}}")
 	private String dataSourceDriverClassName;
 
 	/**
@@ -227,7 +225,7 @@ public class TaskController {
 			builder.setParameter("spring.datasource.password", dataSourcePassword );
 		}
 
-		builder.setParameter("spring.datasource.driver-class-name",
+		builder.setParameter("spring.datasource.driverClassName",
 				(StringUtils.hasText(dataSourceDriverClassName)) ? dataSourceDriverClassName :
 						DEFAULT_TASK_DATASOURCE_DRIVER_CLASS_NAME);
 

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/TaskController.java
@@ -21,7 +21,10 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.dataflow.admin.repository.TaskDefinitionRepository;
+import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
+import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 import org.springframework.cloud.dataflow.core.ArtifactCoordinates;
 import org.springframework.cloud.dataflow.core.ArtifactType;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
@@ -29,8 +32,6 @@ import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
-import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
-import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +41,7 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -59,6 +61,14 @@ import org.springframework.web.bind.annotation.RestController;
 @ExposesResourceFor(TaskDefinitionResource.class)
 public class TaskController {
 
+	private final String DEFAULT_TASK_DATASOURCE_URL = "jdbc:h2:tcp://localhost:9092/mem:testdb";
+
+	private final String DEFAULT_TASK_DATASOURCE_USER_NAME = "sa";
+
+	private final String DEFAULT_TASK_DATASOURCE_PASSWORD = "";
+
+	private final String DEFAULT_TASK_DATASOURCE_DRIVER_CLASS_NAME = "org.h2.Driver";
+
 	private final Assembler taskAssembler = new Assembler();
 
 	@Autowired
@@ -67,6 +77,18 @@ public class TaskController {
 	@Autowired
 	@Qualifier("taskModuleDeployer")
 	private ModuleDeployer moduleDeployer;
+
+	@Value("${spring.datasource.url:#{null}}")
+	private String dataSourceUrl;
+
+	@Value("${spring.datasource.username:#{null}}")
+	private String dataSourceUserName;
+
+	@Value("${spring.datasource.password:#{null}}")
+	private String dataSourcePassword;
+
+	@Value("${spring.datasource.driver-class-name:#{null}}")
+	private String dataSourceDriverClassName;
 
 	/**
 	 * The artifact registry this controller will use to look up modules.
@@ -156,6 +178,7 @@ public class TaskController {
 		ArtifactCoordinates coordinates = registration.getCoordinates();
 
 		Map<String, String> deploymentProperties = new HashMap<>();
+		module = updateTaskProperties(module, module.getName() );
 		deploymentProperties.putAll(DeploymentPropertiesUtils.parse(properties));
 		deploymentProperties.put(ModuleDeployer.GROUP_DEPLOYMENT_ID, taskDefinition.getName()
 				+ "-" + System.currentTimeMillis());
@@ -188,5 +211,26 @@ public class TaskController {
 			taskDefinitionResource.setStatus(moduleDeployer.status(id).getState().name());
 			return taskDefinitionResource;
 		}
+	}
+
+	private ModuleDefinition updateTaskProperties(ModuleDefinition moduleDefinition, String taskDefinitionName) {
+		ModuleDefinition.Builder builder = ModuleDefinition.Builder.from(moduleDefinition);
+		builder.setParameter("spring.datasource.url",
+				(StringUtils.hasText(dataSourceUrl)) ? dataSourceUrl :
+						DEFAULT_TASK_DATASOURCE_URL);
+
+		builder.setParameter("spring.datasource.username",
+				(StringUtils.hasText(dataSourceUserName)) ? dataSourceUserName :
+						DEFAULT_TASK_DATASOURCE_USER_NAME);
+
+		if(StringUtils.hasText(dataSourcePassword)) {//password may be empty
+			builder.setParameter("spring.datasource.password", dataSourcePassword );
+		}
+
+		builder.setParameter("spring.datasource.driver-class-name",
+				(StringUtils.hasText(dataSourceDriverClassName)) ? dataSourceDriverClassName :
+						DEFAULT_TASK_DATASOURCE_DRIVER_CLASS_NAME);
+
+		return builder.build();
 	}
 }


### PR DESCRIPTION
* Added H2 as default datasource to connect via tcp for tasks
* Added H2 TCP Listener Server to make embedded h2 accesible by tasks.
* Added H2 TCP Listener Server will not start unless the spring.datasource.url has the prefix of `jdbc:h2:tcp://`
* Passes datasource connection info to tasks.

Resolves spring-cloud/spring-cloud-dataflow#307