### PR TITLE
Updated docs removing task registration from stream adoc

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
@@ -87,3 +87,5 @@ The following are links to the deployer SPI projects that correspond to the Data
 * link:https://github.com/spring-cloud/spring-cloud-deployer-mesos[Apache Mesos]
 
 * link:https://github.com/spring-cloud/spring-cloud-deployer-kubernetes[Kubernetes]
+
+

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -79,7 +79,7 @@ dataflow:>app import --uri file:///<YOUR_FILE_LOCATION>/stream-apps.properties
 ```
 
 For convenience, we have the static files with application-URIs (for both maven and docker) available for all the out-of-the-box 
-Stream and Task app-starters. You can point to this file and import all the application-URIs in bulk. Otherwise, as explained in 
+Stream app-starters. You can point to this file and import all the application-URIs in bulk. Otherwise, as explained in
 previous paragraphs, you can register them individually or have your own custom property file with only the required application-URIs 
 in it. It is recommended, however, to have a "focused" list of desired application-URIs in a custom property file.
 
@@ -88,10 +88,8 @@ List of available static property files:
 
 * Maven based Stream Applications with RabbitMQ Binder: http://bit.ly/stream-applications-rabbit-maven
 * Maven based Stream Applications with Kafka Binder: http://bit.ly/stream-applications-kafka-maven
-* Maven based Task Applications: http://bit.ly/task-applications-maven
 * Docker based Stream Applications with RabbitMQ Binder: http://bit.ly/stream-applications-rabbit-docker
 * Docker based Stream Applications with Kafka Binder: http://bit.ly/stream-applications-kafka-docker
-* Docker based Task Applications: http://bit.ly/task-applications-docker
 
 For example, if you would like to register all out-of-the-box stream applications built with the RabbitMQ binder in bulk, you can with
 the following command.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -65,6 +65,23 @@ Then use the `app import` command and provide the location of the properties fil
 ```
 app import --uri file:///tmp/task-apps.properties
 ```
+For convenience, we have the static files with application-URIs (for both maven and docker) available for all the out-of-the-box
+Task app-starters. You can point to this file and import all the application-URIs in bulk. Otherwise, as explained in
+previous paragraphs, you can register them individually or have your own custom property file with only the required application-URIs
+in it. It is recommended, however, to have a "focused" list of desired application-URIs in a custom property file.
+
+
+List of available static property files:
+
+* Maven based Task Applications: http://bit.ly/task-applications-maven
+* Docker based Task Applications: http://bit.ly/task-applications-docker
+
+For example, if you would like to register all out-of-the-box task applications in bulk, you can with
+the following command.
+
+```
+dataflow:>app import --uri http://bit.ly/task-applications-maven
+```
 
 You can also pass the `--local` option (which is TRUE by default) to indicate whether the
 properties file location should be resolved within the shell process itself. If the location should


### PR DESCRIPTION
* Added instructions to use http://bit.ly/tasks... to the tasks section
* added lines to overview doc so that the getting started section would show up properly

resolves #725