### PR TITLE
Disable analytics feature by default

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -36,7 +36,7 @@ One can enable, disable these features by setting the following boolean properti
 * `spring.cloud.dataflow.features.tasks-enabled`
 * `spring.cloud.dataflow.features.analytics-enabled`
 
-By default, all these features except 'analytics' features are enabled.
+By default, all the features except 'analytics' are enabled.
 
 The REST endpoint `/features` provides information on the features enabled/disabled.
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -36,7 +36,7 @@ One can enable, disable these features by setting the following boolean properti
 * `spring.cloud.dataflow.features.tasks-enabled`
 * `spring.cloud.dataflow.features.analytics-enabled`
 
-By default, all these features are enabled for `local` dataflow server.
+By default, all these features except 'analytics' features are enabled.
 
 The REST endpoint `/features` provides information on the features enabled/disabled.
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/AnalyticsConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/AnalyticsConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.retry.support.RetryTemplate;
  * @author Ilayaperumal Gopinathan
  */
 @Configuration
-@ConditionalOnProperty(prefix = FeaturesProperties.FEATURES_PREFIX, name = FeaturesProperties.ANALYTICS_ENABLED, matchIfMissing = true)
+@ConditionalOnProperty(prefix = FeaturesProperties.FEATURES_PREFIX, name = FeaturesProperties.ANALYTICS_ENABLED)
 public class AnalyticsConfiguration {
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesConfiguration.java
@@ -18,14 +18,17 @@ package org.springframework.cloud.dataflow.server.config.features;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.RedisHealthIndicator;
+import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.RdbmsDeploymentIdRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 /**
  * Configuration class that imports analytics, stream and task configuration classes. Also
@@ -34,15 +37,43 @@ import org.springframework.context.annotation.Import;
  * @author Ilayaperumal Gopinathan
  */
 @Configuration
-@Import({ AnalyticsConfiguration.class, StreamConfiguration.class, TaskConfiguration.class })
+@Import({ AnalyticsConfiguration.class, StreamConfiguration.class,
+		TaskConfiguration.class })
 public class FeaturesConfiguration {
+
+	@Autowired()
+	private RedisConnectionFactory redisConnectionFactory;
+
+	@Autowired(required = false)
+	private MetricRepository metricRepository;
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnExpression("#{'${" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.STREAMS_ENABLED
-			+ ":true}'.equalsIgnoreCase('true') || " + "'${" + FeaturesProperties.FEATURES_PREFIX + "."
+	@ConditionalOnExpression("#{'${" + FeaturesProperties.FEATURES_PREFIX + "."
+			+ FeaturesProperties.STREAMS_ENABLED + ":true}'.equalsIgnoreCase('true') || "
+			+ "'${" + FeaturesProperties.FEATURES_PREFIX + "."
 			+ FeaturesProperties.TASKS_ENABLED + ":true}'.equalsIgnoreCase('true') }")
 	public DeploymentIdRepository deploymentIdRepository(DataSource dataSource) {
 		return new RdbmsDeploymentIdRepository(dataSource);
+	}
+
+	@Bean
+	RedisHealthIndicator redisHealthIndicator() {
+		return new CustomRedisHealthIndicator(redisConnectionFactory);
+	}
+
+	private class CustomRedisHealthIndicator extends RedisHealthIndicator {
+
+		public CustomRedisHealthIndicator(RedisConnectionFactory redisConnectionFactory) {
+			super(redisConnectionFactory);
+		}
+
+		@Override
+		protected void doHealthCheck(Health.Builder builder) throws Exception {
+			// Check Redis health only if analytics feature is enabled.
+			if (metricRepository != null) {
+				super.doHealthCheck(builder);
+			}
+		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 		TaskConfiguration.class })
 public class FeaturesConfiguration {
 
-	@Autowired()
+	@Autowired
 	private RedisConnectionFactory redisConnectionFactory;
 
 	@Autowired(required = false)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
@@ -33,7 +33,7 @@ public class FeaturesProperties {
 
     public static final String ANALYTICS_ENABLED = "analytics-enabled";
 
-    private boolean analyticsEnabled = true;
+    private boolean analyticsEnabled;
 
     private boolean streamsEnabled = true;
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
@@ -33,7 +33,7 @@ public class FeaturesProperties {
 
     public static final String ANALYTICS_ENABLED = "analytics-enabled";
 
-    private boolean analyticsEnabled;
+    private boolean analyticsEnabled = false;
 
     private boolean streamsEnabled = true;
 

--- a/spring-cloud-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalConfigurationTests.java
+++ b/spring-cloud-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalConfigurationTests.java
@@ -18,9 +18,7 @@ package org.springframework.cloud.dataflow.server.local;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import org.junit.After;
 import org.junit.Test;
@@ -78,7 +76,6 @@ public class LocalConfigurationTests {
 				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.STREAMS_ENABLED + "=false"});
 		assertNotNull(context.getBean(TaskDefinitionRepository.class));
 		assertNotNull(context.getBean(DeploymentIdRepository.class));
-		assertNotNull(context.getBean(FieldValueCounterRepository.class));
 		try {
 			context.getBean(StreamDefinitionRepository.class);
 			fail("Stream features should have been disabled.");
@@ -94,7 +91,6 @@ public class LocalConfigurationTests {
 				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.TASKS_ENABLED + "=false"});
 		assertNotNull(context.getBean(StreamDefinitionRepository.class));
 		assertNotNull(context.getBean(DeploymentIdRepository.class));
-		assertNotNull(context.getBean(FieldValueCounterRepository.class));
 		try {
 			context.getBean(TaskDefinitionRepository.class);
 			fail("Task features should have been disabled.");

--- a/spring-cloud-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalConfigurationTests.java
+++ b/spring-cloud-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalConfigurationTests.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.dataflow.server.local;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import org.junit.After;
 import org.junit.Test;


### PR DESCRIPTION
- Set default analytics feature to be 'false'
 - Override redis health indicator to only check health if analytics configuration is enabled otherwise it will return 'UNKNOWN'
   - this will avoid false info on overall app status to be 'DOWN'

Fixes #857