### PR TITLE
Fix NPE for undeploy

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -368,10 +368,13 @@ public class StreamDeploymentController {
 		for (ModuleDefinition module : stream.getModuleDefinitions()) {
 			String key = DeploymentKey.forApp(module);
 			String id = this.deploymentIdRepository.findOne(key);
-			AppStatus status = this.deployer.status(id);
-			if (!EnumSet.of(DeploymentState.unknown, DeploymentState.undeployed)
-					.contains(status.getState())) {
-				this.deployer.undeploy(id);
+			// if id is null, assume nothing is deployed
+			if (id != null) {
+				AppStatus status = this.deployer.status(id);
+				if (!EnumSet.of(DeploymentState.unknown, DeploymentState.undeployed)
+						.contains(status.getState())) {
+					this.deployer.undeploy(id);
+				}
 			}
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -421,6 +421,27 @@ public class StreamControllerTests {
 	}
 
 	@Test
+	public void testUndeployNonDeployedStream() throws Exception {
+		repository.save(new StreamDefinition("myStream", "time | log"));
+		mockMvc.perform(
+				delete("/streams/deployments/myStream").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk());
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(appDeployer, times(0)).undeploy(captor.capture());
+	}
+
+	@Test
+	public void testUndeployAllNonDeployedStream() throws Exception {
+		repository.save(new StreamDefinition("myStream1", "time | log"));
+		repository.save(new StreamDefinition("myStream2", "time | log"));
+		mockMvc.perform(
+				delete("/streams/deployments").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk());
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(appDeployer, times(0)).undeploy(captor.capture());
+	}
+
+	@Test
 	public void testDeployWithProperties() throws Exception {
 		repository.save(new StreamDefinition("myStream", "time | log"));
 		mockMvc.perform(


### PR DESCRIPTION
- Now checking `ID` from `deploymentIdRepository` is null before
  trying to use it with deployer undeploy. Effectively
  assuming that module is not deployed.
- Added missing mock tests for trying to undeploy
  a stream which is not deployed.
- Fixes #511