### PR TITLE
Fix CounterController Metric value type & add tests

### DIFF
--- a/spring-cloud-dataflow-registry/pom.xml
+++ b/spring-cloud-dataflow-registry/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<name>spring-cloud-dataflow-registry</name>
 	<artifactId>spring-cloud-dataflow-registry</artifactId>
 	<packaging>jar</packaging>
 	<parent>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/CounterController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/CounterController.java
@@ -46,7 +46,6 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Eric Bottard
  * @author Mark Fisher
- * @author Ilayaperumal Gopinathan
  */
 @RestController
 @RequestMapping("/metrics/counters")
@@ -57,10 +56,10 @@ public class CounterController {
 
 	private final MetricRepository metricRepository;
 
-	private final ResourceAssembler<Metric<Long>, CounterResource> counterResourceAssembler =
+	private final ResourceAssembler<Metric<Double>, CounterResource> counterResourceAssembler =
 			new DeepCounterResourceAssembler();
 
-	protected final ResourceAssembler<Metric<Long>, ? extends MetricResource> shallowResourceAssembler =
+	protected final ResourceAssembler<Metric<Double>, ? extends MetricResource> shallowResourceAssembler =
 			new ShallowMetricResourceAssembler();
 
 	/**
@@ -79,12 +78,12 @@ public class CounterController {
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	public PagedResources<? extends MetricResource> list(
 			Pageable pageable,
-			PagedResourcesAssembler<Metric<Long>> pagedAssembler,
+			PagedResourcesAssembler<Metric<Double>> pagedAssembler,
 			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
 		/* Page */ Iterable<Metric<?>> metrics = metricRepository.findAll(/* pageable */);
-		List<Metric<Long>> content = filterCounters(metrics);
-		Page<Metric<Long>> page = new PageImpl<>(content);
-		ResourceAssembler<Metric<Long>, ? extends MetricResource> assemblerToUse =
+		List<Metric<Double>> content = filterCounters(metrics);
+		Page<Metric<Double>> page = new PageImpl<>(content);
+		ResourceAssembler<Metric<Double>, ? extends MetricResource> assemblerToUse =
 				detailed ? counterResourceAssembler : shallowResourceAssembler;
 		return pagedAssembler.toResource(page, assemblerToUse);
 	}
@@ -94,7 +93,7 @@ public class CounterController {
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	public CounterResource display(@PathVariable("name") String name) {
-		Metric<Long> c = findCounter(name);
+		Metric<Double> c = findCounter(name);
 		return counterResourceAssembler.toResource(c);
 	}
 
@@ -104,7 +103,7 @@ public class CounterController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	protected void delete(@PathVariable("name") String name) {
-		Metric<Long> c = findCounter(name);
+		Metric<Double> c = findCounter(name);
 		metricRepository.reset(c.getName());
 	}
 
@@ -112,9 +111,9 @@ public class CounterController {
 	 * Find a given counter, taking care of name conversion between the Spring Boot domain and our domain.
 	 * @throws MetricsMvcEndpoint.NoSuchMetricException if the counter does not exist
 	 */
-	private Metric<Long> findCounter(@PathVariable("name") String name) {
+	private Metric<Double> findCounter(@PathVariable("name") String name) {
 		@SuppressWarnings("unchecked")
-		Metric<Long> c = (Metric<Long>) metricRepository.findOne(COUNTER_PREFIX + name);
+		Metric<Double> c = (Metric<Double>) metricRepository.findOne(COUNTER_PREFIX + name);
 		if (c == null) {
 			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
 		}
@@ -143,19 +142,19 @@ public class CounterController {
 	 * @author Eric Bottard
 	 */
 	static class ShallowMetricResourceAssembler extends
-			ResourceAssemblerSupport<Metric<Long>, MetricResource> {
+			ResourceAssemblerSupport<Metric<Double>, MetricResource> {
 
 		public ShallowMetricResourceAssembler() {
 			super(CounterController.class, MetricResource.class);
 		}
 
 		@Override
-		public MetricResource toResource(Metric<Long> entity) {
+		public MetricResource toResource(Metric<Double> entity) {
 			return createResourceWithId(entity.getName().substring(COUNTER_PREFIX.length()), entity);
 		}
 
 		@Override
-		protected MetricResource instantiateResource(Metric<Long> entity) {
+		protected MetricResource instantiateResource(Metric<Double> entity) {
 			return new MetricResource(entity.getName().substring(COUNTER_PREFIX.length()));
 		}
 
@@ -167,19 +166,19 @@ public class CounterController {
 	 * @author Eric Bottard
 	 */
 	static class DeepCounterResourceAssembler extends
-			ResourceAssemblerSupport<Metric<Long>, CounterResource> {
+			ResourceAssemblerSupport<Metric<Double>, CounterResource> {
 
 		public DeepCounterResourceAssembler() {
 			super(CounterController.class, CounterResource.class);
 		}
 
 		@Override
-		public CounterResource toResource(Metric<Long> entity) {
+		public CounterResource toResource(Metric<Double> entity) {
 			return createResourceWithId(entity.getName().substring(COUNTER_PREFIX.length()), entity);
 		}
 
 		@Override
-		protected CounterResource instantiateResource(Metric<Long> entity) {
+		protected CounterResource instantiateResource(Metric<Double> entity) {
 			return new CounterResource(entity.getName().substring(COUNTER_PREFIX.length()), entity.getValue().longValue());
 		}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType.HAL;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.repository.InMemoryMetricRepository;
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
+import org.springframework.boot.actuate.metrics.writer.DefaultCounterService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+/**
+ * Tests for {@link CounterController}.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {CounterControllerTests.Config.class})
+@WebAppConfiguration
+public class CounterControllerTests {
+
+	@Autowired
+	private MetricRepository repository;
+
+	@Autowired
+	private CounterService counterService;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	private MockMvc mockMvc;
+
+	@Before
+	public void setupMockMVC() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(
+				get("/").accept(MediaType.APPLICATION_JSON)).build();
+	}
+
+	@After
+	public void cleanUp() {
+		for (Metric counter : repository.findAll()) {
+			repository.reset(counter.getName());
+		}
+	}
+
+	@Test
+	public void testList() throws Exception {
+		counterService.increment("foo");
+		counterService.increment("bar");
+		mockMvc.perform(get("/metrics/counters").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.page.totalElements", is(2)))
+				.andExpect(jsonPath("$.content.*.name", containsInAnyOrder("foo", "bar")));
+	}
+
+	@Test
+	public void testGetAndDelete() throws Exception {
+		counterService.increment("foo");
+		counterService.increment("foo");
+		mockMvc.perform(
+				get("/metrics/counters/foo").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.name", is("foo")))
+				.andExpect(jsonPath("$.value", is(2)));
+
+		mockMvc.perform(
+				delete("/metrics/counters/foo").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+
+		mockMvc.perform(
+				get("/metrics/counters/foo").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
+
+	}
+
+	@Configuration
+	@EnableSpringDataWebSupport
+	@EnableHypermediaSupport(type = HAL)
+	@EnableWebMvc
+	public static class Config {
+
+		@Bean
+		public MetricRepository counterRepository() {
+			return new InMemoryMetricRepository();
+		}
+
+
+		@Bean
+		public CounterController counterController(MetricRepository metricRepository) {
+			return new CounterController(metricRepository);
+		}
+
+		@Bean
+		public CounterService counterService(MetricRepository metricRepository) {
+			return new DefaultCounterService(metricRepository);
+		}
+
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
@@ -32,11 +32,14 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.actuate.metrics.Metric;
-import org.springframework.boot.actuate.metrics.repository.InMemoryMetricRepository;
 import org.springframework.boot.actuate.metrics.repository.MetricRepository;
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
 import org.springframework.boot.actuate.metrics.writer.DefaultCounterService;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.MediaType;
@@ -116,11 +119,15 @@ public class CounterControllerTests {
 	@EnableSpringDataWebSupport
 	@EnableHypermediaSupport(type = HAL)
 	@EnableWebMvc
+	@Import(RedisAutoConfiguration.class)
 	public static class Config {
+
+		@Autowired
+		RedisConnectionFactory redisConnectionFactory;
 
 		@Bean
 		public MetricRepository counterRepository() {
-			return new InMemoryMetricRepository();
+			return new RedisMetricRepository(redisConnectionFactory);
 		}
 
 


### PR DESCRIPTION
- The metric value type used in the CounterController is set to use `Long` instead of `Double`
 - Add CounterControllerTests

Resolves spring-cloud/spring-cloud-dataflow#526 
Resolves spring-cloud/spring-cloud-dataflow#460