### PR TITLE
Update bit.ly links 

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -117,7 +117,7 @@ By default, the application registry will be empty. If you would like to registe
 +
 [source,bash,subs=attributes]
 ----
-$ dataflow:>app import --uri http://bit.ly/stream-applications-kafka-maven
+$ dataflow:>app import --uri http://bit.ly/1-0-4-GA-stream-applications-kafka-maven
 ----
 +
 . You can now use the shell commands to list available applications (source/processors/sink) and create streams. For example:

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/spring-cloud-dataflow-overview.adoc
@@ -10,18 +10,21 @@ fashion, or you can skip sections if something doesn't interest you.
 
 [[dataflow-documentation-intro]]
 == Introducing Spring Cloud Data Flow
-Spring Cloud Data Flow is a cloud native programming and operating model for composable data microservices on modern runtimes.  With Spring Cloud Data Flow, developers can create and orchestrate data pipelines for common use cases such as data ingest, real-time analytics, and data import/export.
+Spring Cloud Data Flow is a cloud-native orchestration service for composable microservice applications on modern runtimes. With Spring Cloud Data Flow, developers can create and orchestrate data pipelines for common use cases such as data ingest, real-time analytics, and data import/export.
 
-Spring Cloud Data Flow is the cloud native redesign of link:http://projects.spring.io/spring-xd/[Spring XD] – a project that aimed to simplify development of Big Data applications.  The streaming and batch modules from Spring XD are refactored into Spring Boot link:http://cloud.spring.io/spring-cloud-stream-modules/[data microservice] applications that are now autonomous deployment units and they can "natively" run in modern runtimes such as Cloud Foundry, Apache YARN, Apache Mesos, and Kubernetes.
+Spring Cloud Data Flow is the cloud native redesign of link:http://projects.spring.io/spring-xd/[Spring XD] – a project that aimed to simplify development of Big Data applications. The stream and batch modules from Spring XD are refactored as Spring Boot based link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] microservice applications respectively. These applications are now autonomous deployment units and they can "natively" run in modern runtimes such as Cloud Foundry, Apache YARN, Apache Mesos, and Kubernetes.
 
-Spring Cloud Data Flow offers a collection of patterns and best practices for microservices-based distributed streaming and batch data pipelines. 
+Spring Cloud Data Flow offers a collection of patterns and best practices for microservices-based distributed streaming and task/batch data pipelines.
 
 === Features
 
-* Orchestrate applications across a variety of distributed modern runtimes including: Cloud Foundry, Apache YARN, Apache Mesos, and Kubernetes
-* Separate runtime dependencies backed by *spring profiles*
-* Consume stream and batch data-microservices as maven dependencies
-* Develop using: DSL, Shell, REST-APIs, Data Flow Server UI, and Flo
-* Take advantage of metrics, health checks and remote management of each data microservice
-* Scale stream and batch pipelines without interrupting data flows
+* Develop using DSL, REST-APIs, Dashboard, and the drag-and-drop GUI - Flo
+* Create, unit-test, troubleshoot and manage microservice applications in isolation
+* Build data pipelines rapidly using the out-of-the-box stream and task/batch applications
+* Consume microservice applications as maven or docker artifacts
+* Scale data pipelines without interrupting data flows
+* Orchestrate data-centric applications on a variety of modern runtime platforms including Cloud Foundry, Apache YARN, Apache Mesos, and Kubernetes
+* Take advantage of metrics, health checks, and the remote management of each microservice application
+
+
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -78,24 +78,35 @@ Then to import the apps in bulk, use the `app import` command and provide the lo
 dataflow:>app import --uri file:///<YOUR_FILE_LOCATION>/stream-apps.properties
 ```
 
-For convenience, we have the static files with application-URIs (for both maven and docker) available for all the out-of-the-box
-Stream app-starters. You can point to this file and import all the application-URIs in bulk. Otherwise, as explained in
-previous paragraphs, you can register them individually or have your own custom property file with only the required application-URIs
-in it. It is recommended, however, to have a "focused" list of desired application-URIs in a custom property file.
+For convenience, we have the static files with application-URIs (for both maven and docker) available 
+for all the out-of-the-box stream and task/batch app-starters. You can point to this file and import
+all the application-URIs in bulk. Otherwise, as explained in previous paragraphs, you can register them individually or have your own custom property file with only the required application-URIs in it. It is recommended, however, to have a "focused" list of desired application-URIs in a custom property file.
 
+List of available Stream Application Starters:
 
-List of available static property files:
+[width="100%",frame="topbot",options="header"]
+|======================
+|Artifact Type |Stable Release |SNAPSHOT Release
+|RabbitMQ + Maven |link:http://bit.ly/1-0-4-GA-stream-applications-rabbit-maven[http://bit.ly/1-0-4-GA-stream-applications-rabbit-maven] |link:http://bit.ly/1-1-0-SNAPSHOT-stream-applications-rabbit-maven[http://bit.ly/1-1-0-SNAPSHOT-stream-applications-rabbit-maven]
+|RabbitMQ + Docker|link:http://bit.ly/1-0-4-GA-stream-applications-rabbit-docker[http://bit.ly/1-0-4-GA-stream-applications-rabbit-docker] | link:http://bit.ly/1-1-0-SNAPSHOT-stream-applications-rabbit-docker[http://bit.ly/1-1-0-SNAPSHOT-stream-applications-rabbit-docker]
+|Kafka + Maven 	  |link:http://bit.ly/1-0-4-GA-stream-applications-kafka-maven[http://bit.ly/1-0-4-GA-stream-applications-kafka-maven] |link:http://bit.ly/1-1-0-SNAPSHOT-stream-applications-kafka-maven[http://bit.ly/1-1-0-SNAPSHOT-stream-applications-kafka-maven]
+|Kafka + Docker   |link:http://bit.ly/1-0-4-GA-stream-applications-kafka-docker[http://bit.ly/1-0-4-GA-stream-applications-kafka-docker] | link:http://bit.ly/1-1-0-SNAPSHOT-stream-applications-kafka-docker[http://bit.ly/1-1-0-SNAPSHOT-stream-applications-kafka-docker]
+|======================
 
-* Maven based Stream Applications with RabbitMQ Binder: http://bit.ly/stream-applications-rabbit-maven
-* Maven based Stream Applications with Kafka Binder: http://bit.ly/stream-applications-kafka-maven
-* Docker based Stream Applications with RabbitMQ Binder: http://bit.ly/stream-applications-rabbit-docker
-* Docker based Stream Applications with Kafka Binder: http://bit.ly/stream-applications-kafka-docker
+List of available Task Applicaiton Starters:
+
+[width="100%",frame="topbot",options="header"]
+|======================
+|Artifact Type |Stable Release |SNAPSHOT Release
+|Maven   |link:http://bit.ly/1-0-1-GA-task-applications-maven[http://bit.ly/1-0-1-GA-task-applications-maven] |link:http://bit.ly/1-0-2-SNAPSHOT-task-applications-maven[http://bit.ly/1-0-2-SNAPSHOT-task-applications-maven]
+|Docker  |link:http://bit.ly/1-0-1-GA-task-applications-docker[http://bit.ly/1-0-1-GA-task-applications-docker] | link:http://bit.ly/1-0-2-SNAPSHOT-task-applications-docker[http://bit.ly/1-0-2-SNAPSHOT-task-applications-docker]
+|======================
 
 For example, if you would like to register all out-of-the-box stream applications built with the RabbitMQ binder in bulk, you can with
 the following command.
 
 ```
-dataflow:>app import --uri http://bit.ly/stream-applications-rabbit-maven
+dataflow:>app import --uri http://bit.ly/1-0-4-GA-stream-applications-rabbit-maven
 ```
 
 You can also pass the `--local` option (which is TRUE by default) to indicate whether the


### PR DESCRIPTION
Resolves spring-cloud/spring-cloud-dataflow#917
- this PR adds a new table to list all the latest app-starter bit.ly's
- automatic version replacement to this section would be addressed via spring-cloud/spring-cloud-dataflow#943

Resolves spring-cloud/spring-cloud-dataflow#933
Moved the "common application properties" to "creating a stream" section

Lastly, this PR also includes an update to project description and features section, so that it is in sync with project site content.
