### PR TITLE
Refactor for full auto-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 		<module>spring-cloud-dataflow-registry</module>
 		<module>spring-cloud-dataflow-rest-resource</module>
 		<module>spring-cloud-dataflow-server-core</module>
+		<module>spring-cloud-dataflow-server-local-autoconfig</module>
 		<module>spring-cloud-dataflow-server-local</module>
 		<module>spring-cloud-dataflow-rest-client</module>
 		<module>spring-cloud-dataflow-shell</module>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -66,6 +66,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-server-local-autoconfig</artifactId>
+				<version>1.1.1.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-dataflow-server-local</artifactId>
 				<version>1.1.1.BUILD-SNAPSHOT</version>
 			</dependency>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -151,6 +151,7 @@
 				<includes>
 					<include>META-INF/spring.factories</include>
 					<include>banner.txt</include>
+					<include>META-INF/dataflow-server-defaults.yml</include>
 					<include>*.sql</include>
 				</includes>
 			</resource>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/EnableDataFlowServer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/EnableDataFlowServer.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.cloud.dataflow.server.config.DataFlowServerConfiguration;
+import org.springframework.cloud.dataflow.server.config.EnableDataFlowServerConfiguration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -35,6 +35,6 @@ import org.springframework.context.annotation.Import;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Import(DataFlowServerConfiguration.class)
+@Import(EnableDataFlowServerConfiguration.class)
 public @interface EnableDataFlowServer {
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -26,8 +26,10 @@ import org.springframework.analytics.rest.controller.CounterController;
 import org.springframework.analytics.rest.controller.FieldValueCounterController;
 import org.springframework.batch.admin.service.JobService;
 import org.springframework.boot.actuate.metrics.repository.MetricRepository;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -89,8 +91,9 @@ import org.springframework.hateoas.EntityLinks;
 @SuppressWarnings("all")
 @Configuration
 @Import(CompletionConfiguration.class)
-@ConditionalOnBean({AppDeployer.class, TaskLauncher.class})
+@ConditionalOnBean({EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class})
 @EnableConfigurationProperties({FeaturesProperties.class})
+@ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class DataFlowControllerAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerAutoConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.config;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto-configuration for dataflow server.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@AutoConfigureBefore(value = JacksonAutoConfiguration.class)
+@ConditionalOnBean(EnableDataFlowServerConfiguration.Marker.class)
+@Import(DataFlowServerConfiguration.class)
+@ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class DataFlowServerAutoConfiguration {
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -25,11 +25,9 @@ import javax.sql.DataSource;
 import org.h2.tools.Server;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
@@ -69,7 +67,6 @@ import org.springframework.util.StringUtils;
 @Configuration
 @Import({CompletionConfiguration.class, FeaturesConfiguration.class, WebConfiguration.class})
 @ComponentScan(basePackageClasses = {StreamDefinitionRepository.class, BasicAuthSecurityConfiguration.class})
-@EnableAutoConfiguration(exclude=SessionAutoConfiguration.class)
 @EnableConfigurationProperties({BatchProperties.class, CommonApplicationProperties.class})
 public class DataFlowServerConfiguration {
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
@@ -35,39 +35,53 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 /**
- * Contributes the values from {@code dataflow-server.yml} if it exists, before any of Spring Boot's normal
+ * Contributes the values from {@code META-INF/dataflow-server-defaults.yml} and
+ * {@code dataflow-server.yml} if it exists, before any of Spring Boot's normal
  * configuration contributions apply. This has the effect of supplying overridable defaults to the
  * various Spring Cloud Data Flow Deployer SPI implementations that in turn override the defaults
  * provided by Spring Boot.
  *
  * @author Josh Long
+ * @author Janne Valkealahti
  */
 public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
-	private Resource resource = new ClassPathResource("/dataflow-server.yml");
+	private static Log logger = LogFactory.getLog(DefaultEnvironmentPostProcessor.class);
+	private final Resource serverResource = new ClassPathResource("/dataflow-server.yml");
+	private final Resource serverDefaultsResource = new ClassPathResource("META-INF/dataflow-server-defaults.yml");
 
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Map<String, Object> internalDefaults = new HashMap<>();
 		Map<String, Object> defaults = new HashMap<>();
 		MutablePropertySources existingPropertySources = environment.getPropertySources();
 
-		this.contributeDefaults(defaults);
+		contributeDefaults(internalDefaults, serverDefaultsResource);
+		contributeDefaults(defaults, serverResource);
 
 		String defaultPropertiesKey = "defaultProperties";
 
 		if (!existingPropertySources.contains(defaultPropertiesKey) ||
 				existingPropertySources.get(defaultPropertiesKey) == null) {
+			existingPropertySources.addLast(new MapPropertySource(defaultPropertiesKey, internalDefaults));
 			existingPropertySources.addLast(new MapPropertySource(defaultPropertiesKey, defaults));
 		}
 		else {
 			PropertySource<?> propertySource = existingPropertySources.get(defaultPropertiesKey);
 			@SuppressWarnings("unchecked")
 			Map<String, Object> mapOfProperties = Map.class.cast(propertySource.getSource());
+			for (String k : internalDefaults.keySet()) {
+				Set<String> setOfPropertyKeys = mapOfProperties.keySet();
+				if (!setOfPropertyKeys.contains(k)) {
+					mapOfProperties.put(k, internalDefaults.get(k));
+					logger.info(k + '=' + internalDefaults.get(k));
+				}
+			}
 			for (String k : defaults.keySet()) {
 				Set<String> setOfPropertyKeys = mapOfProperties.keySet();
 				if (!setOfPropertyKeys.contains(k)) {
 					mapOfProperties.put(k, defaults.get(k));
-					LogFactory.getLog(getClass()).info(k + '=' + defaults.get(k));
+					logger.info(k + '=' + defaults.get(k));
 				}
 			}
 		}
@@ -79,10 +93,10 @@ public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor
 		return 0;
 	}
 
-	private void contributeDefaults(Map<String, Object> defaults) {
-		if (this.resource.exists()) {
+	private static void contributeDefaults(Map<String, Object> defaults, Resource resource) {
+		if (resource.exists()) {
 			YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
-			yamlPropertiesFactoryBean.setResources(this.resource);
+			yamlPropertiesFactoryBean.setResources(resource);
 			yamlPropertiesFactoryBean.afterPropertiesSet();
 			Properties p = yamlPropertiesFactoryBean.getObject();
 			for (Object k : p.keySet()) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/EnableDataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/EnableDataFlowServerConfiguration.java
@@ -14,20 +14,26 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.local;
+package org.springframework.cloud.dataflow.server.config;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
- * Bootstrap class for the local Spring Cloud Data Flow Server.
+ * Configuration for {@link EnableDataFlowServer} which adds
+ * a marker bean which auto-config classes can use to conditionally
+ * check if auto configuration should be activated.
  *
- * @author Mark Fisher
+ * @author Janne Valkealahti
  */
-@EnableDataFlowServer
-public class LocalTestDataFlowServer {
+@Configuration
+public class EnableDataFlowServerConfiguration {
 
-	public static void main(String[] args) {
-		SpringApplication.run(LocalTestDataFlowServer.class, args);
+	@Bean
+	public Marker enableConfigServerMarker() {
+		return new Marker();
 	}
+
+	class Marker {}
 }

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,0 +1,3 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.session.SessionAutoConfiguration

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
   org.springframework.cloud.dataflow.server.config.DefaultEnvironmentPostProcessor
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.springframework.cloud.dataflow.server.config.DataFlowServerAutoConfiguration,\
   org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
@@ -26,6 +26,10 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 import org.springframework.cloud.dataflow.server.service.TaskService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
@@ -58,6 +62,11 @@ public class DataFlowServerConfigurationTests {
 		context.setId("testDataFlowConfig");
 		context.register(
 				DataFlowServerConfigurationTests.TestConfiguration.class,
+				RedisAutoConfiguration.class,
+				SecurityAutoConfiguration.class,
+				DataFlowServerAutoConfiguration.class,
+				DataFlowControllerAutoConfiguration.class,
+				DataSourceAutoConfiguration.class,
 				DataFlowServerConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class);
 		environment = new StandardEnvironment();
@@ -118,6 +127,7 @@ public class DataFlowServerConfigurationTests {
 		assertFalse(context.containsBean("initH2TCPServer"));
 	}
 
+	@EnableDataFlowServer
 	private static class TestConfiguration {
 
 		@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
@@ -17,14 +17,23 @@
 package org.springframework.cloud.dataflow.server.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.cloud.dataflow.server.service.TaskService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationManager;
 
 /**
  * @author Josh Long
@@ -36,7 +45,9 @@ public class DefaultEnvironmentPostProcessorTests {
 	private static final String CONTRIBUTED_PATH = "/bar";
 
 	@Configuration
+	@Import(TestConfiguration.class)
 	@EnableAutoConfiguration(exclude=SessionAutoConfiguration.class)
+	@EnableDataFlowServer
 	public static class EmptyDefaultApp {
 	}
 
@@ -54,6 +65,29 @@ public class DefaultEnvironmentPostProcessorTests {
 				"--spring.config.name=test", "--server.port=0")) {
 			String cp = ctx.getEnvironment().getProperty(MANAGEMENT_CONTEXT_PATH);
 			assertEquals(cp, "/foo");
+		}
+	}
+
+	private static class TestConfiguration {
+
+		@Bean
+		public AppDeployer appDeployer() {
+			return mock(AppDeployer.class);
+		}
+
+		@Bean
+		public TaskLauncher taskLauncher() {
+			return mock(TaskLauncher.class);
+		}
+
+		@Bean
+		public AuthenticationManager authenticationManager() {
+			return mock(AuthenticationManager.class);
+		}
+
+		@Bean
+		public TaskService taskService() {
+			return mock(DefaultTaskService.class);
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-local-autoconfig/pom.xml
+++ b/spring-cloud-dataflow-server-local-autoconfig/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-dataflow-server-local-autoconfig</artifactId>
+	<version>1.1.1.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>spring-cloud-dataflow-server-local-autoconfig</name>
+	<description>Data Flow Local Server Autoconfig</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-parent</artifactId>
+		<version>1.1.1.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-server-core</artifactId>
+			<version>1.1.1.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-resource-maven</artifactId>
+			<version>${spring-cloud-deployer.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
+			<version>${spring-cloud-deployer.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-resource-support</artifactId>
+			<version>${spring-cloud-deployer.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalDataFlowServerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalDataFlowServerAutoConfiguration.java
@@ -14,24 +14,32 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.local;
+package org.springframework.cloud.dataflow.autoconfigure.local;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration;
 import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 
 /**
- * Configuration class for Local Data Flow Server.
+ * Auto-configuration for local dataflow server.
  *
- * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
+ *
  */
-public class LocalDataFlowServerConfiguration {
+@Configuration
+@AutoConfigureBefore(DataFlowControllerAutoConfiguration.class)
+@ConditionalOnProperty(prefix = "dataflow.server.local", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class LocalDataFlowServerAutoConfiguration {
 
 	@Bean
 	public DelegatingResourceLoader delegatingResourceLoader(MavenProperties mavenProperties) {

--- a/spring-cloud-dataflow-server-local-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.springframework.cloud.dataflow.autoconfigure.local.LocalDataFlowServerAutoConfiguration

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.dataflow.server.config.DataFlowServerConfiguration;
+import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 import org.springframework.cloud.dataflow.shell.command.JobCommandTemplate;
 import org.springframework.cloud.dataflow.shell.command.StreamCommandTemplate;
 import org.springframework.cloud.dataflow.shell.command.TaskCommandTemplate;
@@ -104,7 +104,7 @@ public abstract class AbstractShellIntegrationTest {
 				shutdownAfterRun = Boolean.getBoolean(SHUTDOWN_AFTER_RUN);
 			}
 
-			SpringApplication application = new SpringApplicationBuilder(DataFlowServerConfiguration.class).build();
+			SpringApplication application = new SpringApplicationBuilder(TestConfig.class).build();
 
 			int randomPort = SocketUtils.findAvailableTcpPort();
 			String dataFlowUri = String.format("--dataflow.uri=http://localhost:%s", serverPort);
@@ -211,4 +211,8 @@ public abstract class AbstractShellIntegrationTest {
 		}
 	}
 
+	@EnableAutoConfiguration
+	@EnableDataFlowServer
+	public static class TestConfig {
+	}
 }

--- a/spring-cloud-starter-dataflow-server-local/pom.xml
+++ b/spring-cloud-starter-dataflow-server-local/pom.xml
@@ -24,6 +24,10 @@
 			<artifactId>spring-cloud-dataflow-server-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-server-local-autoconfig</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.directory.server</groupId>
 			<artifactId>apacheds-protocol-ldap</artifactId>
 			<version>1.5.5</version>

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import org.junit.rules.ExternalResource;
 import org.springframework.boot.SpringApplication;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.local.dataflowapp.LocalTestDataFlowServer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.StringUtils;

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/TestUtils.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/TestUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.local;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+}

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/dataflowapp/LocalTestDataFlowServer.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/dataflowapp/LocalTestDataFlowServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.local;
+package org.springframework.cloud.dataflow.server.local.dataflowapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,15 +23,16 @@ import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 /**
  * Bootstrap class for the local Spring Cloud Data Flow Server.
  *
+ * Multiple SpringBootApplication's needs to be in
+ * their own directories due to component scanning.
+ *
  * @author Mark Fisher
- * @author Ilayaperumal Gopinathan
- * @author Janne Valkealahti
  */
 @SpringBootApplication
 @EnableDataFlowServer
-public class LocalDataFlowServer {
+public class LocalTestDataFlowServer {
 
 	public static void main(String[] args) {
-		SpringApplication.run(LocalDataFlowServer.class, args);
+		SpringApplication.run(LocalTestDataFlowServer.class, args);
 	}
 }

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/nodataflowapp/LocalTestNoDataFlowServer.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/nodataflowapp/LocalTestNoDataFlowServer.java
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.local;
+package org.springframework.cloud.dataflow.server.local.nodataflowapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 
 /**
- * Bootstrap class for the local Spring Cloud Data Flow Server.
+ * Bootstrap class for dummy spring boot app having
+ * no enabled dataflow server configs.
  *
- * @author Mark Fisher
- * @author Ilayaperumal Gopinathan
+ * Multiple SpringBootApplication's needs to be in
+ * their own directories due to component scanning.
+ *
  * @author Janne Valkealahti
  */
 @SpringBootApplication
-@EnableDataFlowServer
-public class LocalDataFlowServer {
+public class LocalTestNoDataFlowServer {
 
 	public static void main(String[] args) {
-		SpringApplication.run(LocalDataFlowServer.class, args);
+		SpringApplication.run(LocalTestNoDataFlowServer.class, args);
 	}
 }


### PR DESCRIPTION
- This commit has one goal, Removal of @EnableAutoConfiguration
  from DataFlowServerConfiguration so that dataflow server can be
  build and run by just having needed deps and @SpringBootApplication
  in a main class.
- NOTE: This will be a breaking change with our use of @EnableDataFlowServer
  as it will no longer enable auto configuration thus it will now be
  required to use i.e. @SpringBootApplication.
- Add DataFlowServerAutoConfiguration which is a passthrough for
  @EnableDataFlowServer. For conveniance 'dataflow.server.enabled' is
  added for conditionally disable this autoconfig. JacksonAutoConfiguration
  needs to happen after as otherwise we hit issues with
  github.com/spring-projects/spring-boot/issues/5984. Previously
  DataFlowServerConfiguration enabled autoconfig and pretty much did
  same thing because of a use of @EnableDataFlowServer in a
  main class.
- Adding package for LocalDataFlowServerAutoConfiguration to get
  DelegatingResourceLoader(for docker and maven) created as previously
  this was imported manually from LocalDataFlowServer. Property
  'dataflow.server.local.enabled' is also added.
- Refactor some of a tests which previously relied auto-config to kick
  in automatically via DataFlowServerConfiguration.
- SessionAutoConfiguration used to be explicitely exluded via annotation
  as it will cause failure if redis is not available and we need to have
  a way to disable things around that. Boot guys recommended to set
  'spring.session.store-type=none' instead of disabling that autoconfig.
  This is now explicitely on DefaultEnvironmentPostProcessor which
  adds new yml file META-INF/dataflow-server-defaults.yml where we
  can place internal default props.
- Fixes #1026

Squashed, fixes for session autoconfig and use of @EnableDataFlowServer

- dataflow-server-defaults.yml now uses spring.autoconfigure.exclude which seems to
  work for excluding SessionAutoConfiguration instead of setting session store
  type to none.
- I still kept actual dataflow server configuration to happen via auto-config but it
  is now enabled conditionally if @EnableDataFlowServer is used. Without use of
  @EnableDataFlowServer auto-config doesn't happen. Logic for this is same as done in
  Spring Cloud ConfigServer
  github.com/spring-cloud/spring-cloud-config/blob/master/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/EnableConfigServer.java
  which adds a marker bean and auto-config conditionally checks if marker bean exists.
  Benefit for this is that we get same ordering of bean creation in all cases. If @EnableDataFlowServer
  would simply cause raw @Import of configs conditionally bean ordering might be different because
  @EnableDataFlowServer would fire imports from app's main class.
