### PR TITLE
Rearrange doc sections

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -91,8 +91,28 @@ In some cases the Resource is resolved on the server side, whereas in others the
 URI will be passed to a runtime container instance where it is resolved. Consult
 the specific documentation of each Data Flow Server for more detail.
 
+[[spring-cloud-dataflow-stream-app-whitelisting]]
+=== Whitelisting application properties
+
+Stream applications are Spring Boot applications which are aware of many link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties[common application properties], e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
+
+To whitelist application properties create a file named `spring-configuration-metadata-whitelist.propreties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of propety, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.
+
+The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simle example of the file source's `spring-configuration-metadata-whitelist.properties` file
+
+```
+configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
+```
+
+If for some reason we also wanted to add `server.port` to this file, it would look like
+
+```
+configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
+configuration-properties.names=server.port
+```
+
 [[spring-cloud-dataflow-create-stream]]
-== Creating a Simple Stream
+== Creating a Stream
 
 The Spring Cloud Data Flow Server exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use is it is via the Spring Cloud Data Flow shell. Start the shell as described in the xref:Getting-Started#getting-started[Getting Started] section.
 
@@ -135,8 +155,8 @@ dataflow:> stream deploy --name ticktock --properties "app.time.count=3"
 
 IMPORTANT: See <<spring-cloud-dataflow-stream-app-labels>>.
 
-[[spring-cloud-dataflow-delete-stream]]
-== Deleting a Stream
+[[spring-cloud-dataflow-destroy-stream]]
+== Destroying a Stream
 
 You can delete a stream by issuing the `stream destroy` command from the shell:
 
@@ -344,23 +364,3 @@ This can be done using the DSL syntax `http > :mydestination` or `:mydestination
 Second, you may need to determine the output channel of a stream based on some information that is only known at runtime.
 In that case, a router may be used in the sink position of a stream definition. For more information, refer to the Router Sink starter's
 link:https://github.com/spring-cloud/spring-cloud-stream-app-starters/tree/master/router/spring-cloud-starter-stream-sink-router[README].
-
-[[spring-cloud-dataflow-stream-app-whitelisting]]
-=== Whitelisting application properties
-
-Stream applications are Spring Boot applications which are aware of many link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties[common application properties], e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
-
-To whitelist application properties create a file named `spring-configuration-metadata-whitelist.propreties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of propety, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.  
-
-The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simle example of the file source's `spring-configuration-metadata-whitelist.properties` file
-
-```
-configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
-```
-
-If for some reason we also wanted to add `server.port` to this file, it would look like
-
-```
-configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
-configuration-properties.names=server.port
-```

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -35,7 +35,7 @@ The shell provides tab completion for application properties and also the shell 
 == Register a Stream App
 
 Register a Stream App with the App Registry using the Spring Cloud Data Flow Shell
-`app register` command. You must provide a unique name and a URI that can be
+`app register` command. You must provide a unique name, application type, and a URI that can be
 resolved to the app artifact. For the type, specify "source", "processor", or "sink".
 Here are a few examples:
 
@@ -96,15 +96,15 @@ the specific documentation of each Data Flow Server for more detail.
 
 Stream applications are Spring Boot applications which are aware of many link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties[common application properties], e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
 
-To whitelist application properties create a file named `spring-configuration-metadata-whitelist.propreties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of propety, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.
+To whitelist application properties create a file named `spring-configuration-metadata-whitelist.properties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of property, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.
 
-The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simle example of the file source's `spring-configuration-metadata-whitelist.properties` file
+The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simple example of the file source's `spring-configuration-metadata-whitelist.properties` file
 
 ```
 configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
 ```
 
-If for some reason we also wanted to add `server.port` to this file, it would look like
+If for some reason we also wanted to add `file.prefix` to this file, it would look like
 
 ```
 configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
@@ -240,7 +240,7 @@ Will result in an uppercased 'HELLO' in the log
 To demonstrate the data partitioning functionality, let's deploy the following stream with Kafka as the binder.
 
 ```
-dataflow:>stream create words --definition "http --server.port=9900 | splitter --expression=payload.split(' ') | log"
+dataflow:>stream create --name words --definition "http --server.port=9900 | splitter --expression=payload.split(' ') | log"
 Created new stream 'words'
 
 dataflow:>stream deploy words --properties "app.splitter.producer.partitionKeyExpression=payload,app.log.count=2"

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -23,130 +23,7 @@ http --server.port=8091 | file --directory=/tmp/httpdata/
 ```
 To create these stream definitions you use the shell or make an HTTP POST request to the Spring Cloud Data Flow Server. More details can be found in the sections below.
 
-[[spring-cloud-dataflow-create-stream]]
-== Creating a Simple Stream
-
-The Spring Cloud Data Flow Server exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use is it is via the Spring Cloud Data Flow shell. Start the shell as described in the xref:Getting-Started#getting-started[Getting Started] section.
-
-New streams are created by posting stream definitions. The definitions are built from a simple DSL. For example, let's walk through what happens if we execute the following shell command:
-
-```
-dataflow:> stream create --definition "time | log" --name ticktock
-```
-This defines a stream named `ticktock` based off the DSL expression `time | log`.  The DSL uses the "pipe" symbol `|`, to connect a source to a sink.
-
-Then to deploy the stream execute the following shell command (or alternatively add the `--deploy` flag when creating the stream so that this step is not needed):
-
-```
-dataflow:> stream deploy --name ticktock
-```
-The Data Flow Server resolves `time` and `log` to maven coordinates and uses those to launch the `time` and `log` applications of the stream.
-
-```
-2016-06-01 09:41:21.728  INFO 79016 --- [nio-9393-exec-6] o.s.c.d.spi.local.LocalAppDeployer       : deploying app ticktock.log instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481708/ticktock.log
-2016-06-01 09:41:21.914  INFO 79016 --- [nio-9393-exec-6] o.s.c.d.spi.local.LocalAppDeployer       : deploying app ticktock.time instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481910/ticktock.time
-```
-
-In this example, the time source simply sends the current time as a message each second, and the log sink outputs it using the logging framework.
-You can tail the `stdout` log (which has an "_<instance>" suffix). The log files are located within the directory displayed in the Data Flow Server's log output, as shown above.
-
-```
-$ tail -f /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481708/ticktock.log/stdout_0.log
-2016-06-01 09:45:11.250  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:11
-2016-06-01 09:45:12.250  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:12
-2016-06-01 09:45:13.251  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:13
-```
-
-If you would like to have multiple instances of an application in the stream, you can include a property with the deploy command:
-
-```
-dataflow:> stream deploy --name ticktock --properties "app.time.count=3"
-```
-
-IMPORTANT: See <<spring-cloud-dataflow-stream-app-labels>>.
-
-[[spring-cloud-dataflow-delete-stream]]
-== Deleting a Stream
-
-You can delete a stream by issuing the `stream destroy` command from the shell:
-
-```
-dataflow:> stream destroy --name ticktock
-```
-
-If the stream was deployed, it will be undeployed before the stream definition is deleted.
-
-[[spring-cloud-dataflow-deploy—undeploy-stream]]
-== Deploying and Undeploying Streams
-
-Often you will want to stop a stream, but retain the name and definition for future use. In that case you can `undeploy` the stream by name and issue the `deploy` command at a later time to restart it.
-```
-dataflow:> stream undeploy --name ticktock
-dataflow:> stream deploy --name ticktock
-```
-
-[[spring-cloud-dataflow-stream-app-types]]
-== Other Source and Sink Types
-
-Let's try something a bit more complicated and swap out the `time` source for something else. Another supported source type is `http`, which accepts data for ingestion over HTTP POSTs. Note that the `http` source accepts data on a different port from the Data Flow Server (default 8080). By default the port is randomly assigned.
-
-To create a stream using an `http` source, but still using the same `log` sink, we would change the original command above to
-
-```
-dataflow:> stream create --definition "http | log" --name myhttpstream --deploy
-```
-which will produce the following output from the server
-
-```
-2016-06-01 09:47:58.920  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.log instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788878747/myhttpstream.log
-2016-06-01 09:48:06.396  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.http instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788886383/myhttpstream.http
-```
-
-Note that we don't see any other output this time until we actually post some data (using a shell command). In order to see the randomly assigned port on which the http source is listening, execute:
-
-```
-dataflow:> runtime apps
-```
-You should see that the corresponding http source has a `url` property containing the host and port information on which it is listening. You are now ready to post to that url, e.g.:
-```
-dataflow:> http post --target http://localhost:1234 --data "hello"
-dataflow:> http post --target http://localhost:1234 --data "goodbye"
-```
-and the stream will then funnel the data from the http source to the output log implemented by the log sink
-
-```
-2016-06-01 09:50:22.121  INFO 79654 --- [  kafka-binder-] log.sink    : hello
-2016-06-01 09:50:26.810  INFO 79654 --- [  kafka-binder-] log.sink    : goodbye
-```
-
-Of course, we could also change the sink implementation. You could pipe the output to a file (`file`), to hadoop (`hdfs`) or to any of the other sink apps which are available. You can also define your own apps.
-
-[[spring-cloud-dataflow-simple-stream]]
-== Simple Stream Processing
-
-As an example of a simple processing step, we can transform the payload of the HTTP posted data to upper case using the stream definitions
-```
-http | transform --expression=payload.toUpperCase() | log
-```
-To create this stream enter the following command in the shell
-```
-dataflow:> stream create --definition "http | transform --expression=payload.toUpperCase() | log" --name mystream --deploy
-```
-Posting some data (using a shell command)
-```
-dataflow:> http post --target http://localhost:1234 --data "hello"
-```
-Will result in an uppercased 'HELLO' in the log
-
-```
-2016-06-01 09:54:37.749  INFO 80083 --- [  kafka-binder-] log.sink    : HELLO
-```
-
-== DSL Syntax
+== Stream DSL
 
 In the examples above, we connected a source to a sink using the pipe symbol `|`. You can also pass properties to the source and sink configurations. The property names will depend on the individual app implementations, but as an example, the `http` source app exposes a `server.port` setting which allows you to change the data ingestion port from the default value. To create the stream using port 8000, we would use
 ```
@@ -214,104 +91,128 @@ In some cases the Resource is resolved on the server side, whereas in others the
 URI will be passed to a runtime container instance where it is resolved. Consult
 the specific documentation of each Data Flow Server for more detail.
 
-=== Whitelisting application properties
+[[spring-cloud-dataflow-create-stream]]
+== Creating a Simple Stream
 
-Stream applications are Spring Boot applications which are aware of many link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties[common application properties], e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
+The Spring Cloud Data Flow Server exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use is it is via the Spring Cloud Data Flow shell. Start the shell as described in the xref:Getting-Started#getting-started[Getting Started] section.
 
-To whitelist application properties create a file named `spring-configuration-metadata-whitelist.propreties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of propety, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.  
-
-The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simle example of the file source's `spring-configuration-metadata-whitelist.properties` file
-
-```
-configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
-```
-
-If for some reason we also wanted to add `server.port` to this file, it would look like
+New streams are created by posting stream definitions. The definitions are built from a simple DSL. For example, let's walk through what happens if we execute the following shell command:
 
 ```
-configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
-configuration-properties.names=server.port
+dataflow:> stream create --definition "time | log" --name ticktock
 ```
+This defines a stream named `ticktock` based off the DSL expression `time | log`.  The DSL uses the "pipe" symbol `|`, to connect a source to a sink.
 
-[[spring-cloud-dataflow-stream-advanced]]
-== Advanced Features
-
-If directed graphs are needed instead of the simple linear streams described above, two features are relevant.
-
-First, named destinations may be used as a way to combine the output from multiple streams or for multiple consumers to share the output from a single stream.
-This can be done using the DSL syntax `http > :mydestination` or `:mydestination > log`.
-
-Second, you may need to determine the output channel of a stream based on some information that is only known at runtime.
-In that case, a router may be used in the sink position of a stream definition. For more information, refer to the Router Sink starter's
-link:https://github.com/spring-cloud/spring-cloud-stream-app-starters/tree/master/router/spring-cloud-starter-stream-sink-router[README].
-
-[[spring-cloud-dataflow-stream-app-labels]]
-== App Labels
-
-When a stream is comprised of multiple apps with the same name, they must be qualified with labels:
-```
-stream create --definition "http | firstLabel: transform --expression=payload.toUpperCase() | secondLabel: transform --expression=payload+'!' | log" --name myStreamWithLabels --deploy
-```
-
-[[spring-cloud-dataflow-stream-tap-dsl]]
-== Tap DSL
-
-Taps can be created at various producer endpoints in a stream. For a stream like this:
+Then to deploy the stream execute the following shell command (or alternatively add the `--deploy` flag when creating the stream so that this step is not needed):
 
 ```
-stream create --definition "http | step1: transform --expression=payload.toUpperCase() | step2: transform --expression=payload+'!' | log" --name mainstream --deploy
+dataflow:> stream deploy --name ticktock
+```
+The Data Flow Server resolves `time` and `log` to maven coordinates and uses those to launch the `time` and `log` applications of the stream.
 
 ```
-taps can be created at the output of `http`, `step1` and `step2`.
-
-To create a stream that acts as a 'tap' on another stream requires to specify the `source destination name` for the tap stream. The syntax for source destination name is:
-
-```
-`:<stream-name>.<label/app-name>`
-```
-To create a tap at the output of `http` in the stream above, the source destination name is `mainstream.http`
-To create a tap at the output of the first transform app in the stream above, the source destination name is `mainstream.step1`
-
-The tap stream DSL looks like this:
-
-```
-stream create --definition ":mainstream.http > counter" --name tap_at_http --deploy
-
-stream create --definition ":mainstream.step1 > jdbc" --name tap_at_step1_transformer --deploy
+2016-06-01 09:41:21.728  INFO 79016 --- [nio-9393-exec-6] o.s.c.d.spi.local.LocalAppDeployer       : deploying app ticktock.log instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481708/ticktock.log
+2016-06-01 09:41:21.914  INFO 79016 --- [nio-9393-exec-6] o.s.c.d.spi.local.LocalAppDeployer       : deploying app ticktock.time instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481910/ticktock.time
 ```
 
-Note the colon (:) prefix before the destination names. The colon allows the parser to recognize this as a destination name instead of an app name.
-
-[[spring-cloud-dataflow-stream-explicit-destination-names]]
-== Connecting to explicit destination names at the broker
-
-One can connect to a specific destination name located in the broker (Rabbit, Kafka etc.,) either at the `source` or at the `sink` position.
-
-The following stream has the destination name at the `source` position:
+In this example, the time source simply sends the current time as a message each second, and the log sink outputs it using the logging framework.
+You can tail the `stdout` log (which has an "_<instance>" suffix). The log files are located within the directory displayed in the Data Flow Server's log output, as shown above.
 
 ```
-stream create --definition ":myDestination > log" --name ingest_from_broker --deploy
+$ tail -f /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/ticktock-1464788481708/ticktock.log/stdout_0.log
+2016-06-01 09:45:11.250  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:11
+2016-06-01 09:45:12.250  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:12
+2016-06-01 09:45:13.251  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:13
 ```
 
-This stream receives messages from the destination `myDestination` located at the broker and connects it to the `log` app.
-
-
-The following stream has the destination name at the `sink` position:
+If you would like to have multiple instances of an application in the stream, you can include a property with the deploy command:
 
 ```
-stream create --definition "http > :myDestination" --name ingest_to_broker --deploy
-```
-This stream sends the messages from the `http` app to the destination `myDestination` located at the broker.
-
-From the above streams, notice that the `http` and `log` apps are interacting with each other via the broker (through the destination `myDestination`) rather than having a pipe directly between `http` and `log` within a single stream.
-
-It is also possible to connect two different destinations (`source` and `sink` positions) at the broker in a stream.
-
-```
-stream create --definition ":destination1 > :destination2" --name bridge_destinations --deploy
+dataflow:> stream deploy --name ticktock --properties "app.time.count=3"
 ```
 
-In the above stream, both the destinations (`destination1` and `destination2`) are located in the broker. The messages flow from the source destination to the sink destination via a `bridge` app that connects them.
+IMPORTANT: See <<spring-cloud-dataflow-stream-app-labels>>.
+
+[[spring-cloud-dataflow-delete-stream]]
+== Deleting a Stream
+
+You can delete a stream by issuing the `stream destroy` command from the shell:
+
+```
+dataflow:> stream destroy --name ticktock
+```
+
+If the stream was deployed, it will be undeployed before the stream definition is deleted.
+
+[[spring-cloud-dataflow-deploy-undeploy-stream]]
+== Deploying and Undeploying Streams
+
+Often you will want to stop a stream, but retain the name and definition for future use. In that case you can `undeploy` the stream by name and issue the `deploy` command at a later time to restart it.
+```
+dataflow:> stream undeploy --name ticktock
+dataflow:> stream deploy --name ticktock
+```
+
+[[spring-cloud-dataflow-stream-app-types]]
+== Other Source and Sink Application Types
+
+Let's try something a bit more complicated and swap out the `time` source for something else. Another supported source type is `http`, which accepts data for ingestion over HTTP POSTs. Note that the `http` source accepts data on a different port from the Data Flow Server (default 8080). By default the port is randomly assigned.
+
+To create a stream using an `http` source, but still using the same `log` sink, we would change the original command above to
+
+```
+dataflow:> stream create --definition "http | log" --name myhttpstream --deploy
+```
+which will produce the following output from the server
+
+```
+2016-06-01 09:47:58.920  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.log instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788878747/myhttpstream.log
+2016-06-01 09:48:06.396  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.http instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788886383/myhttpstream.http
+```
+
+Note that we don't see any other output this time until we actually post some data (using a shell command). In order to see the randomly assigned port on which the http source is listening, execute:
+
+```
+dataflow:> runtime apps
+```
+You should see that the corresponding http source has a `url` property containing the host and port information on which it is listening. You are now ready to post to that url, e.g.:
+```
+dataflow:> http post --target http://localhost:1234 --data "hello"
+dataflow:> http post --target http://localhost:1234 --data "goodbye"
+```
+and the stream will then funnel the data from the http source to the output log implemented by the log sink
+
+```
+2016-06-01 09:50:22.121  INFO 79654 --- [  kafka-binder-] log.sink    : hello
+2016-06-01 09:50:26.810  INFO 79654 --- [  kafka-binder-] log.sink    : goodbye
+```
+
+Of course, we could also change the sink implementation. You could pipe the output to a file (`file`), to hadoop (`hdfs`) or to any of the other sink apps which are available. You can also define your own apps.
+
+[[spring-cloud-dataflow-simple-stream]]
+== Simple Stream Processing
+
+As an example of a simple processing step, we can transform the payload of the HTTP posted data to upper case using the stream definitions
+```
+http | transform --expression=payload.toUpperCase() | log
+```
+To create this stream enter the following command in the shell
+```
+dataflow:> stream create --definition "http | transform --expression=payload.toUpperCase() | log" --name mystream --deploy
+```
+Posting some data (using a shell command)
+```
+dataflow:> http post --target http://localhost:1234 --data "hello"
+```
+Will result in an uppercased 'HELLO' in the log
+
+```
+2016-06-01 09:54:37.749  INFO 80083 --- [  kafka-binder-] log.sink    : HELLO
+```
 
 [[spring-cloud-dataflow-stream-partitions]]
 == Stateful Stream Processing
@@ -363,3 +264,103 @@ Review the `words.log instance 1` logs:
 ```
 
 This shows that payload splits that contain the same word are routed to the same application instance.
+
+[[spring-cloud-dataflow-stream-tap-dsl]]
+== Tap a Stream
+
+Taps can be created at various producer endpoints in a stream. For a stream like this:
+
+```
+stream create --definition "http | step1: transform --expression=payload.toUpperCase() | step2: transform --expression=payload+'!' | log" --name mainstream --deploy
+
+```
+taps can be created at the output of `http`, `step1` and `step2`.
+
+To create a stream that acts as a 'tap' on another stream requires to specify the `source destination name` for the tap stream. The syntax for source destination name is:
+
+```
+`:<stream-name>.<label/app-name>`
+```
+To create a tap at the output of `http` in the stream above, the source destination name is `mainstream.http`
+To create a tap at the output of the first transform app in the stream above, the source destination name is `mainstream.step1`
+
+The tap stream DSL looks like this:
+
+```
+stream create --definition ":mainstream.http > counter" --name tap_at_http --deploy
+
+stream create --definition ":mainstream.step1 > jdbc" --name tap_at_step1_transformer --deploy
+```
+
+Note the colon (:) prefix before the destination names. The colon allows the parser to recognize this as a destination name instead of an app name.
+
+[[spring-cloud-dataflow-stream-app-labels]]
+== Using Labels in a Stream
+
+When a stream is comprised of multiple apps with the same name, they must be qualified with labels:
+```
+stream create --definition "http | firstLabel: transform --expression=payload.toUpperCase() | secondLabel: transform --expression=payload+'!' | log" --name myStreamWithLabels --deploy
+```
+
+[[spring-cloud-dataflow-stream-explicit-destination-names]]
+== Explicit Broker Destinations in a Stream
+
+One can connect to a specific destination name located in the broker (Rabbit, Kafka etc.,) either at the `source` or at the `sink` position.
+
+The following stream has the destination name at the `source` position:
+
+```
+stream create --definition ":myDestination > log" --name ingest_from_broker --deploy
+```
+
+This stream receives messages from the destination `myDestination` located at the broker and connects it to the `log` app.
+
+
+The following stream has the destination name at the `sink` position:
+
+```
+stream create --definition "http > :myDestination" --name ingest_to_broker --deploy
+```
+This stream sends the messages from the `http` app to the destination `myDestination` located at the broker.
+
+From the above streams, notice that the `http` and `log` apps are interacting with each other via the broker (through the destination `myDestination`) rather than having a pipe directly between `http` and `log` within a single stream.
+
+It is also possible to connect two different destinations (`source` and `sink` positions) at the broker in a stream.
+
+```
+stream create --definition ":destination1 > :destination2" --name bridge_destinations --deploy
+```
+
+In the above stream, both the destinations (`destination1` and `destination2`) are located in the broker. The messages flow from the source destination to the sink destination via a `bridge` app that connects them.
+
+[[spring-cloud-dataflow-stream-advanced]]
+== Directed Graphs in a Stream
+
+If directed graphs are needed instead of the simple linear streams described above, two features are relevant.
+
+First, named destinations may be used as a way to combine the output from multiple streams or for multiple consumers to share the output from a single stream.
+This can be done using the DSL syntax `http > :mydestination` or `:mydestination > log`.
+
+Second, you may need to determine the output channel of a stream based on some information that is only known at runtime.
+In that case, a router may be used in the sink position of a stream definition. For more information, refer to the Router Sink starter's
+link:https://github.com/spring-cloud/spring-cloud-stream-app-starters/tree/master/router/spring-cloud-starter-stream-sink-router[README].
+
+[[spring-cloud-dataflow-stream-app-whitelisting]]
+=== Whitelisting application properties
+
+Stream applications are Spring Boot applications which are aware of many link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties[common application properties], e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
+
+To whitelist application properties create a file named `spring-configuration-metadata-whitelist.propreties` in the `META-INF` resource directory.  There are two property keys that can be used inside this file. The first key is named `configuration-properties.classes`.  The value is a comma separated list of fully qualified `@ConfigurationProperty` class names.  The second key is `configuration-properties.names` whose value is a comma separated list of property names.  This can contain the full name of propety, such as `server.port` or a partial name to whitelist a category of property names, e.g. `spring.jmx`.  
+
+The link:https://github.com/spring-cloud/spring-cloud-stream-app-starters[Spring Cloud Stream application starters] are a good place to look for examples of usage.  Here is a simle example of the file source's `spring-configuration-metadata-whitelist.properties` file
+
+```
+configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
+```
+
+If for some reason we also wanted to add `server.port` to this file, it would look like
+
+```
+configuration.classes=org.springframework.cloud.stream.app.file.sink.FileSinkProperties
+configuration-properties.names=server.port
+```

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -32,7 +32,7 @@ typical lifecycle for tasks in the context of Spring Cloud Data Flow:
 4. Task Execution
 5. Destroy a Task Definition
 
-=== Register a Task App
+=== Registering a Task Application
 Register a Task App with the App Registry using the Spring Cloud Data Flow Shell
 `app register` command. You must provide a unique name and a URI that can be
 resolved to the app artifact. For the type, specify "task". Here are a few examples:
@@ -80,7 +80,7 @@ URI will be passed to a runtime container instance where it is resolved. Consult
 the specific documentation of each Data Flow Server for more detail.
 
 
-=== Create a Task Definition
+=== Creating a Task
 Create a Task Definition from a Task App by providing a definition name as well as
 properties that apply to the task execution.  Creating a task definition can be done via
 the restful API or the shell.  To create a task definition using the shell, use the
@@ -94,7 +94,7 @@ dataflow:>task create mytask --definition "timestamp --format=\"yyyy\""
 A listing of the current task definitions can be obtained via the restful API or the
 shell.  To get the task definition list using the shell, use the `task list` command.
 
-=== Launch an ad-hoc Task
+=== Launching a Task
 An adhoc task can be launched via the restful API or via the shell.  To launch an ad-hoc
 task via the shell use the `task launch` command.  For Example:
 
@@ -103,7 +103,7 @@ dataflow:>task launch mytask
  Launched task 'mytask'
 ```
 
-=== Task Execution
+=== Reviewing Task Executions
 Once the task is launched the state of the task is stored in a relational DB.  The state
 includes:
 
@@ -123,7 +123,7 @@ the task definition name, for example `task execution list --name foo`.  To retr
 details for a task execution use the `task display` command with the id of the task execution
 , for example `task display --id 549`.
 
-=== Destroy a Task Definition
+=== Destroying a Task
 Destroying a Task Definition will remove the definition from the definition repository.
 This can be done via the restful API or via the shell.  To destroy a task via the shell
 use the `task destroy` command. For Example:
@@ -202,7 +202,7 @@ spring:
 ```
 
 [[spring-cloud-dataflow-task-events]]
-== Subscribing to Task/Batch events
+== Subscribing to Task/Batch Events
 
 You can also tap into various task/batch events when the task is launched.
 If the task is enabled to generate task and/or batch events (with the additional dependencies `spring-cloud-task-stream` and `spring-cloud-stream-binder-kafka`, in the case of Kafka as the binder), those events are published during the task lifecycle. 


### PR DESCRIPTION
- reorder stream sections
![image](https://cloud.githubusercontent.com/assets/1562654/16014835/cc88a73e-3147-11e6-8e48-874341831d2b.png)

- rename task headings
![image](https://cloud.githubusercontent.com/assets/1562654/16014707/3e4076c8-3147-11e6-95c5-a616dd6670ff.png)

With these changes, spring-cloud/spring-cloud-dataflow-server-cloudfoundry#116 will be adapted to include the `streams.adoc` and `dashboard.adoc` directly as follows.

```
include::{dataflow-asciidoc}/streams.adoc[]

include::{dataflow-asciidoc}/dashboard.adoc[]
```

(_`tasks.adoc` won't be included for CF-server_)