### PR TITLE
Fix task launching properties handling

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -160,6 +160,22 @@ to the task application can be set when launching the task as follows:
 dataflow:>task launch mytask --arguments "--server.port=8080,--foo=bar"
 ```
 
+Additional properties meant for a `TaskLauncher` itself can be passed
+in using a `--properties` option. Format of this option is a comma
+delimited string of propertys prefixed with `app.<task definition
+name>.<property>`.
+
+If actual property is prefixed with `spring.cloud.deployer` it is
+passed to `TaskLauncher` as a deployment property and its meaning may
+be `TaskLauncher` implementation specific. Other propertys are passed
+to `TaskLauncher` as application properties and it is up to an
+implementation to choose how those are passed into an actual task
+application.
+
+```
+dataflow:>task launch mytask --properties "app.timestamp.spring.cloud.deployer.foo1=bar1,app.timestamp.foo2=bar2"
+```
+
 === Reviewing Task Executions
 Once the task is launched the state of the task is stored in a relational DB.  The state
 includes:

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package org.springframework.cloud.dataflow.rest.job.support;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.Test;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
@@ -34,6 +36,16 @@ import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 public class DeploymentPropertiesUtilsTests {
 
 	@Test
+	public void testDeploymentProperties() {
+		assertProps("app.timestamp.foo1=bar1",
+				new String[] { "app.timestamp.foo1" },
+				new String[] { "bar1" });
+		assertProps("app.timestamp.foo1=bar1,app.timestamp.foo2=bar2",
+				new String[] { "app.timestamp.foo1", "app.timestamp.foo2" },
+				new String[] { "bar1", "bar2" });
+	}
+
+	@Test
 	public void testCommandLineParamsParsing() {
 		assertArrays(new String[] { "--format=yyyy-MM-dd" }, new String[] { "--format=yyyy-MM-dd" });
 		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'" }, new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS" });
@@ -45,6 +57,13 @@ public class DeploymentPropertiesUtilsTests {
 		assertArrays(new String[] { " --foo1=bar1 ", " --foo2=bar2 " }, new String[] { "--foo1=bar1", "--foo2=bar2" });
 		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'", "--foo1=bar1" },
 				new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS", "--foo1=bar1" });
+	}
+
+	private static void assertProps(String left, String[] rightKeys, String[] rightValues) {
+		Map<String, String> props = DeploymentPropertiesUtils.parse(left);
+		for (int i = 0; i < rightKeys.length; i++) {
+			assertThat(props, hasEntry(rightKeys[i], rightValues[i]));
+		}
 	}
 
 	private static void assertArrays(String[] left, String[] right) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.h2.util.Task;
 
@@ -139,7 +140,7 @@ public class DefaultTaskService implements TaskService {
 
 		taskDefinition = this.updateTaskProperties(taskDefinition);
 
-		Map<String, String> deploymentProperties = new HashMap<>(runtimeProperties);
+		Map<String, String> deploymentProperties = extractAppDeploymentProperties(taskDefinition, runtimeProperties);
 		URI uri = this.registry.find(String.format("task.%s",
 				taskDefinition.getRegisteredAppName()));
 		Resource resource = this.resourceLoader.getResource(uri.toString());
@@ -158,6 +159,18 @@ public class DefaultTaskService implements TaskService {
 		if (deploymentIdRepository.findOne(deploymentKey) == null) {
 			this.deploymentIdRepository.save(deploymentKey, id);
 		}
+	}
+
+	private static Map<String, String> extractAppDeploymentProperties(TaskDefinition taskDefinition,
+			Map<String, String> taskDeploymentProperties) {
+		String appPrefix = String.format("app.%s.", taskDefinition.getRegisteredAppName());
+		Map<String, String> deploymentProperties = new HashMap<>();
+		for (Entry<String, String> entry : taskDeploymentProperties.entrySet()) {
+			if (entry.getKey().startsWith(appPrefix)) {
+				deploymentProperties.put(entry.getKey().substring(appPrefix.length()), entry.getValue());
+			}
+		}
+		return deploymentProperties;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -263,6 +263,7 @@ public class TaskControllerTests {
 
 		mockMvc.perform(
 				post("/tasks/deployments/{name}", "myTask3")
+				.param("properties", "app.foo3.foo1=bar1,app.foo3.spring.cloud.deployer.foo2=bar2")
 				.param("arguments", "--foobar=jee", "--foobar2=jee2", "--foobar3='jee3 jee3'")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isCreated());
@@ -276,6 +277,8 @@ public class TaskControllerTests {
 		assertThat(request.getCommandlineArguments().get(1), is("--foobar2=jee2"));
 		assertThat(request.getCommandlineArguments().get(2), is("--foobar3=jee3 jee3"));
 		assertEquals("myTask3", request.getDefinition().getProperties().get("spring.cloud.task.name"));
+		assertThat(request.getDefinition().getProperties().get("foo1"), is("bar1"));
+		assertThat(request.getDeploymentProperties().get("spring.cloud.deployer.foo2"), is("bar2"));
 	}
 
 	@Test


### PR DESCRIPTION
- Fixed DefaultTaskService to strip i.e. "app.timestamp" out from
  a passed properties string so that this prefix is not passed
  into an task app itself. This is how stream apps are handled.
- Added tests to verify properties handling.
- Added docs how properties can be used during a task launch.
- Effectively i.e with local server launch
  task launch --name footask1 --properties "app.timestamp.foo1=bar1,app.timestamp.foo2=bar2,app.timestamp.spring.cloud.deployer.foo3=bar3"
  will add 'foo1=bar1' and 'foo2=bar2' as task app environment variables
  and 'foo3=bar3' as a deployment property.
- Fixes #1076