### PR TITLE
gh-854 Improve search capability in the list pages

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -22,6 +22,7 @@ import org.springframework.cloud.dataflow.server.repository.DeploymentIdReposito
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
 import org.springframework.data.domain.Pageable;
@@ -116,13 +117,22 @@ public class TaskDefinitionController {
 	 *
 	 * @param pageable  page-able collection of {@code TaskDefinitionResource}.
 	 * @param assembler assembler for the {@link TaskDefinition}
+	 * @param search optional search parameter
 	 * @return a list of task definitions
 	 */
 	@RequestMapping(value="", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public PagedResources<TaskDefinitionResource> list(Pageable pageable,
+	public PagedResources<TaskDefinitionResource> list(Pageable pageable, @RequestParam(required=false) String search,
 			PagedResourcesAssembler<TaskDefinition> assembler) {
-		return assembler.toResource(repository.findAll(pageable), taskAssembler);
+
+		if (search != null) {
+			final SearchPageable searchPageable = new SearchPageable(pageable, search);
+			searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+			return assembler.toResource(repository.search(searchPageable), taskAssembler);
+		}
+		else {
+			return assembler.toResource(repository.findAll(pageable), taskAssembler);
+		}
 	}
 
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.dataflow.server.repository;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -25,4 +27,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface StreamDefinitionRepository extends PagingAndSortingRepository<StreamDefinition, String> {
+
+	Page<StreamDefinition>search(SearchPageable searchPageable);
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 package org.springframework.cloud.dataflow.server.repository;
 
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
  * @author Michael Minella
+ * @author Gunnar Hillert
  */
 public interface TaskDefinitionRepository extends PagingAndSortingRepository<TaskDefinition, String> {
+	Page<TaskDefinition>search(SearchPageable searchPageable);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.repository.support;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.Assert;
+
+/**
+ * Simple class that is composed of a {@link Pageable}
+ * and several properties to encapsulate search queries.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class SearchPageable {
+
+	private final Pageable pageable;
+	private final String searchQuery;
+	private final LinkedHashSet<String> columns = new LinkedHashSet<>(0);
+
+	/**
+	 *
+	 * @param pageable
+	 * @param searchQuery
+	 * @param columns
+	 */
+	public SearchPageable(Pageable pageable, String searchQuery) {
+		super();
+		Assert.notNull(pageable, "pageable must not be null");
+		Assert.hasText(searchQuery, "searchQuery must not be empty");
+
+		this.pageable = pageable;
+		this.searchQuery = searchQuery;
+	}
+
+	/**
+	 * @return Never null
+	 */
+	public Pageable getPageable() {
+		return pageable;
+	}
+
+	/**
+	 * @return SearchQuery will never be empty.
+	 */
+	public String getSearchQuery() {
+		return searchQuery;
+	}
+
+	/**
+	 * @return A set with the specified column names
+	 */
+	public LinkedHashSet<String> getColumns() {
+		return columns;
+	}
+
+	/**
+	 * Allows you to add additional columns.
+	 *
+	 * @param columns Must not be null
+	 */
+	public void addColumns(String... columns) {
+		Assert.notEmpty(columns, "You must specify at least 1 column.");
+		this.columns.addAll(Arrays.asList(columns));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
@@ -73,10 +73,15 @@ public class SearchPageable {
 	/**
 	 * Allows you to add additional columns.
 	 *
-	 * @param columns Must not be null
+	 * @param columns Must not be null or empty
 	 */
 	public void addColumns(String... columns) {
 		Assert.notEmpty(columns, "You must specify at least 1 column.");
+
+		for (String column : columns) {
+			Assert.hasText(column, "Column names cannot be null or empty.");
+		}
+
 		this.columns.addAll(Arrays.asList(columns));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageable.java
@@ -35,10 +35,11 @@ public class SearchPageable {
 	private final LinkedHashSet<String> columns = new LinkedHashSet<>(0);
 
 	/**
+	 * Initialize a {@link SearchPageable}. Must provide a {@link Pageable} and a searchQuery.
+	 * Don't forget to also provide the column names for the search using {@link #addColumns(String...)}.
 	 *
-	 * @param pageable
-	 * @param searchQuery
-	 * @param columns
+	 * @param pageable Must not be null
+	 * @param searchQuery Must not be empty
 	 */
 	public SearchPageable(Pageable pageable, String searchQuery) {
 		super();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryStreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryStreamDefinitionRepository.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -120,6 +121,11 @@ public class InMemoryStreamDefinitionRepository implements StreamDefinitionRepos
 	@Override
 	public void deleteAll() {
 		definitions.clear();
+	}
+
+	@Override
+	public Page<StreamDefinition> search(SearchPageable searchPageable) {
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryTaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryTaskDefinitionRepository.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +35,7 @@ import org.springframework.data.domain.Sort;
  * @author Michael Minella
  * @author Mark Fisher
  * @author Patrick Peralta
+ * @author Gunnar Hillert
  */
 public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepository {
 
@@ -123,4 +125,8 @@ public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepositor
 		definitions.clear();
 	}
 
+	@Override
+	public Page<TaskDefinition> search(SearchPageable searchPageable) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepositoryTests.java
@@ -34,6 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.repository.support.DataflowRdbmsInitializer;
+import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
@@ -366,6 +367,148 @@ public class RdbmsStreamDefinitionRepositoryTests {
 		Pageable pageable = new PageRequest(1, 2, sort);
 		String[] names = new String[]{"stream3"};
 		findAllPageable(pageable, names);
+	}
+
+	// Search Tests
+
+	@Test
+	public void findAllUsingSearchPageablePage2TestDESC() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.DESC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.DESC, "DEFINITION"));
+		Pageable pageable = new PageRequest(1, 2, sort);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "stream");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream1"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableDefinitionStringTestDESC() {
+		final Sort sort = new Sort(new Sort.Order(Sort.Direction.DESC, "DEFINITION"));
+		final Pageable pageable = new PageRequest(0, 2, sort);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "eam");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{ "stream1", "stream2"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableDefinitionStringTestDESC2() {
+		final Sort sort = new Sort(new Sort.Order(Sort.Direction.DESC, "DEFINITION"));
+		final Pageable pageable = new PageRequest(1, 2, sort);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "stream");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{ "stream3"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC1() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "stream");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream1", "stream2", "stream3"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC2() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "stream1");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream1"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC3() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "str");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream1", "stream2", "stream3"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC4() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "m1");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream1"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC5() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "m3");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream3"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC6() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "does not exist");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");;
+
+		String[] names = new String[]{};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC7() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "logB");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");;
+
+		String[] names = new String[]{"stream2"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	@Test
+	public void findAllUsingSearchPageableTestASC8() {
+		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC, "DEFINITION_NAME"), new Sort.Order(Sort.Direction.ASC, "DEFINITION"));
+		Pageable pageable = new PageRequest(0, 10, sort);
+
+		final SearchPageable searchPageable = new SearchPageable(pageable, "LOGB");
+		searchPageable.addColumns("DEFINITION_NAME", "DEFINITION");
+
+		String[] names = new String[]{"stream2"};
+		findAllUsingSearchPageable(searchPageable, names);
+	}
+
+	private void findAllUsingSearchPageable(SearchPageable searchPageable, String[] expectedOrder) {
+
+		assertFalse(repository.findAll().iterator().hasNext());
+		initializeRepositoryNotInOrder();
+
+		final Iterable<StreamDefinition> items = repository.search(searchPageable);
+
+		makeSortAssertions(items, expectedOrder);
+
 	}
 
 	private void findAllPageable(Pageable pageable, String[] expectedOrder) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageableTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageableTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository.support;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class SearchPageableTests {
+
+	@Test
+	public void initializeSearchPageableWithNullPageable() throws Exception{
+		try {
+			new SearchPageable(null, null);
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("pageable must not be null", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void initializeSearchPageableWithNullSearchQuery() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		try {
+			new SearchPageable(pageable, null);
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("searchQuery must not be empty", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void initializeSearchPageableWithEmptySearchQuery() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		try {
+			new SearchPageable(pageable, "  ");
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("searchQuery must not be empty", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void addNullCollumn() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "search query");
+
+		try {
+			searchPageable.addColumns(new String[]{});
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("You must specify at least 1 column.", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void addNullCollumn2() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "search query");
+
+		try {
+			searchPageable.addColumns("c1", null);
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("Column names cannot be null or empty.", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void addWhitespaceCollumn() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "search query");
+
+		try {
+			searchPageable.addColumns("     ");
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("Column names cannot be null or empty.", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void testSearchPageableGetters() throws Exception{
+		final PageRequest pageable = new PageRequest(1, 5);
+		final SearchPageable searchPageable = new SearchPageable(pageable, "search query");
+
+		assertThat(searchPageable.getColumns(), is(empty()));
+		assertNotNull(searchPageable.getPageable());
+		assertEquals(searchPageable.getSearchQuery(), "search query");
+
+		searchPageable.addColumns("c1", "c2");
+
+		assertThat(searchPageable.getColumns(), hasSize(2));
+		assertThat(searchPageable.getColumns(), contains("c1", "c2"));
+
+	}
+}


### PR DESCRIPTION
* Add server-backed search for the StreamDefinition list endpoint
* Add server-backed search for the TaskDefinition list endpoint
* Add search-support to `AbstractRdbmsKeyValueRepository`
* Add tests

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/854