### PR TITLE
Register TapOnChannelExpansionStrategy appropriately

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/completion/TapOnChannelRecoveryStrategy.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/completion/TapOnChannelRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.admin.completion;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.admin.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.completion.CompletionProposal;
 import org.springframework.cloud.dataflow.completion.RecoveryStrategy;
@@ -33,11 +32,15 @@ import org.springframework.cloud.dataflow.core.dsl.ParseException;
  * <p>Lives in this package as it needs access to a {@link StreamDefinitionRepository}.</p>
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
-public class TapOnChannelExpansionStrategy implements RecoveryStrategy<ParseException> {
+public class TapOnChannelRecoveryStrategy implements RecoveryStrategy<ParseException> {
 
-	@Autowired
-	private StreamDefinitionRepository streamDefinitionRepository;
+	private final StreamDefinitionRepository streamDefinitionRepository;
+
+	public TapOnChannelRecoveryStrategy(StreamDefinitionRepository streamDefinitionRepository) {
+		this.streamDefinitionRepository = streamDefinitionRepository;
+	}
 
 	@Override
 	public boolean shouldTrigger(String dslStart, Exception exception) {

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.springframework.cloud.dataflow.completion;
 
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Import;
 /**
  * Include this Configuration class to expose a fully configured {@link StreamCompletionProvider}.
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @Import({ModuleResolverConfiguration.class, ModuleConfigurationMetadataResolverAutoConfiguration.class})
@@ -51,24 +52,22 @@ public class CompletionConfiguration {
 	@Bean
 	@SuppressWarnings("unchecked")
 	public StreamCompletionProvider streamCompletionProvider() {
-		List<RecoveryStrategy<?>> recoveryStrategies = Arrays.<RecoveryStrategy<?>>asList(
-				emptyStartYieldsModulesRecoveryStrategy(),
-				expandOneDashToTwoDashesRecoveryStrategy(),
-				configurationPropertyNameAfterDashDashRecoveryStrategy(),
-				unfinishedConfigurationPropertyNameRecoveryStrategy(),
-				channelNameYieldsModulesRecoveryStrategy(),
-				modulesAfterPipeRecoveryStrategy(),
-				configurationPropertyValueHintRecoveryStrategy()
+		List<RecoveryStrategy<?>> recoveryStrategies = new ArrayList<>();
+		recoveryStrategies.add(emptyStartYieldsModulesRecoveryStrategy());
+		recoveryStrategies.add(expandOneDashToTwoDashesRecoveryStrategy());
+		recoveryStrategies.add(configurationPropertyNameAfterDashDashRecoveryStrategy());
+		recoveryStrategies.add(unfinishedConfigurationPropertyNameRecoveryStrategy());
+		recoveryStrategies.add(channelNameYieldsModulesRecoveryStrategy());
+		recoveryStrategies.add(modulesAfterPipeRecoveryStrategy());
+		recoveryStrategies.add(configurationPropertyValueHintRecoveryStrategy());
 
-		);
-		List<ExpansionStrategy> expansionStrategies = Arrays.asList(
-				addModuleOptionsExpansionStrategy(),
-				pipeIntoOtherModulesExpansionStrategy(),
-				unfinishedModuleNameExpansionStrategy(),
-				// Make sure this one runs last, as it may clear already computed proposals
-				// and return its own as the sole candidates
-				configurationPropertyValueHintExpansionStrategy()
-		);
+		List<ExpansionStrategy> expansionStrategies = new ArrayList<>();
+		expansionStrategies.add(addModuleOptionsExpansionStrategy());
+		expansionStrategies.add(pipeIntoOtherModulesExpansionStrategy());
+		expansionStrategies.add(unfinishedModuleNameExpansionStrategy());
+		// Make sure this one runs last, as it may clear already computed proposals
+		// and return its own as the sole candidates
+		expansionStrategies.add(configurationPropertyValueHintExpansionStrategy());
 		return new StreamCompletionProvider(recoveryStrategies, expansionStrategies);
 	}
 

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/StreamCompletionProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/StreamCompletionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.cloud.dataflow.core.StreamDefinition;
  * Provides code completion on a (maybe ill-formed) stream definition.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public class StreamCompletionProvider {
 
@@ -67,5 +68,9 @@ public class StreamCompletionProvider {
 			strategy.addProposals(dslStart, parsed, detailLevel, collector);
 		}
 		return collector;
+	}
+
+	public void addCompletionRecoveryStrategy(RecoveryStrategy recoveryStrategy) {
+		this.completionRecoveryStrategies.add(recoveryStrategy);
 	}
 }


### PR DESCRIPTION
 - Since this bean is made conditional, the exact type needs to be specified as there are few other beans with the same interface type exist
 - Need to explicitly `add` this bean to the StreamCompletionProvider
 - Rename `TapOnChannelExpansionStrategy` to `TapOnChannelRecoveryStrategy`

This resolves #371