### PR TITLE
Handle instanceCount and indexed properties

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -221,6 +221,13 @@ public class StreamDeploymentController {
 			Map<String, String> appDeploymentProperties = extractAppDeploymentProperties(currentApp, streamDeploymentProperties);
 			appDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
 			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp, streamDeploymentProperties);
+			// Set instance count property
+			if (appDeploymentProperties.containsKey(AppDeployer.COUNT_PROPERTY_KEY)) {
+				appDeploymentProperties.put(StreamPropertyKeys.INSTANCE_COUNT, appDeploymentProperties.get(AppDeployer.COUNT_PROPERTY_KEY));
+			}
+			if (!type.equals(ApplicationType.source)) {
+				appDeploymentProperties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
+			}
 			// consumer app partition properties
 			if (upstreamAppSupportsPartition) {
 				updateConsumerPartitionProperties(appDeploymentProperties);
@@ -409,10 +416,6 @@ public class StreamDeploymentController {
 	 */
 	private void updateConsumerPartitionProperties(Map<String, String> properties) {
 		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
-		if (properties.containsKey(AppDeployer.COUNT_PROPERTY_KEY)) {
-			properties.put(StreamPropertyKeys.INSTANCE_COUNT, properties.get(AppDeployer.COUNT_PROPERTY_KEY));
-			properties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
-		}
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -442,7 +442,7 @@ public class StreamControllerTests {
 		assertEquals(2, requests.size());
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
-		assertEquals(logRequest.getDeploymentProperties().get("spring.cloud.deployer.indexed"), "true");
+		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
 	}
@@ -462,6 +462,7 @@ public class StreamControllerTests {
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
 		assertEquals("WARN", logAppProps.get("log.level"));
+		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
 		assertNull(logAppProps.get("level"));
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
@@ -486,6 +487,7 @@ public class StreamControllerTests {
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
+		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
 		assertEquals("ERROR", logAppProps.get("log.level"));
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
@@ -508,6 +510,7 @@ public class StreamControllerTests {
 		assertEquals(2, requests.size());
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("b"));
+		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
 		assertEquals("ERROR", logAppProps.get("log.level"));
 		AppDeploymentRequest timeRequest = requests.get(1);
@@ -612,11 +615,11 @@ public class StreamControllerTests {
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
-		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
 		assertEquals("2", logAppProps.get(StreamPropertyKeys.INSTANCE_COUNT));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
+		assertEquals(logDeploymentProps.get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
 		assertEquals("2", logDeploymentProps.get(AppDeployer.COUNT_PROPERTY_KEY));
 		assertEquals("myStream", logDeploymentProps.get(AppDeployer.GROUP_PROPERTY_KEY));
 		assertEquals("true", logDeploymentProps.get(AppDeployer.INDEXED_PROPERTY_KEY));
@@ -648,7 +651,7 @@ public class StreamControllerTests {
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
-		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
+		assertEquals("2", logAppProps.get(StreamPropertyKeys.INSTANCE_COUNT));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
@@ -686,7 +689,7 @@ public class StreamControllerTests {
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
-		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
+		assertEquals("2", logAppProps.get(StreamPropertyKeys.INSTANCE_COUNT));
 		assertEquals("fakeHost", logAppProps.get("spring.cloud.stream.fake.binder.host"));
 		assertEquals("fakePort", logAppProps.get("spring.cloud.stream.fake.binder.port"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -56,6 +56,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
@@ -441,6 +442,7 @@ public class StreamControllerTests {
 		assertEquals(2, requests.size());
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
+		assertEquals(logRequest.getDeploymentProperties().get("spring.cloud.deployer.indexed"), "true");
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
 	}
@@ -613,6 +615,7 @@ public class StreamControllerTests {
 		assertEquals("2", logAppProps.get("spring.cloud.stream.instanceCount"));
 		assertEquals("true", logAppProps.get("spring.cloud.stream.bindings.input.consumer.partitioned"));
 		assertEquals("3", logAppProps.get("spring.cloud.stream.bindings.input.consumer.concurrency"));
+		assertEquals("2", logAppProps.get(StreamPropertyKeys.INSTANCE_COUNT));
 		Map<String, String> logDeploymentProps = logRequest.getDeploymentProperties();
 		assertEquals("2", logDeploymentProps.get(AppDeployer.COUNT_PROPERTY_KEY));
 		assertEquals("myStream", logDeploymentProps.get(AppDeployer.GROUP_PROPERTY_KEY));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -442,7 +442,7 @@ public class StreamControllerTests {
 		assertEquals(2, requests.size());
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
-		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
+		assertEquals("true", logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY));
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
 	}
@@ -462,7 +462,7 @@ public class StreamControllerTests {
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
 		assertEquals("WARN", logAppProps.get("log.level"));
-		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
+		assertEquals("true", logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY));
 		assertNull(logAppProps.get("level"));
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
@@ -487,7 +487,7 @@ public class StreamControllerTests {
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("log"));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
-		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
+		assertEquals("true", logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY));
 		assertEquals("ERROR", logAppProps.get("log.level"));
 		AppDeploymentRequest timeRequest = requests.get(1);
 		assertThat(timeRequest.getDefinition().getName(), is("time"));
@@ -510,7 +510,7 @@ public class StreamControllerTests {
 		assertEquals(2, requests.size());
 		AppDeploymentRequest logRequest = requests.get(0);
 		assertThat(logRequest.getDefinition().getName(), is("b"));
-		assertEquals(logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY), "true");
+		assertEquals("true", logRequest.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY));
 		Map<String, String> logAppProps = logRequest.getDefinition().getProperties();
 		assertEquals("ERROR", logAppProps.get("log.level"));
 		AppDeploymentRequest timeRequest = requests.get(1);


### PR DESCRIPTION
 - Always set instanceCount when the app count is specified. By default it will use `1` specified in SCSt
 - Set `spring.cloud.deployer.indexed` property to `true` for the consumer applications (processor/sink/task)
 - Update tests