### PR TITLE
Add "Logging" section to how-to guides

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/howto.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/howto.adoc
@@ -82,3 +82,92 @@ environment properties using the platform specific environment-setting capabilit
 in Cloud Foundry, you'd be passing them as `cf set-env SPRING_APPLICATION_JSON`.
 
 
+== Logging
+
+Spring Cloud Data Flow is built upon several Spring projects, but ultimately the dataflow-server is a 
+Spring Boot app, so the logging techniques that applies to any link:http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot] 
+application is applicable here as well. 
+
+
+While troubleshooting, following are the two primary areas where enabling the DEBUG logs could be 
+useful.
+
+=== Deployment Logs
+Spring Cloud Data Flow builds upon link:https://github.com/spring-cloud/spring-cloud-deployer[Spring Cloud Deployer] SPI 
+and the platform specific dataflow-server uses the respective link:https://github.com/spring-cloud?utf8=%E2%9C%93&query=deployer[SPI implementations]. 
+Specifically, if we were to troubleshoot deployment specific issues; such as the network errors, it'd 
+be useful to enable the DEBUG logs at the deployers and the libraries used by it. 
+
+. For instance, if you'd like to enable DEBUG logs for the link:https://github.com/spring-cloud/spring-cloud-deployer/tree/master/spring-cloud-deployer-local[local-deployer], 
+you'd be starting the server with following.
+
++
+[source,bash]
+----
+$ java -jar <dataflow-server>.jar --logging.level.org.springframework.cloud.deployer.spi.local=DEBUG
+----
++
+
+(_where, `org.springframework.cloud.deployer.spi.local` is the global package for everything local-deployer
+related_)
+
+. For instance, if you'd like to enable DEBUG logs for the link:https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry[cloudfoundry-deployer], 
+you'd be setting the following environment variable and upon restaging the dataflow-server, we will 
+see more logs around request, response and the elaborate stack traces (_upon failures_). The cloudfoundry-deployer 
+uses link:https://github.com/cloudfoundry/cf-java-client[cf-java-client], so we will have to enable DEBUG 
+logs for this library. 
+
+
++
+[source,bash]
+----
+$ cf set-env dataflow-server JAVA_OPTS '-Dlogging.level.cloudfoundry-client=DEBUG'
+$ cf restage dataflow-server
+----
++
+
+(_where, `cloudfoundry-client` is the global package for everything `cf-java-client` related_)
+
+. If there's a need to review Reactor logs, which is used by the `cf-java-client`, then the following 
+would be helpful.
+
++
+[source,bash]
+----
+$ cf set-env dataflow-server JAVA_OPTS '-Dlogging.level.cloudfoundry-client=DEBUG -Dlogging.level.reactor.ipc.netty=DEBUG'
+$ cf restage dataflow-server
+----
++
+
+(_where, `reactor.ipc.netty` is the global package for everything `reactor-netty` related_)
+
+NOTE: Similar to the `local-deployer` and `cloudfoundry-deployer` options as discussed above, there
+are equivalent settings available for Apache YARN, Apache Mesos and Kubernetes varaints, too. Check out the 
+respective link:https://github.com/spring-cloud?utf8=%E2%9C%93&query=deployer[SPI implementations] to 
+find out more details about the packages to configure for logging.
+
+=== Application Logs
+
+The streaming applications in Spring Cloud Data Flow are Spring Boot applications and they can be 
+independently setup with logging configurations. 
+
+For instance, if you'd have to troubleshoot the `header` and `payload` specifics that's being passed 
+around between source, processor and sink channels, you'd be deploying the streams with the following
+options.
+
+
+[source,bash]
+----
+dataflow:>stream create foo --definition "http --logging.level.org.springframework.integration=DEBUG | transform --logging.level.org.springframework.integration=DEBUG | log --logging.level.org.springframework.integration=DEBUG" --deploy
+----
+
+(_where, `org.springframework.integration` is the global package for everything Spring Integration related, 
+which is responsible for messaging channels_)
+
+
+
+
+
+
+
+

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/howto.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/howto.adoc
@@ -152,7 +152,7 @@ The streaming applications in Spring Cloud Data Flow are Spring Boot application
 independently setup with logging configurations. 
 
 For instance, if you'd have to troubleshoot the `header` and `payload` specifics that's being passed 
-around between source, processor and sink channels, you'd be deploying the streams with the following
+around between source, processor and sink channels, you'd be deploying the stream with the following
 options.
 
 
@@ -163,11 +163,3 @@ dataflow:>stream create foo --definition "http --logging.level.org.springframewo
 
 (_where, `org.springframework.integration` is the global package for everything Spring Integration related, 
 which is responsible for messaging channels_)
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR adds a new section to the how-to guide. The goal was to address "deployment" and "application" level log configurations with examples, so it'd be useful for someone trying to troubleshoot deployment and application specific issues, respectively.

Also, this is part of the common docs and it'd be automatically included in all the SCDF reference guides. 