### PR TITLE
gh-1114 Shell: Use HttpClient for all operations

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -216,7 +216,7 @@ dataflow:> dataflow config server https://localhost:8443/
 **Skip Certificate Validation**
 
 Alternatively, you can also bypass the certification validation by providing the
-optional command-line parameter `--skip-ssl-validation`.
+optional command-line parameter `--dataflow.skip-ssl-validation=true`.
 
 Using this command-line parameter, the shell will accept any (self-signed) SSL
 certificate.

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
@@ -83,6 +83,10 @@ public class Target {
 
 	public static final String DEFAULT_UNSPECIFIED_PASSWORD = "__NULL__";
 
+	public static final String DEFAULT_SPECIFIED_SKIP_SSL_VALIDATION = "true";
+
+	public static final String DEFAULT_UNSPECIFIED_SKIP_SSL_VALIDATION = "false";
+
 	public static final String DEFAULT_TARGET = DEFAULT_SCHEME + "://" + DEFAULT_HOST + ":" + DEFAULT_PORT + "/";
 
 	private final URI targetUri;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,8 @@ public class Target {
 
 	private final URI targetUri;
 
+	private final boolean skipSslValidation;
+
 	private final Credentials targetCredentials;
 
 	private Exception targetException;
@@ -102,11 +104,14 @@ public class Target {
 	 * @param targetUriAsString Must not be empty
 	 * @param targetUsername    May be empty, if access is unauthenticated
 	 * @param targetPassword    May be empty
+	 * @param skipSslValidation
 	 * @throws IllegalArgumentException if the given string violates RFC 2396.
 	 */
-	public Target(String targetUriAsString, String targetUsername, String targetPassword) {
+	public Target(String targetUriAsString, String targetUsername, String targetPassword, boolean skipSslValidation) {
 		Assert.hasText(targetUriAsString, "The provided targetUriAsString must neither be null nor empty.");
 		this.targetUri = URI.create(targetUriAsString);
+		this.skipSslValidation = skipSslValidation;
+
 		if (StringUtils.isEmpty(targetUsername)) {
 			this.targetCredentials = null;
 		} else {
@@ -121,7 +126,7 @@ public class Target {
 	 * @throws IllegalArgumentException if the given string violates RFC 2396
 	 */
 	public Target(String targetUriAsString) {
-		this(targetUriAsString, null, null);
+		this(targetUriAsString, null, null, false);
 	}
 
 	/**
@@ -167,6 +172,14 @@ public class Target {
 	 */
 	public String getTargetUriAsString() {
 		return targetUri.toString();
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isSkipSslValidation() {
+		return skipSslValidation;
 	}
 
 	/**

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetHolder.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.cloud.dataflow.shell;
 
 import org.springframework.cloud.dataflow.shell.command.ConfigCommands;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.dataflow.shell.autoconfigure;
 
-import java.util.Arrays;
+import javax.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,12 +33,6 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.shell.CommandLine;
 import org.springframework.shell.core.JLineShell;
 import org.springframework.shell.core.JLineShellComponent;
-
-import javax.annotation.PostConstruct;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * Configures the various commands that are part of the default Spring Shell experience.
@@ -84,35 +77,6 @@ public class BaseShellAutoConfiguration {
 	@ConditionalOnMissingBean(JLineShell.class)
 	public JLineShellComponent shell() {
 		return new JLineShellComponent();
-	}
-
-	@PostConstruct
-	public void skipSSLValidation() {
-		if (Arrays.asList(commandLine.getArgs()).contains("--skip-ssl-validation")) {
-			// Create a trust manager that does not validate certificate chains
-			TrustManager[] allTrustingManagers = new TrustManager[]{
-				new X509TrustManager() {
-					public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-						return null;
-					}
-					public void checkClientTrusted(
-						java.security.cert.X509Certificate[] certs, String authType) {
-					}
-					public void checkServerTrusted(
-						java.security.cert.X509Certificate[] certs, String authType) {
-					}
-				}
-			};
-
-			// Install it
-			try {
-				SSLContext sc = SSLContext.getInstance("SSL");
-				sc.init(null, allTrustingManagers, new java.security.SecureRandom());
-				HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-			} catch (Exception e) {
-				logger.error("Error while installing all-trusting SSL factory", e);
-			}
-		}
 	}
 
 	@Configuration

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,25 @@
 
 package org.springframework.cloud.dataflow.shell.command;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.JobExecution;
-import org.springframework.batch.core.JobInstance;
-import org.springframework.batch.core.JobParameter;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,30 +42,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.dataflow.rest.client.DataFlowServerException;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
-import org.springframework.cloud.dataflow.rest.client.VndErrorResponseErrorHandler;
-import org.springframework.cloud.dataflow.rest.client.support.ExecutionContextJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.ExitStatusJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.JobExecutionJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.JobInstanceJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.JobParameterJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.JobParametersJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.StepExecutionHistoryJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.client.support.StepExecutionJacksonMixIn;
-import org.springframework.cloud.dataflow.rest.job.StepExecutionHistory;
-import org.springframework.cloud.dataflow.shell.TargetHolder;
 import org.springframework.cloud.dataflow.shell.Target;
+import org.springframework.cloud.dataflow.shell.TargetHolder;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
-import org.springframework.hateoas.hal.Jackson2HalModule;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.shell.CommandLine;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
@@ -70,11 +63,6 @@ import org.springframework.shell.table.TableModelBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Configuration commands for the Shell.  The default Data Flow Server location is
@@ -125,6 +113,13 @@ public class ConfigCommands implements CommandMarker,
 
 	private volatile boolean initialized;
 
+	private Environment environment;
+
+	@Autowired
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
 	@Autowired
 	public void setCommandLine(CommandLine commandLine) {
 		this.commandLine = commandLine;
@@ -152,6 +147,11 @@ public class ConfigCommands implements CommandMarker,
 		this.restTemplate = restTemplate;
 	}
 
+	@Bean
+	public RestTemplate restTemplate(Environment ev) {
+		return DataFlowTemplate.getDefaultDataflowRestTemplate();
+	}
+
 	// This is for unit testing
 
 	public void setServerUri(String serverUri) {
@@ -169,20 +169,25 @@ public class ConfigCommands implements CommandMarker,
 			@CliOption(mandatory = false, key = {"password"},
 					help = "the password for authenticated access to the Admin REST endpoint (valid only with a username)",
 					specifiedDefaultValue = Target.DEFAULT_SPECIFIED_PASSWORD,
-					unspecifiedDefaultValue = Target.DEFAULT_UNSPECIFIED_PASSWORD) String targetPassword) {
+					unspecifiedDefaultValue = Target.DEFAULT_UNSPECIFIED_PASSWORD) String targetPassword,
+			@CliOption(mandatory = false, key = {"skip-ssl-validation"},
+					help = "accept any SSL certificate (even self-signed)",
+					specifiedDefaultValue = "false",
+					unspecifiedDefaultValue = Target.DEFAULT_UNSPECIFIED_PASSWORD) boolean skipSslValidation){
 
 		if (!StringUtils.isEmpty(targetPassword) && StringUtils.isEmpty(targetUsername)) {
 				return "A password may be specified only together with a username";
 		}
+
 		if (StringUtils.isEmpty(targetPassword) && !StringUtils.isEmpty(targetUsername)) {
 			// read password from the command line
 			targetPassword = userInput.prompt("Password", "", false);
 		}
 
-
-
 		try {
-			this.targetHolder.setTarget(new Target(targetUriString, targetUsername, targetPassword));
+			this.targetHolder.setTarget(new Target(targetUriString, targetUsername, targetPassword, skipSslValidation));
+
+			final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
 			if (StringUtils.hasText(targetUsername) && StringUtils.hasText(targetPassword)) {
 				final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -190,14 +195,29 @@ public class ConfigCommands implements CommandMarker,
 						new UsernamePasswordCredentials(
 								targetHolder.getTarget().getTargetCredentials().getUsername(),
 								targetHolder.getTarget().getTargetCredentials().getPassword()));
-				final CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build();
-				final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
-
-				this.restTemplate.setRequestFactory(requestFactory);
+				httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 			}
 
+			if (skipSslValidation) {
+				SSLContext sslContext = SSLContexts
+						.custom()
+						.loadTrustMaterial(new TrustStrategy() {
+							@Override
+							public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+								return true;
+							}
+						})
+						.build();
+				httpClientBuilder.setSSLContext(sslContext);
+				httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+			}
+
+			final CloseableHttpClient httpClient = httpClientBuilder.build();
+			final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+			this.restTemplate.setRequestFactory(requestFactory);
+
 			this.shell.setDataFlowOperations(new DataFlowTemplate(targetHolder.getTarget().getTargetUri(), this.restTemplate));
-			return(String.format("Successfully targeted %s", targetUriString));
+			this.targetHolder.getTarget().setTargetResultMessage(String.format("Successfully targeted %s", targetUriString));
 		}
 		catch (Exception e) {
 			this.targetHolder.getTarget().setTargetException(e);
@@ -211,13 +231,15 @@ public class ConfigCommands implements CommandMarker,
 				else {
 					logger.warn(message);
 				}
-				return message;
+				this.targetHolder.getTarget().setTargetResultMessage(message);
 			}
 			else {
-				return(String.format("Unable to contact Data Flow Server at '%s': '%s'.",
+				this.targetHolder.getTarget().setTargetResultMessage(String.format("Unable to contact Data Flow Server at '%s': '%s'.",
 						targetUriString, e.toString()));
 			}
 		}
+		return(this.targetHolder.getTarget().getTargetResultMessage());
+
 	}
 
 	@CliCommand(value = {"dataflow config info"}, help = "Show the Dataflow server being used")
@@ -228,6 +250,11 @@ public class ConfigCommands implements CommandMarker,
 		final Target target = targetHolder.getTarget();
 
 		statusValues.put("Target", target.getTargetUriAsString());
+
+		if (target.isSkipSslValidation()) {
+			statusValues.put("SSL Validation", "skipped");
+		}
+
 		if (target.getTargetCredentials() != null) {
 			statusValues.put("Credentials", target.getTargetCredentials().getDisplayableContents());
 		}
@@ -256,12 +283,11 @@ public class ConfigCommands implements CommandMarker,
 		return sb.toString();
 	}
 
-
 	@Override
 	public void onApplicationEvent(ApplicationReadyEvent event) {
 		//Only invoke if the shell is executing in the same application context as the data flow server.
 		if (!initialized) {
-			target(this.serverUri, this.userName, this.password);
+			target(this.serverUri, this.userName, this.password, isSkipSslValidation(this.environment));
 		}
 	}
 
@@ -270,17 +296,27 @@ public class ConfigCommands implements CommandMarker,
 		//Only invoke this lifecycle method if the shell is executing in stand-alone mode.
 		if (applicationContext != null && !applicationContext.containsBean("streamDefinitionRepository")) {
 			initialized = true;
-			target(this.serverUri, this.userName, this.password);
+			target(this.serverUri, this.userName, this.password, isSkipSslValidation(this.environment));
 		}
 	}
 
-	@Bean
-	public static RestTemplate restTemplate() {
-		return DataFlowTemplate.getDefaultDataflowRestTemplate();
+	private boolean isSkipSslValidation(Environment env) {
+		final boolean skipSslValidation;
+
+		if (env.containsProperty("skip-ssl-validation")
+			&& (env.getProperty("skip-ssl-validation").isEmpty() || env.getProperty("skip-ssl-validation").equalsIgnoreCase("true"))) {
+			skipSslValidation = true;
+		}
+		else {
+			skipSslValidation = false;
+		}
+
+		return skipSslValidation;
 	}
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
 	}
+
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/HttpClientUtils.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/HttpClientUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.command.support;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.TrustStrategy;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Provides utilities for the Apache {@link HttpClient}, used to make REST calls by the Shell.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class HttpClientUtils {
+
+	/**
+	 * Ensures that the passed-in {@link RestTemplate} is using the Apache HTTP Client. If the optional {@code username} AND
+	 * {@code password} are not empty, then a {@link BasicCredentialsProvider} will be added to the {@link CloseableHttpClient}.
+	 *
+	 * Furthermore, you can set the underlying {@link SSLContext} of the {@link HttpClient} allowing you to accept self-signed
+	 * certificates.
+	 *
+	 * @param restTemplate Must not be null
+	 * @param username Can be null
+	 * @param password Can be null
+	 * @param skipSslValidation Use with caution! If true certificate warnings will be ignored.
+	 */
+	public static void prepareRestTemplate(
+			RestTemplate restTemplate,
+			String username,
+			String password,
+			boolean skipSslValidation) {
+
+		Assert.notNull(restTemplate, "The provided RestTemplate must not be null.");
+
+		final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+		if (StringUtils.hasText(username) && StringUtils.hasText(password)) {
+			final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+			credentialsProvider.setCredentials(AuthScope.ANY,
+					new UsernamePasswordCredentials(
+							username,
+							password));
+			httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+		}
+
+		if (skipSslValidation) {
+			httpClientBuilder.setSSLContext(HttpClientUtils.buildCertificateIgnoringSslContext());
+			httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+		}
+
+		final CloseableHttpClient httpClient = httpClientBuilder.build();
+		final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+		restTemplate.setRequestFactory(requestFactory);
+	}
+
+	/**
+	 * Will create a certificate-ignoring {@link SSLContext}. Please use with utmost caution as it undermines security,
+	 * but may be useful in certain testing or development scenarios.
+	 *
+	 * @return The SSLContext
+	 */
+	public static SSLContext buildCertificateIgnoringSslContext() {
+		try {
+			return SSLContexts
+				.custom()
+				.loadTrustMaterial(new TrustStrategy() {
+					@Override
+					public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+						return true;
+					}
+				})
+				.build();
+		}
+		catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
+			throw new IllegalStateException("Unexpected exception while building the certificate-ignoring SSLContext.", e);
+		}
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/package-info.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides supporting classes and utilities for the shell command classes.
+ */
+package org.springframework.cloud.dataflow.shell.command.support;

--- a/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
+++ b/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
@@ -2,7 +2,7 @@ Data Flow Options:
   --dataflow.uri=<uri>                  Address of the Data Flow Server [default: http://localhost:9393].
   --dataflow.username=<USER>            Username of the Data Flow Server [no default].
   --dataflow.password=<PASSWORD>        Password of the Data Flow Server [no default].
-  --spring.shell.historySize=<SIZE>     Default size of the shell log file [default: 3000]
+  --dataflow.skip-ssl-validation=true   Accept any SSL certificate (even self-signed) [default: no].
+  --spring.shell.historySize=<SIZE>     Default size of the shell log file [default: 3000].
   --spring.shell.commandFile=<FILE>     Data Flow Shell executes commands read from the file(s) and then exits.
-  --skip-ssl-validation                 Accept any SSL certificate (even self-signed)
   --help                                This message.

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -34,7 +34,6 @@ import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.mock.env.MockEnvironment;
 import org.springframework.shell.CommandLine;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -70,8 +69,6 @@ public class ConfigCommandTests {
 		when(restTemplate.getForObject(Mockito.any(URI.class), Mockito.eq(ResourceSupport.class))).thenThrow(e);
 
 		configCommands.setTargetHolder(new TargetHolder());
-		configCommands.setCommandLine(commandLine);
-		configCommands.setEnvironment(new MockEnvironment());
 		configCommands.setRestTemplate(restTemplate);
 		configCommands.setDataFlowShell(dataFlowShell);
 		configCommands.setServerUri("http://localhost:9393");

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.shell.CommandLine;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -70,6 +71,7 @@ public class ConfigCommandTests {
 
 		configCommands.setTargetHolder(new TargetHolder());
 		configCommands.setCommandLine(commandLine);
+		configCommands.setEnvironment(new MockEnvironment());
 		configCommands.setRestTemplate(restTemplate);
 		configCommands.setDataFlowShell(dataFlowShell);
 		configCommands.setServerUri("http://localhost:9393");


### PR DESCRIPTION
* Ensure that the Shell uses Apache HttpClient for all "target" opererations
* Make `--skip-ssl-validation` (command-line) part of the Target command
* Add a `skip-ssl-validation` to the Target command (Within Shell)

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1114