### PR TITLE
Check Redis availability for tests

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
 import org.springframework.boot.actuate.metrics.writer.DefaultCounterService;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -60,6 +62,9 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @ContextConfiguration(classes = {CounterControllerTests.Config.class})
 @WebAppConfiguration
 public class CounterControllerTests {
+
+	@Rule
+	public RedisTestSupport redisTestSupport = new RedisTestSupport();
 
 	@Autowired
 	private MetricRepository repository;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/FieldValueCounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/FieldValueCounterControllerTests.java
@@ -26,12 +26,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.analytics.metrics.FieldValueCounterRepository;
 import org.springframework.analytics.metrics.memory.InMemoryFieldValueCounterRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
@@ -54,6 +56,9 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @ContextConfiguration(classes = {FieldValueCounterControllerTests.Config.class})
 @WebAppConfiguration
 public class FieldValueCounterControllerTests {
+
+	@Rule
+	public RedisTestSupport redisTestSupport = new RedisTestSupport();
 
 	@Autowired
 	private FieldValueCounterRepository repository;


### PR DESCRIPTION
 - Add RedisTestSupport to skip redis dependent tests if redis is not available

This resolves #799