### PR TITLE
StreamDeploymentController to process all the app deployment requests

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -22,6 +22,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.cloud.dataflow.core.ArtifactType;
 import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
@@ -65,6 +68,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/streams/deployments")
 @ExposesResourceFor(StreamDeploymentResource.class)
 public class StreamDeploymentController {
+
+	private static Log loggger = LogFactory.getLog(StreamDeploymentController.class);
 
 	private static final String INSTANCE_COUNT_PROPERTY_KEY = "count";
 
@@ -197,8 +202,15 @@ public class StreamDeploymentController {
 			AppDefinition definition = new AppDefinition(currentModule.getLabel(), currentModule.getParameters());
 			Resource resource = this.registry.find(currentModule.getName(), type).getResource();
 			AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, moduleDeploymentProperties);
-			String id = this.deployer.deploy(request);
-			this.deploymentIdRepository.save(DeploymentKey.forApp(currentModule), id);
+			try {
+				String id = this.deployer.deploy(request);
+				this.deploymentIdRepository.save(DeploymentKey.forApp(currentModule), id);
+			}
+			// If the deployer implementation handles the deployment request synchronously, log warning message if
+			// any exception is thrown out of the deployment and proceed to the next deployment.
+			catch (Exception e) {
+				loggger.warn(String.format("Exception when deploying the app %s:%s", currentModule, e.getMessage()));
+			}
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -209,7 +209,7 @@ public class StreamDeploymentController {
 			// If the deployer implementation handles the deployment request synchronously, log warning message if
 			// any exception is thrown out of the deployment and proceed to the next deployment.
 			catch (Exception e) {
-				loggger.warn(String.format("Exception when deploying the app %s:%s", currentModule, e.getMessage()));
+				loggger.warn(String.format("Exception when deploying the app %s: %s", currentModule, e.getMessage()));
 			}
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -508,4 +508,15 @@ public class StreamControllerTests {
 		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(unknown)), is(undeployed));
 	}
 
+	@Test
+	public void testAppDeploymentFailure() throws Exception {
+		when(appDeployer.deploy(any(AppDeploymentRequest.class))).thenThrow(new RuntimeException());
+		repository.save(new StreamDefinition("myStream", "time | log"));
+		mockMvc.perform(
+				post("/streams/deployments/myStream").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isCreated());
+		ArgumentCaptor<AppDeploymentRequest> captor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(appDeployer, times(2)).deploy(captor.capture());
+	}
+
 }


### PR DESCRIPTION
- Irrespective of the exception thrown during the app deployments when using synchronous deployer implementation, the stream deployment controller proceeds to deploy all the apps in request and log the warning message in case of exception thrown on a deployment
 - Add test

This resolves #524