### PR TITLE
Completion for task

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsTaskExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsTaskExpansionStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.core.io.Resource;
+
+/**
+ * Adds missing application configuration properties at the end of a well formed task definition.
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+class AddAppOptionsTaskExpansionStrategy implements TaskExpansionStrategy {
+
+	private final AppRegistry appRegistry;
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+
+	public AddAppOptionsTaskExpansionStrategy(AppRegistry appRegistry, ApplicationConfigurationMetadataResolver metadataResolver) {
+		this.appRegistry = appRegistry;
+		this.metadataResolver = metadataResolver;
+	}
+
+	@Override
+	public boolean addProposals(String text, TaskDefinition taskDefinition, int detailLevel,
+	                            List<CompletionProposal> collector) {
+		String appName = taskDefinition.getRegisteredAppName();
+		AppRegistration appRegistration = this.appRegistry.find(appName, ApplicationType.task);
+		if (appRegistration == null) {
+			// Not a valid app, do nothing
+			return false;
+		}
+		Set<String> alreadyPresentOptions = new HashSet<>(taskDefinition.getProperties().keySet());
+		Resource jarFile = appRegistration.getResource();
+		CompletionProposal.Factory proposals = expanding(text);
+
+		// For whitelisted properties, use their simple name
+		for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile)) {
+			if (!alreadyPresentOptions.contains(property.getName())) {
+				collector.add(proposals.withSeparateTokens("--" + property.getName() + "=", property.getShortDescription()));
+			}
+		}
+
+		// For other properties (including WL'ed in full form), use their id
+		if (detailLevel > 1) {
+			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile, true)) {
+				if (!alreadyPresentOptions.contains(property.getId())) {
+					collector.add(proposals.withSeparateTokens("--" + property.getId() + "=", property.getShortDescription()));
+				}
+			}
+
+		}
+
+		return false;
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -136,4 +136,64 @@ public class CompletionConfiguration {
 	public ValueHintProvider booleanValueHintProvider() {
 		return new BooleanValueHintProvider();
 	}
+	
+	@Bean
+	public TaskCompletionProvider taskCompletionProvider() {
+		List<RecoveryStrategy<?>> recoveryStrategies = Arrays.<RecoveryStrategy<?>>asList(
+				emptyStartYieldsAppsTaskRecoveryStrategy(),
+				expandOneDashToTwoDashesTaskRecoveryStrategy(),
+				configurationPropertyNameAfterDashDashTaskRecoveryStrategy(),
+				unfinishedConfigurationPropertyNameTaskRecoveryStrategy(),
+				configurationPropertyValueHintTaskRecoveryStrategy()
+		);
+		List<TaskExpansionStrategy> expansionStrategies = Arrays.asList(
+				addTaskAppOptionsExpansionStrategy(),
+				unfinishedTaskAppNameExpansionStrategy(),
+				// Make sure this one runs last, as it may clear already computed proposals
+				// and return its own as the sole candidates
+				taskConfigurationPropertyValueHintExpansionStrategy()
+		);
+
+		return new TaskCompletionProvider(recoveryStrategies, expansionStrategies);
+	}
+	
+	@Bean
+	public RecoveryStrategy<?> emptyStartYieldsAppsTaskRecoveryStrategy() {
+		return new EmptyStartYieldsSourceAppsTaskRecoveryStrategy(appRegistry);
+	}
+
+	@Bean
+	public TaskExpansionStrategy addTaskAppOptionsExpansionStrategy() {
+		return new AddAppOptionsTaskExpansionStrategy(appRegistry, metadataResolver);
+	}
+
+	@Bean
+	public TaskExpansionStrategy unfinishedTaskAppNameExpansionStrategy() {
+		return new UnfinishedTaskAppNameExpansionStrategy(appRegistry);
+	}
+
+	@Bean
+	public TaskExpansionStrategy taskConfigurationPropertyValueHintExpansionStrategy() {
+		return new ConfigurationPropertyValueHintTaskExpansionStrategy(appRegistry, metadataResolver);
+	}
+
+	@Bean
+	public RecoveryStrategy<?> expandOneDashToTwoDashesTaskRecoveryStrategy() {
+		return new ExpandOneDashToTwoDashesTaskRecoveryStrategy();
+	}
+	
+	@Bean
+	public ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy configurationPropertyNameAfterDashDashTaskRecoveryStrategy() {
+		return new ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy(appRegistry, metadataResolver);
+	}
+
+	@Bean
+	public RecoveryStrategy<?> configurationPropertyValueHintTaskRecoveryStrategy() {
+		return new ConfigurationPropertyValueHintTaskRecoveryStrategy(appRegistry, metadataResolver);
+	}
+
+	@Bean
+	public RecoveryStrategy<?> unfinishedConfigurationPropertyNameTaskRecoveryStrategy() {
+		return new UnfinishedConfigurationPropertyNameTaskRecoveryStrategy(appRegistry, metadataResolver);
+	}
 }

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.TaskPropertyKeys;
 
 /**
  * Various utility methods used throughout the completion package.
@@ -39,12 +40,15 @@ public class CompletionUtils {
 	 * even though the user did not type them himself.
 	 */
 	static final Set<String> IMPLICIT_PARAMETER_NAMES = new HashSet<>();
+	static final Set<String> IMPLICIT_TASK_PARAMETER_NAMES = new HashSet<>();
 	static {
 		IMPLICIT_PARAMETER_NAMES.add(BindingPropertyKeys.INPUT_DESTINATION);
 		IMPLICIT_PARAMETER_NAMES.add(BindingPropertyKeys.INPUT_GROUP);
 		IMPLICIT_PARAMETER_NAMES.add(BindingPropertyKeys.OUTPUT_REQUIRED_GROUPS);
 		IMPLICIT_PARAMETER_NAMES.add(BindingPropertyKeys.OUTPUT_DESTINATION);
+		IMPLICIT_TASK_PARAMETER_NAMES.add(TaskPropertyKeys.TASK_NAME);
 	}
+
 
 	/**
 	 * Return the type(s) a given stream app definition <em>could</em> have, in the context of code completion.

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.core.io.Resource;
+
+
+/**
+ * Provides completion proposals when the user has typed the two dashes that
+ * precede an app configuration property.
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+class ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy
+		extends StacktraceFingerprintingTaskRecoveryStrategy<CheckPointedParseException> {
+
+	private final AppRegistry appRegistry;
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+
+	ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy(AppRegistry appRegistry,
+	                                                       ApplicationConfigurationMetadataResolver metadataResolver) {
+		super(CheckPointedParseException.class, "file --");
+		this.appRegistry = appRegistry;
+		this.metadataResolver = metadataResolver;
+	}
+
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception,
+	                         int detailLevel, List<CompletionProposal> collector) {
+
+		String safe = exception.getExpressionStringUntilCheckpoint();
+		TaskDefinition taskDefinition = new TaskDefinition("__dummy", safe);
+
+		String appName = taskDefinition.getRegisteredAppName();
+		AppRegistration appRegistration = appRegistry.find(appName, ApplicationType.task);
+		if (appRegistration == null) {
+			// Not a valid app name, do nothing
+			return;
+		}
+		Set<String> alreadyPresentOptions = new HashSet<>(taskDefinition.getProperties().keySet());
+		
+		Resource jarFile = appRegistration.getResource();
+
+		CompletionProposal.Factory proposals = expanding(dsl);
+
+		// For whitelisted properties, use their shortname
+		for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile)) {
+			if (!alreadyPresentOptions.contains(property.getName())) {
+				collector.add(proposals.withSuffix(property.getName() + "=", property.getShortDescription()));
+			}
+		}
+
+		// For other properties, use their fully qualified name
+		if (detailLevel > 1) {
+			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile, true)) {
+				if (!alreadyPresentOptions.contains(property.getId())) {
+					collector.add(proposals.withSuffix(property.getId() + "=", property.getShortDescription()));
+				}
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintTaskExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintTaskExpansionStrategy.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.configurationmetadata.ValueHint;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.core.dsl.Token;
+import org.springframework.cloud.dataflow.core.dsl.TokenKind;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.core.io.Resource;
+
+/**
+ * Attempts to fill in possible values after a {@literal --foo=prefix}
+ * (syntactically valid) construct in the DSL.
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class ConfigurationPropertyValueHintTaskExpansionStrategy implements TaskExpansionStrategy {
+
+	private final AppRegistry appRegistry;
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+
+	@Autowired
+	private ValueHintProvider[] valueHintProviders = new ValueHintProvider[0];
+
+	ConfigurationPropertyValueHintTaskExpansionStrategy(AppRegistry appRegistry,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		this.appRegistry = appRegistry;
+		this.metadataResolver = metadataResolver;
+	}
+
+	@Override
+	public boolean addProposals(String text, TaskDefinition parseResult,
+			int detailLevel, List<CompletionProposal> collector) {
+		Set<String> propertyNames = new HashSet<>(parseResult.getProperties().keySet());
+		propertyNames.removeAll(CompletionUtils.IMPLICIT_TASK_PARAMETER_NAMES);
+		if (text.endsWith(" ") || propertyNames.isEmpty()) {
+			return false;
+		}
+
+		String propertyName = recoverPropertyName(text);
+
+		String alreadyTyped = parseResult.getProperties().get(propertyName);
+		
+		String appName = parseResult.getRegisteredAppName();
+		AppRegistration appRegistration = appRegistry.find(appName, ApplicationType.task);
+		if (appRegistration == null) {
+			// Not a valid app name, do nothing
+			return false;
+		}
+		Resource appResource = appRegistration.getResource();
+
+		CompletionProposal.Factory proposals = expanding(text);
+
+		List<ConfigurationMetadataProperty> allProps = metadataResolver.listProperties(appResource, true);
+		List<ConfigurationMetadataProperty> whiteListedProps = metadataResolver.listProperties(appResource);
+
+		URLClassLoader classLoader = null;
+		try {
+			for (ConfigurationMetadataProperty property : allProps) {
+				if (CompletionUtils.isMatchingProperty(propertyName, property, whiteListedProps)) {
+					if (classLoader == null) {
+						classLoader = metadataResolver.createAppClassLoader(appResource);
+					}
+					for (ValueHintProvider valueHintProvider : valueHintProviders) {
+						List<ValueHint> valueHints = valueHintProvider.generateValueHints(property, classLoader);
+						if (!valueHints.isEmpty() && valueHintProvider.isExclusive(property)) {
+							collector.clear();
+						}
+						for (ValueHint valueHint : valueHints) {
+							String candidate = String.valueOf(valueHint.getValue());
+							if (!candidate.equals(alreadyTyped) && candidate.startsWith(alreadyTyped)) {
+								collector.add(proposals.withSuffix(candidate.substring(alreadyTyped.length()),
+										valueHint.getShortDescription()));
+							}
+						}
+						if (!valueHints.isEmpty() && valueHintProvider.isExclusive(property)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			if (classLoader != null) {
+				try {
+					classLoader.close();
+				}
+				catch (IOException e) {
+					// ignore
+				}
+			}
+		}
+
+		return false;
+	}
+
+	// This may be the safest way to backtrack to the property name
+	// to avoid dealing with escaped space characters, etc.
+	private String recoverPropertyName(String text) {
+		try {
+			new TaskDefinition("__dummy", text + " --");
+		}
+		catch (CheckPointedParseException exception) {
+			List<Token> tokens = exception.getTokens();
+			int end = tokens.size() - 1 - 2; // -2 for skipping dangling -- and space preceding it
+			int tokenPointer = end;
+			while (!tokens.get(tokenPointer - 1).isKind(TokenKind.DOUBLE_MINUS)) {
+				tokenPointer--;
+			}
+			StringBuilder builder;
+			for (builder = new StringBuilder(); tokenPointer < end; tokenPointer++) {
+				Token t = tokens.get(tokenPointer);
+				if (t.isIdentifier()) {
+					builder.append(t.stringValue());
+				}
+				else {
+					builder.append(t.getKind().getTokenChars());
+				}
+			}
+			return builder.toString();
+		}
+		throw new AssertionError("Can't be reached");
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintTaskRecoveryStrategy.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.configurationmetadata.ValueHint;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.core.dsl.Token;
+import org.springframework.cloud.dataflow.core.dsl.TokenKind;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.core.io.Resource;
+
+/**
+ * Attempts to fill in possible values after a {@literal --foo=} dangling construct in the DSL.
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class ConfigurationPropertyValueHintTaskRecoveryStrategy extends StacktraceFingerprintingTaskRecoveryStrategy<CheckPointedParseException> {
+
+	private final AppRegistry appRegistry;
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+
+	@Autowired
+	private ValueHintProvider[] valueHintProviders = new ValueHintProvider[0];
+
+	ConfigurationPropertyValueHintTaskRecoveryStrategy(AppRegistry appRegistry, ApplicationConfigurationMetadataResolver metadataResolver) {
+		super(CheckPointedParseException.class, "foo --bar=");
+		this.appRegistry = appRegistry;
+		this.metadataResolver = metadataResolver;
+	}
+
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception, int detailLevel, List<CompletionProposal> collector) {
+
+		String propertyName = recoverPropertyName(exception);
+
+		AppRegistration appRegistration = lookupLastApp(exception);
+
+		if (appRegistration == null) {
+			// Not a valid app name, do nothing
+			return;
+		}
+		Resource appResource = appRegistration.getResource();
+
+		CompletionProposal.Factory proposals = expanding(dsl);
+
+		List<ConfigurationMetadataProperty> whiteList = metadataResolver.listProperties(appResource);
+
+		URLClassLoader classLoader = null;
+		try {
+			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(appResource, true)) {
+				if (CompletionUtils.isMatchingProperty(propertyName, property, whiteList)) {
+					if (classLoader == null) {
+						classLoader = metadataResolver.createAppClassLoader(appResource);
+					}
+					for (ValueHintProvider valueHintProvider : valueHintProviders) {
+						for (ValueHint valueHint : valueHintProvider.generateValueHints(property, classLoader)) {
+							collector.add(proposals.withSuffix(String.valueOf(valueHint.getValue()), valueHint.getShortDescription()));
+						}
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		finally {
+			if (classLoader != null) {
+				try {
+					classLoader.close();
+				}
+				catch (IOException e) {
+					// ignore
+				}
+			}
+		}
+	}
+
+	private AppRegistration lookupLastApp(CheckPointedParseException exception) {
+		String safe = exception.getExpressionStringUntilCheckpoint();
+		TaskDefinition taskDefinition = new TaskDefinition("__dummy", safe);
+		String appName = taskDefinition.getRegisteredAppName();
+		AppRegistration appRegistration = this.appRegistry.find(appName, ApplicationType.task);
+		return appRegistration;
+	}
+
+	private String recoverPropertyName(CheckPointedParseException exception) {
+		List<Token> tokens = exception.getTokens();
+		int tokenPointer = tokens.size() - 1;
+		while (!tokens.get(tokenPointer - 1).isKind(TokenKind.DOUBLE_MINUS)) {
+			tokenPointer--;
+		}
+		StringBuilder builder;
+		final int equalSignPointer = tokens.size() - 1;
+		for (builder = new StringBuilder(); tokenPointer < equalSignPointer; tokenPointer++) {
+			Token t = tokens.get(tokenPointer);
+			if (t.isIdentifier()) {
+				builder.append(t.stringValue());
+			}
+			else {
+				builder.append(t.getKind().getTokenChars());
+			}
+		}
+		return builder.toString();
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceAppsTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceAppsTaskRecoveryStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+
+/**
+ * Proposes source app names when the user has typed nothing.
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+class EmptyStartYieldsSourceAppsTaskRecoveryStrategy extends
+		StacktraceFingerprintingTaskRecoveryStrategy<CheckPointedParseException> {
+
+	private final AppRegistry registry;
+
+	public EmptyStartYieldsSourceAppsTaskRecoveryStrategy(AppRegistry registry) {
+		super(CheckPointedParseException.class, "");
+		this.registry = registry;
+	}
+
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception,
+			int detailLevel, List<CompletionProposal> proposals) {
+		CompletionProposal.Factory completionFactory = CompletionProposal.expanding(dsl);
+		for (AppRegistration app : this.registry.findAll()) {
+			if (app.getType() == ApplicationType.task) {
+				proposals.add(completionFactory.withSeparateTokens(app.getName(),
+						"Choose a task app"));
+			}
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ExpandOneDashToTwoDashesTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ExpandOneDashToTwoDashesTaskRecoveryStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.core.dsl.ParseException;
+import org.springframework.util.Assert;
+
+/**
+ * Provides completion when the user has typed in the first dash to a module configuration property.
+ *
+ * @author Eric Bottard
+ * @author Andy Clement
+ */
+class ExpandOneDashToTwoDashesTaskRecoveryStrategy extends StacktraceFingerprintingTaskRecoveryStrategy<ParseException> {
+
+	@Autowired
+	private ConfigurationPropertyNameAfterDashDashTaskRecoveryStrategy recoveryAfterDashDash;
+
+	public ExpandOneDashToTwoDashesTaskRecoveryStrategy() {
+		super(ParseException.class, "file -");
+	}
+
+	@Override
+	public void addProposals(String dsl, ParseException exception, int detailLevel, List<CompletionProposal> proposals) {
+		// Pretend there was an additional dash and invoke the dedicated strategy for that case
+		String withDashDash = dsl + "-";
+		try {
+			new TaskDefinition("__dummy", withDashDash);
+		}
+		catch (CheckPointedParseException recoverable) {
+			Assert.isTrue(recoveryAfterDashDash.shouldTrigger(withDashDash, recoverable));
+			recoveryAfterDashDash.addProposals(withDashDash, recoverable, detailLevel, proposals);
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/StacktraceFingerprintingTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/StacktraceFingerprintingTaskRecoveryStrategy.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.util.Assert;
+
+/**
+ * A recovery strategy that will trigger if the parser failure is similar
+ * to that of some sample unfinished task definition. The match is decided
+ * by analyzing the top frames of the stack trace emitted by the parser when it
+ * encounters the ill formed input. Multiple fingerprints are supported, as the
+ * control flow in the parser code may be different depending on the form of the
+ * expression. See {@link StacktraceFingerprintingRecoveryStrategy}.
+ *
+ * @author Eric Bottard
+ * @author Andy Clement
+ */
+public abstract class StacktraceFingerprintingTaskRecoveryStrategy<E extends Exception> implements
+		RecoveryStrategy<E> {
+
+	private final Set<List<StackTraceElement>> fingerprints = new LinkedHashSet<>();
+
+	private final Class<E> exceptionClass;
+
+	/**
+	 * Construct a new StacktraceFingerprintingRecoveryStrategy given the parser,
+	 * and the expected exception class to be thrown for sample fragments of a
+	 * stream definition that is to be parsed.
+	 *
+	 * @param exceptionClass the expected exception that results from parsing
+	 * the sample fragment stream definitions. Stack frames from the thrown
+	 * exception are used to store the fingerprint of this exception thrown
+	 * by the parser.
+	 * @param samples the sample fragments of stream definitions.
+	 */
+	public StacktraceFingerprintingTaskRecoveryStrategy(Class<E> exceptionClass,
+			String... samples) {
+		Assert.notNull(exceptionClass, "exceptionClass should not be null");
+		Assert.notEmpty(samples, "samples should not be null or empty");
+		this.exceptionClass = exceptionClass;
+		initFingerprints(samples);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void initFingerprints(String... samples) {
+		for (String sample : samples) {
+			try {
+				new TaskDefinition("__dummy", sample);
+			}
+			catch (RuntimeException exception) {
+				if (this.exceptionClass.isAssignableFrom(exception.getClass())) {
+					addFingerprintForException((E) exception);
+				}
+				else {
+					throw exception;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Extract the top frames (until the call to the {@link StreamDefinition}
+	 * constructor appears) of the given exception.
+	 */
+	private void addFingerprintForException(E exception) {
+		boolean seenParserClass = false;
+		List<StackTraceElement> fingerPrint = new ArrayList<StackTraceElement>();
+		for (StackTraceElement frame : exception.getStackTrace()) {
+			if (frame.getClassName().equals(TaskDefinition.class.getName())) {
+				seenParserClass = true;
+			}
+			else if (seenParserClass) {
+				break;
+			}
+			fingerPrint.add(frame);
+		}
+		fingerprints.add(fingerPrint);
+	}
+
+	private boolean fingerprintMatches(E exception,
+			List<StackTraceElement> fingerPrint) {
+		int i = 0;
+		StackTraceElement[] stackTrace = exception.getStackTrace();
+		for (StackTraceElement frame : fingerPrint) {
+			if (!stackTrace[i++].equals(frame)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean shouldTrigger(String dslStart, Exception exception) {
+		if (!exceptionClass.isAssignableFrom(exception.getClass())) {
+			return false;
+		}
+		for (List<StackTraceElement> fingerPrint : fingerprints) {
+			if (fingerprintMatches((E) exception, fingerPrint)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/TaskCompletionProvider.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/TaskCompletionProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+
+/**
+ * Provides code completion on a (maybe ill-formed) task definition.
+ *
+ * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
+ * @author Andy Clement
+ */
+public class TaskCompletionProvider {
+
+	private final List<RecoveryStrategy<?>> completionRecoveryStrategies;
+
+	private final List<TaskExpansionStrategy> completionExpansionStrategies;
+
+	public TaskCompletionProvider(
+			List<RecoveryStrategy<?>> completionRecoveryStrategies,
+			List<TaskExpansionStrategy> completionExpansionStrategies) {
+		this.completionRecoveryStrategies = new ArrayList<>(completionRecoveryStrategies);
+		this.completionExpansionStrategies = new ArrayList<>(completionExpansionStrategies);
+	}
+
+	/*
+	 * Attempt to parse the text the user has already typed in. This either succeeds,
+	 * in which case we may propose to expand what she has typed, or it fails
+	 * (most likely because this is not well formed), in which case we try to
+	 * recover from the parsing failure and still add proposals.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public List<CompletionProposal> complete(String dslStart, int detailLevel) {
+		List<CompletionProposal> collector = new ArrayList<>();
+
+		TaskDefinition parsed;
+		try {
+			parsed = new TaskDefinition("__dummy", dslStart);
+		}
+		catch (Exception recoverable) {
+			for (RecoveryStrategy strategy : completionRecoveryStrategies) {
+				if (strategy.shouldTrigger(dslStart, recoverable)) {
+					strategy.addProposals(dslStart, recoverable, detailLevel, collector);
+				}
+			}
+
+			return collector;
+		}
+
+		for (TaskExpansionStrategy strategy : completionExpansionStrategies) {
+			strategy.addProposals(dslStart, parsed, detailLevel, collector);
+		}
+		return collector;
+	}
+
+	public void addCompletionRecoveryStrategy(RecoveryStrategy<?> recoveryStrategy) {
+		this.completionRecoveryStrategies.add(recoveryStrategy);
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/TaskExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/TaskExpansionStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+
+/**
+ * Used to enhance a well formed task definition by adding yet more text to
+ * it (<i>e.g.</i> adding more options to a module).
+ *
+ * @author Eric Bottard
+ * @author Andy Clement
+ */
+public interface TaskExpansionStrategy {
+
+	/**
+	 * For a given stream DSL text and {@link TaskDefinition},
+	 * <ul>
+	 *   <li>
+	 *     Generate {@link CompletionProposal}s that apply (if any)
+	 *     and add them to the provided {@code collector} list
+	 *   </li>
+	 *   <li>
+	 *     Return {@code true} if no other strategies should be applied for
+	 *     the task DSL text (this strategy make take the liberty to erase
+	 *     already collected proposals)
+	 *   </li>
+	 * </ul>
+	 *
+	 * @param text DSL text for the stream
+	 * @param taskDefinition task definition
+	 * @param detailLevel integer representing the amount of detail to include
+	 * in the generated {@code CompletionProposal}s (higher values mean more details.
+	 * typical range is [1..5])
+	 * @param collector list of {@code CompletionProposal}s to add/remove from
+	 * if this strategy applies
+	 * @return {@code true} if no other strategies should be applied for
+	 * the task DSL text
+	 */
+	boolean addProposals(String text, TaskDefinition taskDefinition, int detailLevel,
+			List<CompletionProposal> collector);
+
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameTaskRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameTaskRecoveryStrategy.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.springframework.cloud.dataflow.completion.CompletionProposal.expanding;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.core.dsl.Token;
+import org.springframework.cloud.dataflow.core.dsl.TokenKind;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.core.io.Resource;
+
+
+/**
+ * Provides completions for the case where the user has started to type
+ * an app configuration property name but it is not typed in full yet.
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class UnfinishedConfigurationPropertyNameTaskRecoveryStrategy
+		extends StacktraceFingerprintingTaskRecoveryStrategy<CheckPointedParseException> {
+
+	private final AppRegistry appRegistry;
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+
+	UnfinishedConfigurationPropertyNameTaskRecoveryStrategy(AppRegistry appRegistry,
+	                                                    ApplicationConfigurationMetadataResolver metadataResolver) {
+		super(CheckPointedParseException.class, "file --foo", "file --foo.");
+		this.appRegistry = appRegistry;
+		this.metadataResolver = metadataResolver;
+	}
+
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception,
+	                         int detailLevel, List<CompletionProposal> collector) {
+
+		String safe = exception.getExpressionStringUntilCheckpoint();
+
+		List<Token> tokens = exception.getTokens();
+		int tokenPointer = tokens.size() - 1;
+		while (!tokens.get(tokenPointer - 1).isKind(TokenKind.DOUBLE_MINUS)) {
+			tokenPointer--;
+		}
+		StringBuilder builder = null;
+		for (builder = new StringBuilder(); tokenPointer < tokens.size(); tokenPointer++) {
+			Token t = tokens.get(tokenPointer);
+			if (t.isIdentifier()) {
+				builder.append(t.stringValue());
+			}
+			else {
+				builder.append(t.getKind().getTokenChars());
+			}
+		}
+		String buffer = builder.toString();
+
+		TaskDefinition taskDefinition = new TaskDefinition("__dummy", safe);
+
+		String lastAppName = taskDefinition.getRegisteredAppName();
+		AppRegistration appRegistration = appRegistry.find(lastAppName, ApplicationType.task);
+		if (appRegistration == null) {
+			// Not a valid app name, do nothing
+			return;
+		}
+		Set<String> alreadyPresentOptions = new HashSet<>(taskDefinition.getProperties().keySet());
+
+		Resource jarFile = appRegistration.getResource();
+
+		CompletionProposal.Factory proposals = expanding(safe);
+
+		// For whitelisted properties, use their simple name
+		for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile)) {
+			String name = property.getName();
+			if (!alreadyPresentOptions.contains(name) && name.startsWith(buffer)) {
+				collector.add(proposals.withSeparateTokens("--" + name
+						+ "=", property.getShortDescription()));
+			}
+		}
+
+		// For other props, use their full id
+		if (detailLevel > 1) {
+			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(jarFile, true)) {
+				String id = property.getId();
+				if (!alreadyPresentOptions.contains(id) && id.startsWith(buffer)) {
+					collector.add(proposals.withSeparateTokens("--" + id
+							+ "=", property.getShortDescription()));
+				}
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedTaskAppNameExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedTaskAppNameExpansionStrategy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+
+/**
+ * Provides completions by finding apps whose name starts with a
+ * prefix (which was assumed to be a correct app name, but wasn't).
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class UnfinishedTaskAppNameExpansionStrategy implements TaskExpansionStrategy {
+
+	private final AppRegistry appRegistry;
+
+	UnfinishedTaskAppNameExpansionStrategy(AppRegistry appRegistry) {
+		this.appRegistry = appRegistry;
+	}
+
+	@Override
+	public boolean addProposals(String text, TaskDefinition taskDefinition,
+			int detailLevel, List<CompletionProposal> collector) {
+
+		Set<String> parameterNames = new HashSet<>(taskDefinition.getProperties().keySet());
+		parameterNames.removeAll(CompletionUtils.IMPLICIT_TASK_PARAMETER_NAMES);
+		if( !parameterNames.isEmpty() || !text.endsWith(taskDefinition.getRegisteredAppName())) {
+			return false;
+		}
+
+		// Actually add completions
+
+		String alreadyTyped = taskDefinition.getRegisteredAppName();
+		CompletionProposal.Factory proposals = CompletionProposal.expanding(text);
+
+		List<ApplicationType> validTypesAtThisPosition = Arrays.asList(ApplicationType.task);
+
+		for (AppRegistration appRegistration : appRegistry.findAll()) {
+			String candidateName = appRegistration.getName();
+			if (validTypesAtThisPosition.contains(appRegistration.getType())
+					&& !alreadyTyped.equals(candidateName) && candidateName.startsWith(alreadyTyped)) {
+				String expansion = appRegistration.getName();//CompletionUtils.maybeQualifyWithLabel(appRegistration.getName(), taskDefinition);
+
+				collector.add(proposals.withSuffix(expansion.substring(alreadyTyped.length())));
+			}
+		}
+		return false;
+
+	}
+}

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.dataflow.completion.Proposals.proposalThat;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.Assert;
+
+/**
+ * Integration tests for TaskCompletionProvider.
+ *
+ * <p>These tests work hand in hand with a custom {@link AppRegistry} and
+ * {@link ApplicationConfigurationMetadataResolver} to provide completions for a fictional
+ * set of well known apps.</p>
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+@SuppressWarnings("unchecked")
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {CompletionConfiguration.class, TaskCompletionProviderTests.Mocks.class})
+public class TaskCompletionProviderTests {
+
+	@Autowired
+	private TaskCompletionProvider completionProvider;
+
+	@Test
+	// <TAB> => basic,plum,etc
+	public void testEmptyStartShouldProposeSourceApps() {
+		assertThat(completionProvider.complete("", 1), hasItems(
+				proposalThat(is("basic")),
+				proposalThat(is("plum"))
+		));
+		assertThat(completionProvider.complete("", 1), not(hasItems(
+				proposalThat(is("log"))
+		)));
+	}
+
+	@Test
+	// b<TAB> => basic
+	public void testUnfinishedAppNameShouldReturnCompletions() {
+		assertThat(completionProvider.complete("b", 1), hasItems(
+				proposalThat(is("basic"))
+		));
+		assertThat(completionProvider.complete("ba", 1), hasItems(
+				proposalThat(is("basic"))
+		));
+		assertThat(completionProvider.complete("pl", 1), not(hasItems(
+				proposalThat(is("basic"))
+		)));
+	}
+
+	@Test
+	// basic<TAB> => basic --foo=, etc
+	public void testValidSubStreamDefinitionShouldReturnAppOptions() {
+		System.out.println(completionProvider.complete("basic", 1));
+		assertThat(completionProvider.complete("basic ", 1), hasItems(
+				proposalThat(is("basic --expression=")),
+				proposalThat(is("basic --expresso="))
+		));
+		// Same as above, no final space
+		assertThat(completionProvider.complete("basic", 1), hasItems(
+				proposalThat(is("basic --expression=")),
+				proposalThat(is("basic --expresso="))
+		));
+	}
+
+	@Test
+	// file | filter -<TAB> => file | filter --foo,etc
+	public void testOneDashShouldReturnTwoDashes() {
+		System.out.println(completionProvider.complete("basic -", 1));
+		assertThat(completionProvider.complete("basic -", 1), hasItems(
+				proposalThat(is("basic --expression=")),
+				proposalThat(is("basic --expresso="))
+		));
+	}
+
+	@Test
+	// basic --<TAB> => basic --foo,etc
+	public void testTwoDashesShouldReturnOptions() {
+		assertThat(completionProvider.complete("basic --", 1), hasItems(
+				proposalThat(is("basic --expression=")),
+				proposalThat(is("basic --expresso="))
+		));
+	}
+
+	@Test
+	// file --p<TAB> => file --preventDuplicates=, file --pattern=
+	public void testUnfinishedOptionNameShouldComplete() {
+		assertThat(completionProvider.complete("basic --foo", 1), hasItems(
+				proposalThat(is("basic --fooble="))
+		));
+	}
+
+	@Test
+	// file | counter --name=<TAB> => nothing
+	public void testInGenericOptionValueCantProposeAnything() {
+		assertThat(completionProvider.complete("http --port=", 1), empty());
+	}
+
+	@Test
+	// plum --use-ssl=<TAB> => propose true|false
+	public void testValueHintForBooleans() {
+		assertThat(completionProvider.complete("plum --use-ssl=", 1), hasItems(
+				proposalThat(is("plum --use-ssl=true")),
+				proposalThat(is("plum --use-ssl=false"))
+		));
+	}
+
+	@Test
+	// basic --enum-value=<TAB> => propose enum values
+	public void testValueHintForEnums() {
+		assertThat(completionProvider.complete("basic --expresso=", 1), hasItems(
+				proposalThat(is("basic --expresso=SINGLE")),
+				proposalThat(is("basic --expresso=DOUBLE"))
+		));
+	}
+
+	@Test
+	public void testUnrecognizedPrefixesDontBlowUp() {
+		assertThat(completionProvider.complete("foo", 1), empty());
+		assertThat(completionProvider.complete("foo --", 1), empty());
+		assertThat(completionProvider.complete("http --notavalidoption", 1), empty());
+		assertThat(completionProvider.complete("http --notavalidoption=", 1), empty());
+		assertThat(completionProvider.complete("foo --some-option", 1), empty());
+		assertThat(completionProvider.complete("foo --some-option=", 1), empty());
+		assertThat(completionProvider.complete("foo --some-option=prefix", 1), empty());
+	}
+
+	/*
+	 * http --use-ssl=tr<TAB> => must be true or false, no need to present "...=tr --other.prop"
+	 */
+	@Test
+	public void testClosedSetValuesShouldBeExclusive() {
+		assertThat(completionProvider.complete("http --use-ssl=tr", 1), not(hasItems(
+				proposalThat(startsWith("http --port=12 --use-ssl=tr "))
+		)));
+	}
+
+	/**
+	 * A set of mocks that consider the contents of the {@literal apps/} directory as app
+	 * archives.
+	 *
+	 * @author Eric Bottard
+	 * @author Mark Fisher
+	 */
+	@Configuration
+	public static class Mocks {
+
+		private static final File ROOT = new File("src/test/resources", Mocks.class.getPackage().getName().replace('.', '/') + "/apps");
+
+		private static final FileFilter FILTER = new FileFilter() {
+			@Override
+			public boolean accept(File pathname) {
+				return pathname.isDirectory() && pathname.getName().matches(".+-.+");
+			}
+		};
+
+		@Bean
+		public AppRegistry appRegistry() {
+			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
+			return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+				@Override
+				public AppRegistration find(String name, ApplicationType type) {
+					String filename = name + "-" + type;
+					File file = new File(ROOT, filename);
+					if (file.exists()) {
+						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+					}
+					else {
+						return null;
+					}
+				}
+
+				@Override
+				public List<AppRegistration> findAll() {
+					List<AppRegistration> result = new ArrayList<>();
+					for (File file : ROOT.listFiles(FILTER)) {
+						result.add(makeAppRegistration(file));
+					}
+					return result;
+				}
+
+				private AppRegistration makeAppRegistration(File file) {
+					String fileName = file.getName();
+					Matcher matcher = Pattern.compile("(?<name>.+)-(?<type>.+)").matcher(fileName);
+					Assert.isTrue(matcher.matches());
+					String name = matcher.group("name");
+					ApplicationType type = ApplicationType.valueOf(matcher.group("type"));
+					System.out.println("makeAppRegistration "+fileName);
+					return new AppRegistration(name, type, file.toURI(), resourceLoader);
+				}
+			};
+		}
+
+		@Bean
+		public ApplicationConfigurationMetadataResolver metadataResolver() {
+			return new BootApplicationConfigurationMetadataResolver(TaskCompletionProviderTests.class.getClassLoader());
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/basic-task/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/basic-task/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,1 @@
+configuration-properties.classes=foo.bar.BasicProperties

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/basic-task/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/basic-task/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,31 @@
+{
+  "groups": [
+    {
+      "name": "basic",
+      "type": "foo.bar.BasicProperties",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],"properties": [
+    {
+      "name": "basic.expression",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.fooble",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.expresso",
+      "type": "org.springframework.cloud.dataflow.completion.Expresso",
+      "description": "A property of type enum and whose name starts like 'expression'",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],
+  "hints": []
+}

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/plum-task/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/plum-task/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,3 @@
+configuration-properties.classes=foo.bar.PlumProperties
+configuration-properties.names = server.port
+

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/plum-task/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/plum-task/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,30 @@
+{
+  "groups": [
+    {
+      "name": "plum",
+      "type": "foo.bar.PlumProperties",
+      "sourceType": "foo.bar.PlumProperties"
+    },
+    {
+      "name": "server",
+      "type": "foo.bar.ServerProperties",
+      "sourceType": "foo.bar.ServerProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "plum.use-ssl",
+      "type": "java.lang.Boolean",
+      "description": "Whether to use SSL encryption or not",
+      "sourceType": "foo.bar.PlumProperties"
+    },
+    {
+      "name": "server.port",
+      "type": "java.lang.Integer",
+      "description": "The port to listen on",
+      "sourceType": "foo.bar.ServerProperties"
+    }
+  ],
+
+  "hints": []
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPropertyKeys.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.core;
+
+/**
+ * Spring Cloud Task property keys.
+ *
+ * @author Andy Clement
+ */
+public class TaskPropertyKeys {
+	
+	static final String PREFIX = "spring.cloud.task.";
+
+	public static final String TASK_NAME = PREFIX + "name";
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
 import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
+import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
@@ -83,6 +84,7 @@ import org.springframework.hateoas.EntityLinks;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Andy Clement
  */
 @SuppressWarnings("all")
 @Configuration
@@ -210,8 +212,8 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public CompletionController completionController(StreamCompletionProvider completionProvider) {
-		return new CompletionController(completionProvider);
+	public CompletionController completionController(StreamCompletionProvider completionProvider, TaskCompletionProvider taskCompletionProvider) {
+		return new CompletionController(completionProvider, taskCompletionProvider);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/CompletionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/CompletionController.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.cloud.dataflow.completion.CompletionProposal;
 import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
+import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
 import org.springframework.cloud.dataflow.rest.resource.CompletionProposalsResource;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
@@ -28,9 +29,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Exposes the DSL completion features of {@link StreamCompletionProvider} as a REST API.
+ * Exposes the DSL completion features of {@link StreamCompletionProvider} and {@link TaskCompletionProvider} as a REST API.
  *
  * @author Eric Bottard
+ * @author Andy Clement
  */
 @RestController
 @RequestMapping("/completions")
@@ -38,14 +40,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class CompletionController {
 
 	private final StreamCompletionProvider completionProvider;
+	
+	private final TaskCompletionProvider taskCompletionProvider;
 
 	private final Assembler assembler = new Assembler();
 
 	/**
-	 * Create a controller for the provided {@link StreamCompletionProvider}.
+	 * Create a controller for the provided {@link StreamCompletionProvider} and {@link TaskCompletionProvider}.
 	 */
-	public CompletionController(StreamCompletionProvider completionProvider) {
+	public CompletionController(StreamCompletionProvider completionProvider, TaskCompletionProvider taskCompletionProvider) {
 		this.completionProvider = completionProvider;
+		this.taskCompletionProvider = taskCompletionProvider;
 	}
 
 	/**
@@ -60,6 +65,20 @@ public class CompletionController {
 			@RequestParam("start") String start,
 			@RequestParam(value = "detailLevel", defaultValue = "1") int detailLevel) {
 		return assembler.toResource(completionProvider.complete(start, detailLevel));
+	}
+
+	/**
+	 * Return a list of possible completions given a prefix string that the user has started typing.
+	 *
+	 * @param start the amount of text written so far
+	 * @param detailLevel the level of detail the user wants in completions, starting at 1.
+	 * Higher values request more detail, with values typically in the range [1..5]
+	 */
+	@RequestMapping(value = "/task")
+	public CompletionProposalsResource taskCompletions(
+			@RequestParam("start") String start,
+			@RequestParam(value = "detailLevel", defaultValue = "1") int detailLevel) {
+		return assembler.toResource(taskCompletionProvider.complete(start, detailLevel));
 	}
 
 	/**


### PR DESCRIPTION
This is submitted for feedback, not necessarily immediate integration. Basically I've copied the pattern from stream content assist. Due to them not sharing a parser this meant a bunch of very similar classes getting created.  It may be possible to refactor what is there for stream to support both task and stream but they would get uglier and possibly when composed task DSL comes along the fact that task completion is separate _might_ be useful.  I've confirmed that this all works with client side changes too.

![scdf_27oct](https://cloud.githubusercontent.com/assets/226298/19775801/7ade7068-9c26-11e6-807c-0b19044efcec.gif)