### PR TITLE
Reference Spring Cloud Release train directly vs. individual jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,7 @@
 		<spring-cloud-deployer.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-deployer-local.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 		<spring-cloud-task.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-task.version>
-		<spring-cloud-commons.version>1.1.3.RELEASE</spring-cloud-commons.version>
-		<spring-cloud-config.version>1.2.0.RELEASE</spring-cloud-config.version>
+		<spring-cloud.version>Camden.SR2</spring-cloud.version>
 		<spring-framework.version>4.3.3.RELEASE</spring-framework.version>
 		<spring-boot.version>1.4.1.RELEASE</spring-boot.version>
 		<spring-analytics.version>1.1.0.M1</spring-analytics.version>
@@ -67,20 +66,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-task-dependencies</artifactId>
 				<version>${spring-cloud-task.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-commons-dependencies</artifactId>
-				<version>${spring-cloud-commons.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-config-dependencies</artifactId>
-				<version>${spring-cloud-config.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -134,6 +119,13 @@
 				<artifactId>spring-session</artifactId>
 				<version>${spring-session.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<build>
@@ -171,6 +163,21 @@
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
 					<version>${jacoco-maven-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.0.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.10.4</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
* Add additional plugin versions to avoid maven project warnings

Fixes #988