### PR TITLE
Improving error handling for app registration

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
@@ -114,7 +114,8 @@ public class AppRegistry {
 	private AppRegistration createAppRegistration(String key, URI uri) {
 		String[] tokens = key.split("\\.", 2);
 		if (tokens.length != 2) {
-			throw new IllegalArgumentException("Invalid application key: " + key);
+			throw new IllegalArgumentException("Invalid application key: " + key +
+					"; the expected format is <name>.<type>");
 		}
 		return new AppRegistration(tokens[1], ApplicationType.valueOf(tokens[0]), uri, this.resourceLoader);
 	}

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.core.io.ResourceLoader;
  *
  * @author Mark Fisher
  * @author Gunnar Hillert
+ * @author Thomas Risberg
  */
 public class AppRegistry {
 
@@ -75,10 +76,17 @@ public class AppRegistry {
 
 	public List<AppRegistration> importAll(boolean overwrite, String... resourceUris) {
 		List<AppRegistration> apps = new ArrayList<>();
-		Map<String, URI> registered = this.uriRegistryPopulator.populateRegistry(
-				overwrite, this.uriRegistry, resourceUris);
-		for (Map.Entry<String, URI> entry : registered.entrySet()) {
-			apps.add(createAppRegistration(entry.getKey(), entry.getValue()));
+		for (String uri : resourceUris) {
+			try {
+				Map<String, URI> registered = this.uriRegistryPopulator.populateRegistry(
+						overwrite, this.uriRegistry, uri);
+				for (Map.Entry<String, URI> entry : registered.entrySet()) {
+					apps.add(createAppRegistration(entry.getKey(), entry.getValue()));
+				}
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Error when registering applications from " + uri + ": " + e.getMessage(), e);
+			}
 		}
 		return apps;
 	}
@@ -105,6 +113,9 @@ public class AppRegistry {
 
 	private AppRegistration createAppRegistration(String key, URI uri) {
 		String[] tokens = key.split("\\.", 2);
+		if (tokens.length != 2) {
+			throw new IllegalArgumentException("Invalid application key: " + key);
+		}
 		return new AppRegistration(tokens[1], ApplicationType.valueOf(tokens[0]), uri, this.resourceLoader);
 	}
 }

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
@@ -82,8 +82,11 @@ public class RdbmsUriRegistry implements UriRegistry {
 
 	@Override
 	public void register(String name, URI uri) {
-		Assert.notNull(uri, "Error when registering " + name + ": uri is required");
-		Assert.hasText(uri.toString(), "Error when registering " + name + ": uri must not be blank");
+		Assert.notNull(uri, "Error when registering " + name + ": URI is required");
+		Assert.hasText(uri.getScheme(), "Error when registering " + name + " with URI " + uri +
+				": URI scheme must be specified");
+		Assert.hasText(uri.getSchemeSpecificPart(), "Error when registering " + name + " with URI " + uri +
+				": URI scheme-specific part must be specified");
 		String uriString = uri.toString();
 		if (find(name) != null) {
 			jdbcTemplate.update(UPDATE_SQL, new Object[] { uriString, name },

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  *
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
+ * @author Thomas Risberg
  */
 public class RdbmsUriRegistry implements UriRegistry {
 
@@ -81,6 +82,8 @@ public class RdbmsUriRegistry implements UriRegistry {
 
 	@Override
 	public void register(String name, URI uri) {
+		Assert.notNull(uri, "Error when registering " + name + ": uri is required");
+		Assert.hasText(uri.toString(), "Error when registering " + name + ": uri must not be blank");
 		String uriString = uri.toString();
 		if (find(name) != null) {
 			jdbcTemplate.update(UPDATE_SQL, new Object[] { uriString, name },

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Eric Bottard
  * @author Gary Russell
  * @author Patrick Peralta
+ * @author Thomas Risberg
  */
 @RestController
 @RequestMapping("/apps")
@@ -179,6 +180,9 @@ public class AppRegistryController {
 		else if (!CollectionUtils.isEmpty(apps)) {
 			for (String key : apps.stringPropertyNames()) {
 				String[] tokens = key.split("\\.", 2);
+				if (tokens.length != 2) {
+					throw new IllegalArgumentException("Invalid application key: " + key);
+				}
 				String name = tokens[1];
 				ApplicationType type = ApplicationType.valueOf(tokens[0]);
 				if (force || null == appRegistry.find(name, type)) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -181,7 +181,8 @@ public class AppRegistryController {
 			for (String key : apps.stringPropertyNames()) {
 				String[] tokens = key.split("\\.", 2);
 				if (tokens.length != 2) {
-					throw new IllegalArgumentException("Invalid application key: " + key);
+					throw new IllegalArgumentException("Invalid application key: " + key +
+							"; the expected format is <name>.<type>");
 				}
 				String name = tokens[1];
 				ApplicationType type = ApplicationType.valueOf(tokens[0]);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -90,6 +90,20 @@ public class AppRegistryControllerTests {
 	}
 
 	@Test
+	public void testRegisterAll() throws Exception {
+		mockMvc.perform(
+				post("/apps").param("apps", "sink.foo=file:///bar").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isCreated());
+	}
+
+	@Test
+	public void testRegisterAllWithBadApplication() throws Exception {
+		mockMvc.perform(
+				post("/apps").param("apps", "sink-foo=file:///bar").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().is5xxServerError());
+	}
+
+	@Test
 	public void testListApplications() throws Exception {
 		mockMvc.perform(
 				get("/apps").accept(MediaType.APPLICATION_JSON)).andDo(print())

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author David Turanski
  * @author Patrick Peralta
  * @author Mark Fisher
+ * @author Thomas Risberg
  */
 @Component
 public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
@@ -248,7 +249,13 @@ public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
 			try {
 				Resource resource = this.resourceLoader.getResource(uri);
 				Properties applications = PropertiesLoaderUtils.loadProperties(resource);
-				PagedResources<AppRegistrationResource> registered = appRegistryOperations().registerAll(applications, force);
+				PagedResources<AppRegistrationResource> registered = null;
+				try {
+					registered = appRegistryOperations().registerAll(applications, force);
+				}
+				catch (Exception e) {
+					return "Error when registering applications from " + uri + ": " + e.getMessage();
+				}
 				long numRegistered = registered.getMetadata().getTotalElements();
 				return (applications.keySet().size() == numRegistered)
 						? String.format("Successfully registered applications: %s", applications.keySet())


### PR DESCRIPTION
- if provided properties file entries don't resolve to a valid format then throw the best available error message

- require that app registrations have a URI

Resolves #1103