### PR TITLE
RuntimeModulesController using deployment id

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -109,8 +109,8 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	public RuntimeModulesController runtimeModulesController(StreamDefinitionRepository repository,
-			AppDeployer appDeployer) {
-		return new RuntimeModulesController(repository, appDeployer);
+			DeploymentIdRepository deploymentIdRepository, AppDeployer appDeployer) {
+		return new RuntimeModulesController(repository, deploymentIdRepository, appDeployer);
 	}
 
 	@Bean


### PR DESCRIPTION
- Fix RuntimeModulesController to use deployment id
  so that `runtime modules` command wont fail with
  deployers expecting correct format when status
  is queried.
- Generic polish, javadocs, sts warnings.
- Fixes #544