### PR TITLE
GH-322 Provide group information for streams

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
@@ -20,12 +20,9 @@ import static org.springframework.hateoas.config.EnableHypermediaSupport.Hyperme
 
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.StringTokenizer;
-import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.logging.Log;
 import org.h2.tools.Server;
 import org.slf4j.LoggerFactory;
 

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -137,8 +137,10 @@ public class StreamControllerTests {
 		ModuleDefinition logDefinition = myStream.getModuleDefinitions().get(1);
 		assertEquals(1, timeDefinition.getParameters().size());
 		assertEquals("myStream.0", timeDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
-		assertEquals(1, logDefinition.getParameters().size());
+		assertEquals(3, logDefinition.getParameters().size());
 		assertEquals("myStream.0", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", logDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", logDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -191,11 +193,15 @@ public class StreamControllerTests {
 		ModuleDefinition logDefinition = myStream.getModuleDefinitions().get(2);
 		assertEquals(1, timeDefinition.getParameters().size());
 		assertEquals("myStream.0", timeDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
-		assertEquals(2, filterDefinition.getParameters().size());
+		assertEquals(4, filterDefinition.getParameters().size());
 		assertEquals("myStream.0", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("myStream.1", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
-		assertEquals(1, logDefinition.getParameters().size());
+		assertEquals(3, logDefinition.getParameters().size());
 		assertEquals("myStream.1", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", logDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", logDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -212,8 +218,10 @@ public class StreamControllerTests {
 		assertEquals("myStream", myStream.getName());
 		assertEquals(1, myStream.getModuleDefinitions().size());
 		ModuleDefinition logDefinition = myStream.getModuleDefinitions().get(0);
-		assertEquals(1, logDefinition.getParameters().size());
+		assertEquals(3, logDefinition.getParameters().size());
 		assertEquals("queue:foo", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("myStream", logDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", logDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -230,12 +238,16 @@ public class StreamControllerTests {
 		assertEquals("myStream", myStream.getName());
 		assertEquals(2, myStream.getModuleDefinitions().size());
 		ModuleDefinition filterDefinition = myStream.getModuleDefinitions().get(0);
-		assertEquals(2, filterDefinition.getParameters().size());
+		assertEquals(4, filterDefinition.getParameters().size());
 		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("myStream", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("myStream.0", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 		ModuleDefinition logDefinition = myStream.getModuleDefinitions().get(1);
-		assertEquals(1, logDefinition.getParameters().size());
+		assertEquals(3, logDefinition.getParameters().size());
 		assertEquals("myStream.0", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", logDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", logDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -273,8 +285,10 @@ public class StreamControllerTests {
 		assertEquals(1, timeDefinition.getParameters().size());
 		assertEquals("myStream.0", timeDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 		ModuleDefinition filterDefinition = myStream.getModuleDefinitions().get(1);
-		assertEquals(2, filterDefinition.getParameters().size());
+		assertEquals(4, filterDefinition.getParameters().size());
 		assertEquals("myStream.0", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
@@ -293,8 +307,10 @@ public class StreamControllerTests {
 		assertEquals("myStream", myStream.getName());
 		assertEquals(1, myStream.getModuleDefinitions().size());
 		ModuleDefinition filterDefinition = myStream.getModuleDefinitions().get(0);
-		assertEquals(2, filterDefinition.getParameters().size());
+		assertEquals(4, filterDefinition.getParameters().size());
 		assertEquals("queue:bar", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("myStream", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 
 		ArgumentCaptor<ModuleDeploymentRequest> captor = ArgumentCaptor.forClass(ModuleDeploymentRequest.class);

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -219,7 +219,7 @@ public class StreamControllerTests {
 		assertEquals(1, myStream.getModuleDefinitions().size());
 		ModuleDefinition logDefinition = myStream.getModuleDefinitions().get(0);
 		assertEquals(3, logDefinition.getParameters().size());
-		assertEquals("queue:foo", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("foo", logDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("myStream", logDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 		assertEquals("true", logDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
@@ -239,7 +239,7 @@ public class StreamControllerTests {
 		assertEquals(2, myStream.getModuleDefinitions().size());
 		ModuleDefinition filterDefinition = myStream.getModuleDefinitions().get(0);
 		assertEquals(4, filterDefinition.getParameters().size());
-		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("foo", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("myStream", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("myStream.0", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
@@ -265,7 +265,7 @@ public class StreamControllerTests {
 		assertEquals(1, myStream.getModuleDefinitions().size());
 		ModuleDefinition timeDefinition = myStream.getModuleDefinitions().get(0);
 		assertEquals(1, timeDefinition.getParameters().size());
-		assertEquals("queue:foo", timeDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertEquals("foo", timeDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -289,7 +289,7 @@ public class StreamControllerTests {
 		assertEquals("myStream.0", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("default", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
-		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertEquals("foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -308,10 +308,10 @@ public class StreamControllerTests {
 		assertEquals(1, myStream.getModuleDefinitions().size());
 		ModuleDefinition filterDefinition = myStream.getModuleDefinitions().get(0);
 		assertEquals(4, filterDefinition.getParameters().size());
-		assertEquals("queue:bar", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("bar", filterDefinition.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("myStream", filterDefinition.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 		assertEquals("true", filterDefinition.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
-		assertEquals("queue:foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertEquals("foo", filterDefinition.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 
 		ArgumentCaptor<ModuleDeploymentRequest> captor = ArgumentCaptor.forClass(ModuleDeploymentRequest.class);
 		verify(moduleDeployer).deploy(captor.capture());

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
@@ -40,6 +40,8 @@ public class CompletionUtils {
 	static final Set<String> IMPLICIT_PARAMETER_NAMES = new HashSet<>();
 	static {
 		IMPLICIT_PARAMETER_NAMES.add(BindingProperties.INPUT_BINDING_KEY);
+		IMPLICIT_PARAMETER_NAMES.add(BindingProperties.INPUT_GROUP_KEY);
+		IMPLICIT_PARAMETER_NAMES.add(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY);
 		IMPLICIT_PARAMETER_NAMES.add(BindingProperties.OUTPUT_BINDING_KEY);
 	}
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
@@ -54,6 +54,16 @@ public class BindingProperties {
 	public static final String OUTPUT_TYPE_KEY = OUTPUT_BINDING_KEY_PREFIX + CONTENT_TYPE_KEY;
 
 	/**
+	 * Group property key for input.
+	 */
+	public static final String INPUT_GROUP_KEY = INPUT_BINDING_KEY_PREFIX + "group";
+
+	/**
+	 * Subscription durability for input.
+	 */
+	public static final String INPUT_DURABLE_SUBSCRIPTION_KEY = INPUT_BINDING_KEY_PREFIX + "durableSubscription";
+
+	/**
 	 * Partition properties
 	 */
 	public static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/BindingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.core;
  * Spring Cloud Stream property names mostly used for binding.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
  */
 public class BindingProperties {
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.springframework.cloud.dataflow.core.dsl.ArgumentNode;
+import org.springframework.cloud.dataflow.core.dsl.ChannelType;
 import org.springframework.cloud.dataflow.core.dsl.ModuleNode;
 import org.springframework.cloud.dataflow.core.dsl.SinkChannelNode;
 import org.springframework.cloud.dataflow.core.dsl.SourceChannelNode;
@@ -98,20 +99,32 @@ class ModuleDefinitionBuilder {
 		}
 		SourceChannelNode sourceChannel = streamNode.getSourceChannelNode();
 		if (sourceChannel != null) {
+			String sourceChannelName = removeChannelTypePrefix(sourceChannel.getChannelName());
 			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY,
-					sourceChannel.getChannelName());
+					sourceChannelName);
 			builders.getLast().setParameter(BindingProperties.INPUT_GROUP_KEY, streamName);
 			builders.getLast().setParameter(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY,"true");
 		}
 		SinkChannelNode sinkChannel = streamNode.getSinkChannelNode();
 		if (sinkChannel != null) {
+			String sinkChannelName = removeChannelTypePrefix(sinkChannel.getChannelName());
 			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY,
-					sinkChannel.getChannelName());
+					sinkChannelName);
 		}
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(builders.size());
 		for (ModuleDefinition.Builder builder : builders) {
 			moduleDefinitions.add(builder.build());
 		}
 		return moduleDefinitions;
+	}
+
+	private String removeChannelTypePrefix(String sourceChannelName) {
+		if (sourceChannelName.startsWith(ChannelType.QUEUE.getStringRepresentation())) {
+			sourceChannelName = sourceChannelName.substring(ChannelType.QUEUE.getStringRepresentation().length());
+		}
+		else if (sourceChannelName.startsWith(ChannelType.TOPIC.getStringRepresentation())) {
+			sourceChannelName = sourceChannelName.substring(ChannelType.TOPIC.getStringRepresentation().length());
+		}
+		return sourceChannelName;
 	}
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -118,13 +118,13 @@ class ModuleDefinitionBuilder {
 		return moduleDefinitions;
 	}
 
-	private String removeChannelTypePrefix(String sourceChannelName) {
-		if (sourceChannelName.startsWith(ChannelType.QUEUE.getStringRepresentation())) {
-			sourceChannelName = sourceChannelName.substring(ChannelType.QUEUE.getStringRepresentation().length());
+	private String removeChannelTypePrefix(String channelName) {
+		if (channelName.startsWith(ChannelType.QUEUE.getStringRepresentation())) {
+			channelName = channelName.substring(ChannelType.QUEUE.getStringRepresentation().length());
 		}
-		else if (sourceChannelName.startsWith(ChannelType.TOPIC.getStringRepresentation())) {
-			sourceChannelName = sourceChannelName.substring(ChannelType.TOPIC.getStringRepresentation().length());
+		else if (channelName.startsWith(ChannelType.TOPIC.getStringRepresentation())) {
+			channelName = channelName.substring(ChannelType.TOPIC.getStringRepresentation().length());
 		}
-		return sourceChannelName;
+		return channelName;
 	}
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,11 @@ import org.springframework.util.Assert;
  * @author Patrick Peralta
  * @author Andy Clement
  * @author Eric Bottard
+ * @author Marius Bogoevici
  */
 class ModuleDefinitionBuilder {
+
+	public static final String DEFAULT_CONSUMER_GROUP_NAME = "default";
 
 	private final String streamName;
 
@@ -83,8 +86,9 @@ class ModuleDefinitionBuilder {
 				}
 			}
 			if (m > 0) {
-				builder.setParameter(BindingProperties.INPUT_BINDING_KEY,
-						String.format("%s.%d", streamName, m - 1));
+				builder.setParameter(BindingProperties.INPUT_BINDING_KEY, String.format("%s.%d", streamName, m - 1));
+				builder.setParameter(BindingProperties.INPUT_GROUP_KEY, DEFAULT_CONSUMER_GROUP_NAME);
+				builder.setParameter(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY,"true");
 			}
 			if (m < moduleNodes.size() - 1) {
 				builder.setParameter(BindingProperties.OUTPUT_BINDING_KEY,
@@ -96,6 +100,8 @@ class ModuleDefinitionBuilder {
 		if (sourceChannel != null) {
 			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY,
 					sourceChannel.getChannelName());
+			builders.getLast().setParameter(BindingProperties.INPUT_GROUP_KEY, streamName);
+			builders.getLast().setParameter(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY,"true");
 		}
 		SinkChannelNode sinkChannel = streamNode.getSinkChannelNode();
 		if (sinkChannel != null) {

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -129,7 +129,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "topic:foo > goo | blah | file");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
-		assertEquals("topic:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("test", requests.get(0).getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 	}
 
@@ -138,7 +138,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "boo | blah | aaak > queue:foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
-		assertEquals("queue:foo", requests.get(2).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertEquals("foo", requests.get(2).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "bart > queue:foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
-		assertEquals("queue:foo", requests.get(0).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
+		assertEquals("foo", requests.get(0).getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class StreamDefinitionTests {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "queue:foo > boot");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
-		assertEquals("queue:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("test", requests.get(0).getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 		assertEquals("true", requests.get(0).getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.core.dsl.ParseException;
  * @author Mark Fisher
  * @author David Turanski
  * @author Patrick Peralta
+ * @author Marius Bogoevici
  */
 public class StreamDefinitionTests {
 
@@ -51,6 +52,8 @@ public class StreamDefinitionTests {
 		assertEquals("log", log.getName());
 		assertEquals("log", log.getLabel());
 		assertEquals("ticktock.0", log.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", log.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", log.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertFalse(log.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
@@ -68,8 +71,10 @@ public class StreamDefinitionTests {
 		assertEquals("test.0", source.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 		assertEquals("bar", sink.getName());
 		assertEquals("test", sink.getGroup());
-		assertEquals(1, sink.getParameters().size());
+		assertEquals(3, sink.getParameters().size());
 		assertEquals("test.0", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", sink.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", sink.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -95,7 +100,7 @@ public class StreamDefinitionTests {
 		assertEquals("filter", filter.getName());
 		assertEquals("test", filter.getGroup());
 		Map<String, String> filterParameters = filter.getParameters();
-		assertEquals(3, filterParameters.size());
+		assertEquals(5, filterParameters.size());
 		assertEquals("payload.matches('hello world')", filterParameters.get("expression"));
 	}
 
@@ -115,7 +120,7 @@ public class StreamDefinitionTests {
 		assertEquals("bar", sink.getName());
 		assertEquals("test", sink.getGroup());
 		Map<String, String> sinkParameters = sink.getParameters();
-		assertEquals(2, sinkParameters.size());
+		assertEquals(4, sinkParameters.size());
 		assertEquals("3", sinkParameters.get("z"));
 	}
 
@@ -125,6 +130,7 @@ public class StreamDefinitionTests {
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
 		assertEquals("topic:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("test", requests.get(0).getParameters().get(BindingProperties.INPUT_GROUP_KEY));
 	}
 
 	@Test
@@ -164,6 +170,8 @@ public class StreamDefinitionTests {
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
 		assertEquals("queue:foo", requests.get(0).getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("test", requests.get(0).getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", requests.get(0).getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 	}
 
 	@Test
@@ -197,6 +205,8 @@ public class StreamDefinitionTests {
 		assertFalse(source.getParameters().containsKey(BindingProperties.INPUT_BINDING_KEY));
 		assertEquals("log", sink.getLabel());
 		assertEquals("ticktock.0", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", sink.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", sink.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertFalse(sink.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 
@@ -215,10 +225,14 @@ public class StreamDefinitionTests {
 
 		assertEquals("filter", processor.getLabel());
 		assertEquals("ticktock.0", processor.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", processor.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", processor.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertEquals("ticktock.1", processor.getParameters().get(BindingProperties.OUTPUT_BINDING_KEY));
 
 		assertEquals("log", sink.getLabel());
 		assertEquals("ticktock.1", sink.getParameters().get(BindingProperties.INPUT_BINDING_KEY));
+		assertEquals("default", sink.getParameters().get(BindingProperties.INPUT_GROUP_KEY));
+		assertEquals("true", sink.getParameters().get(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY));
 		assertFalse(sink.getParameters().containsKey(BindingProperties.OUTPUT_BINDING_KEY));
 	}
 


### PR DESCRIPTION
Resolves #322
Streams create durable, named group subscriptions for consumers, as follows:
* intra-stream consumers will use the `default` group subscription;
* consumers from named queues will use the stream name as consumer group;

Also provides a basic way to align with Spring Cloud Stream dropping `topic:` and `queue:` support by not passing them on to the bindings - support at DSL level should address this more comprehensively (see https://github.com/spring-cloud/spring-cloud-dataflow/issues/336). 