### PR TITLE
Update docs to include binder dependency

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -202,7 +202,7 @@ spring:
 == Subscribing to Task/Batch events
 
 You can also tap into various task/batch events when the task is launched.
-If the task is enabled to generate task and or batch events (with the additional dependency of `spring-cloud-task-stream`), those events are published during the task lifecycle.
+If the task is enabled to generate task and/or batch events (with the additional dependencies `spring-cloud-task-stream` and `spring-cloud-stream-binder-kafka`, in the case of Kafka as the binder), those events are published during the task lifecycle. 
 By default, the destination names for those published events on the broker (rabbit, kafka etc.,) are the event names themselves (for instance: `task-events`, `job-execution-events` etc.,).
 
 ```


### PR DESCRIPTION
I followed the docs to tease out tapping the `task-events`; however, without the binder dependency, we would get the following exception while launching the task/batch.

```
RELEASE.jar!/:4.2.5.RELEASE]
	... 39 common frames omitted
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.cloud.stream.binder.BinderTypeRegistry]: Factory method 'binderTypeRegistry' threw exception; nested exception is org.springframework.beans.factory.BeanCreationException: Cannot create binder factory, no `META-INF/spring.binders` resources found on the classpath
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189) ~[spring-beans-4.2.5.RELEASE.jar!/:4.2.5.RELEASE]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588) ~[spring-beans-4.2.5.RELEASE.jar!/:4.2.5.RELEASE]
	... 52 common frames omitted
Caused by: org.springframework.beans.factory.BeanCreationException: Cannot create binder factory, no `META-INF/spring.binders` resources found on the classpath
	at org.springframework.cloud.stream.config.BinderFactoryConfiguration.binderTypeRegistry(BinderFactoryConfiguration.java:100) ~[spring-cloud-stream-1.0.0.RC3.jar!/:1.0.0.RC3]
	at org.springframework.cloud.stream.config.BinderFactoryConfiguration$$EnhancerBySpringCGLIB$$f5d04127.CGLIB$binderTypeRegistry$0(<generated>) ~[spring-cloud-stream-1.0.0.RC3.jar!/:1.0.0.RC3]
	at org.springframework.cloud.stream.config.BinderFactoryConfiguration$$EnhancerBySpringCGLIB$$f5d04127$$FastClassBySpringCGLIB$$349fb6c2.invoke(<generated>) ~[spring-cloud-stream-1.0.0.RC3.jar!/:1.0.0.RC3]
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228) ~[spring-core-4.2.5.RELEASE.jar!/:4.2.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:355) ~[spring-context-4.2.5.RELEASE.jar!/:4.2.5.RELEASE]
	at org.springframework.cloud.stream.config.BinderFactoryConfiguration$$EnhancerBySpringCGLIB$$f5d04127.binderTypeRegistry(<generated>) ~[spring-cloud-stream-1.0.0.RC3.jar!/:1.0.0.RC3]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_31]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_31]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_31]
	at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0_31]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162) ~[spring-beans-4.2.5.RELEASE.jar!/:4.2.5.RELEASE]
	... 53 common frames omitted

```

This PR includes indication to include the binder dependency.