### PR TITLE
gh-1101 Fix `MethodArgumentTypeMismatchException` should not trigger `500` Http Status

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * Apply common behavior (exception handling etc.,) to all the REST controllers.
@@ -132,7 +133,10 @@ public class RestControllerAdvice {
 	 * Log the exception message at warn level and stack trace as trace level.
 	 * Return response status HttpStatus.BAD_REQUEST (400).
 	 */
-	@ExceptionHandler({MissingServletRequestParameterException.class})
+	@ExceptionHandler({
+		MissingServletRequestParameterException.class,
+		MethodArgumentTypeMismatchException.class
+	})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ResponseBody
 	public VndErrors onClientGenericBadRequest(Exception e) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -209,6 +209,14 @@ public class StreamControllerTests {
 	}
 
 	@Test
+	public void testMethodArgumentTypeMismatchFailure() throws Exception {
+		mockMvc.perform(get("/streams/definitions/myStream1/related")
+				.param("nested", "in-correct-value")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().is4xxClientError());
+	}
+
+	@Test
 	public void testFindRelatedAndNestedStreams() throws Exception {
 		assertEquals(0, repository.count());
 		mockMvc.perform(


### PR DESCRIPTION
* Ensure a `400` Status (Bad Request) is issued for a thrown MethodArgumentTypeMismatchException
* Add Test

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1101