### PR TITLE
Solve problem proxy without authentication

### DIFF
--- a/spring-cloud-dataflow-app-launcher/src/main/java/org/springframework/cloud/dataflow/app/resolver/AetherModuleResolver.java
+++ b/spring-cloud-dataflow-app-launcher/src/main/java/org/springframework/cloud/dataflow/app/resolver/AetherModuleResolver.java
@@ -136,6 +136,11 @@ public class AetherModuleResolver implements ModuleResolver {
 					remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
 							proxyProperties.getPort(), authentication));
 				}
+				else {
+					//If proxy doesn't need authentication to use it
+					remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
+							proxyProperties.getPort()));
+				}
 				this.remoteRepositories.add(remoteRepositoryBuilder.build());
 			}
 		}

--- a/spring-cloud-dataflow-app-launcher/src/main/java/org/springframework/cloud/dataflow/app/resolver/AetherModuleResolver.java
+++ b/spring-cloud-dataflow-app-launcher/src/main/java/org/springframework/cloud/dataflow/app/resolver/AetherModuleResolver.java
@@ -131,15 +131,17 @@ public class AetherModuleResolver implements ModuleResolver {
 			for (Map.Entry<String, String> remoteRepo : remoteRepositories.entrySet()) {
 				RemoteRepository.Builder remoteRepositoryBuilder = new RemoteRepository.Builder(remoteRepo.getKey(),
 						DEFAULT_CONTENT_TYPE, remoteRepo.getValue());
-				if (this.authentication != null) {
-					//todo: Set direct authentication for the remote repositories
-					remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
-							proxyProperties.getPort(), authentication));
-				}
-				else {
-					//If proxy doesn't need authentication to use it
-					remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
-							proxyProperties.getPort()));
+				if (isProxyEnabled()) {
+					if(this.authentication != null) {
+						//todo: Set direct authentication for the remote repositories
+						remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
+								proxyProperties.getPort(), authentication));	
+					}
+					else {
+						//If proxy doesn't need authentication to use it
+						remoteRepositoryBuilder.setProxy(new Proxy(proxyProperties.getProtocol(), proxyProperties.getHost(),
+								proxyProperties.getPort()));						
+					}
 				}
 				this.remoteRepositories.add(remoteRepositoryBuilder.build());
 			}


### PR DESCRIPTION
If a proxy doesn't need authentication but the user has no choice to use it, he can set a proxy with an authentication set as null