### PR TITLE
Fix spring-cloud-dataflow-dependencies BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,19 @@
 	</scm>
 	<properties>
 		<java.version>1.7</java.version>
+		<spring-cloud-dataflow-ui.version>1.1.0.M2</spring-cloud-dataflow-ui.version>
+		<spring-cloud-deployer.version>1.1.0.M1</spring-cloud-deployer.version>
+		<spring-cloud-task.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-task.version>
+		<spring-cloud-commons.version>1.1.3.RELEASE</spring-cloud-commons.version>
+		<spring-cloud-config.version>1.2.0.RELEASE</spring-cloud-config.version>
 		<spring-framework.version>4.3.3.RELEASE</spring-framework.version>
+		<spring-boot.version>1.4.1.RELEASE</spring-boot.version>
+		<spring-analytics.version>1.1.0.M1</spring-analytics.version>
+		<spring-batch-admin-manager.version>1.3.1.RELEASE</spring-batch-admin-manager.version>
+		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
+		<spring-session.version>1.2.2.RELEASE</spring-session.version>
 		<jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
-		<spring-boot.version>1.4.1.RELEASE</spring-boot.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-configuration-metadata</module>
@@ -49,14 +58,80 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-dependencies</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-task-dependencies</artifactId>
+				<version>${spring-cloud-task.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-commons-dependencies</artifactId>
+				<version>${spring-cloud-commons.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-config-dependencies</artifactId>
+				<version>${spring-cloud-config.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-ui</artifactId>
+				<version>${spring-cloud-dataflow-ui.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-spi</artifactId>
+				<version>${spring-cloud-deployer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-resource-support</artifactId>
+				<version>${spring-cloud-deployer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-resource-maven</artifactId>
+				<version>${spring-cloud-deployer.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-local</artifactId>
+				<version>${spring-cloud-deployer.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-core</artifactId>
 				<version>${spring-framework.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.batch</groupId>
+				<artifactId>spring-batch-admin-manager</artifactId>
+				<version>${spring-batch-admin-manager.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.analytics</groupId>
+				<artifactId>spring-analytics</artifactId>
+				<version>${spring-analytics.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.shell</groupId>
+				<artifactId>spring-shell</artifactId>
+				<version>${spring-shell.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.session</groupId>
+				<artifactId>spring-session</artifactId>
+				<version>${spring-session.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -12,139 +12,62 @@
 	<packaging>pom</packaging>
 	<name>spring-cloud-dataflow-dependencies</name>
 	<description>Spring Cloud Data Flow Dependencies BOM designed to support consumption of Spring Cloud Data Flow from the Spring Initializr.</description>
-	<properties>
-		<spring-analytics.version>1.1.0.M1</spring-analytics.version>
-		<spring-cloud-task.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-task.version>
-		<spring-cloud-commons.version>1.1.3.RELEASE</spring-cloud-commons.version>
-		<spring-cloud-config.version>1.2.0.RELEASE</spring-cloud-config.version>
-		<spring-batch-admin-dependencies.version>1.3.1.RELEASE</spring-batch-admin-dependencies.version>
-		<spring-cloud-dataflow-ui.version>1.1.0.M2</spring-cloud-dataflow-ui.version>
-		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
-		<spring-session.version>1.2.2.RELEASE</spring-session.version>
-		<spring-cloud-deployer.version>1.1.0.M1</spring-cloud-deployer.version>
-	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-task-dependencies</artifactId>
-				<version>${spring-cloud-task.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-commons-dependencies</artifactId>
-				<version>${spring-cloud-commons.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-config-dependencies</artifactId>
-				<version>${spring-cloud-config.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.batch</groupId>
-				<artifactId>spring-batch-admin-manager</artifactId>
-				<version>${spring-batch-admin-dependencies.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.analytics</groupId>
-				<artifactId>spring-analytics</artifactId>
-				<version>${spring-analytics.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-shell</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-shell-core</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-completion</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-core</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-rest-client</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-configuration-metadata</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-registry</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dataflow-ui</artifactId>
-				<version>${spring-cloud-dataflow-ui.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-server-core</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-server-local</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
-				<version>1.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-deployer-spi</artifactId>
-				<version>${spring-cloud-deployer.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-deployer-resource-support</artifactId>
-				<version>${spring-cloud-deployer.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-deployer-resource-maven</artifactId>
-				<version>${spring-cloud-deployer.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-deployer-local</artifactId>
-				<version>${spring-cloud-deployer.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.shell</groupId>
-				<artifactId>spring-shell</artifactId>
-				<version>${spring-shell.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.session</groupId>
-				<artifactId>spring-session</artifactId>
-				<version>${spring-session.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
- Move external dependencies out of `spring-cloud-dataflow-dependencies` BOM and to `spring-cloud-dataflow` parent
 - Fix BOM only to have dataflow project dependencies
 - Use `project.version` wherever appropriate

Resolves #976