### PR TITLE
Add additional env vars to deployed module

### DIFF
--- a/spring-cloud-dataflow-deployer-local/pom.xml
+++ b/spring-cloud-dataflow-deployer-local/pom.xml
@@ -25,6 +25,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployer.java
@@ -26,8 +26,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,9 +39,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentRequest;
@@ -53,20 +56,22 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 /**
- * A ModuleDeployer implementation that spins off a new JVM process per
- * module instance.
+ * A ModuleDeployer implementation that spins off a new JVM process per module instance.
  * @author Eric Bottard
  * @author Marius Bogoevici
  */
 public class OutOfProcessModuleDeployer implements ModuleDeployer {
-
+	
 	private static final String APP_LAUNCHER = "spring-cloud-dataflow-app-launcher";
 
 	private String moduleLauncherPath;
 
 	private Path logPathRoot;
 
-	private static final Logger logger = LoggerFactory.getLogger(OutOfProcessModuleDeployer.class);
+	private static final Log logger = LogFactory.getLog(OutOfProcessModuleDeployer.class);
+
+	private static final Collection<String> ARRAY_PROPERTIES = new HashSet<>(
+			Arrays.asList("includes", "excludes"));
 
 	private Map<ModuleDeploymentId, List<Instance>> running = new ConcurrentHashMap<>();
 
@@ -80,57 +85,75 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 		String module = request.getCoordinates().toString();
 
-		ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId.fromModuleDefinition(request.getDefinition());
+		ModuleDeploymentId moduleDeploymentId = ModuleDeploymentId
+				.fromModuleDefinition(request.getDefinition());
 		List<Instance> processes = new ArrayList<>();
 		running.put(moduleDeploymentId, processes);
 
-		boolean useDynamicPort = !request.getDefinition().getParameters().containsKey(SERVER_PORT_KEY);
+		boolean useDynamicPort = !request.getDefinition().getParameters()
+				.containsKey(SERVER_PORT_KEY);
 
 		HashMap<String, String> args = new HashMap<>();
 		args.put("modules", request.getCoordinates().toString());
-		args.putAll(ModuleArgumentQualifier.qualifyArgs(0, request.getDefinition().getParameters()));
-		args.putAll(ModuleArgumentQualifier.qualifyArgs(0, request.getDeploymentProperties()));
-		String jmxDomainName = String.format("%s.%s", request.getDefinition().getGroup(), request.getDefinition().getLabel());
-		args.putAll(ModuleArgumentQualifier.qualifyArgs(0, Collections.singletonMap(JMX_DEFAULT_DOMAIN_KEY, jmxDomainName)));
+		@SuppressWarnings("unchecked")
+		Map<String, String> custom = mergeProperties(properties.getSharedArgs(),
+				request.getDefinition().getParameters(),
+				request.getDeploymentProperties());
+		args.putAll(ModuleArgumentQualifier.qualifyArgs(0, custom));
+		String jmxDomainName = String.format("%s.%s", request.getDefinition().getGroup(),
+				request.getDefinition().getLabel());
+		args.putAll(ModuleArgumentQualifier.qualifyArgs(0,
+				Collections.singletonMap(JMX_DEFAULT_DOMAIN_KEY, jmxDomainName)));
 
 		args.put("endpoints.shutdown.enabled", "true");
 		args.put("endpoints.jmx.unique-names", "true");
-
+		args.put("module.name", request.getDefinition().getName());
+		args.put("module.group", request.getDefinition().getGroup());
+		args.put("module.label", request.getDefinition().getLabel());
 
 		try {
-			String groupDeploymentId = request.getDeploymentProperties().get(GROUP_DEPLOYMENT_ID);
+			String groupDeploymentId = request.getDeploymentProperties()
+					.get(GROUP_DEPLOYMENT_ID);
 			if (groupDeploymentId == null) {
-				groupDeploymentId = request.getDefinition().getGroup() + "-" + System.currentTimeMillis();
+				groupDeploymentId = request.getDefinition().getGroup() + "-"
+						+ System.currentTimeMillis();
 			}
-			Path moduleDeploymentGroupDir = Paths.get(logPathRoot.toFile().getAbsolutePath(), groupDeploymentId);
+			Path moduleDeploymentGroupDir = Paths
+					.get(logPathRoot.toFile().getAbsolutePath(), groupDeploymentId);
 			if (!Files.exists(moduleDeploymentGroupDir)) {
 				Files.createDirectory(moduleDeploymentGroupDir);
 				moduleDeploymentGroupDir.toFile().deleteOnExit();
 			}
-			Path workDir = Files.createDirectory(Paths.get(moduleDeploymentGroupDir.toFile().getAbsolutePath(),
-					moduleDeploymentId.toString()));
+			Path workDir = Files.createDirectory(
+					Paths.get(moduleDeploymentGroupDir.toFile().getAbsolutePath(),
+							moduleDeploymentId.toString()));
 			if (properties.isDeleteFilesOnExit()) {
 				workDir.toFile().deleteOnExit();
 			}
 			for (int i = 0; i < request.getCount(); i++) {
-				int port = useDynamicPort ? SocketUtils.findAvailableTcpPort(DEFAULT_SERVER_PORT)
-						: Integer.parseInt(request.getDefinition().getParameters().get(SERVER_PORT_KEY));
+				int port = useDynamicPort
+						? SocketUtils.findAvailableTcpPort(DEFAULT_SERVER_PORT)
+						: Integer.parseInt(request.getDefinition().getParameters()
+								.get(SERVER_PORT_KEY));
 				if (useDynamicPort) {
-					args.putAll(ModuleArgumentQualifier.qualifyArgs(0,
-							Collections.singletonMap(SERVER_PORT_KEY, String.valueOf(port))));
+					args.putAll(ModuleArgumentQualifier.qualifyArgs(0, Collections
+							.singletonMap(SERVER_PORT_KEY, String.valueOf(port))));
 				}
 
-				ProcessBuilder builder = new ProcessBuilder(properties.getJavaCmd(), "-jar", moduleLauncherPath);
+				ProcessBuilder builder = new ProcessBuilder(properties.getJavaCmd(),
+						"-jar", moduleLauncherPath);
 				builder.environment().clear();
 				builder.environment().putAll(args);
 
-				Instance instance = new Instance(moduleDeploymentId, i, builder, workDir, port);
+				Instance instance = new Instance(moduleDeploymentId, i, builder, workDir,
+						port);
 				processes.add(instance);
 				if (properties.isDeleteFilesOnExit()) {
 					instance.stdout.deleteOnExit();
 					instance.stderr.deleteOnExit();
 				}
-				logger.info("deploying module {} instance {}\n   Logs will be in {}", module, i, workDir);
+				logger.info("deploying module " + module + " instance " + i
+						+ "\n   Logs will be in " + workDir);
 
 			}
 		}
@@ -138,8 +161,31 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 			throw new RuntimeException("Exception trying to deploy " + request, e);
 		}
 
-
 		return moduleDeploymentId;
+	}
+
+	private Map<String, String> mergeProperties(
+			@SuppressWarnings("unchecked") Map<String, String>... properties) {
+		Map<String, String> result = new LinkedHashMap<String, String>();
+		for (Map<String, String> item : properties) {
+			for (String key : item.keySet()) {
+				if (ARRAY_PROPERTIES.contains(key)) {
+					String value = result.get(key);
+					if (value != null) {
+						value = value + ",";
+					}
+					else {
+						value = "";
+					}
+					value = value + item.get(key);
+					result.put(key, value);
+				}
+				else {
+					result.put(key, item.get(key));
+				}
+			}
+		}
+		return result;
 	}
 
 	@Override
@@ -157,7 +203,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 	private void shutdownAndWait(Instance instance) {
 		try {
-			restTemplate.postForObject(instance.moduleUrl + "/shutdown", null, String.class);
+			restTemplate.postForObject(instance.moduleUrl + "/shutdown", null,
+					String.class);
 			instance.process.waitFor();
 		}
 		catch (InterruptedException | ResourceAccessException e) {
@@ -191,8 +238,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 	}
 
 	/**
-	 * Copies the module launcher jar somewhere at startup, so that it can be invoked later
-	 * via {@literal java -jar}.
+	 * Copies the module launcher jar somewhere at startup, so that it can be invoked
+	 * later via {@literal java -jar}.
 	 */
 	@PostConstruct
 	public void setup() throws IOException {
@@ -226,19 +273,27 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 
 		private final URL moduleUrl;
 
-		private Instance(ModuleDeploymentId moduleDeploymentId, int instanceNumber, ProcessBuilder builder, Path workDir, int port) throws IOException {
+		private Instance(ModuleDeploymentId moduleDeploymentId, int instanceNumber,
+				ProcessBuilder builder, Path workDir, int port) throws IOException {
 			this.moduleDeploymentId = moduleDeploymentId;
 			this.instanceNumber = instanceNumber;
 			builder.directory(workDir.toFile());
 			String workDirPath = workDir.toFile().getAbsolutePath();
-			this.stdout = Files.createFile(Paths.get(workDirPath, "stdout_" + instanceNumber + ".log")).toFile();
-			this.stderr = Files.createFile(Paths.get(workDirPath, "stderr_" + instanceNumber + ".log")).toFile();
+			this.stdout = Files
+					.createFile(
+							Paths.get(workDirPath, "stdout_" + instanceNumber + ".log"))
+					.toFile();
+			this.stderr = Files
+					.createFile(
+							Paths.get(workDirPath, "stderr_" + instanceNumber + ".log"))
+					.toFile();
 			builder.redirectOutput(this.stdout);
 			builder.redirectError(this.stderr);
 			builder.environment().put("INSTANCE_INDEX", Integer.toString(instanceNumber));
 			this.process = builder.start();
 			this.workDir = workDir.toFile();
-			moduleUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(), port, "");
+			moduleUrl = new URL("http", Inet4Address.getLocalHost().getHostAddress(),
+					port, "");
 
 		}
 
@@ -254,7 +309,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 				return DeploymentState.failed;
 			}
 			try {
-				HttpURLConnection urlConnection = (HttpURLConnection) moduleUrl.openConnection();
+				HttpURLConnection urlConnection = (HttpURLConnection) moduleUrl
+						.openConnection();
 				urlConnection.connect();
 				urlConnection.disconnect();
 				return DeploymentState.deployed;
@@ -274,6 +330,7 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 			return result;
 		}
 	}
+
 	// Copy-pasting of JDK8+ isAlive method to retain JDK7 compatibility
 	private static boolean isAlive(Process process) {
 		try {

--- a/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployer.java
+++ b/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployer.java
@@ -61,7 +61,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Marius Bogoevici
  */
 public class OutOfProcessModuleDeployer implements ModuleDeployer {
-	
+
 	private static final String APP_LAUNCHER = "spring-cloud-dataflow-app-launcher";
 
 	private String moduleLauncherPath;
@@ -140,8 +140,8 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 							.singletonMap(SERVER_PORT_KEY, String.valueOf(port))));
 				}
 
-				ProcessBuilder builder = new ProcessBuilder(properties.getJavaCmd(),
-						"-jar", moduleLauncherPath);
+				String[] command = getJavaCommand();
+				ProcessBuilder builder = new ProcessBuilder(command);
 				builder.environment().clear();
 				builder.environment().putAll(args);
 
@@ -162,6 +162,17 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 		}
 
 		return moduleDeploymentId;
+	}
+
+	private String[] getJavaCommand() {
+		String[] command = new String[properties.getJavaOpts().length + 3];
+		command[0] = properties.getJavaCmd();
+		for (int j=0; j<properties.getJavaOpts().length; j++) {
+			command[j+1] = properties.getJavaOpts()[j];
+		}
+		command[properties.getJavaOpts().length + 1] = "-jar";
+		command[properties.getJavaOpts().length + 2] = moduleLauncherPath;
+		return command;
 	}
 
 	private Map<String, String> mergeProperties(
@@ -245,9 +256,11 @@ public class OutOfProcessModuleDeployer implements ModuleDeployer {
 	public void setup() throws IOException {
 		File launcherFile = Files.createTempFile(APP_LAUNCHER, ".jar").toFile();
 		launcherFile.deleteOnExit();
-		FileCopyUtils.copy(new ClassPathResource(APP_LAUNCHER + ".jar").getInputStream(), new FileOutputStream(launcherFile));
+		FileCopyUtils.copy(new ClassPathResource(APP_LAUNCHER + ".jar").getInputStream(),
+				new FileOutputStream(launcherFile));
 		this.moduleLauncherPath = launcherFile.getAbsolutePath();
-		this.logPathRoot = Files.createTempDirectory(properties.getWorkingDirectoriesRoot(), "spring-cloud-data-flow-");
+		this.logPathRoot = Files.createTempDirectory(
+				properties.getWorkingDirectoriesRoot(), "spring-cloud-data-flow-");
 	}
 
 	@PreDestroy

--- a/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployerProperties.java
@@ -52,6 +52,11 @@ public class OutOfProcessModuleDeployerProperties {
 	private String javaCmd = "java";
 
 	/**
+	 * The options to pass to the java virtual machine.
+	 */
+	private String[] javaOpts = new String[0];
+
+	/**
 	 * Additional properties to add to every module's command line
 	 */
 	private Map<String, String> sharedArgs = new LinkedHashMap<>();
@@ -62,6 +67,14 @@ public class OutOfProcessModuleDeployerProperties {
 
 	public void setJavaCmd(String javaCmd) {
 		this.javaCmd = javaCmd;
+	}
+
+	public String[] getJavaOpts() {
+		return javaOpts;
+	}
+
+	public void setJavaOpts(String[] javaOpts) {
+		this.javaOpts = javaOpts;
 	}
 
 	public boolean isUseOutOfProcess() {

--- a/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-deployer-local/src/main/java/org/springframework/cloud/dataflow/deployer/local/OutOfProcessModuleDeployerProperties.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.deployer.local;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -49,6 +51,11 @@ public class OutOfProcessModuleDeployerProperties {
 	 */
 	private String javaCmd = "java";
 
+	/**
+	 * Additional properties to add to every module's command line
+	 */
+	private Map<String, String> sharedArgs = new LinkedHashMap<>();
+
 	public String getJavaCmd() {
 		return javaCmd;
 	}
@@ -79,5 +86,13 @@ public class OutOfProcessModuleDeployerProperties {
 
 	public void setDeleteFilesOnExit(boolean deleteFilesOnExit) {
 		this.deleteFilesOnExit = deleteFilesOnExit;
+	}
+	
+	public void setSharedArgs(Map<String, String> sharedArgs) {
+		this.sharedArgs = sharedArgs;
+	}
+
+	public Map<String, String> getSharedArgs() {
+		return sharedArgs;
 	}
 }


### PR DESCRIPTION
User can specify additional command line args like this in the
local deployer app:

```
deployer:
  local:
    sharedArgs:
      includes: org.springframework.cloud:spring-cloud-starter-config:1.1.0.BUILD-SNAPSHOT
      spring.application.name: ${module.label}
      spring.cloud.config.uri: http://localhost:8888
```

Then all modules are launched with "includes" on the classpath
and enough information to bootstrap the config client.

The "includes" is a feature of the module launcher, and it is a
comma separated list, so we have to be careful to merge
module and deployment specific arguments with the same name.