### PR TITLE
Fix tab completion for taps DSL

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DestinationNameYieldsAppsRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/DestinationNameYieldsAppsRecoveryStrategy.java
@@ -37,7 +37,7 @@ class DestinationNameYieldsAppsRecoveryStrategy extends
 	private final AppRegistry appRegistry;
 
 	public DestinationNameYieldsAppsRecoveryStrategy(AppRegistry appRegistry) {
-		super(CheckPointedParseException.class, "queue:foo >", "queue:foo > ");
+		super(CheckPointedParseException.class, ":foo >", ":foo > ");
 		this.appRegistry = appRegistry;
 	}
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -171,27 +171,24 @@ public class StreamCompletionProviderTests {
 	}
 
 	@Test
-	// queue:foo > <TAB>  ==> add app names
+	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoApps() {
-		assertThat(completionProvider.complete("queue:foo >", 1), hasItems(
-				proposalThat(is("queue:foo > filter")),
-				proposalThat(is("queue:foo > log"))
+		assertThat(completionProvider.complete(":foo >", 1), hasItems(
+				proposalThat(is(":foo > filter")),
+				proposalThat(is(":foo > log"))
 		));
-		assertThat(completionProvider.complete("queue:foo >", 1), not(hasItems(
-				proposalThat(is("queue:foo > http"))
+		assertThat(completionProvider.complete(":foo >", 1), not(hasItems(
+				proposalThat(is(":foo > http"))
 		)));
 	}
 
 	@Test
-	// tap:stream:foo > <TAB>  ==> add app names
+	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoAppsVariant() {
-		assertThat(completionProvider.complete("tap:stream:foo >", 1), hasItems(
-				proposalThat(is("tap:stream:foo > filter")),
-				proposalThat(is("tap:stream:foo > log"))
+		assertThat(completionProvider.complete(":foo >", 1), hasItems(
+				proposalThat(is(":foo > filter")),
+				proposalThat(is(":foo > log"))
 		));
-		assertThat(completionProvider.complete("queue:foo >", 1), not(hasItems(
-				proposalThat(is("tap:stream:foo > http"))
-		)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AppParser.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AppParser.java
@@ -66,6 +66,12 @@ public class AppParser {
 	 */
 	protected AppNode eatApp() {
 		Token label = null;
+		if (tokens.peek(TokenKind.COLON)) {
+			if (tokens.getTokenStream().size() == 1) {
+				tokens.raiseException(tokens.peek().startPos,
+						DSLMessage.EXPECTED_STREAM_NAME_AFTER_LABEL_COLON);
+			}
+		}
 		Token name = tokens.next();
 		if (!name.isKind(TokenKind.IDENTIFIER)) {
 			tokens.raiseException(name.startPos, DSLMessage.EXPECTED_APPNAME,

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
@@ -92,7 +92,8 @@ public enum DSLMessage {
 			145,
 			"no whitespace is allowed between dot and components of a name"),
 	DESTINATIONS_UNSUPPORTED_HERE(ERROR, 146, "a destination is not supported in this kind of definition"),
-	EXPECTED_WHITESPACE_AFTER_LABEL_COLON(ERROR, 147, "whitespace is expected after an app label"), //
+	EXPECTED_WHITESPACE_AFTER_LABEL_COLON(ERROR, 147, "whitespace is expected after an app label"),
+	EXPECTED_STREAM_NAME_AFTER_LABEL_COLON(ERROR, 148, "stream name is expected after an app label")
 	;
 
 	private Kind kind;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/DataFlowServerUtil.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/DataFlowServerUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+
+/**
+ * Utility class holding helper methods used by the server core.
+ *
+ * @author Mark Fisher
+ * @author Ilayaperumal Gopinathan
+ */
+public class DataFlowServerUtil {
+
+    /**
+     * Return the {@link ApplicationType} for a {@link AppDefinition} in the context
+     * of a defined stream.
+     *
+     * @param appDefinition the app for which to determine the type
+     * @return {@link ApplicationType} for the given app
+     */
+    public static ApplicationType determineApplicationType(StreamAppDefinition appDefinition) {
+        // Parser has already taken care of source/sink destinations, etc
+        boolean hasOutput = appDefinition.getProperties().containsKey(BindingPropertyKeys.OUTPUT_DESTINATION);
+        boolean hasInput = appDefinition.getProperties().containsKey(BindingPropertyKeys.INPUT_DESTINATION);
+        if (hasInput && hasOutput) {
+            return ApplicationType.processor;
+        }
+        else if (hasInput) {
+            return ApplicationType.sink;
+        }
+        else if (hasOutput) {
+            return ApplicationType.source;
+        }
+        else {
+            throw new IllegalStateException(appDefinition.getName() + " had neither input nor output set");
+        }
+    }
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/completion/TapOnDestinationRecoveryStrategy.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/completion/TapOnDestinationRecoveryStrategy.java
@@ -58,7 +58,9 @@ public class TapOnDestinationRecoveryStrategy implements RecoveryStrategy<ParseE
 		if (streamName.contains(".")) {
 			String[] splits = streamName.split("\\.");
 			streamName = splits[0];
-			appName = splits[1];
+			if (splits.length > 1) {
+				appName = splits[1];
+			}
 		}
 
 		StreamDefinition streamDefinition = streamDefinitionRepository.findOne(streamName);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
@@ -202,7 +203,7 @@ public class StreamDeploymentController {
 		boolean isDownStreamAppPartitioned = false;
 		while (iterator.hasNext()) {
 			StreamAppDefinition currentApp = iterator.next();
-			ApplicationType type = StreamDefinitionController.determineApplicationType(currentApp);
+			ApplicationType type = DataFlowServerUtil.determineApplicationType(currentApp);
 			Map<String, String> appDeploymentProperties = extractAppDeploymentProperties(currentApp, streamDeploymentProperties);
 			appDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
 			if (appDeploymentProperties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.completion;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hamcrest.FeatureMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.loader.LaunchedURLClassLoader;
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
+import org.springframework.cloud.dataflow.completion.CompletionProposal;
+import org.springframework.cloud.dataflow.completion.RecoveryStrategy;
+import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.server.repository.InMemoryStreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
+import org.springframework.cloud.stream.configuration.metadata.AppJarLauncher;
+import org.springframework.cloud.stream.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.Assert;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { CompletionConfiguration.class, TabOnTapCompletionProviderTests.Mocks.class })
+public class TabOnTapCompletionProviderTests {
+
+	@Autowired
+	private StreamCompletionProvider completionProvider;
+
+	@Before
+	public void setup() {
+		StreamDefinitionRepository streamDefinitionRepository = new InMemoryStreamDefinitionRepository();
+		streamDefinitionRepository.save(new StreamDefinition("foo", "time | transform | log"));
+		streamDefinitionRepository.save(new StreamDefinition("bar", "time | log"));
+		completionProvider.addCompletionRecoveryStrategy(new TapOnDestinationRecoveryStrategy(streamDefinitionRepository));
+	}
+
+    @Test
+    // :foo  ==> add appropriate app names
+    public void testAppNamesAfterStreamName() {
+        assertThat(completionProvider.complete(":foo", 1), hasItems(
+				proposalThat(is(":foo.time")),
+				proposalThat(is(":foo.transform"))
+		));
+    }
+
+	@Test
+	// :foo.  ==> add appropriate app names
+	public void testAppNamesAfterStreamNameWithDotAfterStreamName() {
+		assertThat(completionProvider.complete(":foo.", 1), hasItems(
+				proposalThat(is(":foo.time")),
+				proposalThat(is(":foo.transform"))
+		));
+	}
+
+	@Test
+	// :  ==> add stream name
+	public void testStreamNameAfterColon() {
+		assertThat(completionProvider.complete(":", 1), hasItems(
+				proposalThat(is(":foo")),
+				proposalThat(is(":bar"))
+		));
+	}
+
+	private static org.hamcrest.Matcher<CompletionProposal> proposalThat(org.hamcrest.Matcher<String> matcher) {
+		return new FeatureMatcher<CompletionProposal, String>(matcher, "a proposal whose text", "text") {
+			@Override
+			protected String featureValueOf(CompletionProposal actual) {
+				return actual.getText();
+			}
+		};
+	}
+
+	/**
+	 * A set of mocks that consider the contents of the {@literal apps/} directory as app
+	 * archives.
+	 *
+	 * @author Eric Bottard
+	 * @author Mark Fisher
+	 */
+	@Configuration
+	public static class Mocks {
+
+		private static final File ROOT = new File("src/test/resources/apps");
+
+		private static final FileFilter FILTER = new FileFilter() {
+			@Override
+			public boolean accept(File pathname) {
+				return pathname.isDirectory() && pathname.getName().matches(".+-.+");
+			}
+		};
+
+		@Bean
+		public AppRegistry appRegistry() {
+			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
+			return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+				@Override
+				public AppRegistration find(String name, ApplicationType type) {
+					String filename = name + "-" + type;
+					File file = new File(ROOT, filename);
+					if (file.exists()) {
+						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+					} else {
+						return null;
+					}
+				}
+
+				@Override
+				public List<AppRegistration> findAll() {
+					List<AppRegistration> result = new ArrayList<>();
+					for (File file : ROOT.listFiles(FILTER)) {
+						result.add(makeAppRegistration(file));
+					}
+					return result;
+				}
+
+				private AppRegistration makeAppRegistration(File file) {
+					String fileName = file.getName();
+					Matcher matcher = Pattern.compile("(?<name>.+)-(?<type>.+)").matcher(fileName);
+					Assert.isTrue(matcher.matches());
+					String name = matcher.group("name");
+					ApplicationType type = ApplicationType.valueOf(matcher.group("type"));
+					return new AppRegistration(name, type, file.toURI(), resourceLoader);
+				}
+			};
+		}
+
+		@Bean
+		public ApplicationConfigurationMetadataResolver configurationMetadataResolver() {
+			return new ApplicationConfigurationMetadataResolver() {
+				// Narrow ClassLoader visibility for tests
+				@Override
+				protected ClassLoader createClassLoader(Archive archive) throws Exception {
+					ClassLoaderExposingJarLauncher jarLauncher = new ClassLoaderExposingJarLauncher(archive) {
+						@Override
+						protected ClassLoader createClassLoader(URL[] urls) throws Exception {
+							return new LaunchedURLClassLoader(urls, null);
+						}
+					};
+					return jarLauncher.createClassLoader();
+				}
+			};
+		}
+	}
+
+	private static class ClassLoaderExposingJarLauncher extends AppJarLauncher {
+
+		public ClassLoaderExposingJarLauncher(Archive archive) {
+			super(archive);
+		}
+
+		protected ClassLoader createClassLoader() throws Exception {
+			List<Archive> classPathArchives = getClassPathArchives();
+			return createClassLoader(classPathArchives);
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/apps/filter-processor/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/apps/filter-processor/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,18 @@
+{
+  "properties": [
+    {
+      "name": "expression",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.FilterProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "expresso",
+      "type": "org.springframework.cloud.dataflow.completion.Expresso",
+      "description": "A property of type enum and whose name starts like 'expression'",
+      "sourceType": "foo.bar.FilterProperties"
+    }
+  ],
+  "hints": []
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/apps/hdfs-source/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/apps/hdfs-source/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,45 @@
+{
+  "groups": [
+    {
+      "name": "some.long.prefix",
+      "type": "foo.bar.HdfsProperties",
+      "sourceType": "foo.bar.HdfsProperties"
+    },
+    {
+      "name": "some.long.prefix.nested",
+      "type": "foo.bar.OtherHdfsProperties",
+      "sourceType": "foo.bar.HdfsProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "directory",
+      "type": "java.lang.String",
+      "description": "A path",
+      "sourceType": "com.foo.DifferentHdfsProperties",
+      "defaultValue": "/tmp"
+    },
+    {
+      "name": "some.long.prefix.option1",
+      "type": "java.lang.String",
+      "description": "An option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "foo"
+    },
+    {
+      "name": "some.long.prefix.option2",
+      "type": "java.lang.String",
+      "description": "Another option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "bar"
+    },
+    {
+      "name": "some.long.prefix.nested.itworks",
+      "type": "java.lang.String",
+      "description": "Nested option",
+      "sourceType": "foo.bar.HdfsProperties",
+      "defaultValue": "wizz"
+    }
+  ],
+  "hints": []
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/apps/http-source/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/apps/http-source/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,25 @@
+{
+  "groups": [
+    {
+      "name": "",
+      "type": "foo.bar.HttpProperties",
+      "sourceType": "foo.bar.HttpProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "port",
+      "type": "java.lang.Integer",
+      "description": "The port to listen on",
+      "sourceType": "foo.bar.HttpProperties",
+      "defaultValue": 8080
+    },
+    {
+      "name": "use.ssl",
+      "type": "java.lang.Boolean",
+      "description": "Whether to use SSL encryption or not",
+      "sourceType": "foo.bar.HttpProperties"
+    }
+  ],
+  "hints": []
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/apps/log-sink/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/apps/log-sink/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,30 @@
+{
+  "properties": [
+    {
+      "name": "level",
+      "type": "java.lang.String",
+      "description": "The logger level",
+      "sourceType": "com.foo.LogProperties",
+      "defaultValue": "debug"
+    }
+  ],
+  "hints": [
+    {
+      "name": "level",
+      "values": [
+        {
+          "value": "debug"
+        },
+        {
+          "value": "info"
+        },
+        {
+          "value": "warn"
+        },
+        {
+          "value": "error"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Fix the DSL parser to throw appropriate error message based on the shell provided DSL text
 - If the DSL starts with tap prefix ":", then provide auto completion proposals
   - with the stream names from stream definition repositories
   - the app definition label names (except for the sink apps)
   - Move the app definition `determineModuleType` static method into util so that all the classes under server core could use it
 - Fix the DestinationNameYieldsModulesRecoveryStrategy with the appropriate samples
 - Fix tests

This resolves #610