### PR TITLE
Add validation on app definitions

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -99,7 +99,8 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public DataFlowUriRegistryPopulator dataflowUriRegistryPopulator(UriRegistry uriRegistry, DataFlowUriRegistryPopulatorProperties properties) {
+	public DataFlowUriRegistryPopulator dataflowUriRegistryPopulator(UriRegistry uriRegistry,
+			DataFlowUriRegistryPopulatorProperties properties) {
 		return new DataFlowUriRegistryPopulator(uriRegistry, uriRegistryPopulator(), properties);
 	}
 
@@ -121,14 +122,15 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	public StreamDefinitionController streamDefinitionController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController, AppDeployer deployer) {
-		return new StreamDefinitionController(repository, deploymentIdRepository, deploymentController, deployer);
+			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController,
+			AppDeployer deployer, AppRegistry appRegistry) {
+		return new StreamDefinitionController(repository, deploymentIdRepository, deploymentController, deployer,
+				appRegistry);
 	}
 
 	@Bean
 	public StreamDeploymentController streamDeploymentController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
-			DelegatingResourceLoader resourceLoader) {
+			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer) {
 		return new StreamDeploymentController(repository, deploymentIdRepository, registry, deployer);
 	}
 
@@ -177,7 +179,7 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public JobInstanceController jobInstanceController(TaskJobService repository){
+	public JobInstanceController jobInstanceController(TaskJobService repository) {
 		return new JobInstanceController(repository);
 	}
 
@@ -202,7 +204,8 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public ModuleController moduleController(AppRegistry appRegistry, ModuleConfigurationMetadataResolver metadataResolver) {
+	public ModuleController moduleController(AppRegistry appRegistry,
+			ModuleConfigurationMetadataResolver metadataResolver) {
 		return new ModuleController(appRegistry, metadataResolver);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -16,10 +16,19 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.dataflow.core.ArtifactType;
+import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
@@ -36,15 +45,13 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.EnumSet;
-import java.util.Set;
 
 /**
  * Controller for operations on {@link StreamDefinition}. This
@@ -78,6 +85,11 @@ public class StreamDefinitionController {
 	private final AppDeployer deployer;
 
 	/**
+	 * The app registry this controller will use to lookup apps.
+	 */
+	private final AppRegistry appRegistry;
+
+	/**
 	 * Assembler for {@link StreamDefinitionResource} objects.
 	 */
 	private final Assembler streamDefinitionAssembler = new Assembler();
@@ -99,17 +111,20 @@ public class StreamDefinitionController {
 	 * @param deploymentIdRepository the repository this controller will use for deployment IDs
 	 * @param deploymentController the deployment controller to delegate deployment operations
 	 * @param deployer             the deployer this controller will use to compute deployment status
+	 * @param appRegistry          the app registry to look up registered apps
 	 */
 	public StreamDefinitionController(StreamDefinitionRepository repository, DeploymentIdRepository deploymentIdRepository,
-			StreamDeploymentController deploymentController, AppDeployer deployer) {
+			StreamDeploymentController deploymentController, AppDeployer deployer, AppRegistry appRegistry) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(deploymentController, "StreamDeploymentController must not be null");
 		Assert.notNull(deployer, "AppDeployer must not be null");
+		Assert.notNull(appRegistry, "AppRegistry must not be null");
 		this.deploymentController = deploymentController;
 		this.deploymentIdRepository = deploymentIdRepository;
 		this.repository = repository;
 		this.deployer = deployer;
+		this.appRegistry = appRegistry;
 	}
 
 	/**
@@ -140,9 +155,46 @@ public class StreamDefinitionController {
 					 @RequestParam(value = "deploy", defaultValue = "false")
 					 boolean deploy) {
 		StreamDefinition stream = new StreamDefinition(name, dsl);
+		List<String> errorMessages = new ArrayList<>();
+		for (ModuleDefinition appDefintion: stream.getModuleDefinitions()) {
+			String appName = appDefintion.getName();
+			ArtifactType artifactType = determineModuleType(appDefintion);
+			if (appRegistry.find(appName, artifactType) == null) {
+				errorMessages.add(String.format("Application name '%s' with type '%s' does not exist in the app registry.",
+						appName, artifactType));
+			}
+		}
+		if (!errorMessages.isEmpty()) {
+			throw new IllegalArgumentException(StringUtils.collectionToDelimitedString(errorMessages, System.lineSeparator()));
+		}
 		this.repository.save(stream);
 		if (deploy) {
 			deploymentController.deploy(name, null);
+		}
+	}
+
+	/**
+	 * Return the {@link ArtifactType} for a {@link ModuleDefinition} in the context
+	 * of a defined stream.
+	 *
+	 * @param moduleDefinition the module for which to determine the type
+	 * @return {@link ArtifactType} for the given module
+	 */
+	 static ArtifactType determineModuleType(ModuleDefinition moduleDefinition) {
+		// Parser has already taken care of source/sink destinations, etc
+		boolean hasOutput = moduleDefinition.getParameters().containsKey(BindingPropertyKeys.OUTPUT_DESTINATION);
+		boolean hasInput = moduleDefinition.getParameters().containsKey(BindingPropertyKeys.INPUT_DESTINATION);
+		if (hasInput && hasOutput) {
+			return ArtifactType.processor;
+		}
+		else if (hasInput) {
+			return ArtifactType.sink;
+		}
+		else if (hasOutput) {
+			return ArtifactType.source;
+		}
+		else {
+			throw new IllegalStateException(moduleDefinition + " had neither input nor output set");
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -179,7 +179,7 @@ public class StreamDeploymentController {
 		long timestamp = System.currentTimeMillis();
 		while (iterator.hasNext()) {
 			ModuleDefinition currentModule = iterator.next();
-			ArtifactType type = determineModuleType(currentModule);
+			ArtifactType type = StreamDefinitionController.determineModuleType(currentModule);
 			Map<String, String> moduleDeploymentProperties = extractModuleDeploymentProperties(currentModule, streamDeploymentProperties);
 			moduleDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentModule.getGroup());
 			if (moduleDeploymentProperties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) {
@@ -216,30 +216,6 @@ public class StreamDeploymentController {
 		}
 	}
 
-	/**
-	 * Return the {@link ArtifactType} for a {@link ModuleDefinition} in the context
-	 * of a defined stream.
-	 *
-	 * @param moduleDefinition the module for which to determine the type
-	 * @return {@link ArtifactType} for the given module
-	 */
-	private ArtifactType determineModuleType(ModuleDefinition moduleDefinition) {
-		// Parser has already taken care of source/sink destinations, etc
-		boolean hasOutput = moduleDefinition.getParameters().containsKey(BindingPropertyKeys.OUTPUT_DESTINATION);
-		boolean hasInput = moduleDefinition.getParameters().containsKey(BindingPropertyKeys.INPUT_DESTINATION);
-		if (hasInput && hasOutput) {
-			return ArtifactType.processor;
-		}
-		else if (hasInput) {
-			return ArtifactType.sink;
-		}
-		else if (hasOutput) {
-			return ArtifactType.source;
-		}
-		else {
-			throw new IllegalStateException(moduleDefinition + " had neither input nor output set");
-		}
-	}
 
 	/**
 	 * Extract and return a map of properties for a specific module within the

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -87,7 +87,8 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	@Bean
 	public StreamDefinitionController streamDefinitionController(StreamDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController) {
-		return new StreamDefinitionController(repository, deploymentIdRepository, deploymentController, appDeployer());
+		return new StreamDefinitionController(repository, deploymentIdRepository, deploymentController, appDeployer(),
+				appRegistry());
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -20,6 +20,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -74,6 +76,7 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -124,19 +127,19 @@ public class StreamControllerTests {
 	public void testConstructorMissingRepository() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(new InMemoryStreamDefinitionRepository(),
 				new InMemoryDeploymentIdRepository(), appRegistry, appDeployer);
-		new StreamDefinitionController(null, null, deploymentController, appDeployer);
+		new StreamDefinitionController(null, null, deploymentController, appDeployer, appRegistry);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingDeploymentController() {
-		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), null, appDeployer);
+		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), null, appDeployer, appRegistry);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingDeployer() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(new InMemoryStreamDefinitionRepository(),
 				new InMemoryDeploymentIdRepository(), appRegistry, appDeployer);
-		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), deploymentController, null);
+		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), deploymentController, null, appRegistry);
 	}
 
 	@Test
@@ -159,6 +162,16 @@ public class StreamControllerTests {
 		assertEquals(2, logDefinition.getParameters().size());
 		assertEquals("myStream.time", logDefinition.getParameters().get(BindingPropertyKeys.INPUT_DESTINATION));
 		assertEquals("myStream", logDefinition.getParameters().get(BindingPropertyKeys.INPUT_GROUP));
+	}
+
+	@Test
+	public void testSaveInvalidAppDefintions() throws Exception {
+		String response = mockMvc.perform(
+				post("/streams/definitions/").param("name", "myStream").param("definition", "foo | bar")
+							.accept(MediaType.APPLICATION_JSON)).andReturn().getResponse().getContentAsString();
+		assertTrue(response.contains("IllegalArgumentException"));
+		assertTrue(response.contains("Application name 'foo' with type 'source' does not exist in the app registry."));
+		assertTrue(response.contains("Application name 'bar' with type 'sink' does not exist in the app registry."));
 	}
 
 	@Test


### PR DESCRIPTION
 - validate app names based on their type when the stream definition is created
  - this way we don't need to inject the app registry at the parser level but the validation is always performed when the defintion is created
  - use app registry to find if the names exist in the registry

 - Add test

This resolves #574