### PR TITLE
Add commandline params for tasks

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.rest.client;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -43,8 +44,8 @@ public interface TaskOperations {
 	/**
 	 * Launch an already created task.
 	 */
-	void launch(String name, Map<String, String> properties);
-	
+	void launch(String name, Map<String, String> properties, List<String> params);
+
 	/**
 	 * Destroy an existing task.
 	 */

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.rest.client;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -27,6 +28,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -108,9 +110,10 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	@Override
-	public void launch(String name, Map<String, String> properties) {
+	public void launch(String name, Map<String, String> properties, List<String> params) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("properties", DeploymentPropertiesUtils.format(properties));
+		values.add("params", StringUtils.collectionToDelimitedString(params, " "));
 		restTemplate.postForObject(deploymentLink.expand(name).getHref(), values, Object.class, name);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.List;
+
 import org.springframework.cloud.dataflow.rest.resource.TaskDeploymentResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.service.TaskService;
@@ -63,11 +65,13 @@ public class TaskDeploymentController {
 	 * @param taskName the name of the existing task to be executed (required)
 	 * @param properties the runtime properties for the task, as a comma-delimited list of
 	 * 					 key=value pairs
+	 * @param params the runtime commandline arguments
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public void deploy(@PathVariable("name") String taskName, @RequestParam(required = false) String properties) {
-		this.taskService.executeTask(taskName, DeploymentPropertiesUtils.parse(properties));
+	public void deploy(@PathVariable("name") String taskName, @RequestParam(required = false) String properties,
+			@RequestParam(required = false) List<String> params) {
+		this.taskService.executeTask(taskName, DeploymentPropertiesUtils.parse(properties), params);
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.service;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,7 +36,8 @@ public interface TaskService {
 	 *
 	 * @param taskName Name of the task. Must not be null or empty.
 	 * @param runtimeProperties Optional runtime properties. Must not be null.
+	 * @param runtimeParams Optional runtime commandline arguments
 	 */
-	void executeTask(String taskName, Map<String, String> runtimeProperties);
+	void executeTask(String taskName, Map<String, String> runtimeProperties, List<String> runtimeParams);
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -206,7 +206,7 @@ public class DefaultTaskJobService implements TaskJobService {
 			throw new NoSuchTaskDefinitionException(taskExecution.getTaskName());
 		}
 
-		taskService.executeTask(taskDefinition.getName(), taskDefinition.getParameters());
+		taskService.executeTask(taskDefinition.getName(), taskDefinition.getParameters(), taskExecution.getParameters());
 
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.h2.util.Task;
@@ -145,7 +146,7 @@ public class DefaultTaskService implements TaskService {
 	}
 
 	@Override
-	public void executeTask(String taskName, Map<String, String> runtimeProperties) {
+	public void executeTask(String taskName, Map<String, String> runtimeProperties, List<String> runtimeParams) {
 
 		Assert.hasText(taskName, "The provided taskName must not be null or empty.");
 		Assert.notNull(runtimeProperties, "The provided runtimeProperties must not be null.");
@@ -163,7 +164,7 @@ public class DefaultTaskService implements TaskService {
 		AppDefinition definition = new AppDefinition(module.getLabel(), module.getParameters());
 		URI uri = this.registry.find(String.format("task.%s", module.getName()));
 		Resource resource = this.resourceLoader.getResource(uri.toString());
-		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties, runtimeParams);
 		String id = this.taskLauncher.launch(request);
 		this.deploymentIdRepository.save(DeploymentKey.forApp(module), id);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.dataflow.server.controller;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -210,7 +212,7 @@ public class TaskControllerTests {
 				.andExpect(status().isCreated());
 
 		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
-		verify(this.taskLauncher).launch(argumentCaptor.capture());
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertThat(request.getResource(), instanceOf(MavenResource.class));
@@ -221,5 +223,32 @@ public class TaskControllerTests {
 		assertEquals("jar", mavenResource.getExtension());
 		assertEquals("1", mavenResource.getVersion());
 		assertEquals("myTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
+	}
+
+	@Test
+	public void testLaunchWithParams() throws Exception {
+		repository.save(new TaskDefinition("myTask2", "foo2"));
+		this.registry.register("task.foo2", new URI("maven://org.springframework.cloud:foo2:1"));
+
+		mockMvc.perform(
+				post("/tasks/deployments/{name}", "myTask2")
+				.param("params", "--foobar=jee")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isCreated());
+
+		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
+
+		AppDeploymentRequest request = argumentCaptor.getValue();
+		assertThat(request.getCommandlineArguments().size(), is(1));
+		assertThat(request.getCommandlineArguments().get(0), is("--foobar=jee"));
+		assertThat(request.getResource(), instanceOf(MavenResource.class));
+		MavenResource mavenResource = (MavenResource) request.getResource();
+		assertEquals("org.springframework.cloud", mavenResource.getGroupId());
+		assertEquals("foo2", mavenResource.getArtifactId());
+		assertEquals("", mavenResource.getClassifier());
+		assertEquals("jar", mavenResource.getExtension());
+		assertEquals("1", mavenResource.getVersion());
+		assertEquals("myTask2", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 	}
 }

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.dataflow.shell.command;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -40,6 +42,7 @@ import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableBuilder;
 import org.springframework.shell.table.TableModelBuilder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Task commands.
@@ -66,6 +69,8 @@ public class TaskCommands implements CommandMarker {
 	private static final String PROPERTIES_OPTION = "properties";
 
 	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
+
+	private static final String PARAMS_OPTION = "params";
 
 	private static final String EXECUTION_LIST = "task execution list";
 
@@ -101,7 +106,8 @@ public class TaskCommands implements CommandMarker {
 	public String launch(
 			@CliOption(key = { "", "name" }, help = "the name of the task to launch", mandatory = true) String name,
 			@CliOption(key = { PROPERTIES_OPTION }, help = "the properties for this launch", mandatory = false) String properties,
-			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile
+			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile,
+			@CliOption(key = { PARAMS_OPTION }, help = "the commandline arguments for this launch", mandatory = false) String params
 			) throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION, propertiesFile);
 		Map<String, String> propertiesToUse;
@@ -122,10 +128,14 @@ public class TaskCommands implements CommandMarker {
 			default:
 				throw new AssertionError();
 		}
-		taskOperations().launch(name, propertiesToUse);
+		List<String> paramsToUse = new ArrayList<String>();
+		if (StringUtils.hasText(params)) {
+			paramsToUse.add(params);
+		}
+		taskOperations().launch(name, propertiesToUse, paramsToUse);
 		return String.format("Launched task '%s'", name);
 	}
-	
+
 	@CliCommand(value = DESTROY, help = "Destroy an existing task")
 	public String destroy(
 			@CliOption(key = { "", "name" }, help = "the name of the task to destroy", mandatory = true) String name) {


### PR DESCRIPTION
- Modify shell launch command.
- Add raw list of params throughout a chain
  from shell into a deployer SPI call.
- Added one test verifying params.
- In DefaultTaskJobService.restartJobExecution() params are
  coming from TaskExecution, theory at least, but this is not
  testable right now as we don't have restart command.
- Fixes #503
- Fixes #523