### PR TITLE
Remove short-form app properties after qualifying

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -282,8 +282,9 @@ public class StreamDeploymentController {
 					assertNoAmbiguity(longForms);
 					mutatedProps.put(longForms.iterator().next().getId(), entry.getValue());
 				}
-				// Note that we also leave the original property
-				mutatedProps.put(provided, entry.getValue());
+				else {
+					mutatedProps.put(provided, entry.getValue());
+				}
 			}
 			else {
 				mutatedProps.put(provided, entry.getValue());


### PR DESCRIPTION
 - When the white listed properties are qualified with their corresponding long forms, the short form names should be removed from app properties map
This will make sure to avoid any collision with the underlying properties (possibly from boot)

This resolves #783