### PR TITLE
Reject task definition if unknown to registry

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -126,14 +126,14 @@ public class DataFlowControllerAutoConfiguration {
 	@ConditionalOnBean(StreamDefinitionRepository.class)
 	public StreamDeploymentController streamDeploymentController(StreamDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
-             ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties appsProperties) {
+			 ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties appsProperties) {
 		return new StreamDeploymentController(repository, deploymentIdRepository, registry, deployer, metadataResolver, appsProperties);
 	}
 
 	@Bean
 	@ConditionalOnBean(StreamDefinitionRepository.class)
 	public RuntimeAppsController runtimeAppsController(StreamDefinitionRepository repository,
-													   DeploymentIdRepository deploymentIdRepository, AppDeployer appDeployer) {
+													DeploymentIdRepository deploymentIdRepository, AppDeployer appDeployer) {
 		return new RuntimeAppsController(repository, deploymentIdRepository, appDeployer);
 	}
 
@@ -153,8 +153,8 @@ public class DataFlowControllerAutoConfiguration {
 	@Bean
 	@ConditionalOnBean(TaskDefinitionRepository.class)
 	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, TaskLauncher taskLauncher) {
-		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher);
+			DeploymentIdRepository deploymentIdRepository, TaskLauncher taskLauncher, AppRegistry appRegistry) {
+		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher, appRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -126,7 +126,7 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	@Bean
 	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository) {
-		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher());
+		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher(), appRegistry());
 	}
 
 	public TaskExecutionController taskExecutionController(TaskExplorer explorer) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -38,10 +38,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.InMemoryTaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
@@ -79,6 +80,9 @@ public class TaskControllerTests {
 	@Autowired
 	private TaskLauncher taskLauncher;
 
+	@Autowired
+	private AppRegistry appRegistry;
+
 	@Before
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(
@@ -99,12 +103,12 @@ public class TaskControllerTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTaskDefinitionControllerConstructorMissingRepository() {
-		new TaskDefinitionController(null, null, taskLauncher);
+		new TaskDefinitionController(null, null, taskLauncher, appRegistry);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTaskDefinitionControllerConstructorMissingDeployer() {
-		new TaskDefinitionController(new InMemoryTaskDefinitionRepository(), null, null);
+		new TaskDefinitionController(new InMemoryTaskDefinitionRepository(), null, null, appRegistry);
 	}
 
 	@Test
@@ -119,9 +123,21 @@ public class TaskControllerTests {
 	}
 
 	@Test
-	public void testSave() throws Exception {
+	public void testSaveErrorNotInRegistry() throws Exception {
 		assertEquals(0, repository.count());
 
+		mockMvc.perform(
+				post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
+						.accept(MediaType.APPLICATION_JSON)).andDo(print())
+						.andExpect(status().is5xxServerError());
+
+		assertEquals(0, repository.count());
+	}
+
+	@Test
+	public void testSave() throws Exception {
+		assertEquals(0, repository.count());
+		appRegistry.save("task", ApplicationType.task, new URI("http://fake.example.com/"));
 		mockMvc.perform(
 				post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
 						.accept(MediaType.APPLICATION_JSON)).andDo(print())

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -24,12 +24,16 @@ import java.util.UUID;
 
 import javax.sql.DataSource;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
+import org.springframework.cloud.deployer.resource.registry.UriRegistry;
+import org.springframework.cloud.deployer.resource.registry.UriRegistryPopulator;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.shell.core.CommandResult;
 import org.springframework.shell.table.Table;
@@ -38,6 +42,8 @@ import org.springframework.shell.table.Table;
  * @author Glenn Renfro
  */
 public class TaskCommandTests extends AbstractShellIntegrationTest {
+
+	private static final String APPS_URI = "classpath:META-INF/test-task-apps.properties";
 
 	private static final Logger logger = LoggerFactory.getLogger(TaskCommandTests.class);
 
@@ -58,6 +64,14 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	private static final Date endTime = new Date(startTime.getTime() + 5000);
 
 	private static final String EXTERNAL_EXECUTION_ID = "WOW22";
+
+	@Before
+	public void registerApps() {
+		UriRegistry registry = applicationContext.getBean(UriRegistry.class);
+		UriRegistryPopulator populator = new UriRegistryPopulator();
+		populator.setResourceLoader(new DefaultResourceLoader());
+		populator.populateRegistry(true, registry, APPS_URI);
+	}
 
 	@BeforeClass
 	public static void setUp() {
@@ -89,7 +103,7 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	public void testCreateTask() throws InterruptedException {
 		logger.info("Create Task Test");
 		String taskName = generateUniqueName();
-		task().create(taskName, "foobar");
+		task().create(taskName, "timestamp");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
@@ -1,0 +1,1 @@
+task.timestamp=maven://org.springframework.cloud.task.app:task-timestamp:1.0.0.BUILD-SNAPSHOT


### PR DESCRIPTION
- Use same concepts StreamDefinitionController to reject
  adding task definition if its app is not in a registry.
- Pass in AppRegistry to TaskDefinitionController.
- Add and modify tests to verify new changed functionality,
  for some existing tests register task apps.
- Fixes #1001