### PR TITLE
Properly report 'not found' and 'already exists' errors at http level

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/RestControllerAdvice.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.dataflow.admin.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.dataflow.admin.repository.DuplicateStreamDefinitionException;
+import org.springframework.cloud.dataflow.admin.repository.DuplicateTaskException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -46,6 +48,15 @@ public class RestControllerAdvice {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ResponseBody
 	public VndErrors onException(Exception e) {
+		String logref = logError(e);
+		String msg = StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
+		return new VndErrors(logref, msg);
+	}
+
+	@ExceptionHandler({DuplicateStreamDefinitionException.class, DuplicateTaskException.class})
+	@ResponseStatus(HttpStatus.CONFLICT)
+	@ResponseBody
+	public VndErrors onConflictException(Exception e) {
 		String logref = logError(e);
 		String msg = StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
 		return new VndErrors(logref, msg);

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/RestControllerAdvice.java
@@ -19,8 +19,11 @@ package org.springframework.cloud.dataflow.admin.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.boot.actuate.endpoint.mvc.MetricsMvcEndpoint;
 import org.springframework.cloud.dataflow.admin.repository.DuplicateStreamDefinitionException;
 import org.springframework.cloud.dataflow.admin.repository.DuplicateTaskException;
+import org.springframework.cloud.dataflow.admin.repository.NoSuchStreamDefinitionException;
+import org.springframework.cloud.dataflow.admin.repository.NoSuchTaskDefinitionException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -61,6 +64,19 @@ public class RestControllerAdvice {
 		String msg = StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
 		return new VndErrors(logref, msg);
 	}
+
+	@ExceptionHandler({NoSuchStreamDefinitionException.class,
+			NoSuchTaskDefinitionException.class,
+			MetricsMvcEndpoint.NoSuchMetricException.class})
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ResponseBody
+	public VndErrors onNotFoundException(Exception e) {
+		String logref = logError(e);
+		String msg = StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
+		return new VndErrors(logref, msg);
+	}
+
+
 
 	private String logError(Throwable t) {
 		logger.error("Caught exception while handling a request", t);

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDefinitionController.java
@@ -131,12 +131,6 @@ public class StreamDefinitionController {
 	                 @RequestParam("definition") String dsl,
 	                 @RequestParam(value = "deploy", defaultValue = "true")
 	                 boolean deploy) {
-		if (this.repository.exists(name)) {
-			throw new DuplicateStreamDefinitionException(
-					String.format("Cannot create stream %s because another one has already " +
-							"been created with the same name", name));
-		}
-
 		StreamDefinition stream = new StreamDefinition(name, dsl);
 		this.repository.save(stream);
 		if (deploy) {

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDefinitionController.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.dataflow.admin.repository.DuplicateStreamDefinitionException;
+import org.springframework.cloud.dataflow.admin.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.admin.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
@@ -145,6 +146,9 @@ public class StreamDefinitionController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	public void delete(@PathVariable("name") String name) {
+		if(repository.findOne(name) == null) {
+			throw new NoSuchStreamDefinitionException(name);
+		}
 		deploymentController.undeploy(name);
 		this.repository.delete(name);
 	}
@@ -156,7 +160,11 @@ public class StreamDefinitionController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public StreamDefinitionResource display(@PathVariable("name") String name) {
-		return streamDefinitionAssembler.toResource(repository.findOne(name));
+		StreamDefinition definition = repository.findOne(name);
+		if (definition == null) {
+			throw new NoSuchStreamDefinitionException(name);
+		}
+		return streamDefinitionAssembler.toResource(definition);
 	}
 
 	/**

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/controller/StreamDeploymentController.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.dataflow.admin.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.admin.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration;
 import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
@@ -111,7 +112,9 @@ public class StreamDeploymentController {
 	@ResponseStatus(HttpStatus.OK)
 	public void undeploy(@PathVariable("name") String name) {
 		StreamDefinition stream = this.repository.findOne(name);
-		Assert.notNull(stream, String.format("no stream defined: %s", name));
+		if (stream == null) {
+			throw new NoSuchStreamDefinitionException(name);
+		}
 		undeployStream(stream);
 	}
 
@@ -137,7 +140,9 @@ public class StreamDeploymentController {
 	public void deploy(@PathVariable("name") String name,
 			@RequestParam(required = false) String properties) {
 		StreamDefinition stream = this.repository.findOne(name);
-		Assert.notNull(stream, String.format("no stream defined: %s", name));
+		if (stream == null) {
+			throw new NoSuchStreamDefinitionException(name);
+		}
 		deployStream(stream, DeploymentPropertiesUtils.parse(properties));
 	}
 

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/InMemoryStreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/InMemoryStreamDefinitionRepository.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.admin.repository;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,16 +51,20 @@ public class InMemoryStreamDefinitionRepository implements StreamDefinitionRepos
 
 	@Override
 	public <S extends StreamDefinition> Iterable<S> save(Iterable<S> iterableDefinitions) {
-		Map<String, StreamDefinition> holder = new HashMap<>();
 		for (S definition : iterableDefinitions) {
-			holder.put(definition.getName(), definition);
+			save(definition);
 		}
-		definitions.putAll(holder);
 		return iterableDefinitions;
 	}
 
 	@Override
 	public <S extends StreamDefinition> S save(S definition) {
+		if(definitions.containsKey(definition.getName())) {
+			throw new DuplicateTaskException(
+					String.format("Cannot register stream definition %s because another one has already " +
+									"been registered with the same name",
+							definition.getName()));
+		}
 		definitions.put(definition.getName(), definition);
 		return definition;
 	}

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/NoSuchStreamDefinitionException.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/NoSuchStreamDefinitionException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.admin.repository;
+
+/**
+ * Thrown when a stream definition of a given name was expected but did not exist.
+ *
+ * @author Eric Bottard
+ */
+public class NoSuchStreamDefinitionException extends RuntimeException {
+
+	private String name;
+
+	public NoSuchStreamDefinitionException(String name) {
+		this(name, "Could not find stream definition named " + name);
+	}
+
+	public NoSuchStreamDefinitionException(String name, String message) {
+		super(message);
+		this.name = name;
+	}
+
+	/**
+	 * Return the name of the stream definition that could not be found.
+	 */
+	public String getName() {
+		return name;
+	}
+}

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/NoSuchTaskDefinitionException.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/repository/NoSuchTaskDefinitionException.java
@@ -17,27 +17,23 @@
 package org.springframework.cloud.dataflow.admin.repository;
 
 /**
- * Thrown when a stream definition of a given name was expected but did not exist.
+ * Thrown when a task definition of a given name was expected but did not exist.
  *
  * @author Eric Bottard
  */
-public class NoSuchStreamDefinitionException extends RuntimeException {
+public class NoSuchTaskDefinitionException extends RuntimeException {
 
+	/**
+	 * The name of the task definition that could not be found.
+	 */
 	private final String name;
 
-	public NoSuchStreamDefinitionException(String name) {
-		this(name, "Could not find stream definition named " + name);
-	}
-
-	public NoSuchStreamDefinitionException(String name, String message) {
+	public NoSuchTaskDefinitionException(String name, String message) {
 		super(message);
 		this.name = name;
 	}
 
-	/**
-	 * Return the name of the stream definition that could not be found.
-	 */
-	public String getName() {
-		return name;
+	public NoSuchTaskDefinitionException(String name) {
+		this(name, "Could not find task definition named " + name);
 	}
 }

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -368,7 +368,7 @@ public class StreamControllerTests {
 	public void testDestroyStreamNotFound() throws Exception {
 		mockMvc.perform(
 				delete("/streams/definitions/myStream").accept(MediaType.APPLICATION_JSON)).andDo(print())
-				.andExpect(status().is5xxServerError());
+				.andExpect(status().isNotFound());
 		assertEquals(0, repository.count());
 	}
 

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -150,7 +150,7 @@ public class StreamControllerTests {
 		mockMvc.perform(
 				post("/streams/definitions/").param("name", "myStream").param("definition", "time | log")
 						.accept(MediaType.APPLICATION_JSON)).andDo(print())
-						.andExpect(status().is5xxServerError());
+						.andExpect(status().isConflict());
 		assertEquals(1, repository.count());
 	}
 

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
@@ -130,7 +130,7 @@ public class TaskControllerTests {
 		mockMvc.perform(
 				post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
 						.accept(MediaType.APPLICATION_JSON)).andDo(print())
-						.andExpect(status().is5xxServerError());
+						.andExpect(status().isConflict());
 
 		assertEquals(1, repository.count());
 	}

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/TaskControllerTests.java
@@ -171,7 +171,7 @@ public class TaskControllerTests {
 	public void testDestroyTaskNotFound() throws Exception {
 		mockMvc.perform(
 				delete("/tasks/definitions/myTask").accept(MediaType.APPLICATION_JSON)).andDo(print())
-				.andExpect(status().isOk());
+				.andExpect(status().isNotFound());
 
 		assertEquals(0, repository.count());
 	}
@@ -192,8 +192,8 @@ public class TaskControllerTests {
 		mockMvc.perform(
 				post("/tasks/deployments/{name}", "myFoo")
 						.accept(MediaType.APPLICATION_JSON)).andDo(print())
-			.andExpect(status().is5xxServerError())
-			.andExpect(content().json("[{message: \"no task defined: myFoo\"}]"));
+			.andExpect(status().isNotFound())
+			.andExpect(content().json("[{message: \"Could not find task definition named myFoo\"}]"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes  spring-cloud/spring-cloud-dataflow#327 and
fixes spring-cloud/spring-cloud-dataflow#266