### PR TITLE
Add instructions to import app-starter URIs from static files

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -78,6 +78,28 @@ Then to import the apps in bulk, use the `app import` command and provide the lo
 dataflow:>app import --uri file:///<YOUR_FILE_LOCATION>/stream-apps.properties
 ```
 
+For convenience, we have the static files with application-URIs (for both maven and docker) available for all the out-of-the-box 
+Stream and Task app-starters. You can point to this file and import all the application-URIs in bulk. Otherwise, as explained in 
+previous paragraphs, you can register them individually or have your own custom property file with only the required application-URIs 
+in it. It is recommended, however, to have a "focused" list of desired application-URIs in a custom property file.
+
+
+List of available static property files:
+
+* Maven based Stream Applications with RabbitMQ Binder: http://bit.ly/rabbit-stream-apps-maven
+* Maven based Stream Applications with Kafka Binder: http://bit.ly/kafka-stream-apps-maven
+* Maven based Task Applications: http://bit.ly/task-apps-maven
+* Docker based Stream Applications with RabbitMQ Binder: http://bit.ly/rabbit-stream-apps-docker
+* Docker based Stream Applications with Kafka Binder: http://bit.ly/kafka-stream-apps-docker
+* Docker based Task Applications: http://bit.ly/task-apps-docker
+
+For example, if you would like to register all out-of-the-box applications built with the RabbitMQ binder in bulk, you can with 
+the following command.
+
+```
+dataflow:>app import --uri http://bit.ly/rabbit-stream-apps-maven
+```
+
 You can also pass the `--local` option (which is TRUE by default) to indicate whether the
 properties file location should be resolved within the shell process itself. If the location should
 be resolved from the Data Flow Server process, specify `--local false`.

--- a/spring-cloud-dataflow-server-local/README.adoc
+++ b/spring-cloud-dataflow-server-local/README.adoc
@@ -90,10 +90,6 @@ If you tail the `stdout_0.log` file from the directory mentioned, you should see
 2016-04-26 15:10:20.322  INFO 59890 --- [pool-1-thread-1] log.sink    : 04/26/16 15:10:20
 ----
 
-If you want to use RabbitMQ instead of Kafka as the binder, you can simply pass `--binder=rabbit` as a command line
-argument when starting the `spring-cloud-dataflow-server-local` JAR (and be sure to start the RabbitMQ server).
-
-
 ## Configuration
 
 ### Default


### PR DESCRIPTION
- introduce the change and include example to import apps from static file
- add all the other available links
- remove `--binder` mention from the docs