### PR TITLE
Remove dependency on scs-test-support-internal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 		<module>spring-cloud-dataflow-server-local</module>
 		<module>spring-cloud-dataflow-rest-client</module>
 		<module>spring-cloud-dataflow-shell</module>
+		<module>spring-cloud-dataflow-test-support</module>
 		<module>spring-cloud-dataflow-docs</module>
 		<module>spring-cloud-dataflow-completion</module>
 		<module>spring-cloud-dataflow-dependencies</module>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -62,6 +62,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-test-support</artifactId>
+				<version>1.0.1.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-completion</artifactId>
 				<version>1.0.1.BUILD-SNAPSHOT</version>
 			</dependency>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -100,7 +100,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
+			<artifactId>spring-cloud-dataflow-test-support</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CounterControllerTests.java
@@ -37,7 +37,7 @@ import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
 import org.springframework.boot.actuate.metrics.writer.DefaultCounterService;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.dataflow.test.RedisTestSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/FieldValueCounterControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/FieldValueCounterControllerTests.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 import org.springframework.analytics.metrics.FieldValueCounterRepository;
 import org.springframework.analytics.metrics.memory.InMemoryFieldValueCounterRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.dataflow.test.RedisTestSupport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisDeploymentIdRepositoryTests.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.dataflow.test.RedisTestSupport;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisStreamDefinitionRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RedisStreamDefinitionRepositoryTests.java
@@ -31,7 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.dataflow.test.RedisTestSupport;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 

--- a/spring-cloud-dataflow-test-support/pom.xml
+++ b/spring-cloud-dataflow-test-support/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-dataflow-test-support</artifactId>
+	<packaging>jar</packaging>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-parent</artifactId>
+		<version>1.0.1.BUILD-SNAPSHOT</version>
+	</parent>
+	<description>Set of classes and utility code that may assist in testing
+		spring-cloud-dataflow
+	</description>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-dataflow-test-support/src/main/java/org/springframework/cloud/dataflow/test/AbstractExternalResourceTestSupport.java
+++ b/spring-cloud-dataflow-test-support/src/main/java/org/springframework/cloud/dataflow/test/AbstractExternalResourceTestSupport.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.test;
+
+import static org.junit.Assert.fail;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import org.springframework.util.Assert;
+
+/**
+ * Abstract base class for JUnit {@link Rule}s that detect the presence of some external
+ * resource. If the resource is indeed present, it will be available during the test
+ * lifecycle through {@link #getResource()}. If it is not, tests will either fail or be
+ * skipped, depending on the value of system property
+ * {@value #SCS_EXTERNAL_SERVERS_REQUIRED}.
+ *
+ * @author Eric Bottard
+ * @author Gary Russell
+ */
+public abstract class AbstractExternalResourceTestSupport<R> implements TestRule {
+
+	public static final String SCS_EXTERNAL_SERVERS_REQUIRED = "SCS_EXTERNAL_SERVERS_REQUIRED";
+
+	protected R resource;
+
+	private String resourceDescription;
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	protected AbstractExternalResourceTestSupport(String resourceDescription) {
+		Assert.hasText(resourceDescription, "resourceDescription is required");
+		this.resourceDescription = resourceDescription;
+	}
+
+	@Override
+	public Statement apply(final Statement base, Description description) {
+		try {
+			obtainResource();
+		}
+		catch (Exception e) {
+			maybeCleanup();
+
+			return failOrSkip(e);
+		}
+
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				try {
+					base.evaluate();
+				}
+				finally {
+					try {
+						cleanupResource();
+					}
+					catch (Exception ignored) {
+						logger.warn("Exception while trying to cleanup proper resource",
+								ignored);
+					}
+				}
+			}
+
+		};
+	}
+
+	private Statement failOrSkip(final Exception e) {
+		String serversRequired = System.getenv(SCS_EXTERNAL_SERVERS_REQUIRED);
+		if ("true".equalsIgnoreCase(serversRequired)) {
+			logger.error(resourceDescription + " IS REQUIRED BUT NOT AVAILABLE", e);
+			fail(resourceDescription + " IS NOT AVAILABLE");
+			// Never reached, here to satisfy method signature
+			return null;
+		}
+		else {
+			logger.error(resourceDescription + " IS NOT AVAILABLE, SKIPPING TESTS", e);
+			return new Statement() {
+
+				@Override
+				public void evaluate() throws Throwable {
+					Assume.assumeTrue("Skipping test due to " + resourceDescription
+							+ " not being available " + e, false);
+				}
+			};
+		}
+	}
+
+	private void maybeCleanup() {
+		if (resource != null) {
+			try {
+				cleanupResource();
+			}
+			catch (Exception ignored) {
+				logger.warn("Exception while trying to cleanup failed resource", ignored);
+			}
+		}
+	}
+
+	public R getResource() {
+		return resource;
+	}
+
+	/**
+	 * Perform cleanup of the {@link #resource} field, which is guaranteed to be non null.
+	 *
+	 * @throws Exception any exception thrown by this method will be logged and swallowed
+	 */
+	protected abstract void cleanupResource() throws Exception;
+
+	/**
+	 * Try to obtain and validate a resource. Implementors should either set the
+	 * {@link #resource} field with a valid resource and return normally, or throw an
+	 * exception.
+	 */
+	protected abstract void obtainResource() throws Exception;
+
+}

--- a/spring-cloud-dataflow-test-support/src/main/java/org/springframework/cloud/dataflow/test/RedisTestSupport.java
+++ b/spring-cloud-dataflow-test-support/src/main/java/org/springframework/cloud/dataflow/test/RedisTestSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.test;
+
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+/**
+ * JUnit {@link org.junit.Rule} that detects the fact that a Redis server is running on localhost.
+ *
+ * @author Gary Russell
+ * @author Eric Bottard
+ */
+public class RedisTestSupport extends AbstractExternalResourceTestSupport<JedisConnectionFactory> {
+
+	public RedisTestSupport() {
+		super("REDIS");
+	}
+
+	@Override
+	protected void obtainResource() throws Exception {
+		resource = new JedisConnectionFactory();
+		resource.afterPropertiesSet();
+		resource.getConnection().close();
+	}
+
+	@Override
+	protected void cleanupResource() throws Exception {
+		resource.destroy();
+	}
+}


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-dataflow#849

This will ease migrating SCDF to boot 1.4, as boot upgrades its spring-data version