### PR TITLE
The getParameters has been updated to use getArguments

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
@@ -91,7 +91,7 @@ public class TaskExecutionResource extends ResourceSupport {
 		this.exitCode = taskJobExecutionRel.getTaskExecution().getExitCode();
 		this.taskName = taskJobExecutionRel.getTaskExecution().getTaskName();
 		this.exitMessage = taskJobExecutionRel.getTaskExecution().getExitMessage();
-		this.arguments = Collections.unmodifiableList(taskJobExecutionRel.getTaskExecution().getParameters());
+		this.arguments = Collections.unmodifiableList(taskJobExecutionRel.getTaskExecution().getArguments());
 		this.startTime = taskJobExecutionRel.getTaskExecution().getStartTime();
 		this.endTime = taskJobExecutionRel.getTaskExecution().getEndTime();
 		if(taskJobExecutionRel.getJobExecutionIds() == null){

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -208,7 +208,7 @@ public class DefaultTaskJobService implements TaskJobService {
 			throw new NoSuchTaskDefinitionException(taskExecution.getTaskName());
 		}
 
-		taskService.executeTask(taskDefinition.getName(), taskDefinition.getProperties(), taskExecution.getParameters());
+		taskService.executeTask(taskDefinition.getName(), taskDefinition.getProperties(), taskExecution.getArguments());
 	}
 
 	@Override


### PR DESCRIPTION
This is based on the change in SCT where TaskExecution.getParameters
was replaced with TaskExecution.getArguments.

Do not merge until https://github.com/spring-cloud/spring-cloud-task/pull/148 is merged (because this PR is a breaking change)

resolves #667