### PR TITLE
Fix in-process deployer

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalDeployerAutoConfiguration.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalDeployerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.admin.spi.local;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -32,9 +33,11 @@ import org.springframework.context.annotation.Import;
  *
  * @author Eric Bottard
  * @author Josh Long
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
-public class LocalAutoConfiguration {
+@ConditionalOnClass(ModuleDeployer.class)
+public class LocalDeployerAutoConfiguration {
 
 	static final String LOCAL_DEPLOYER_PREFIX = "deployer.local";
 

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/OutOfProcessModuleDeployerProperties.java
@@ -26,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Eric Bottard
  */
-@ConfigurationProperties(prefix = LocalAutoConfiguration.LOCAL_DEPLOYER_PREFIX)
+@ConfigurationProperties(prefix = LocalDeployerAutoConfiguration.LOCAL_DEPLOYER_PREFIX)
 public class OutOfProcessModuleDeployerProperties {
 
 	/**

--- a/spring-cloud-dataflow-admin-local/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-admin-local/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.cloud.dataflow.admin.spi.local.LocalAutoConfiguration
+  org.springframework.cloud.dataflow.admin.spi.local.LocalDeployerAutoConfiguration

--- a/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/LocalConfigurationTests.java
+++ b/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/LocalConfigurationTests.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.dataflow.admin.AdminApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 /**
- * Tests for {@link LocalAutoConfiguration}.
+ * Tests for {@link LocalDeployerAutoConfiguration}.
  *
  * @author Janne Valkealahti
  * @author Eric Bottard


### PR DESCRIPTION
 - Since the auto configuration class will be enabled as long as the `local` jar path is in the classpath, make this auto configuration class
conditional only if the class `ModuleDeployer` is also present
 - Rename `LocalAutoConfiguration` to `LocalDeployerAutoConfiguration` as `local` looks more generic when used in the context of other application

This resolves #356