### PR TITLE
Fix pom versions

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.app.resolver.ModuleResolverConfiguration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.stream.configuration.metadata.ModuleConfigurationMetadataResolver;
 import org.springframework.cloud.stream.configuration.metadata.ModuleConfigurationMetadataResolverAutoConfiguration;
@@ -36,7 +35,7 @@ import org.springframework.context.annotation.Import;
  * @author Mark Fisher
  */
 @Configuration
-@Import({ModuleResolverConfiguration.class, ModuleConfigurationMetadataResolverAutoConfiguration.class})
+@Import({ModuleConfigurationMetadataResolverAutoConfiguration.class})
 public class CompletionConfiguration {
 
 	@Autowired

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -13,9 +13,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dataflow-app-launcher</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-loader</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/stream/configuration/metadata/ClassloaderUtils.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/stream/configuration/metadata/ClassloaderUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.configuration.metadata;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.loader.LaunchedURLClassLoader;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class ClassloaderUtils {
+
+	private static final Log log = LogFactory.getLog(ClassloaderUtils.class);
+
+	/**
+	 * Creates a ClassLoader for the launched modules by merging the URLs supplied as argument with the URLs that
+	 * make up the additional classpath of the launched JVM (retrieved from the application classloader), and
+	 * setting the extension classloader of the JVM as parent, if accessible.
+	 *
+	 * @param urls a list of library URLs
+	 * @return the resulting classloader
+	 */
+	public static ClassLoader createModuleClassloader(URL[] urls) {
+		ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+		if (log.isDebugEnabled()) {
+			log.debug("systemClassLoader is " + systemClassLoader);
+		}
+		if (systemClassLoader instanceof URLClassLoader) {
+			// add the URLs of the application classloader to the created classloader
+			// to compensate for LaunchedURLClassLoader not delegating to parent to retrieve resources
+			@SuppressWarnings("resource")
+			URLClassLoader systemUrlClassLoader = (URLClassLoader) systemClassLoader;
+			URL[] mergedUrls = new URL[urls.length + systemUrlClassLoader.getURLs().length];
+			if (log.isDebugEnabled()) {
+				log.debug("Original URLs: " +
+						StringUtils.arrayToCommaDelimitedString(urls));
+				log.debug("Java Classpath URLs: " +
+						StringUtils.arrayToCommaDelimitedString(systemUrlClassLoader.getURLs()));
+			}
+			System.arraycopy(urls, 0, mergedUrls, 0, urls.length);
+			System.arraycopy(systemUrlClassLoader.getURLs(), 0, mergedUrls, urls.length,
+					systemUrlClassLoader.getURLs().length);
+			// add the extension classloader as parent to the created context, if accessible
+			if (log.isDebugEnabled()) {
+				log.debug("Classloader URLs: " + StringUtils.arrayToCommaDelimitedString(mergedUrls));
+			}
+			return new LaunchedURLClassLoader(mergedUrls, systemUrlClassLoader.getParent());
+		}
+		return new LaunchedURLClassLoader(urls, systemClassLoader);
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/stream/configuration/metadata/ModuleJarLauncher.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/stream/configuration/metadata/ModuleJarLauncher.java
@@ -22,7 +22,6 @@ import java.net.URL;
 
 import org.springframework.boot.loader.JarLauncher;
 import org.springframework.boot.loader.archive.Archive;
-import org.springframework.cloud.dataflow.app.utils.ClassloaderUtils;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -14,6 +14,8 @@
 	<name>spring-cloud-dataflow-dependencies</name>
 	<description>Spring Cloud Data Flow Dependencies BOM designed to support consumption of Spring Cloud Data Flow from the Spring Initializr.</description>
 	<properties>
+		<spring-cloud-dataflow.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
+		<spring-cloud-dataflow-ui.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
 		<spring-shell.version>1.2.0.M1</spring-shell.version>
 	</properties>
@@ -22,62 +24,57 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-shell</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-completion</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-core</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-rest-client</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dataflow-app-launcher</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-configuration-metadata</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-registry</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-ui</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow-ui.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-server-core</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-server-local</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
-				<version>${project.version}</version>
+				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.cloudfoundry</groupId>

--- a/spring-cloud-dataflow-registry/pom.xml
+++ b/spring-cloud-dataflow-registry/pom.xml
@@ -9,6 +9,9 @@
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
+	<properties>
+		<spring-cloud-deployer.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -25,7 +28,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-support</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<version>${spring-cloud-deployer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-starter-dataflow-server-local/pom.xml
+++ b/spring-cloud-starter-dataflow-server-local/pom.xml
@@ -15,11 +15,14 @@
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
+	<properties>
+		<spring-cloud-deployer.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-local</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<version>${spring-cloud-deployer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
- Remove spring-cloud-dataflow-app-launcher and bring
  back missing stuff needed for metadata.
- spring-cloud-dataflow-dependencies remove project.version
- spring-cloud-dataflow-registry, spring-cloud-starter-dataflow-server-local
  and spring-cloud-starter-dataflow-server-local remove hardcoded version.
- Fixes #570