### PR TITLE
Set spring cloud deployer count property when count is set

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -185,6 +185,10 @@ public class StreamDeploymentController {
 			Map<String, String> moduleDeploymentProperties = extractModuleDeploymentProperties(currentModule, streamDeploymentProperties);
 			moduleDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentModule.getGroup());
 			moduleDeploymentProperties.put(ModuleDeployer.GROUP_DEPLOYMENT_ID, currentModule.getGroup() + "-" + timestamp);
+			if (moduleDeploymentProperties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) {
+				moduleDeploymentProperties.put(AppDeployer.COUNT_PROPERTY_KEY,
+						moduleDeploymentProperties.get(INSTANCE_COUNT_PROPERTY_KEY));
+			}
 			boolean upstreamModuleSupportsPartition = upstreamModuleHasPartitionInfo(stream, currentModule, streamDeploymentProperties);
 			// consumer module partition properties
 			if (upstreamModuleSupportsPartition) {
@@ -197,9 +201,7 @@ public class StreamDeploymentController {
 			nextModuleCount = getModuleCount(moduleDeploymentProperties);
 			isDownStreamModulePartitioned = isPartitionedConsumer(currentModule, moduleDeploymentProperties,
 					upstreamModuleSupportsPartition);
-
 			currentModule = postProcessLibraryProperties(currentModule);
-
 			AppDefinition definition = new AppDefinition(currentModule.getLabel(), currentModule.getParameters());
 			MavenResource resource = MavenResource.parse(coordinates.toString(), mavenProperties);
 			AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, moduleDeploymentProperties);


### PR DESCRIPTION
- When the app deployment property `count` is set, then set the property `spring.cloud.deployer.count` and pass it as environment property for the app definition

This resolves #464