### PR TITLE
Set appropriate shutdown URL for in-process deployer

### DIFF
--- a/spring-cloud-dataflow-admin-local/pom.xml
+++ b/spring-cloud-dataflow-admin-local/pom.xml
@@ -35,7 +35,6 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>META-INF/spring.factories</include>
-					<include>admin.yml</include>
 					<include>banner.txt</include>
 				</includes>
 			</resource>

--- a/spring-cloud-dataflow-admin-local/pom.xml
+++ b/spring-cloud-dataflow-admin-local/pom.xml
@@ -34,6 +34,7 @@
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 				<includes>
+					<include>admin.yml</include>
 					<include>META-INF/spring.factories</include>
 					<include>banner.txt</include>
 				</includes>

--- a/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalDeployerAutoConfiguration.java
+++ b/spring-cloud-dataflow-admin-local/src/main/java/org/springframework/cloud/dataflow/admin/spi/local/LocalDeployerAutoConfiguration.java
@@ -47,12 +47,9 @@ public class LocalDeployerAutoConfiguration {
 	@Import(ModuleLauncherConfiguration.class)
 	public static class InProcess {
 
-		@Value("${management.contextPath}")
-		private String contextPath;
-
 		@Bean
 		public ModuleDeployer processModuleDeployer(ModuleLauncher moduleLauncher) {
-			return new InProcessModuleDeployer(moduleLauncher, this.contextPath);
+			return new InProcessModuleDeployer(moduleLauncher);
 		}
 
 		@Bean

--- a/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/AdminDefaultTestEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/AdminDefaultTestEnvironmentPostProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.admin.spi.local;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+public class AdminDefaultTestEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		if (environment.getPropertySources().contains("defaultProperties")) {
+			environment.getPropertySources().remove("defaultProperties");
+		}
+	}
+}

--- a/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/InProcessModuleDeployerTests.java
+++ b/spring-cloud-dataflow-admin-local/src/test/java/org/springframework/cloud/dataflow/admin/spi/local/InProcessModuleDeployerTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.admin.spi.local;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.dataflow.module.deployer.ModuleDeployer;
 import org.springframework.cloud.dataflow.module.deployer.test.AbstractModuleDeployerTests;
@@ -27,7 +27,6 @@ import org.springframework.cloud.stream.module.launcher.ModuleLauncherConfigurat
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.env.Environment;
 
 /**
  * Integration tests for the {@link InProcessModuleDeployer}.
@@ -56,12 +55,9 @@ public class InProcessModuleDeployerTests extends AbstractModuleDeployerTests {
 	@Import(ModuleLauncherConfiguration.class)
 	public static class Config {
 
-		@Autowired
-		private Environment environment;
-
 		@Bean
 		ModuleDeployer moduleDeployer(ModuleLauncher moduleLauncher) {
-			return new InProcessModuleDeployer(moduleLauncher, this.environment.getProperty("management.contextPath"));
+			return new InProcessModuleDeployer(moduleLauncher);
 		}
 
 	}

--- a/spring-cloud-dataflow-admin-local/src/test/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-admin-local/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.springframework.cloud.dataflow.admin.spi.local.AdminDefaultTestEnvironmentPostProcessor

--- a/spring-cloud-dataflow-admin-starter/pom.xml
+++ b/spring-cloud-dataflow-admin-starter/pom.xml
@@ -125,7 +125,6 @@
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 				<includes>
-					<include>admin.yml</include>
 					<include>META-INF/spring.factories</include>
 					<include>banner.txt</include>
 				</includes>


### PR DESCRIPTION
 - The modules deployed by the in-process deployer should not use `managementContextPath` from the deployer environment.
The modules are supposed to have their own environment. Currently, the inclusion of `spring-cloud-dataflow-admin-starter` classes directory in the module launcher
classloader results in invoking `AdminDefaultEnvironmentPostProcessor` which in turn sets up `defaultProperties` environment from the deployer itself.
 - This also means that the modules can not be undeployed when using in-process deployer because of the incorrect shutdown URL

This resolves #362