### PR TITLE
Align dependencies with BOMs in Spring Cloud

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -s .settings.xml -P spring
+-DaltSnapshotDeploymentRepository=repo.spring.io::default::https://repo.spring.io/libs-snapshot-local -P spring

--- a/.settings.xml
+++ b/.settings.xml
@@ -9,6 +9,12 @@
   </servers>
   <profiles>
 	<profile>
+      <!--
+          N.B. this profile is only here to support users and IDEs that do not use Maven 3.3. 
+          It isn't needed on the command line if you use the wrapper script (mvnw) or if you use 
+          a native Maven with the right version. Eclipse users should points their Maven tooling to
+          this settings file, or copy the profile into their ~/.m2/settings.xml.
+      -->
 	  <id>spring</id>
 	  <activation><activeByDefault>true</activeByDefault></activation>
 	  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 		<!-- Note, latest version is 1.11.2.RELEASE and get a failing test when upgrading -->
 		<spring-data-commons.version>1.9.1.RELEASE</spring-data-commons.version>
 		<spring-cloud-dataflow-ui.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
-		<spring-shell.version>1.2.0.M1</spring-shell.version>
 		<spring-cloud-stream.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-task.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-task.version>
 		<spring-cloud-commons.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
@@ -54,6 +53,19 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-configuration-metadata</artifactId>
 				<version>${spring-cloud-stream-configuration-metadata.version}</version>
+			</dependency>
+				<!-- TODO: remove this (it should be in stream modules BOM) -->
+			<dependency>
+				<groupId>org.springframework.cloud.stream.module</groupId>
+				<artifactId>spring-cloud-stream-modules-analytics</artifactId>
+				<version>1.0.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-dependencies</artifactId>
+				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,12 @@
 		<!-- Note, latest version is 1.11.2.RELEASE and get a failing test when upgrading -->
 		<spring-data-commons.version>1.9.1.RELEASE</spring-data-commons.version>
 		<spring-cloud-dataflow-ui.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
-		<spring-cloud-stream-configuration-metadata.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-stream-configuration-metadata.version>
 		<spring-shell.version>1.2.0.M1</spring-shell.version>
-		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
-		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
+		<spring-cloud-stream.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-task.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-task.version>
+		<spring-cloud-commons.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-config.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-config.version>
+		<spring-cloud-stream-configuration-metadata.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-stream-configuration-metadata.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-artifact-registry</module>
@@ -49,29 +50,45 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<!-- TODO: remove this (it should be in stream BOM) -->
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-configuration-metadata</artifactId>
+				<version>${spring-cloud-stream-configuration-metadata.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-parent</artifactId>
+				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${spring-boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>${spring-cloud.version}</version>
+				<artifactId>spring-cloud-stream-dependencies</artifactId>
+				<version>${spring-cloud-stream.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.cloudfoundry</groupId>
-				<artifactId>cloudfoundry-client-lib</artifactId>
-				<version>${cloudfoundry-client-lib.version}</version>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-commons-dependencies</artifactId>
+				<version>${spring-cloud-commons.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
-			<!-- To be moved to bom -->
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-configuration-metadata</artifactId>
-				<version>${spring-cloud-stream-configuration-metadata.version}</version>
+				<artifactId>spring-cloud-config-dependencies</artifactId>
+				<version>${spring-cloud-config.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-task-dependencies</artifactId>
+				<version>${spring-cloud-task.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-admin-local/pom.xml
+++ b/spring-cloud-dataflow-admin-local/pom.xml
@@ -17,7 +17,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-admin-starter/pom.xml
+++ b/spring-cloud-dataflow-admin-starter/pom.xml
@@ -12,32 +12,26 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-configuration-metadata</artifactId>
-			<version>${spring-cloud-stream-configuration-metadata.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-completion</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-artifact-registry</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-module-deployer-spi</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -58,7 +52,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-ui</artifactId>
-			<version>${spring-cloud-dataflow-ui.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -75,7 +68,6 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
-			<version>${spring-data-commons.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -88,7 +80,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud.stream.module</groupId>
 			<artifactId>spring-cloud-stream-modules-analytics</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -98,7 +89,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>${spring-cloud-task.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.skyscreamer</groupId>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -15,18 +15,69 @@
 	<description>Spring Cloud Data Flow Dependencies BOM designed to support consumption of Spring Cloud Data Flow from the Spring Initializr.</description>
 	<properties>
 		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
+		<spring-shell.version>1.2.0.M1</spring-shell.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-completion</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-core</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-rest-client</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-artifact-registry</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-module-deployer-spi</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-ui</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-admin-local</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.cloudfoundry</groupId>
 				<artifactId>cloudfoundry-client-lib</artifactId>
 				<version>${cloudfoundry-client-lib.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
-				<version>${project.version}</version>
+				<groupId>org.springframework.shell</groupId>
+				<artifactId>spring-shell</artifactId>
+				<version>${spring-shell.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -2,10 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<!--
-		NB: This BOM is designed to support consumption of Spring Cloud Data Flow
-		from the <a href="http://start.spring.io">Spring Initializr</a>.
- 	-->
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
@@ -18,16 +14,14 @@
 	<name>spring-cloud-dataflow-dependencies</name>
 	<description>Spring Cloud Data Flow Dependencies BOM designed to support consumption of Spring Cloud Data Flow from the Spring Initializr.</description>
 	<properties>
-		<spring-cloud-commons.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-commons-dependencies</artifactId>
-				<version>${spring-cloud-commons.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
+				<groupId>org.cloudfoundry</groupId>
+				<artifactId>cloudfoundry-client-lib</artifactId>
+				<version>${cloudfoundry-client-lib.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-module-deployer-spi/pom.xml
+++ b/spring-cloud-dataflow-module-deployer-spi/pom.xml
@@ -9,7 +9,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -17,7 +17,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.plugin</groupId>

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -28,7 +28,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.hateoas</groupId>

--- a/spring-cloud-dataflow-shell/pom.xml
+++ b/spring-cloud-dataflow-shell/pom.xml
@@ -17,12 +17,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-client</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.shell</groupId>
 			<artifactId>spring-shell</artifactId>
-			<version>${spring-shell.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +50,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-admin-local</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-starter-dataflow-server-local/pom.xml
+++ b/spring-cloud-starter-dataflow-server-local/pom.xml
@@ -18,12 +18,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-admin-local</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
To allow users to manage dependencies in application projects
for data flow and the rest of Spring Cloud independently, we
need to clean up the BOM a bit and use the Cloud BOMs individually
in the libraries in data flow.

Also fixes the wrapper configuration so Maven can be used on the
command line to do a manual deployment.