### PR TITLE
Exception handling at JobInstance list endpoint

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobInstanceController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobInstanceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,15 +87,8 @@ public class JobInstanceController {
 	public PagedResources<JobInstanceResource> list(@RequestParam("name") String jobName,
 			Pageable pageable, PagedResourcesAssembler<JobInstanceExecutions> assembler)
 			throws NoSuchJobException {
-		List<JobInstanceExecutions> jobInstances;
-		Page<JobInstanceExecutions> page;
-		try{
-			jobInstances = taskJobService.listTaskJobInstancesForJobName(pageable, jobName);
-			page = new PageImpl<>(jobInstances, pageable, taskJobService.countJobInstances(jobName));
-		}
-		catch (NoSuchJobException e){
-				page = new PageImpl<>(new ArrayList<JobInstanceExecutions>());
-		}
+		List<JobInstanceExecutions> jobInstances = taskJobService.listTaskJobInstancesForJobName(pageable, jobName);
+		Page<JobInstanceExecutions> page = new PageImpl<>(jobInstances, pageable, taskJobService.countJobInstances(jobName));
 		return assembler.toResource(page, jobAssembler);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,8 +139,8 @@ public class JobInstanceControllerTests {
 	public void testGetInstanceByNameNotFound() throws Exception{
 		mockMvc.perform(
 				get("/jobs/instances/").param("name", "BAZ").accept(MediaType.APPLICATION_JSON)
-		).andExpect(status().isOk())
-				.andExpect(jsonPath("$.content", hasSize(0)));
+		).andExpect(status().is4xxClientError())
+				.andReturn().getResponse().getContentAsString().contains("NoSuchJobException");
 	}
 
 	private void createSampleJob(String jobName, int jobExecutionCount){


### PR DESCRIPTION
 - Throw NoSuchJobException when there is no job found of the given name
 - This will make it consistent with other endpoints
 - update test

Resolves #1074