### PR TITLE
move a test dependency to test scope

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -27,6 +27,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This is pretty trivial, moved the spring-boot-starter-test in spring-cloud-dataflow-configuration-metadata to test scope. All tests pass