### PR TITLE
Use persisted id for task status

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -149,8 +149,8 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
-			TaskLauncher taskLauncher) {
-		return new TaskDefinitionController(repository, taskLauncher);
+			DeploymentIdRepository deploymentIdRepository, TaskLauncher taskLauncher) {
+		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -95,8 +95,9 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository) {
-		return new TaskDefinitionController(repository, taskLauncher());
+	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
+			DeploymentIdRepository deploymentIdRepository) {
+		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher());
 	}
 
 	public TaskExecutionController taskExecutionController(TaskExplorer explorer) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -117,12 +117,12 @@ public class TaskControllerTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTaskDefinitionControllerConstructorMissingRepository() {
-		new TaskDefinitionController(null, taskLauncher);
+		new TaskDefinitionController(null, null, taskLauncher);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTaskDefinitionControllerConstructorMissingDeployer() {
-		new TaskDefinitionController(new InMemoryTaskDefinitionRepository(), null);
+		new TaskDefinitionController(new InMemoryTaskDefinitionRepository(), null, null);
 	}
 
 	@Test


### PR DESCRIPTION
- Add missing use of DeploymentIdRepository in a
  TaskDefinitionController when querying task
  status from a TaskLauncher.
- Fixes #512