### PR TITLE
Cleanup deploymentId repo after undeployment

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -364,6 +364,7 @@ public class StreamDeploymentController {
 				if (!EnumSet.of(DeploymentState.unknown, DeploymentState.undeployed)
 						.contains(status.getState())) {
 					this.deployer.undeploy(id);
+					this.deploymentIdRepository.delete(key);
 				}
 			}
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -104,10 +104,12 @@ public class TaskDefinitionController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	public void destroyTask(@PathVariable("name") String name) {
-		if (repository.findOne(name) == null) {
+		TaskDefinition taskDefinition = repository.findOne(name);
+		if (taskDefinition == null) {
 			throw new NoSuchTaskDefinitionException(name);
 		}
 		repository.delete(name);
+		deploymentIdRepository.delete(DeploymentKey.forApp(taskDefinition.getModuleDefinition()));
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentIdRepository.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Repository;
  *
  * @author Janne Valkealahti
  * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
  */
 @Repository
 public interface DeploymentIdRepository extends org.springframework.data.repository.Repository<String, String> {
@@ -43,4 +44,11 @@ public interface DeploymentIdRepository extends org.springframework.data.reposit
 	 * @return the identifier
 	 */
 	String findOne(String key);
+
+	/**
+	 * Delete the entries associated with the app deployment key.
+	 *
+	 * @param key the app deployment key
+	 */
+	void delete(String key);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepository.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  *
  * @author Janne Valkealahti
  * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
  */
 public class InMemoryDeploymentIdRepository implements DeploymentIdRepository {
 
@@ -43,5 +44,10 @@ public class InMemoryDeploymentIdRepository implements DeploymentIdRepository {
 	@Override
 	public String findOne(String key) {
 		return deployments.get(key);
+	}
+
+	@Override
+	public void delete(String key) {
+		deployments.remove(key);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepository.java
@@ -25,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
  *
  * @author Janne Valkealahti
  * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
  */
 public class RedisDeploymentIdRepository implements DeploymentIdRepository {
 
@@ -49,5 +50,10 @@ public class RedisDeploymentIdRepository implements DeploymentIdRepository {
 	@Override
 	public String findOne(String key) {
 		return hashOperations.get(key);
+	}
+
+	@Override
+	public void delete(String key) {
+		hashOperations.delete(key);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepositoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.repository;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.springframework.cloud.dataflow.core.TaskDefinition;
 /**
  * @author Janne Valkealahti
  * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
  */
 public class InMemoryDeploymentIdRepositoryTests {
 
@@ -72,5 +74,24 @@ public class InMemoryDeploymentIdRepositoryTests {
 		String findOne6 = repository.findOne(appDeploymentKey6);
 		assertThat(findOne6, notNullValue());
 		assertThat(findOne6, is("id3"));
+	}
+
+	@Test
+	public void testDeleteKey() {
+		StreamDefinition streamDefinition1 = new StreamDefinition("myStream1", "time | log");
+		ModuleDefinition[] moduleDefinitions1 = streamDefinition1.getModuleDefinitions().toArray(new ModuleDefinition[0]);
+		TaskDefinition taskDefinition1 = new TaskDefinition("myTask", "timestamp");
+		String appDeploymentKey1 = DeploymentKey.forApp(moduleDefinitions1[0]);
+		String appDeploymentKey2 = DeploymentKey.forApp(moduleDefinitions1[1]);
+		String appDeploymentKey3 = DeploymentKey.forApp(taskDefinition1.getModuleDefinition());
+
+		DeploymentIdRepository repository = new InMemoryDeploymentIdRepository();
+		repository.save(appDeploymentKey1, "id1");
+		repository.save(appDeploymentKey2, "id2");
+		repository.save(appDeploymentKey3, "id3");
+		repository.delete(appDeploymentKey1);
+		assertThat(repository.findOne(appDeploymentKey1), nullValue());
+		assertThat(repository.findOne(appDeploymentKey2), notNullValue());
+		assertThat(repository.findOne(appDeploymentKey3), notNullValue());
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepositoryTests.java
@@ -16,10 +16,15 @@
 
 package org.springframework.cloud.dataflow.server.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,12 +32,15 @@ import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
  * Tests for {@link RedisDeploymentIdRepository}.
  *
  * @author Janne Valkealahti
  * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
  */
 public class RedisDeploymentIdRepositoryTests {
 
@@ -41,9 +49,17 @@ public class RedisDeploymentIdRepositoryTests {
 
 	private RedisDeploymentIdRepository repository;
 
+	private static final String DEPLOYMENT_ID_REPO_HASH_KEY = "RedisAppDeploymentRepositoryTests";
+
 	@Before
 	public void setUp() {
-		repository = new RedisDeploymentIdRepository("RedisAppDeploymentRepositoryTests", redisTestSupport.getResource());
+		repository = new RedisDeploymentIdRepository(DEPLOYMENT_ID_REPO_HASH_KEY, redisTestSupport.getResource());
+	}
+
+	@After
+	public void cleanup() {
+		RedisTemplate redisTemplate = new StringRedisTemplate(redisTestSupport.getResource());
+		redisTemplate.delete(DEPLOYMENT_ID_REPO_HASH_KEY);
 	}
 
 	@Test
@@ -60,6 +76,7 @@ public class RedisDeploymentIdRepositoryTests {
 		String appDeploymentKey4 = DeploymentKey.forApp(moduleDefinitions2[1]);
 		String appDeploymentKey5 = DeploymentKey.forApp(taskDefinition1.getModuleDefinition());
 		String appDeploymentKey6 = DeploymentKey.forApp(taskDefinition2.getModuleDefinition());
+
 
 		repository.save(appDeploymentKey1, "id1");
 		repository.save(appDeploymentKey2, "id2");
@@ -85,5 +102,24 @@ public class RedisDeploymentIdRepositoryTests {
 		String findOne6 = repository.findOne(appDeploymentKey6);
 		assertThat(findOne6, notNullValue());
 		assertThat(findOne6, is("id3"));
+	}
+
+	@Test
+	public void testDeleteKey() {
+		StreamDefinition streamDefinition1 = new StreamDefinition("myStream1", "time | log");
+		ModuleDefinition[] moduleDefinitions1 = streamDefinition1.getModuleDefinitions().toArray(new ModuleDefinition[0]);
+		TaskDefinition taskDefinition1 = new TaskDefinition("myTask", "timestamp");
+		String appDeploymentKey1 = DeploymentKey.forApp(moduleDefinitions1[0]);
+		String appDeploymentKey2 = DeploymentKey.forApp(moduleDefinitions1[1]);
+		String appDeploymentKey3 = DeploymentKey.forApp(taskDefinition1.getModuleDefinition());
+
+		DeploymentIdRepository repository = new InMemoryDeploymentIdRepository();
+		repository.save(appDeploymentKey1, "id1");
+		repository.save(appDeploymentKey2, "id2");
+		repository.save(appDeploymentKey3, "id3");
+		repository.delete(appDeploymentKey1);
+		assertThat(repository.findOne(appDeploymentKey1), nullValue());
+		assertThat(repository.findOne(appDeploymentKey2), notNullValue());
+		assertThat(repository.findOne(appDeploymentKey3), notNullValue());
 	}
 }


### PR DESCRIPTION
- When the app is undeployed, the corresponding deployment id gets deleted from the deploymentIdRepository

This resolves #608