### PR TITLE
make the shell executable

### DIFF
--- a/spring-cloud-dataflow-shell/pom.xml
+++ b/spring-cloud-dataflow-shell/pom.xml
@@ -79,6 +79,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<executable>true</executable>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
with this PR people can just run the shell using `./spring-cloud-dataflow-shell.jar` (as opposed to `java -jar spring-cloud-dataflow-shell.jar`). They can still _also_ use `java -jar ..`, of course. It's just nice not to have to. This uses a feature in Spring Boot's Maven plugin introduced in 1.3.