### PR TITLE
Remove EnableConfig prop at SecurityController

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
@@ -46,7 +46,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/security/info")
 @ExposesResourceFor(SecurityInfoResource.class)
-@EnableConfigurationProperties(SecurityProperties.class)
 public class SecurityController {
 
 	private final SecurityProperties securityProperties;


### PR DESCRIPTION
- Since the `SecurityProperties` is set at the constructor level via controller auto configuration, we don't need `EnableConfigurationProperties` for `SecurityProperties` at
SecurityController

This fixes #366