### PR TITLE
Add commandline params for tasks

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.rest.client;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -43,8 +44,8 @@ public interface TaskOperations {
 	/**
 	 * Launch an already created task.
 	 */
-	void launch(String name, Map<String, String> properties);
-	
+	void launch(String name, Map<String, String> properties, List<String> params);
+
 	/**
 	 * Destroy an existing task.
 	 */

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.rest.client;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -27,6 +28,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -108,9 +110,10 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	@Override
-	public void launch(String name, Map<String, String> properties) {
+	public void launch(String name, Map<String, String> properties, List<String> params) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("properties", DeploymentPropertiesUtils.format(properties));
+		values.add("params", StringUtils.collectionToDelimitedString(params, " "));
 		restTemplate.postForObject(deploymentLink.expand(name).getHref(), values, Object.class, name);
 	}
 

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -50,8 +50,18 @@
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
-		<groupId>junit</groupId>
+			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.dataflow.rest.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -40,6 +42,11 @@ public final class DeploymentPropertiesUtils {
 	 * Pattern used for parsing a String of comma-delimited key=value pairs.
 	 */
 	private static final Pattern DEPLOYMENT_PROPERTIES_PATTERN = Pattern.compile(",\\s*module\\.[^\\.]+\\.[^=]+=");
+
+	/**
+	 * Pattern used for parsing a String of command-line arguments.
+	 */
+	private static final Pattern DEPLOYMENT_PARAMS_PATTERN = Pattern.compile("(\\s(?=([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))");
 
 	/**
 	 * Parses a String comprised of 0 or more comma-delimited key=value pairs where each key has the format:
@@ -103,5 +110,59 @@ public final class DeploymentPropertiesUtils {
 			// todo: should key only be a "flag" as in: put(key, true)?
 			properties.put(pair.substring(0, firstEquals).trim(), pair.substring(firstEquals + 1).trim());
 		}
+	}
+
+	/**
+	 * Parses a list of command line parameters and returns a list of parameters
+	 * which doesn't contain any special quoting either for values or whole parameter.
+	 *
+	 * @param params the params
+	 * @return the list
+	 */
+	public static List<String> parseParams(List<String> params) {
+		List<String> paramsToUse = new ArrayList<>();
+		if (params != null) {
+			for (String param : params) {
+				Matcher regexMatcher = DEPLOYMENT_PARAMS_PATTERN.matcher(param);
+				int start = 0;
+				while (regexMatcher.find()) {
+					String p = removeQuoting(param.substring(start, regexMatcher.start()).trim());
+					if (StringUtils.hasText(p)) {
+						paramsToUse.add(p);
+					}
+					start = regexMatcher.start();
+				}
+				if (param != null && param.length() > 0) {
+					String p = removeQuoting(param.substring(start, param.length()).trim());
+					if (StringUtils.hasText(p)) {
+						paramsToUse.add(p);
+					}
+				}
+			}
+		}
+		return paramsToUse;
+	}
+
+	private static String removeQuoting(String param) {
+		param = removeQuote(param, '\'');
+		param = removeQuote(param, '"');
+		if (StringUtils.hasText(param)) {
+			String[] split = param.split("=", 2);
+			if (split.length == 2) {
+				String value = removeQuote(split[1], '\'');
+				value = removeQuote(value, '"');
+				param = split[0] + "=" + value;
+			}
+		}
+		return param;
+	}
+
+	private static String removeQuote(String param, char c) {
+		if (param != null && param.length() > 1) {
+			if (param.charAt(0) == c && param.charAt(param.length()-1) == c) {
+				param = param.substring(1, param.length()-1);
+			}
+		}
+		return param;
 	}
 }

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.job.support;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+
+/**
+ * Tests for {@link DeploymentPropertiesUtils}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DeploymentPropertiesUtilsTests {
+
+	@Test
+	public void testCommandLineParamsParsing() {
+		assertArrays(new String[] { "--format=yyyy-MM-dd" }, new String[] { "--format=yyyy-MM-dd" });
+		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'" }, new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS" });
+		assertArrays(new String[] { "\"--format=yyyy-MM-dd HH:mm:ss.SSS\"" }, new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS" });
+		assertArrays(new String[] { "--format='yyyy-MM-dd HH:mm:ss.SSS'" }, new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS" });
+		assertArrays(new String[] { "--format=\"yyyy-MM-dd HH:mm:ss.SSS\"" }, new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS" });
+		assertArrays(new String[] { "--foo1=bar1 --foo2=bar2" }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { "--foo1=bar1", "--foo2=bar2" }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { " --foo1=bar1 ", " --foo2=bar2 " }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'", "--foo1=bar1" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS", "--foo1=bar1" });
+	}
+
+	private static void assertArrays(String[] left, String[] right) {
+		ArrayList<String> params = new ArrayList<>(Arrays.asList(left));
+		assertThat(DeploymentPropertiesUtils.parseParams(params), containsInAnyOrder(right));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDeploymentController.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.List;
+
 import org.springframework.cloud.dataflow.rest.resource.TaskDeploymentResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.service.TaskService;
@@ -63,11 +65,12 @@ public class TaskDeploymentController {
 	 * @param taskName the name of the existing task to be executed (required)
 	 * @param properties the runtime properties for the task, as a comma-delimited list of
 	 * 					 key=value pairs
+	 * @param params the runtime commandline arguments
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public void deploy(@PathVariable("name") String taskName, @RequestParam(required = false) String properties) {
-		this.taskService.executeTask(taskName, DeploymentPropertiesUtils.parse(properties));
+	public void deploy(@PathVariable("name") String taskName, @RequestParam(required = false) String properties,
+			@RequestParam(required = false) List<String> params) {
+		this.taskService.executeTask(taskName, DeploymentPropertiesUtils.parse(properties), DeploymentPropertiesUtils.parseParams(params));
 	}
-
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.service;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,7 +36,8 @@ public interface TaskService {
 	 *
 	 * @param taskName Name of the task. Must not be null or empty.
 	 * @param runtimeProperties Optional runtime properties. Must not be null.
+	 * @param runtimeParams Optional runtime commandline arguments
 	 */
-	void executeTask(String taskName, Map<String, String> runtimeProperties);
+	void executeTask(String taskName, Map<String, String> runtimeProperties, List<String> runtimeParams);
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -206,7 +206,7 @@ public class DefaultTaskJobService implements TaskJobService {
 			throw new NoSuchTaskDefinitionException(taskExecution.getTaskName());
 		}
 
-		taskService.executeTask(taskDefinition.getName(), taskDefinition.getParameters());
+		taskService.executeTask(taskDefinition.getName(), taskDefinition.getParameters(), taskExecution.getParameters());
 
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.h2.util.Task;
@@ -145,7 +146,7 @@ public class DefaultTaskService implements TaskService {
 	}
 
 	@Override
-	public void executeTask(String taskName, Map<String, String> runtimeProperties) {
+	public void executeTask(String taskName, Map<String, String> runtimeProperties, List<String> runtimeParams) {
 
 		Assert.hasText(taskName, "The provided taskName must not be null or empty.");
 		Assert.notNull(runtimeProperties, "The provided runtimeProperties must not be null.");
@@ -163,7 +164,7 @@ public class DefaultTaskService implements TaskService {
 		AppDefinition definition = new AppDefinition(module.getLabel(), module.getParameters());
 		URI uri = this.registry.find(String.format("task.%s", module.getName()));
 		Resource resource = this.resourceLoader.getResource(uri.toString());
-		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, deploymentProperties, runtimeParams);
 		String id = this.taskLauncher.launch(request);
 		this.deploymentIdRepository.save(DeploymentKey.forApp(module), id);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -259,7 +259,7 @@ public class TaskControllerTests {
 
 		mockMvc.perform(
 				post("/tasks/deployments/{name}", "myTask3")
-				.param("params", "--foobar=jee", "--foobar2=jee2")
+				.param("params", "--foobar=jee", "--foobar2=jee2", "--foobar3='jee3 jee3'")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isCreated());
 
@@ -267,9 +267,10 @@ public class TaskControllerTests {
 		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
-		assertThat(request.getCommandlineArguments().size(), is(2));
+		assertThat(request.getCommandlineArguments().size(), is(3));
 		assertThat(request.getCommandlineArguments().get(0), is("--foobar=jee"));
 		assertThat(request.getCommandlineArguments().get(1), is("--foobar2=jee2"));
+		assertThat(request.getCommandlineArguments().get(2), is("--foobar3=jee3 jee3"));
 		assertThat(request.getResource(), instanceOf(MavenResource.class));
 		MavenResource mavenResource = (MavenResource) request.getResource();
 		assertEquals("org.springframework.cloud", mavenResource.getGroupId());

--- a/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.dataflow.shell.command;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -40,6 +42,7 @@ import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableBuilder;
 import org.springframework.shell.table.TableModelBuilder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Task commands.
@@ -66,6 +69,8 @@ public class TaskCommands implements CommandMarker {
 	private static final String PROPERTIES_OPTION = "properties";
 
 	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
+
+	private static final String PARAMS_OPTION = "params";
 
 	private static final String EXECUTION_LIST = "task execution list";
 
@@ -101,7 +106,8 @@ public class TaskCommands implements CommandMarker {
 	public String launch(
 			@CliOption(key = { "", "name" }, help = "the name of the task to launch", mandatory = true) String name,
 			@CliOption(key = { PROPERTIES_OPTION }, help = "the properties for this launch", mandatory = false) String properties,
-			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile
+			@CliOption(key = { PROPERTIES_FILE_OPTION }, help = "the properties for this launch (as a File)", mandatory = false) File propertiesFile,
+			@CliOption(key = { PARAMS_OPTION }, help = "the commandline arguments for this launch", mandatory = false) String params
 			) throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION, propertiesFile);
 		Map<String, String> propertiesToUse;
@@ -122,10 +128,14 @@ public class TaskCommands implements CommandMarker {
 			default:
 				throw new AssertionError();
 		}
-		taskOperations().launch(name, propertiesToUse);
+		List<String> paramsToUse = new ArrayList<String>();
+		if (StringUtils.hasText(params)) {
+			paramsToUse.add(params);
+		}
+		taskOperations().launch(name, propertiesToUse, paramsToUse);
 		return String.format("Launched task '%s'", name);
 	}
-	
+
 	@CliCommand(value = DESTROY, help = "Destroy an existing task")
 	public String destroy(
 			@CliOption(key = { "", "name" }, help = "the name of the task to destroy", mandatory = true) String name) {


### PR DESCRIPTION
Take 3:

Can now use quoting shown below which are then removed during a parsing assuming that deployer is then responsible to handle proper quoting if needed(i.e. local deployer should not use any type of quoting whatsoever).
```
dataflow:>task launch --name footask --params "'--format=yyyy-MM-dd -- HH:mm:ss.SSS' --foo=bar --jee.juu='asdf'"
dataflow:>task launch --name footask --params "\"--format=yyyy-MM-dd -- HH:mm:ss.SSS\" --foo=bar --jee.juu='asdf'"
dataflow:>task launch --name footask --params "--format=\"yyyy-MM-dd -- HH:mm:ss.SSS\" --foo=bar --jee.juu='asdf'"
```

- Modify shell launch command.
- Add raw list of params throughout a chain
  from shell into a deployer SPI call.
- Added one test verifying params.
- In DefaultTaskJobService.restartJobExecution() params are
  coming from TaskExecution, theory at least, but this is not
  testable right now as we don't have restart command.
- Add parsing logic to DeploymentPropertiesUtils together
  with tests.
- Fixes #503