### PR TITLE
Separate deployer build versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 		<java.version>1.7</java.version>
 		<spring-cloud-dataflow-ui.version>1.1.0.M2</spring-cloud-dataflow-ui.version>
 		<spring-cloud-deployer.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer-local.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 		<spring-cloud-task.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-task.version>
 		<spring-cloud-commons.version>1.1.3.RELEASE</spring-cloud-commons.version>
 		<spring-cloud-config.version>1.2.0.RELEASE</spring-cloud-config.version>
@@ -106,7 +107,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-local</artifactId>
-				<version>${spring-cloud-deployer.version}</version>
+				<version>${spring-cloud-deployer-local.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>


### PR DESCRIPTION
- Use different build properties for deployer spi and
  local versions as those have a different lifecycle.
- Fixes #985