### PR TITLE
adding spring-cloud-starter-dataflow-server-local

### DIFF
--- a/spring-cloud-starter-dataflow-server-local/pom.xml
+++ b/spring-cloud-starter-dataflow-server-local/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>spring-cloud-starter-dataflow-admin-local</artifactId>
+	<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
 	<url>http://projects.spring.io/spring-cloud/</url>
 	<packaging>pom</packaging>
 	<organization>


### PR DESCRIPTION
changes the name of the starter to be foreword compatible 