### PR TITLE
Add shell support for task params

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.rest.client;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -43,8 +44,8 @@ public interface TaskOperations {
 	/**
 	 * Launch an already created task.
 	 */
-	void launch(String name, Map<String, String> properties);
-	
+	void launch(String name, Map<String, String> properties, List<String> arguments);
+
 	/**
 	 * Destroy an existing task.
 	 */

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.rest.client;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -27,6 +28,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -108,9 +110,10 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	@Override
-	public void launch(String name, Map<String, String> properties) {
+	public void launch(String name, Map<String, String> properties, List<String> arguments) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("properties", DeploymentPropertiesUtils.format(properties));
+		values.add("arguments", StringUtils.collectionToDelimitedString(arguments, " "));
 		restTemplate.postForObject(deploymentLink.expand(name).getHref(), values, Object.class, name);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -132,7 +133,8 @@ public class TaskDeploymentController {
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public void deploy(@PathVariable("name") String name, @RequestParam(required = false) String properties) {
+	public void deploy(@PathVariable("name") String name, @RequestParam(required = false) String properties,
+			@RequestParam(required = false) List<String> arguments) {
 		TaskDefinition taskDefinition = this.repository.findOne(name);
 		if (taskDefinition == null) {
 			throw new NoSuchTaskDefinitionException(name);
@@ -148,7 +150,7 @@ public class TaskDeploymentController {
 		AppDefinition definition = new AppDefinition(module.getLabel(), module.getParameters());
 		URI uri = this.registry.find(String.format("task.%s", module.getName()));
 		Resource resource = this.resourceLoader.getResource(uri.toString());
-		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties, arguments);
 		String id = this.taskLauncher.launch(request);
 		this.deploymentIdRepository.save(DeploymentKey.forApp(module), id);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.dataflow.server.controller;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -226,7 +228,7 @@ public class TaskControllerTests {
 				.andExpect(status().isCreated());
 
 		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
-		verify(this.taskLauncher).launch(argumentCaptor.capture());
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertThat(request.getResource(), instanceOf(MavenResource.class));
@@ -237,5 +239,32 @@ public class TaskControllerTests {
 		assertEquals("jar", mavenResource.getExtension());
 		assertEquals("1", mavenResource.getVersion());
 		assertEquals("myTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
+	}
+
+	@Test
+	public void testLaunchWithParams() throws Exception {
+		repository.save(new TaskDefinition("myTask2", "foo2"));
+		this.registry.register("task.foo2", new URI("maven://org.springframework.cloud:foo2:1"));
+
+		mockMvc.perform(
+				post("/tasks/deployments/{name}", "myTask2")
+				.param("arguments", "--foobar=jee")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isCreated());
+
+		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
+
+		AppDeploymentRequest request = argumentCaptor.getValue();
+		assertThat(request.getCommandlineArguments().size(), is(1));
+		assertThat(request.getCommandlineArguments().get(0), is("--foobar=jee"));
+		assertThat(request.getResource(), instanceOf(MavenResource.class));
+		MavenResource mavenResource = (MavenResource) request.getResource();
+		assertEquals("org.springframework.cloud", mavenResource.getGroupId());
+		assertEquals("foo2", mavenResource.getArtifactId());
+		assertEquals("", mavenResource.getClassifier());
+		assertEquals("jar", mavenResource.getExtension());
+		assertEquals("1", mavenResource.getVersion());
+		assertEquals("myTask2", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 	}
 }

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.dataflow.shell.command;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -67,6 +69,8 @@ public class TaskCommands implements CommandMarker {
 
 	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
 
+	private static final String PARAMS_OPTION = "params";
+
 	private static final String EXECUTION_LIST = "task execution list";
 
 
@@ -101,7 +105,8 @@ public class TaskCommands implements CommandMarker {
 	public String launch(
 			@CliOption(key = { "", "name" }, help = "the name of the task to launch", mandatory = true) String name,
 			@CliOption(key = { PROPERTIES_OPTION }, help = "the properties for this launch", mandatory = false) String properties,
-			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile
+			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile,
+			@CliOption(key = { PARAMS_OPTION }, help = "the commandline arguments for this launch", mandatory = false) String params
 			) throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION, propertiesFile);
 		Map<String, String> propertiesToUse;
@@ -122,10 +127,15 @@ public class TaskCommands implements CommandMarker {
 			default:
 				throw new AssertionError();
 		}
-		taskOperations().launch(name, propertiesToUse);
+		// need to pass through raw params string into
+		// List as shell can handle conversion if its
+		// function param is a List<String>.
+		List<String> arguments = new ArrayList<String>();
+		arguments.add(params);
+		taskOperations().launch(name, propertiesToUse, arguments);
 		return String.format("Launched task '%s'", name);
 	}
-	
+
 	@CliCommand(value = DESTROY, help = "Destroy an existing task")
 	public String destroy(
 			@CliOption(key = { "", "name" }, help = "the name of the task to destroy", mandatory = true) String name) {


### PR DESCRIPTION
- Modify shell 'task launch' command to accept raw
  'params' option for java fatjar arguments.
- Modify TaskDeploymentController to accept a list of arguments
  to be passed into SPI's `AppDeploymentRequest`.
- Added one test and had to modify mockito ArgumentCaptor to accept
  'atLeast' as otherwise other tests will capture same calls to deployer.
- Fixes #503 

Testing manually:

Having definition
```
dataflow:>task create --name footask --definition "timestamp"
```
normal launch will output
```
dataflow:>task launch --name footask
2016-04-15 18:32:49.933  INFO 20878 --- [           main] o.s.c.t.t.TaskApplication$TimestampTask  : 2016-04-15 18:32:49.933
```

defining `format` via `params`
```
dataflow:>task launch --name footask --params "--format=yyyy-MM-dd"
2016-04-15 18:32:12.948  INFO 20815 --- [           main] o.s.c.t.t.TaskApplication$TimestampTask  : 2016-04-15
```