### PR TITLE
Exclude `count` as a property in app properties

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -224,6 +224,8 @@ public class StreamDeploymentController {
 			if (appDeploymentProperties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) {
 				appDeploymentProperties.put(AppDeployer.COUNT_PROPERTY_KEY,
 						appDeploymentProperties.get(INSTANCE_COUNT_PROPERTY_KEY));
+				// delete the key `count` from appDeploymentProperties as it is no longer a valid app/deployment property now.
+				appDeploymentProperties.remove(INSTANCE_COUNT_PROPERTY_KEY);
 			}
 			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp, streamDeploymentProperties);
 			// consumer app partition properties
@@ -395,8 +397,8 @@ public class StreamDeploymentController {
 	 */
 	private void updateConsumerPartitionProperties(Map<String, String> properties) {
 		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
-		if (properties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) {
-			properties.put(StreamPropertyKeys.INSTANCE_COUNT, properties.get(INSTANCE_COUNT_PROPERTY_KEY));
+		if (properties.containsKey(AppDeployer.COUNT_PROPERTY_KEY)) {
+			properties.put(StreamPropertyKeys.INSTANCE_COUNT, properties.get(AppDeployer.COUNT_PROPERTY_KEY));
 		}
 	}
 
@@ -419,8 +421,8 @@ public class StreamDeploymentController {
 	 * if the properties do not contain a count, a value of {@code 1} is returned
 	 */
 	private int getInstanceCount(Map<String, String> properties) {
-		return (properties.containsKey(INSTANCE_COUNT_PROPERTY_KEY)) ?
-				Integer.valueOf(properties.get(INSTANCE_COUNT_PROPERTY_KEY)) : 1;
+		return (properties.containsKey(AppDeployer.COUNT_PROPERTY_KEY)) ?
+				Integer.valueOf(properties.get(AppDeployer.COUNT_PROPERTY_KEY)) : 1;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -544,7 +544,6 @@ public class StreamControllerTests {
 		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
-		assertEquals("2", logAppProps.get("count"));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
 		assertEquals("2", logDeploymentProps.get(AppDeployer.COUNT_PROPERTY_KEY));
 		assertEquals("myStream", logDeploymentProps.get(AppDeployer.GROUP_PROPERTY_KEY));
@@ -578,7 +577,6 @@ public class StreamControllerTests {
 		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
-		assertEquals("2", logAppProps.get("count"));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
 		assertEquals("2", logDeploymentProps.get(AppDeployer.COUNT_PROPERTY_KEY));
 		assertEquals("myStream", logDeploymentProps.get(AppDeployer.GROUP_PROPERTY_KEY));
@@ -617,7 +615,6 @@ public class StreamControllerTests {
 		assertEquals("fakePort", logAppProps.get("spring.cloud.stream.fake.binder.port"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
-		assertEquals("2", logAppProps.get("count"));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
 		assertEquals("2", logDeploymentProps.get(AppDeployer.COUNT_PROPERTY_KEY));
 		assertEquals("myStream", logDeploymentProps.get(AppDeployer.GROUP_PROPERTY_KEY));


### PR DESCRIPTION
 When the deployment property `count` is extracted and updated as `spring.cloud.deployer.count` as deployment property, only the SCSt `instanceCount` app property should be set for app property.
The property `count` should not part of app properties.

This resolves #758