### PR TITLE
Rename channel -> destination in StreamParser

### DIFF
--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/completion/TapOnDestinationRecoveryStrategy.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/completion/TapOnDestinationRecoveryStrategy.java
@@ -27,18 +27,18 @@ import org.springframework.cloud.dataflow.core.dsl.DSLMessage;
 import org.springframework.cloud.dataflow.core.dsl.ParseException;
 
 /**
- * Expands constructs that start with {@literal tap:stream} to add stream and maybe module identifiers.
+ * Expands constructs that start with {@literal :} to add stream name and module identifiers.
  *
  * <p>Lives in this package as it needs access to a {@link StreamDefinitionRepository}.</p>
  *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
-public class TapOnChannelRecoveryStrategy implements RecoveryStrategy<ParseException> {
+public class TapOnDestinationRecoveryStrategy implements RecoveryStrategy<ParseException> {
 
 	private final StreamDefinitionRepository streamDefinitionRepository;
 
-	public TapOnChannelRecoveryStrategy(StreamDefinitionRepository streamDefinitionRepository) {
+	public TapOnDestinationRecoveryStrategy(StreamDefinitionRepository streamDefinitionRepository) {
 		this.streamDefinitionRepository = streamDefinitionRepository;
 	}
 

--- a/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
+++ b/spring-cloud-dataflow-admin-starter/src/main/java/org/springframework/cloud/dataflow/admin/config/AdminConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.autoconfigure.security.oauth2.OAuth2AutoConfiguration;
 import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.dataflow.admin.completion.TapOnChannelRecoveryStrategy;
+import org.springframework.cloud.dataflow.admin.completion.TapOnDestinationRecoveryStrategy;
 import org.springframework.cloud.dataflow.admin.controller.StreamDefinitionController;
 import org.springframework.cloud.dataflow.admin.repository.InMemoryStreamDefinitionRepository;
 import org.springframework.cloud.dataflow.admin.repository.InMemoryTaskDefinitionRepository;
@@ -163,9 +163,9 @@ public class AdminConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(TapOnChannelRecoveryStrategy.class)
-	public RecoveryStrategy<?> tapOnChannelExpansionStrategy() {
-		RecoveryStrategy<?> recoveryStrategy = new TapOnChannelRecoveryStrategy(streamDefinitionRepository());
+	@ConditionalOnMissingBean(TapOnDestinationRecoveryStrategy.class)
+	public RecoveryStrategy<?> tapOnDestinationExpansionStrategy() {
+		RecoveryStrategy<?> recoveryStrategy = new TapOnDestinationRecoveryStrategy(streamDefinitionRepository());
 		if (this.streamCompletionProvider != null) {
 			this.streamCompletionProvider.addCompletionRecoveryStrategy(recoveryStrategy);
 		}

--- a/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-admin-starter/src/test/java/org/springframework/cloud/dataflow/admin/controller/StreamControllerTests.java
@@ -205,7 +205,7 @@ public class StreamControllerTests {
 	}
 
 	@Test
-	public void testSourceChannelWithSingleModule() throws Exception {
+	public void testSourceDestinationWithSingleModule() throws Exception {
 		assertEquals(0, repository.count());
 		String definition = ":foo > log";
 		mockMvc.perform(
@@ -225,7 +225,7 @@ public class StreamControllerTests {
 	}
 
 	@Test
-	public void testSourceChannelWithTwoModules() throws Exception {
+	public void testSourceDestinationWithTwoModules() throws Exception {
 		assertEquals(0, repository.count());
 		String definition = ":foo > filter | log";
 		mockMvc.perform(
@@ -251,7 +251,7 @@ public class StreamControllerTests {
 	}
 
 	@Test
-	public void testSinkChannelWithSingleModule() throws Exception {
+	public void testSinkDestinationWithSingleModule() throws Exception {
 		assertEquals(0, repository.count());
 		String definition = "time > :foo";
 		mockMvc.perform(
@@ -269,7 +269,7 @@ public class StreamControllerTests {
 	}
 
 	@Test
-	public void testSinkChannelWithTwoModules() throws Exception {
+	public void testSinkDestinationWithTwoModules() throws Exception {
 		assertEquals(0, repository.count());
 		String definition = "time | filter > :foo";
 		mockMvc.perform(
@@ -293,7 +293,7 @@ public class StreamControllerTests {
 	}
 
 	@Test
-	public void testChannelsOnBothSides() throws Exception {
+	public void testDestinationsOnBothSides() throws Exception {
 		assertEquals(0, repository.count());
 		String definition = ":bar > filter > :foo";
 		mockMvc.perform(

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -57,7 +57,7 @@ public class CompletionConfiguration {
 				expandOneDashToTwoDashesRecoveryStrategy(),
 				configurationPropertyNameAfterDashDashRecoveryStrategy(),
 				unfinishedConfigurationPropertyNameRecoveryStrategy(),
-				channelNameYieldsModulesRecoveryStrategy(),
+				destinationNameYieldsModulesRecoveryStrategy(),
 				modulesAfterPipeRecoveryStrategy(),
 				configurationPropertyValueHintRecoveryStrategy()
 		);
@@ -101,8 +101,8 @@ public class CompletionConfiguration {
 	}
 
 	@Bean
-	public RecoveryStrategy channelNameYieldsModulesRecoveryStrategy() {
-		return new ChannelNameYieldsModulesRecoveryStrategy(artifactRegistry);
+	public RecoveryStrategy destinationNameYieldsModulesRecoveryStrategy() {
+		return new DestinationNameYieldsModulesRecoveryStrategy(artifactRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DestinationNameYieldsModulesRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DestinationNameYieldsModulesRecoveryStrategy.java
@@ -25,16 +25,16 @@ import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistration
 import org.springframework.cloud.dataflow.artifact.registry.ArtifactRegistry;
 
 /**
- * Proposes module names when the user has typed a named channel redirection.
+ * Proposes module names when the user has typed a destination redirection.
  *
  * @author Eric Bottard
  */
-class ChannelNameYieldsModulesRecoveryStrategy extends
+class DestinationNameYieldsModulesRecoveryStrategy extends
 		StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
 
 	private final ArtifactRegistry artifactRegistry;
 
-	public ChannelNameYieldsModulesRecoveryStrategy(ArtifactRegistry artifactRegistry) {
+	public DestinationNameYieldsModulesRecoveryStrategy(ArtifactRegistry artifactRegistry) {
 		super(CheckPointedParseException.class, "queue:foo >", "queue:foo > ");
 		this.artifactRegistry = artifactRegistry;
 	}
@@ -45,7 +45,7 @@ class ChannelNameYieldsModulesRecoveryStrategy extends
 			return false;
 		}
 		// Cast is safe from call to super.
-		// Backtracking would return even before the named channel
+		// Backtracking would return even before the destination
 		return ((CheckPointedParseException)exception).getExpressionStringUntilCheckpoint().trim().isEmpty();
 	}
 
@@ -56,7 +56,7 @@ class ChannelNameYieldsModulesRecoveryStrategy extends
 		for (ArtifactRegistration moduleRegistration : artifactRegistry.findAll()) {
 			if (moduleRegistration.getType() == processor || moduleRegistration.getType() == sink) {
 				proposals.add(completionFactory.withSeparateTokens(moduleRegistration.getName(),
-						"Wire named channel into a " + moduleRegistration.getType() + " module"));
+						"Wire destination into a " + moduleRegistration.getType() + " module"));
 			}
 		}
 	}

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -175,7 +175,7 @@ public class StreamCompletionProviderTests {
 
 	@Test
 	// queue:foo > <TAB>  ==> add module names
-	public void testNamedChannelIntoModules() {
+	public void testDestinationIntoModules() {
 		assertThat(completionProvider.complete("queue:foo >", 1), hasItems(
 				proposalThat(is("queue:foo > filter")),
 				proposalThat(is("queue:foo > log"))
@@ -187,7 +187,7 @@ public class StreamCompletionProviderTests {
 
 	@Test
 	// tap:stream:foo > <TAB>  ==> add module names
-	public void testNamedChannelIntoModulesVariant() {
+	public void testDestinationIntoModulesVariant() {
 		assertThat(completionProvider.complete("tap:stream:foo >", 1), hasItems(
 				proposalThat(is("tap:stream:foo > filter")),
 				proposalThat(is("tap:stream:foo > log"))

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -98,15 +98,15 @@ class ModuleDefinitionBuilder {
 			}
 			builders.add(builder);
 		}
-		SourceDestinationNode sourceChannel = streamNode.getSourceDestinationNode();
-		if (sourceChannel != null) {
-			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY, sourceChannel.getDestinationName());
+		SourceDestinationNode sourceDestination = streamNode.getSourceDestinationNode();
+		if (sourceDestination != null) {
+			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY, sourceDestination.getDestinationName());
 			builders.getLast().setParameter(BindingProperties.INPUT_GROUP_KEY, streamName);
 			builders.getLast().setParameter(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY, "true");
 		}
-		SinkDestinationNode sinkChannel = streamNode.getSinkDestinationNode();
-		if (sinkChannel != null) {
-			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY, sinkChannel.getDestinationName());
+		SinkDestinationNode sinkDestination = streamNode.getSinkDestinationNode();
+		if (sinkDestination != null) {
+			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY, sinkDestination.getDestinationName());
 		}
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(builders.size());
 		for (ModuleDefinition.Builder builder : builders) {

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ModuleDefinitionBuilder.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import org.springframework.cloud.dataflow.core.dsl.ArgumentNode;
 import org.springframework.cloud.dataflow.core.dsl.ModuleNode;
-import org.springframework.cloud.dataflow.core.dsl.SinkChannelNode;
-import org.springframework.cloud.dataflow.core.dsl.SourceChannelNode;
+import org.springframework.cloud.dataflow.core.dsl.SinkDestinationNode;
+import org.springframework.cloud.dataflow.core.dsl.SourceDestinationNode;
 import org.springframework.cloud.dataflow.core.dsl.StreamNode;
 import org.springframework.util.Assert;
 
@@ -98,15 +98,15 @@ class ModuleDefinitionBuilder {
 			}
 			builders.add(builder);
 		}
-		SourceChannelNode sourceChannel = streamNode.getSourceChannelNode();
+		SourceDestinationNode sourceChannel = streamNode.getSourceDestinationNode();
 		if (sourceChannel != null) {
-			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY, sourceChannel.getChannelName());
+			builders.getLast().setParameter(BindingProperties.INPUT_BINDING_KEY, sourceChannel.getDestinationName());
 			builders.getLast().setParameter(BindingProperties.INPUT_GROUP_KEY, streamName);
 			builders.getLast().setParameter(BindingProperties.INPUT_DURABLE_SUBSCRIPTION_KEY, "true");
 		}
-		SinkChannelNode sinkChannel = streamNode.getSinkChannelNode();
+		SinkDestinationNode sinkChannel = streamNode.getSinkDestinationNode();
 		if (sinkChannel != null) {
-			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY, sinkChannel.getChannelName());
+			builders.getFirst().setParameter(BindingProperties.OUTPUT_BINDING_KEY, sinkChannel.getDestinationName());
 		}
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(builders.size());
 		for (ModuleDefinition.Builder builder : builders) {

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
@@ -90,7 +90,7 @@ public enum DSLMessage {
 	NO_WHITESPACE_IN_DOTTED_NAME(ERROR,
 			145,
 			"no whitespace is allowed between dot and components of a name"),
-	NAMED_DESTINATIONS_UNSUPPORTED_HERE(ERROR, 146, "a named destination is not supported in this kind of definition"),
+	DESTINATIONS_UNSUPPORTED_HERE(ERROR, 146, "a destination is not supported in this kind of definition"),
 	EXPECTED_WHITESPACE_AFTER_LABEL_COLON(ERROR, 147, "whitespace is expected after a moudle label"), //
 	;
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
@@ -66,21 +66,20 @@ public enum DSLMessage {
 			"ambiguous module name ''{0}'' in stream named ''{1}'', appears at both position {2} and {3}"), //
 	STREAM_NAME_MATCHING_MODULE_NAME(ERROR, 130,
 			"Stream name ''{0}'' same as that of its modules' names is not allowed."), //
-	CHANNEL_INDEXING_NOT_ALLOWED(ERROR, 131, "Channel does not support indexing"), //
-	EXPECTED_CHANNEL_PREFIX(ERROR, 133, "Expected channel prefix but found ''{0}''"), //
-	CANNOT_USE_COMPOSEDMODULE_HERE_AS_IT_DEFINES_SOURCE_CHANNEL(ERROR,
+	CANNOT_USE_COMPOSEDMODULE_HERE_AS_IT_DEFINES_SOURCE_DESTINATION(ERROR,
 			135,
-			"cannot use composed module ''{0}'' here because it defines a source channel"), //
-	CANNOT_USE_COMPOSEDMODULE_HERE_AS_IT_DEFINES_SINK_CHANNEL(ERROR,
+			"cannot use composed module ''{0}'' here because it defines a source destination"), //
+	CANNOT_USE_COMPOSEDMODULE_HERE_AS_IT_DEFINES_SINK_DESTINATION(ERROR,
 			136,
-			"cannot use composed module ''{0}'' here because it defines a sink channel"), //
-	CANNOT_USE_COMPOSEDMODULE_HERE_ALREADY_HAS_SOURCE_CHANNEL(ERROR,
+			"cannot use composed module ''{0}'' here because it defines a sink destination"), //
+	CANNOT_USE_COMPOSEDMODULE_HERE_ALREADY_HAS_SOURCE_DESTINATION(ERROR,
 			137,
-			"cannot use composed module ''{0}'' here, both that composed module and this stream define a source channel"), //
-	CANNOT_USE_COMPOSEDMODULE_HERE_ALREADY_HAS_SINK_CHANNEL(ERROR,
+			"cannot use composed module ''{0}'' here, both that composed module and this stream define a source destination"), //
+	CANNOT_USE_COMPOSEDMODULE_HERE_ALREADY_HAS_SINK_DESTINATION(ERROR,
 			138,
-			"cannot use composed module ''{0}'' here, both that composed module and this stream define a sink channel"), //
-	NO_WHITESPACE_IN_CHANNEL_DEFINITION(ERROR, 139, "no whitespace allowed between components in a channel name"), //
+			"cannot use composed module ''{0}'' here, both that composed module and this stream define a sink destination"), //
+	EXPECTED_DESTINATION_PREFIX(ERROR, 133, "Expected destination prefix but found ''{0}''"), //
+	NO_WHITESPACE_IN_DESTINATION_DEFINITION(ERROR, 139, "no whitespace allowed between components in a destination name"), //
 	NO_WHITESPACE_BETWEEN_LABEL_NAME_AND_COLON(ERROR, 140, "no whitespace allowed between label name and colon"), //
 	DUPLICATE_LABEL(ERROR,
 			143,
@@ -91,7 +90,7 @@ public enum DSLMessage {
 	NO_WHITESPACE_IN_DOTTED_NAME(ERROR,
 			145,
 			"no whitespace is allowed between dot and components of a name"),
-	NAMED_CHANNELS_UNSUPPORTED_HERE(ERROR, 146, "a named channel is not supported in this kind of definition"),
+	NAMED_DESTINATIONS_UNSUPPORTED_HERE(ERROR, 146, "a named destination is not supported in this kind of definition"),
 	EXPECTED_WHITESPACE_AFTER_LABEL_COLON(ERROR, 147, "whitespace is expected after a moudle label"), //
 	;
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DestinationNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DestinationNode.java
@@ -24,11 +24,11 @@ import java.util.List;
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
  */
-public class ChannelNode extends AstNode {
+public class DestinationNode extends AstNode {
 
 	private List<String> nameComponents;
 
-	public ChannelNode(int startPos, int endPos, List<String> nameComponents) {
+	public DestinationNode(int startPos, int endPos, List<String> nameComponents) {
 		super(startPos, endPos);
 		this.nameComponents = nameComponents;
 	}
@@ -37,7 +37,7 @@ public class ChannelNode extends AstNode {
 	public String stringify(boolean includePositionalInfo) {
 		StringBuilder s = new StringBuilder();
 		s.append("(");
-		s.append(getChannelName());
+		s.append(getDestinationName());
 		if (includePositionalInfo) {
 			s.append(":");
 			s.append(getStartPos()).append(">").append(getEndPos());
@@ -48,10 +48,10 @@ public class ChannelNode extends AstNode {
 
 	@Override
 	public String toString() {
-		return getChannelName();
+		return getDestinationName();
 	}
 
-	String getChannelName() {
+	String getDestinationName() {
 		StringBuilder s = new StringBuilder();
 		for (int t = 0, max = nameComponents.size(); t < max; t++) {
 			if (t != 0) {
@@ -62,7 +62,7 @@ public class ChannelNode extends AstNode {
 		return s.toString();
 	}
 
-	public ChannelNode copyOf() {
-		return new ChannelNode(super.startPos, super.endPos, nameComponents);
+	public DestinationNode copyOf() {
+		return new DestinationNode(super.startPos, super.endPos, nameComponents);
 	}
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SinkDestinationNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SinkDestinationNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,36 +19,36 @@ package org.springframework.cloud.dataflow.core.dsl;
 /**
  * @author Andy Clement
  */
-public class SinkChannelNode extends AstNode {
+public class SinkDestinationNode extends AstNode {
 
-	private final ChannelNode channelNode;
+	private final DestinationNode destinationNode;
 
-	public SinkChannelNode(ChannelNode channelNode, int startPos) {
-		super(startPos, channelNode.endPos);
-		this.channelNode = channelNode;
+	public SinkDestinationNode(DestinationNode destinationNode, int startPos) {
+		super(startPos, destinationNode.endPos);
+		this.destinationNode = destinationNode;
 	}
 
 	/** @inheritDoc */
 	@Override
 	public String stringify(boolean includePositionalInfo) {
-		return ">" + channelNode.stringify(includePositionalInfo);
+		return ">" + destinationNode.stringify(includePositionalInfo);
 	}
 
 	@Override
 	public String toString() {
-		return " > " + channelNode.toString();
+		return " > " + destinationNode.toString();
 	}
 
-	public ChannelNode getChannelNode() {
-		return channelNode;
+	public DestinationNode getDestinationNode() {
+		return destinationNode;
 	}
 
-	public String getChannelName() {
-		return channelNode.getChannelName();
+	public String getDestinationName() {
+		return destinationNode.getDestinationName();
 	}
 
-	public SinkChannelNode copyOf() {
-		return new SinkChannelNode(channelNode.copyOf(), super.startPos);
+	public SinkDestinationNode copyOf() {
+		return new SinkDestinationNode(destinationNode.copyOf(), super.startPos);
 	}
 
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SourceDestinationNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SourceDestinationNode.java
@@ -19,36 +19,36 @@ package org.springframework.cloud.dataflow.core.dsl;
 /**
  * @author Andy Clement
  */
-public class SourceChannelNode extends AstNode {
+public class SourceDestinationNode extends AstNode {
 
-	private final ChannelNode channelNode;
+	private final DestinationNode destinationNode;
 
-	public SourceChannelNode(ChannelNode channelNode, int endPos) {
-		super(channelNode.startPos, endPos);
-		this.channelNode = channelNode;
+	public SourceDestinationNode(DestinationNode destinationNode, int endPos) {
+		super(destinationNode.startPos, endPos);
+		this.destinationNode = destinationNode;
 	}
 
 	/** @inheritDoc */
 	@Override
 	public String stringify(boolean includePositionalInfo) {
-		return channelNode.stringify(includePositionalInfo) + ">";
+		return destinationNode.stringify(includePositionalInfo) + ">";
 	}
 
 	@Override
 	public String toString() {
-		return channelNode.toString() + " > ";
+		return destinationNode.toString() + " > ";
 	}
 
-	public ChannelNode getChannelNode() {
-		return channelNode;
+	public DestinationNode getDestinationNode() {
+		return destinationNode;
 	}
 
-	public SourceChannelNode copyOf() {
-		return new SourceChannelNode(channelNode.copyOf(), super.endPos);
+	public SourceDestinationNode copyOf() {
+		return new SourceDestinationNode(destinationNode.copyOf(), super.endPos);
 	}
 
-	public String getChannelName() {
-		return channelNode.getChannelName();
+	public String getDestinationName() {
+		return destinationNode.getDestinationName();
 	}
 
 }

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamNode.java
@@ -29,18 +29,18 @@ public class StreamNode extends AstNode {
 
 	private final List<ModuleNode> moduleNodes;
 
-	private SourceChannelNode sourceChannelNode;
+	private SourceDestinationNode sourceDestinationNode;
 
-	private SinkChannelNode sinkChannelNode;
+	private SinkDestinationNode sinkDestinationNode;
 
 	public StreamNode(String streamText, String streamName, List<ModuleNode> moduleNodes,
-			SourceChannelNode sourceChannelNode, SinkChannelNode sinkChannelNode) {
+			SourceDestinationNode sourceDestinationNode, SinkDestinationNode sinkDestinationNode) {
 		super(moduleNodes.get(0).getStartPos(), moduleNodes.get(moduleNodes.size() - 1).getEndPos());
 		this.streamText = streamText;
 		this.streamName = streamName;
 		this.moduleNodes = moduleNodes;
-		this.sourceChannelNode = sourceChannelNode;
-		this.sinkChannelNode = sinkChannelNode;
+		this.sourceDestinationNode = sourceDestinationNode;
+		this.sinkDestinationNode = sinkDestinationNode;
 	}
 
 	/** @inheritDoc */
@@ -52,14 +52,14 @@ public class StreamNode extends AstNode {
 		if (getStreamName() != null) {
 			s.append(getStreamName()).append(" = ");
 		}
-		if (sourceChannelNode != null) {
-			s.append(sourceChannelNode.stringify(includePositionalInfo));
+		if (sourceDestinationNode != null) {
+			s.append(sourceDestinationNode.stringify(includePositionalInfo));
 		}
 		for (ModuleNode moduleNode : moduleNodes) {
 			s.append(moduleNode.stringify(includePositionalInfo));
 		}
-		if (sinkChannelNode != null) {
-			s.append(sinkChannelNode.stringify(includePositionalInfo));
+		if (sinkDestinationNode != null) {
+			s.append(sinkDestinationNode.stringify(includePositionalInfo));
 		}
 		s.append("]");
 		return s.toString();
@@ -71,8 +71,8 @@ public class StreamNode extends AstNode {
 		if (getStreamName() != null) {
 			s.append(getStreamName()).append(" = ");
 		}
-		if (sourceChannelNode != null) {
-			s.append(sourceChannelNode.toString());
+		if (sourceDestinationNode != null) {
+			s.append(sourceDestinationNode.toString());
 		}
 		for (int m = 0; m < moduleNodes.size(); m++) {
 			ModuleNode moduleNode = moduleNodes.get(m);
@@ -81,8 +81,8 @@ public class StreamNode extends AstNode {
 				s.append(" | ");
 			}
 		}
-		if (sinkChannelNode != null) {
-			s.append(sinkChannelNode.toString());
+		if (sinkDestinationNode != null) {
+			s.append(sinkDestinationNode.toString());
 		}
 		return s.toString();
 	}
@@ -91,12 +91,12 @@ public class StreamNode extends AstNode {
 		return moduleNodes;
 	}
 
-	public SourceChannelNode getSourceChannelNode() {
-		return sourceChannelNode;
+	public SourceDestinationNode getSourceDestinationNode() {
+		return sourceDestinationNode;
 	}
 
-	public SinkChannelNode getSinkChannelNode() {
-		return sinkChannelNode;
+	public SinkDestinationNode getSinkDestinationNode() {
+		return sinkDestinationNode;
 	}
 
 	public String getStreamName() {

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -173,13 +173,13 @@ public class StreamDefinitionTests {
 	}
 
 	@Test
-	public void namedChannelsForbiddenInComposedModules() {
+	public void destinationsForbiddenInComposedModules() {
 		try {
 			new StreamDefinition("test", ":foo > boot");
 		}
 		catch (ParseException expected) {
 			assertThat(expected.getMessage(),
-					containsString("A named channel is not supported in this kind of definition"));
+					containsString("A destination is not supported in this kind of definition"));
 			assertThat(expected.getPosition(), is(0));
 		}
 		try {
@@ -187,7 +187,7 @@ public class StreamDefinitionTests {
 		}
 		catch (ParseException expected) {
 			assertThat(expected.getMessage(),
-					containsString("A named channel is not supported in this kind of definition"));
+					containsString("A destination is not supported in this kind of definition"));
 			assertThat(expected.getPosition(), is(13));
 		}
 	}

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -126,7 +126,7 @@ public class StreamDefinitionTests {
 	}
 
 	@Test
-	public void sourceChannelNameIsAppliedToSourceModule() throws Exception {
+	public void sourceDestinationNameIsAppliedToSourceModule() throws Exception {
 		StreamDefinition streamDefinition = new StreamDefinition("test", ":foo > goo | blah | file");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
@@ -135,7 +135,7 @@ public class StreamDefinitionTests {
 	}
 
 	@Test
-	public void sinkChannelNameIsAppliedToSinkModule() throws Exception {
+	public void sinkDestinationNameIsAppliedToSinkModule() throws Exception {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "boo | blah | aaak > :foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(3, requests.size());
@@ -143,7 +143,7 @@ public class StreamDefinitionTests {
 	}
 
 	@Test
-	public void simpleSinkNamedChannel() throws Exception {
+	public void simpleSinkDestination() throws Exception {
 		StreamDefinition streamDefinition = new StreamDefinition("test", "bart > :foo");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());
@@ -163,7 +163,7 @@ public class StreamDefinitionTests {
 	}
 
 	@Test
-	public void simpleSourceNamedChannel() throws Exception {
+	public void simpleSourceDestination() throws Exception {
 		StreamDefinition streamDefinition = new StreamDefinition("test", ":foo > boot");
 		List<ModuleDefinition> requests = streamDefinition.getModuleDefinitions();
 		assertEquals(1, requests.size());

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/StreamParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/StreamParserTests.java
@@ -340,48 +340,48 @@ public class StreamParserTests {
 	}
 
 	@Test
-	public void sourceChannel() {
+	public void sourceDestination() {
 		StreamNode sn = parse(":foobar > file");
 		assertEquals("[(foobar:1>7)>(ModuleNode:file:10>14)]", sn.stringify(true));
 	}
 
 	@Test
-	public void sinkChannel() {
+	public void sinkDestination() {
 		StreamNode sn = parse("http > :foo");
 		assertEquals("[(ModuleNode:http:0>4)>(foo:8>11)]", sn.stringify(true));
 	}
 
 	@Test
-	public void channelVariants() {
+	public void destinationVariants() {
 		checkForParseError("http > :test value", DSLMessage.UNEXPECTED_DATA_AFTER_STREAMDEF, 13);
-		checkForParseError(":boo .xx > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 5);
-		checkForParseError(":boo . xx > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 5);
-		checkForParseError(":boo. xx > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 6);
-		checkForParseError(":boo.xx. yy > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 9);
-		checkForParseError(":boo.xx .yy > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 8);
-		checkForParseError(":boo.xx . yy > file", DSLMessage.NO_WHITESPACE_IN_CHANNEL_DEFINITION, 8);
+		checkForParseError(":boo .xx > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 5);
+		checkForParseError(":boo . xx > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 5);
+		checkForParseError(":boo. xx > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 6);
+		checkForParseError(":boo.xx. yy > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 9);
+		checkForParseError(":boo.xx .yy > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 8);
+		checkForParseError(":boo.xx . yy > file", DSLMessage.NO_WHITESPACE_IN_DESTINATION_DEFINITION, 8);
 
 		sn = parse("wibble: http > :bar");
 		assertEquals("[((Label:wibble) ModuleNode:http)>(bar)]", sn.stringify());
 	}
 
 	@Test
-	public void sourceChannel2() {
+	public void sourceDestination2() {
 		parse("foo = http | bar | file");
 		StreamNode ast = parse(":foo.bar > file");
 		assertEquals("[(foo.bar:1>8)>(ModuleNode:file:11>15)]", ast.stringify(true));
-		assertEquals("foo.bar", ast.getSourceChannelNode().getChannelName());
+		assertEquals("foo.bar", ast.getSourceDestinationNode().getDestinationName());
 	}
 
 	@Test
-	public void sourceTapChannel() {
+	public void sourceTapDestination() {
 		parse("mystream = http | file");
 		StreamNode ast = parse(":mystream.http > file");
 		assertEquals(
 				"[(mystream.http:1>14)>(ModuleNode:file:17>21)]",
 				ast.stringify(true));
-		SourceChannelNode sourceChannelNode = ast.getSourceChannelNode();
-		assertEquals("mystream.http", sourceChannelNode.getChannelName());
+		SourceDestinationNode sourceDestinationNode = ast.getSourceDestinationNode();
+		assertEquals("mystream.http", sourceDestinationNode.getDestinationName());
 	}
 
 	@Test
@@ -415,7 +415,7 @@ public class StreamParserTests {
 
 	@Test
 	public void errorCases07() {
-		checkForParseError("foo > bar", DSLMessage.EXPECTED_CHANNEL_PREFIX, 6, "bar");
+		checkForParseError("foo > bar", DSLMessage.EXPECTED_DESTINATION_PREFIX, 6, "bar");
 		checkForParseError(":foo >", DSLMessage.OOD, 6);
 		checkForParseError(":foo > --2323", DSLMessage.EXPECTED_MODULENAME, 7, "--");
 		checkForParseError(":foo > *", DSLMessage.UNEXPECTED_DATA, 7, "*");
@@ -459,7 +459,7 @@ public class StreamParserTests {
 	public void tapWithLabels() {
 		parse("mystream = http | flibble: transform | file");
 		sn = parse(":mystream.flibble > file");
-		assertEquals("mystream.flibble", sn.getSourceChannelNode().getChannelName());
+		assertEquals("mystream.flibble", sn.getSourceDestinationNode().getDestinationName());
 	}
 
 	@Test


### PR DESCRIPTION
 - All the references to `channel` in the StreamParser now changed to `destination`

This resolves spring-cloud/spring-cloud-dataflow#379