### PR TITLE
gh-696 Reduce verbosity for failed shell commands

### DIFF
--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<spring-cloud-dataflow-ui.version>1.0.0.RC1</spring-cloud-dataflow-ui.version>
 		<cloudfoundry-client-lib.version>1.1.3</cloudfoundry-client-lib.version>
-		<spring-shell.version>1.2.0.RC1</spring-shell.version>
+		<spring-shell.version>1.2.0.BUILD-SNAPSHOT</spring-shell.version>
 		<spring-cloud-deployer.version>1.0.0.RC1</spring-cloud-deployer.version>
 	</properties>
 	<dependencyManagement>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -134,6 +134,19 @@ dataflow:> http post --target http://localhost:9000 --data "hello world"
 ----
 Look to see if `hello world` ended up in log files for the `log` application.
 
+[TIP]
+====
+In case you encounter unexpected errors when executing shell commands, you can
+retrieve more detailed error information by setting the exception logging level
+to `WARNING` in `logback.xml`:
+
+[source,xml]
+----
+<logger name="org.springframework.shell.core.JLineShellComponent.exceptions" level="WARNING"/>
+----
+
+====
+
 [[getting-started-security]]
 == Security
 

--- a/spring-cloud-dataflow-shell/src/main/resources/logback.xml
+++ b/spring-cloud-dataflow-shell/src/main/resources/logback.xml
@@ -6,6 +6,8 @@
   </appender>
   <logger name="org.springframework.web.client.RestTemplate" level="ERROR"/>
   <logger name="org.apache.hadoop.util.NativeCodeLoader" level="ERROR"/>
+  <logger name="org.springframework.shell.core.JLineShellComponent.exceptions" level="ERROR"/>
+
   <root level="WARN">
     <appender-ref ref="stdout"/>
   </root>


### PR DESCRIPTION
- By default don't show the stack-trace of failed shell command executions
- Add documentation of how to enable stack-traces

Resolves spring-cloud/spring-cloud-dataflow#696