### PR TITLE
Disable management security by default

### DIFF
--- a/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
+++ b/spring-cloud-dataflow-admin-local/src/main/resources/admin.yml
@@ -2,6 +2,8 @@ server:
   port: 9393
 management:
   contextPath: /management
+  security:
+    enabled: false
 info:
   app:
     name: "@project.artifactId@"


### PR DESCRIPTION
 - Set `management.security.enabled` to `false` to disable actuator endpoints by default

This resolves #360