### PR TITLE
Refactor CL creation in metadata resolver

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
@@ -32,7 +32,7 @@ import org.springframework.boot.loader.archive.Archive;
 import org.springframework.boot.loader.archive.ExplodedArchive;
 import org.springframework.boot.loader.archive.JarFileArchive;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.cloud.dataflow.configuration.metadata.BootClassLoaderCreation;
+import org.springframework.cloud.dataflow.configuration.metadata.BootClassLoaderFactory;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
@@ -105,7 +105,7 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 				try {
 					File file = appResource.getFile();
 					Archive jarFileArchive = file.isDirectory() ? new ExplodedArchive(file) : new JarFileArchive(file);
-					classLoader = new BootClassLoaderCreation(jarFileArchive, Thread.currentThread().getContextClassLoader()).createClassLoader();
+					classLoader = new BootClassLoaderFactory(jarFileArchive, Thread.currentThread().getContextClassLoader()).createClassLoader();
 
 					for (ValueHintProvider valueHintProvider : valueHintProviders) {
 						List<ValueHint> valueHints = valueHintProvider.generateValueHints(property, classLoader);

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.completion;
 
 import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
 
-import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,11 +27,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.configurationmetadata.ValueHint;
-import org.springframework.boot.loader.archive.Archive;
-import org.springframework.boot.loader.archive.ExplodedArchive;
-import org.springframework.boot.loader.archive.JarFileArchive;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.cloud.dataflow.configuration.metadata.BootClassLoaderFactory;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
@@ -59,14 +54,14 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 	private ValueHintProvider[] valueHintProviders = new ValueHintProvider[0];
 
 	ConfigurationPropertyValueHintExpansionStrategy(AppRegistry appRegistry,
-	                                                ApplicationConfigurationMetadataResolver metadataResolver) {
+			ApplicationConfigurationMetadataResolver metadataResolver) {
 		this.appRegistry = appRegistry;
 		this.metadataResolver = metadataResolver;
 	}
 
 	@Override
 	public boolean addProposals(String text, StreamDefinition parseResult,
-	                            int detailLevel, List<CompletionProposal> collector) {
+			int detailLevel, List<CompletionProposal> collector) {
 		Set<String> propertyNames = new HashSet<>(parseResult.getDeploymentOrderIterator()
 				.next().getProperties().keySet());
 		propertyNames.removeAll(CompletionUtils.IMPLICIT_PARAMETER_NAMES);
@@ -99,14 +94,13 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 		List<ConfigurationMetadataProperty> allProps = metadataResolver.listProperties(appResource, true);
 		List<ConfigurationMetadataProperty> whiteListedProps = metadataResolver.listProperties(appResource);
 
-		for (ConfigurationMetadataProperty property : allProps) {
-			if (CompletionUtils.isMatchingProperty(propertyName, property, whiteListedProps)) {
-				ClassLoader classLoader = null;
-				try {
-					File file = appResource.getFile();
-					Archive jarFileArchive = file.isDirectory() ? new ExplodedArchive(file) : new JarFileArchive(file);
-					classLoader = new BootClassLoaderFactory(jarFileArchive, Thread.currentThread().getContextClassLoader()).createClassLoader();
-
+		URLClassLoader classLoader = null;
+		try {
+			for (ConfigurationMetadataProperty property : allProps) {
+				if (CompletionUtils.isMatchingProperty(propertyName, property, whiteListedProps)) {
+					if (classLoader == null) {
+						classLoader = metadataResolver.createAppClassLoader(appResource);
+					}
 					for (ValueHintProvider valueHintProvider : valueHintProviders) {
 						List<ValueHint> valueHints = valueHintProvider.generateValueHints(property, classLoader);
 						if (!valueHints.isEmpty() && valueHintProvider.isExclusive(property)) {
@@ -124,18 +118,18 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 						}
 					}
 				}
-				catch (Exception e) {
-					throw new RuntimeException(e);
+			}
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			if (classLoader != null) {
+				try {
+					classLoader.close();
 				}
-				finally {
-					if (classLoader instanceof Closeable) {
-						try {
-							((Closeable) classLoader).close();
-						}
-						catch (IOException e) {
-							// ignore
-						}
-					}
+				catch (IOException e) {
+					// ignore
 				}
 			}
 		}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
@@ -30,7 +30,7 @@ import org.springframework.boot.loader.archive.Archive;
 import org.springframework.boot.loader.archive.ExplodedArchive;
 import org.springframework.boot.loader.archive.JarFileArchive;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.cloud.dataflow.configuration.metadata.BootClassLoaderCreation;
+import org.springframework.cloud.dataflow.configuration.metadata.BootClassLoaderFactory;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
@@ -86,7 +86,7 @@ public class ConfigurationPropertyValueHintRecoveryStrategy extends StacktraceFi
 
 					File appFile = appResource.getFile();
 					Archive jarFileArchive = appFile.isDirectory() ? new ExplodedArchive(appFile) : new JarFileArchive(appFile);
-					classLoader = new BootClassLoaderCreation(jarFileArchive, Thread.currentThread().getContextClassLoader()).createClassLoader();
+					classLoader = new BootClassLoaderFactory(jarFileArchive, Thread.currentThread().getContextClassLoader()).createClassLoader();
 
 					for (ValueHintProvider valueHintProvider : valueHintProviders) {
 						for (ValueHint valueHint : valueHintProvider.generateValueHints(property, classLoader)) {

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests that the completion mechanism knows how to cope with different versions of Spring Boot, including
+ * using reflection on classes packaged in the boot archive when needed (e.g. enum values completion).
+ *
+ * @author Eric Bottard
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {CompletionConfiguration.class, BootVersionsCompletionProviderTests.Mocks.class})
+public class BootVersionsCompletionProviderTests {
+
+	@Autowired
+	private StreamCompletionProvider completionProvider;
+
+	@Test
+	public void testBoot13Layout() {
+		List<CompletionProposal> result = completionProvider.complete("boot13 --", 0);
+		System.out.println(result);
+		result = completionProvider.complete("boot14 --", 0);
+		System.out.println(result);
+	}
+
+
+	/**
+	 * A set of mocks that consider the contents of the {@literal boot_versions/} directory as app
+	 * archives.
+	 *
+	 * @author Eric Bottard
+	 * @author Mark Fisher
+	 */
+	@Configuration
+	public static class Mocks {
+
+		private static final File ROOT = new File("src/test/resources",
+				BootVersionsCompletionProviderTests.Mocks.class.getPackage().getName().replace('.', '/') + "/boot_versions");
+
+		@Bean
+		public AppRegistry appRegistry() {
+			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
+			return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+
+				/*
+				 * Pretend there is a boot13 and boot14 source.
+				 */
+				@Override
+				public AppRegistration find(String name, ApplicationType type) {
+					String filename = name + "-1.0.0.BUILD-SNAPSHOT.jar";
+					File file = new File(ROOT, filename);
+					if (file.exists()) {
+						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+					}
+					else {
+						return null;
+					}
+				}
+
+				@Override
+				public List<AppRegistration> findAll() {
+					List<AppRegistration> result = new ArrayList<>();
+					result.add(find("boot13", ApplicationType.source));
+					result.add(find("boot14", ApplicationType.source));
+					return result;
+				}
+			};
+		}
+
+		@Bean
+		public ApplicationConfigurationMetadataResolver metadataResolver() {
+			return new BootApplicationConfigurationMetadataResolver(StreamCompletionProviderTests.class.getClassLoader());
+		}
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.dataflow.completion;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.completion.Proposals.proposalThat;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,9 +58,35 @@ public class BootVersionsCompletionProviderTests {
 	@Test
 	public void testBoot13Layout() {
 		List<CompletionProposal> result = completionProvider.complete("boot13 --", 0);
-		System.out.println(result);
-		result = completionProvider.complete("boot14 --", 0);
-		System.out.println(result);
+		assertThat(result, hasItems(
+				proposalThat(is("boot13 --level=")),
+				proposalThat(is("boot13 --number=")),
+				proposalThat(is("boot13 --some-string="))
+		));
+
+		// Test that custom classes can also be loaded correctly
+		result = completionProvider.complete("boot13 --level=", 0);
+		assertThat(result, hasItems(
+				proposalThat(is("boot13 --level=low")),
+				proposalThat(is("boot13 --level=high"))
+		));
+	}
+
+	@Test
+	public void testBoot14Layout() {
+		List<CompletionProposal> result = completionProvider.complete("boot14 --", 0);
+		assertThat(result, hasItems(
+			//	proposalThat(is("boot14 --level=")),
+				proposalThat(is("boot14 --number=")),
+				proposalThat(is("boot14 --some-string="))
+		));
+
+		// Test that custom classes can also be loaded correctly
+		result = completionProvider.complete("boot14 --level=", 0);
+//		assertThat(result, hasItems(
+//				proposalThat(is("boot14 --level=very_low")),
+//				proposalThat(is("boot14 --level=very_high"))
+//		));
 	}
 
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -70,6 +70,12 @@ public class BootVersionsCompletionProviderTests {
 				proposalThat(is("boot13 --level=low")),
 				proposalThat(is("boot13 --level=high"))
 		));
+
+		result = completionProvider.complete("boot13 --number=", 0);
+		assertThat(result, hasItems(
+				proposalThat(is("boot13 --number=one")),
+				proposalThat(is("boot13 --number=two"))
+		));
 	}
 
 	@Test
@@ -87,6 +93,13 @@ public class BootVersionsCompletionProviderTests {
 				proposalThat(is("boot14 --level=very_low")),
 				proposalThat(is("boot14 --level=very_high"))
 		));
+
+		result = completionProvider.complete("boot14 --number=", 0);
+		assertThat(result, hasItems(
+				proposalThat(is("boot14 --number=one")),
+				proposalThat(is("boot14 --number=two"))
+		));
+
 	}
 
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -76,17 +76,17 @@ public class BootVersionsCompletionProviderTests {
 	public void testBoot14Layout() {
 		List<CompletionProposal> result = completionProvider.complete("boot14 --", 0);
 		assertThat(result, hasItems(
-			//	proposalThat(is("boot14 --level=")),
+				proposalThat(is("boot14 --level=")),
 				proposalThat(is("boot14 --number=")),
 				proposalThat(is("boot14 --some-string="))
 		));
 
 		// Test that custom classes can also be loaded correctly
 		result = completionProvider.complete("boot14 --level=", 0);
-//		assertThat(result, hasItems(
-//				proposalThat(is("boot14 --level=very_low")),
-//				proposalThat(is("boot14 --level=very_high"))
-//		));
+		assertThat(result, hasItems(
+				proposalThat(is("boot14 --level=very_low")),
+				proposalThat(is("boot14 --level=very_high"))
+		));
 	}
 
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/Proposals.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/Proposals.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import org.hamcrest.FeatureMatcher;
+
+/**
+ * Contains helper Hamcrest matchers for testing completion proposal related code.
+ *
+ * @author Eric Bottard
+ */
+class Proposals {
+	static org.hamcrest.Matcher<CompletionProposal> proposalThat(org.hamcrest.Matcher<String> matcher) {
+		return new FeatureMatcher<CompletionProposal, String>(matcher, "a proposal whose text", "text") {
+			@Override
+			protected String featureValueOf(CompletionProposal actual) {
+				return actual.getText();
+			}
+		};
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hamcrest.FeatureMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,11 +69,11 @@ public class StreamCompletionProviderTests {
 	// <TAB> => file,http,etc
 	public void testEmptyStartShouldProposeSourceApps() {
 		assertThat(completionProvider.complete("", 1), hasItems(
-				proposalThat(is("http")),
-				proposalThat(is("hdfs"))
+				Proposals.proposalThat(is("http")),
+				Proposals.proposalThat(is("hdfs"))
 		));
 		assertThat(completionProvider.complete("", 1), not(hasItems(
-				proposalThat(is("log"))
+				Proposals.proposalThat(is("log"))
 		)));
 	}
 
@@ -82,14 +81,14 @@ public class StreamCompletionProviderTests {
 	// fi<TAB> => file
 	public void testUnfinishedAppNameShouldReturnCompletions() {
 		assertThat(completionProvider.complete("h", 1), hasItems(
-				proposalThat(is("http")),
-				proposalThat(is("hdfs"))
+				Proposals.proposalThat(is("http")),
+				Proposals.proposalThat(is("hdfs"))
 		));
 		assertThat(completionProvider.complete("ht", 1), hasItems(
-				proposalThat(is("http"))
+				Proposals.proposalThat(is("http"))
 		));
 		assertThat(completionProvider.complete("ht", 1), not(hasItems(
-				proposalThat(is("hdfs"))
+				Proposals.proposalThat(is("hdfs"))
 		)));
 	}
 
@@ -97,10 +96,10 @@ public class StreamCompletionProviderTests {
 	// file | filter <TAB> => file | filter | foo, etc
 	public void testValidSubStreamDefinitionShouldReturnPipe() {
 		assertThat(completionProvider.complete("http | filter ", 1), hasItems(
-				proposalThat(is("http | filter | log"))
+				Proposals.proposalThat(is("http | filter | log"))
 		));
 		assertThat(completionProvider.complete("http | filter ", 1), not(hasItems(
-				proposalThat(is("http | filter | http"))
+				Proposals.proposalThat(is("http | filter | http"))
 		)));
 	}
 
@@ -108,13 +107,13 @@ public class StreamCompletionProviderTests {
 	// file | filter<TAB> => file | filter --foo=, etc
 	public void testValidSubStreamDefinitionShouldReturnAppOptions() {
 		assertThat(completionProvider.complete("http | filter ", 1), hasItems(
-				proposalThat(is("http | filter --expression=")),
-				proposalThat(is("http | filter --expresso="))
+				Proposals.proposalThat(is("http | filter --expression=")),
+				Proposals.proposalThat(is("http | filter --expresso="))
 		));
 		// Same as above, no final space
 		assertThat(completionProvider.complete("http | filter", 1), hasItems(
-				proposalThat(is("http | filter --expression=")),
-				proposalThat(is("http | filter --expresso="))
+				Proposals.proposalThat(is("http | filter --expression=")),
+				Proposals.proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -122,8 +121,8 @@ public class StreamCompletionProviderTests {
 	// file | filter -<TAB> => file | filter --foo,etc
 	public void testOneDashShouldReturnTwoDashes() {
 		assertThat(completionProvider.complete("http | filter -", 1), hasItems(
-				proposalThat(is("http | filter --expression=")),
-				proposalThat(is("http | filter --expresso="))
+				Proposals.proposalThat(is("http | filter --expression=")),
+				Proposals.proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -131,8 +130,8 @@ public class StreamCompletionProviderTests {
 	// file | filter --<TAB> => file | filter --foo,etc
 	public void testTwoDashesShouldReturnOptions() {
 		assertThat(completionProvider.complete("http | filter --", 1), hasItems(
-				proposalThat(is("http | filter --expression=")),
-				proposalThat(is("http | filter --expresso="))
+				Proposals.proposalThat(is("http | filter --expression=")),
+				Proposals.proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -140,11 +139,11 @@ public class StreamCompletionProviderTests {
 	// file |<TAB> => file | foo,etc
 	public void testDanglingPipeShouldReturnExtraApps() {
 		assertThat(completionProvider.complete("http |", 1), hasItems(
-				proposalThat(is("http | filter"))
+				Proposals.proposalThat(is("http | filter"))
 		));
 		assertThat(completionProvider.complete("http | filter |", 1), hasItems(
-				proposalThat(is("http | filter | log")),
-				proposalThat(is("http | filter | filter2: filter"))
+				Proposals.proposalThat(is("http | filter | log")),
+				Proposals.proposalThat(is("http | filter | filter2: filter"))
 		));
 	}
 
@@ -152,7 +151,7 @@ public class StreamCompletionProviderTests {
 	// file --p<TAB> => file --preventDuplicates=, file --pattern=
 	public void testUnfinishedOptionNameShouldComplete() {
 		assertThat(completionProvider.complete("http --p", 1), hasItems(
-				proposalThat(is("http --port="))
+				Proposals.proposalThat(is("http --port="))
 		));
 	}
 
@@ -172,11 +171,11 @@ public class StreamCompletionProviderTests {
 	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoApps() {
 		assertThat(completionProvider.complete(":foo >", 1), hasItems(
-				proposalThat(is(":foo > filter")),
-				proposalThat(is(":foo > log"))
+				Proposals.proposalThat(is(":foo > filter")),
+				Proposals.proposalThat(is(":foo > log"))
 		));
 		assertThat(completionProvider.complete(":foo >", 1), not(hasItems(
-				proposalThat(is(":foo > http"))
+				Proposals.proposalThat(is(":foo > http"))
 		)));
 	}
 
@@ -184,8 +183,8 @@ public class StreamCompletionProviderTests {
 	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoAppsVariant() {
 		assertThat(completionProvider.complete(":foo >", 1), hasItems(
-				proposalThat(is(":foo > filter")),
-				proposalThat(is(":foo > log"))
+				Proposals.proposalThat(is(":foo > filter")),
+				Proposals.proposalThat(is(":foo > log"))
 		));
 	}
 
@@ -193,7 +192,7 @@ public class StreamCompletionProviderTests {
 	// http<TAB> (no space) => NOT "http2: http"
 	public void testAutomaticAppLabellingDoesNotGetInTheWay() {
 		assertThat(completionProvider.complete("http", 1), not(hasItems(
-				proposalThat(is("http2: http"))
+				Proposals.proposalThat(is("http2: http"))
 		)));
 	}
 
@@ -201,8 +200,8 @@ public class StreamCompletionProviderTests {
 	// http --use-ssl=<TAB> => propose true|false
 	public void testValueHintForBooleans() {
 		assertThat(completionProvider.complete("http --use-ssl=", 1), hasItems(
-				proposalThat(is("http --use-ssl=true")),
-				proposalThat(is("http --use-ssl=false"))
+				Proposals.proposalThat(is("http --use-ssl=true")),
+				Proposals.proposalThat(is("http --use-ssl=false"))
 		));
 	}
 
@@ -210,8 +209,8 @@ public class StreamCompletionProviderTests {
 	// .. foo --enum-value=<TAB> => propose enum values
 	public void testValueHintForEnums() {
 		assertThat(completionProvider.complete("http | filter --expresso=", 1), hasItems(
-				proposalThat(is("http | filter --expresso=SINGLE")),
-				proposalThat(is("http | filter --expresso=DOUBLE"))
+				Proposals.proposalThat(is("http | filter --expresso=SINGLE")),
+				Proposals.proposalThat(is("http | filter --expresso=DOUBLE"))
 		));
 	}
 
@@ -233,17 +232,8 @@ public class StreamCompletionProviderTests {
 	@Test
 	public void testClosedSetValuesShouldBeExclusive() {
 		assertThat(completionProvider.complete("http --use-ssl=tr", 1), not(hasItems(
-				proposalThat(startsWith("http --port=12 --use-ssl=tr "))
+				Proposals.proposalThat(startsWith("http --port=12 --use-ssl=tr "))
 		)));
-	}
-
-	private static org.hamcrest.Matcher<CompletionProposal> proposalThat(org.hamcrest.Matcher<String> matcher) {
-		return new FeatureMatcher<CompletionProposal, String>(matcher, "a proposal whose text", "text") {
-			@Override
-			protected String featureValueOf(CompletionProposal actual) {
-				return actual.getText();
-			}
-		};
 	}
 
 	/**

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.completion.Proposals.proposalThat;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -69,11 +70,11 @@ public class StreamCompletionProviderTests {
 	// <TAB> => file,http,etc
 	public void testEmptyStartShouldProposeSourceApps() {
 		assertThat(completionProvider.complete("", 1), hasItems(
-				Proposals.proposalThat(is("http")),
-				Proposals.proposalThat(is("hdfs"))
+				proposalThat(is("http")),
+				proposalThat(is("hdfs"))
 		));
 		assertThat(completionProvider.complete("", 1), not(hasItems(
-				Proposals.proposalThat(is("log"))
+				proposalThat(is("log"))
 		)));
 	}
 
@@ -81,14 +82,14 @@ public class StreamCompletionProviderTests {
 	// fi<TAB> => file
 	public void testUnfinishedAppNameShouldReturnCompletions() {
 		assertThat(completionProvider.complete("h", 1), hasItems(
-				Proposals.proposalThat(is("http")),
-				Proposals.proposalThat(is("hdfs"))
+				proposalThat(is("http")),
+				proposalThat(is("hdfs"))
 		));
 		assertThat(completionProvider.complete("ht", 1), hasItems(
-				Proposals.proposalThat(is("http"))
+				proposalThat(is("http"))
 		));
 		assertThat(completionProvider.complete("ht", 1), not(hasItems(
-				Proposals.proposalThat(is("hdfs"))
+				proposalThat(is("hdfs"))
 		)));
 	}
 
@@ -96,10 +97,10 @@ public class StreamCompletionProviderTests {
 	// file | filter <TAB> => file | filter | foo, etc
 	public void testValidSubStreamDefinitionShouldReturnPipe() {
 		assertThat(completionProvider.complete("http | filter ", 1), hasItems(
-				Proposals.proposalThat(is("http | filter | log"))
+				proposalThat(is("http | filter | log"))
 		));
 		assertThat(completionProvider.complete("http | filter ", 1), not(hasItems(
-				Proposals.proposalThat(is("http | filter | http"))
+				proposalThat(is("http | filter | http"))
 		)));
 	}
 
@@ -107,13 +108,13 @@ public class StreamCompletionProviderTests {
 	// file | filter<TAB> => file | filter --foo=, etc
 	public void testValidSubStreamDefinitionShouldReturnAppOptions() {
 		assertThat(completionProvider.complete("http | filter ", 1), hasItems(
-				Proposals.proposalThat(is("http | filter --expression=")),
-				Proposals.proposalThat(is("http | filter --expresso="))
+				proposalThat(is("http | filter --expression=")),
+				proposalThat(is("http | filter --expresso="))
 		));
 		// Same as above, no final space
 		assertThat(completionProvider.complete("http | filter", 1), hasItems(
-				Proposals.proposalThat(is("http | filter --expression=")),
-				Proposals.proposalThat(is("http | filter --expresso="))
+				proposalThat(is("http | filter --expression=")),
+				proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -121,8 +122,8 @@ public class StreamCompletionProviderTests {
 	// file | filter -<TAB> => file | filter --foo,etc
 	public void testOneDashShouldReturnTwoDashes() {
 		assertThat(completionProvider.complete("http | filter -", 1), hasItems(
-				Proposals.proposalThat(is("http | filter --expression=")),
-				Proposals.proposalThat(is("http | filter --expresso="))
+				proposalThat(is("http | filter --expression=")),
+				proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -130,8 +131,8 @@ public class StreamCompletionProviderTests {
 	// file | filter --<TAB> => file | filter --foo,etc
 	public void testTwoDashesShouldReturnOptions() {
 		assertThat(completionProvider.complete("http | filter --", 1), hasItems(
-				Proposals.proposalThat(is("http | filter --expression=")),
-				Proposals.proposalThat(is("http | filter --expresso="))
+				proposalThat(is("http | filter --expression=")),
+				proposalThat(is("http | filter --expresso="))
 		));
 	}
 
@@ -139,11 +140,11 @@ public class StreamCompletionProviderTests {
 	// file |<TAB> => file | foo,etc
 	public void testDanglingPipeShouldReturnExtraApps() {
 		assertThat(completionProvider.complete("http |", 1), hasItems(
-				Proposals.proposalThat(is("http | filter"))
+				proposalThat(is("http | filter"))
 		));
 		assertThat(completionProvider.complete("http | filter |", 1), hasItems(
-				Proposals.proposalThat(is("http | filter | log")),
-				Proposals.proposalThat(is("http | filter | filter2: filter"))
+				proposalThat(is("http | filter | log")),
+				proposalThat(is("http | filter | filter2: filter"))
 		));
 	}
 
@@ -151,7 +152,7 @@ public class StreamCompletionProviderTests {
 	// file --p<TAB> => file --preventDuplicates=, file --pattern=
 	public void testUnfinishedOptionNameShouldComplete() {
 		assertThat(completionProvider.complete("http --p", 1), hasItems(
-				Proposals.proposalThat(is("http --port="))
+				proposalThat(is("http --port="))
 		));
 	}
 
@@ -171,11 +172,11 @@ public class StreamCompletionProviderTests {
 	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoApps() {
 		assertThat(completionProvider.complete(":foo >", 1), hasItems(
-				Proposals.proposalThat(is(":foo > filter")),
-				Proposals.proposalThat(is(":foo > log"))
+				proposalThat(is(":foo > filter")),
+				proposalThat(is(":foo > log"))
 		));
 		assertThat(completionProvider.complete(":foo >", 1), not(hasItems(
-				Proposals.proposalThat(is(":foo > http"))
+				proposalThat(is(":foo > http"))
 		)));
 	}
 
@@ -183,8 +184,8 @@ public class StreamCompletionProviderTests {
 	// :foo > <TAB>  ==> add app names
 	public void testDestinationIntoAppsVariant() {
 		assertThat(completionProvider.complete(":foo >", 1), hasItems(
-				Proposals.proposalThat(is(":foo > filter")),
-				Proposals.proposalThat(is(":foo > log"))
+				proposalThat(is(":foo > filter")),
+				proposalThat(is(":foo > log"))
 		));
 	}
 
@@ -192,7 +193,7 @@ public class StreamCompletionProviderTests {
 	// http<TAB> (no space) => NOT "http2: http"
 	public void testAutomaticAppLabellingDoesNotGetInTheWay() {
 		assertThat(completionProvider.complete("http", 1), not(hasItems(
-				Proposals.proposalThat(is("http2: http"))
+				proposalThat(is("http2: http"))
 		)));
 	}
 
@@ -200,8 +201,8 @@ public class StreamCompletionProviderTests {
 	// http --use-ssl=<TAB> => propose true|false
 	public void testValueHintForBooleans() {
 		assertThat(completionProvider.complete("http --use-ssl=", 1), hasItems(
-				Proposals.proposalThat(is("http --use-ssl=true")),
-				Proposals.proposalThat(is("http --use-ssl=false"))
+				proposalThat(is("http --use-ssl=true")),
+				proposalThat(is("http --use-ssl=false"))
 		));
 	}
 
@@ -209,8 +210,8 @@ public class StreamCompletionProviderTests {
 	// .. foo --enum-value=<TAB> => propose enum values
 	public void testValueHintForEnums() {
 		assertThat(completionProvider.complete("http | filter --expresso=", 1), hasItems(
-				Proposals.proposalThat(is("http | filter --expresso=SINGLE")),
-				Proposals.proposalThat(is("http | filter --expresso=DOUBLE"))
+				proposalThat(is("http | filter --expresso=SINGLE")),
+				proposalThat(is("http | filter --expresso=DOUBLE"))
 		));
 	}
 
@@ -232,7 +233,7 @@ public class StreamCompletionProviderTests {
 	@Test
 	public void testClosedSetValuesShouldBeExclusive() {
 		assertThat(completionProvider.complete("http --use-ssl=tr", 1), not(hasItems(
-				Proposals.proposalThat(startsWith("http --port=12 --use-ssl=tr "))
+				proposalThat(startsWith("http --port=12 --use-ssl=tr "))
 		)));
 	}
 

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/boot_versions/README.txt
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/boot_versions/README.txt
@@ -1,0 +1,1 @@
+The contents of these 2 boot uberjars has been created using the src/test/support maven project(s).

--- a/spring-cloud-dataflow-completion/src/test/support/boot13/pom.xml
+++ b/spring-cloud-dataflow-completion/src/test/support/boot13/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme</groupId>
+	<artifactId>boot13</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.3.0.RELEASE</version>
+		<relativePath/>
+	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>1.3.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<version>1.3.0.RELEASE</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.acme</groupId>
+			<artifactId>common</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>1.3.0.RELEASE</version>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/AnotherEnumClass13.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/AnotherEnumClass13.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot13;
+
+/**
+ * An enum used in configuration properties class.
+ */
+public enum AnotherEnumClass13 {
+	low, high;
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/Main.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/Main.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot13;
+
+public class Main {
+
+	public static void main(String[] args) {
+		System.out.println("Hello World");
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/MyConfigProperties13.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/java/com/acme/boot13/MyConfigProperties13.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot13;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Eric Bottard
+ */
+@ConfigurationProperties("boot13")
+public class MyConfigProperties13 {
+
+	private AnotherEnumClass13 level;
+
+	public AnotherEnumClass13 getLevel() {
+		return level;
+	}
+
+	public void setLevel(AnotherEnumClass13 level) {
+		this.level = level;
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/support/boot13/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,3 @@
+configuration-properties.classes=\
+  com.acme.boot13.MyConfigProperties13, \
+  com.acme.common.ConfigProperties

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/pom.xml
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme</groupId>
+	<artifactId>boot14</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.4.0.RELEASE</version>
+		<relativePath/>
+	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>1.4.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<version>1.4.0.RELEASE</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.acme</groupId>
+			<artifactId>common</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>1.4.0.RELEASE</version>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/pom.xml
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/pom.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 the original author or authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/AnotherEnumClass14.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/AnotherEnumClass14.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot14;
+
+/**
+ * An enum class used in configuration properties
+ */
+public enum AnotherEnumClass14 {
+	very_high, very_low;
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/Main.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/Main.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot14;
+
+public class Main {
+
+	public static void main(String[] args) {
+		System.out.println("Hello World");
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.boot14;
+
+/**
+ * @author Eric Bottard
+ */
+public class MyConfigProperties14 {
+
+	private AnotherEnumClass14 level;
+
+	public AnotherEnumClass14 getLevel() {
+		return level;
+	}
+
+	public void setLevel(AnotherEnumClass14 level) {
+		this.level = level;
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/java/com/acme/boot14/MyConfigProperties14.java
@@ -16,9 +16,12 @@
 
 package com.acme.boot14;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 /**
  * @author Eric Bottard
  */
+@ConfigurationProperties("boot14")
 public class MyConfigProperties14 {
 
 	private AnotherEnumClass14 level;

--- a/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/support/boot14/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,3 @@
+configuration-properties.classes=\
+  com.acme.boot14.MyConfigProperties14, \
+  com.acme.common.ConfigProperties

--- a/spring-cloud-dataflow-completion/src/test/support/common/pom.xml
+++ b/spring-cloud-dataflow-completion/src/test/support/common/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme</groupId>
+	<artifactId>common</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.3.0.RELEASE</version>
+		<relativePath/>
+	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>1.3.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<version>1.3.0.RELEASE</version>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-dataflow-completion/src/test/support/common/src/main/java/com/acme/common/ConfigProperties.java
+++ b/spring-cloud-dataflow-completion/src/test/support/common/src/main/java/com/acme/common/ConfigProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.common;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Created by ericbottard on 12/09/16.
+ */
+@ConfigurationProperties("common")
+public class ConfigProperties {
+	/**
+	 * Some number.
+	 */
+	private SomeEnum number = SomeEnum.two;
+
+	/**
+	 * Some string.
+	 */
+	private String someString = "hello";
+
+	public String getSomeString() {
+		return someString;
+	}
+
+	public void setSomeString(String someString) {
+		this.someString = someString;
+	}
+
+
+
+	public SomeEnum getNumber() {
+		return number;
+	}
+
+	public void setNumber(SomeEnum number) {
+		this.number = number;
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/support/common/src/main/java/com/acme/common/SomeEnum.java
+++ b/spring-cloud-dataflow-completion/src/test/support/common/src/main/java/com/acme/common/SomeEnum.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.common;
+
+/**
+ * An enum class used in {@link ConfigProperties}. Useful to test, because this class has to be accessible
+ * to the ClassLoader used to retrieve metadata.
+ *
+ * @author Eric Bottard
+ */
+public enum SomeEnum {
+	one, two, three;
+}

--- a/spring-cloud-dataflow-completion/src/test/support/pom.xml
+++ b/spring-cloud-dataflow-completion/src/test/support/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.acme</groupId>
+	<artifactId>parent</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<modules>
+		<module>common</module>
+		<module>boot13</module>
+		<module>boot14</module>
+	</modules>
+</project>

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
@@ -36,6 +38,16 @@ public abstract class ApplicationConfigurationMetadataResolver {
 
 	public List<ConfigurationMetadataProperty> listProperties(Resource app) {
 		return listProperties(app, false);
+	}
+
+	/**
+	 * For resolvers that support it, create a new ClassLoader that is able to load classes for the given app.
+	 * The default implementation returns an empty classloader
+	 * @param app an app to create a ClassLoader for
+	 * @return a new ClassLoader. Callers are responsible for closing the returned class loader.
+	 */
+	public URLClassLoader createAppClassLoader(Resource app) {
+		return new URLClassLoader(new URL[0], null);
 	}
 
 	/**

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -16,13 +16,12 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -53,9 +52,9 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 
 	private static final String WHITELIST_PROPERTIES = "classpath*:/META-INF/spring-configuration-metadata-whitelist.properties";
 
-	public static final String CONFIGURATION_PROPERTIES_CLASSES = "configuration-properties.classes";
+	private static final String CONFIGURATION_PROPERTIES_CLASSES = "configuration-properties.classes";
 
-	public static final String CONFIGURATION_PROPERTIES_NAMES = "configuration-properties.names";
+	private static final String CONFIGURATION_PROPERTIES_NAMES = "configuration-properties.names";
 
 	private final Set<String> globalWhiteListedProperties = new HashSet<>();
 
@@ -81,16 +80,8 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 
 	@Override
 	public boolean supports(Resource app) {
-		File file = null;
 		try {
-			file = app.getFile();
-		}
-		catch (IOException e) {
-			return false;
-		}
-		Archive archive = null;
-		try {
-			archive = file.isDirectory() ? new ExplodedArchive(file) : new JarFileArchive(file);
+			resolveAsArchive(app);
 			return true;
 		}
 		catch (IOException | IllegalArgumentException e) {
@@ -106,29 +97,18 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 	 *            but directories are supported as well
 	 */
 	public List<ConfigurationMetadataProperty> listProperties(Resource app, boolean exhaustive) {
-		File moduleFile = null;
 		try {
-			moduleFile = app.getFile();
-		}
-		catch (IOException e) {
-			return Collections.emptyList();
-		}
-		Archive archive = null;
-		try {
-			archive = moduleFile.isDirectory() ? new ExplodedArchive(moduleFile) : new JarFileArchive(moduleFile);
+			Archive archive = resolveAsArchive(app);
 			return listProperties(archive, exhaustive);
 		}
 		catch (IOException e) {
-			throw new RuntimeException("");
+			throw new RuntimeException("Failed to list properties for " + app, e);
 		}
 	}
 
 	public List<ConfigurationMetadataProperty> listProperties(Archive archive, boolean exhaustive) {
-		ClassLoader moduleClassLoader = null;
-		try {
-
+		try (URLClassLoader moduleClassLoader = new BootClassLoaderFactory(archive, parent).createClassLoader()) {
 			List<ConfigurationMetadataProperty> result = new ArrayList<>();
-			moduleClassLoader = new BootClassLoaderFactory(archive, parent).createClassLoader();
 			ResourcePatternResolver moduleResourceLoader = new PathMatchingResourcePatternResolver(moduleClassLoader);
 			Collection<String> whiteListedClasses = new HashSet<>(globalWhiteListedClasses);
 			Collection<String> whiteListedProperties = new HashSet<>(globalWhiteListedProperties);
@@ -163,16 +143,21 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 		catch (Exception e) {
 			throw new RuntimeException("Exception trying to list configuration properties for application " + archive, e);
 		}
-		finally {
-			if (moduleClassLoader instanceof Closeable) {
-				try {
-					((Closeable) moduleClassLoader).close();
-				}
-				catch (IOException e) {
-					// ignore
-				}
-			}
+	}
+
+	@Override
+	public URLClassLoader createAppClassLoader(Resource app) {
+		try {
+			return new BootClassLoaderFactory(resolveAsArchive(app), parent).createClassLoader();
 		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Archive resolveAsArchive(Resource app) throws IOException {
+			File moduleFile = app.getFile();
+			return moduleFile.isDirectory() ? new ExplodedArchive(moduleFile) : new JarFileArchive(moduleFile);
 	}
 
 	/**

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -128,7 +128,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 		try {
 
 			List<ConfigurationMetadataProperty> result = new ArrayList<>();
-			moduleClassLoader = new BootClassLoaderCreation(archive, parent).createClassLoader();
+			moduleClassLoader = new BootClassLoaderFactory(archive, parent).createClassLoader();
 			ResourcePatternResolver moduleResourceLoader = new PathMatchingResourcePatternResolver(moduleClassLoader);
 			Collection<String> whiteListedClasses = new HashSet<>(globalWhiteListedClasses);
 			Collection<String> whiteListedProperties = new HashSet<>(globalWhiteListedProperties);

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootClassLoaderFactory.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootClassLoaderFactory.java
@@ -110,5 +110,9 @@ public class BootClassLoaderFactory {
 					|| (entry.isDirectory() && entry.getName().equals(BOOT_14_CLASSESS_LOCATION));
 		}
 
+		@Override
+		protected void postProcessClassPathArchives(List<Archive> archives) throws Exception {
+			archives.add(0, getArchive());
+		}
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/DelegatingApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/DelegatingApplicationConfigurationMetadataResolver.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,5 +53,15 @@ public class DelegatingApplicationConfigurationMetadataResolver extends Applicat
 			}
 		}
 		return Collections.emptyList();
+	}
+
+	@Override
+	public URLClassLoader createAppClassLoader(Resource app) {
+		for (ApplicationConfigurationMetadataResolver delegate : delegates) {
+			if (delegate.supports(app)) {
+				return delegate.createAppClassLoader(app);
+			}
+		}
+		return super.createAppClassLoader(app);
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -70,6 +70,22 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		assertThat(properties.size(), is(full.size()));
 	}
 
+	@Test
+	public void testSupportsBoot13Layout() {
+		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new ClassPathResource("apps/boot13-1.0.0.BUILD-SNAPSHOT.jar", getClass()));
+		for (ConfigurationMetadataProperty property : properties) {
+			System.out.println(property.getId());
+		}
+	}
+
+	@Test
+	public void testSupportsBoot14Layout() {
+		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new ClassPathResource("apps/boot14-1.0.0.BUILD-SNAPSHOT.jar", getClass()));
+		for (ConfigurationMetadataProperty property : properties) {
+			System.out.println(property.getId());
+		}
+	}
+
 	private Matcher<ConfigurationMetadataProperty> configPropertyIdentifiedAs(String name) {
 		return hasProperty("id", is(name));
 	}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
@@ -31,7 +30,6 @@ import org.junit.Test;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.DescriptiveResource;
 
 /**
  * Unit tests for {@link ApplicationConfigurationMetadataResolver}.
@@ -58,32 +56,11 @@ public class BootApplicationConfigurationMetadataResolverTests {
 	}
 
 	@Test
-	public void dontFailWithExceptionForNonFileResources() {
-		assertThat(resolver.listProperties(new DescriptiveResource("Doesn't resolve to a java.io.File")), empty());
-	}
-
-	@Test
 	public void shouldReturnEverythingWhenNoDescriptors() {
 		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new ClassPathResource("apps/no-whitelist", getClass()));
 		List<ConfigurationMetadataProperty> full = resolver.listProperties(new ClassPathResource("apps/no-whitelist", getClass()), true);
 		assertThat( properties.size(), greaterThan(0));
 		assertThat(properties.size(), is(full.size()));
-	}
-
-	@Test
-	public void testSupportsBoot13Layout() {
-		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new ClassPathResource("apps/boot13-1.0.0.BUILD-SNAPSHOT.jar", getClass()));
-		for (ConfigurationMetadataProperty property : properties) {
-			System.out.println(property.getId());
-		}
-	}
-
-	@Test
-	public void testSupportsBoot14Layout() {
-		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new ClassPathResource("apps/boot14-1.0.0.BUILD-SNAPSHOT.jar", getClass()));
-		for (ConfigurationMetadataProperty property : properties) {
-			System.out.println(property.getId());
-		}
 	}
 
 	private Matcher<ConfigurationMetadataProperty> configPropertyIdentifiedAs(String name) {


### PR DESCRIPTION
Allows some corner cases to work in commpletion (mainly, being able
to "see" enum classes that are part of any boot 1.3/1.4 uberjar.)

Fixes spring-cloud/spring-cloud-dataflow#852