### PR TITLE
ui-gh-57 Update UI Dashboard dependency and make security changes

### DIFF
--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -18,7 +18,7 @@
 		<spring-cloud-commons.version>1.1.1.RELEASE</spring-cloud-commons.version>
 		<spring-cloud-config.version>1.1.1.RELEASE</spring-cloud-config.version>
 		<spring-batch-admin-dependencies.version>1.3.1.RELEASE</spring-batch-admin-dependencies.version>
-		<spring-cloud-dataflow-ui.version>1.0.1.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
+		<spring-cloud-dataflow-ui.version>1.0.2.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
 		<spring-cloud-deployer.version>1.0.2.RELEASE</spring-cloud-deployer.version>
 	</properties>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -18,7 +18,7 @@
 		<spring-cloud-commons.version>1.1.1.RELEASE</spring-cloud-commons.version>
 		<spring-cloud-config.version>1.1.1.RELEASE</spring-cloud-config.version>
 		<spring-batch-admin-dependencies.version>1.3.1.RELEASE</spring-batch-admin-dependencies.version>
-		<spring-cloud-dataflow-ui.version>1.0.1.RELEASE</spring-cloud-dataflow-ui.version>
+		<spring-cloud-dataflow-ui.version>1.0.1.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
 		<spring-cloud-deployer.version>1.0.2.RELEASE</spring-cloud-deployer.version>
 	</properties>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/SecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/SecurityConfiguration.java
@@ -41,10 +41,13 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	protected void configure(HttpSecurity http) throws Exception {
 		http.antMatcher("/**")
 			.authorizeRequests()
-				.antMatchers("/security/info**", "/login**").permitAll()
+				.antMatchers(
+					"/security/info**", "/login**", "/dashboard/logout-success.html",
+					"/dashboard/styles/**", "/dashboard/images/**", "/dashboard/fonts/**",
+					"/dashboard/lib/**").permitAll()
 				.anyRequest().authenticated()
 			.and().httpBasic()
-			.and().logout().logoutSuccessUrl("/").and().csrf().disable();
+			.and().logout().logoutSuccessUrl("/dashboard/logout-success.html").and().csrf().disable();
 	}
 
 	@Override


### PR DESCRIPTION
In order to support `gh-57`

* Update UI Dashboard dependency to `1.0.1.BUILD-SNAPSHOT`
* Permit certain static web-resources to be accessed without being authenticated

Is required by https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/57