### PR TITLE
Fix incorrect reference to log-sink-rabbit

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -58,7 +58,7 @@ applications built with the RabbitMQ binder, you could do the following:
 
 ```
 dataflow:>app register --name http --type source --uri maven://org.springframework.cloud.stream.app:http-source-rabbit:1.0.0.BUILD-SNAPSHOT
-dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:http-log-rabbit:1.0.0.BUILD-SNAPSHOT
+dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
 ```
 
 If you would like to register multiple apps at one time, you can store them in a properties file


### PR DESCRIPTION
The current reference to `log-sink-rabbit` is incorrect:

```
dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:http-log-rabbit:1.0.0.BUILD-SNAPSHOT
```

It's referenced as `http-log-rabbit` but should be [`log-sink-rabbit`](https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/log-sink-rabbit/)