### PR TITLE
Exception handling at TaskExecution controller

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,8 +168,8 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(TaskDefinitionRepository.class)
-	public TaskExecutionController taskExecutionController(TaskExplorer explorer) {
-		return new TaskExecutionController(explorer);
+	public TaskExecutionController taskExecutionController(TaskExplorer explorer, TaskDefinitionRepository taskDefinitionRepository) {
+		return new TaskExecutionController(explorer, taskDefinitionRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,8 +97,8 @@ public class JobDependencies {
 		return new JobInstanceController(repository);
 	}
 	@Bean
-	public TaskExecutionController taskExecutionController(TaskExplorer explorer) {
-		return new TaskExecutionController(explorer);
+	public TaskExecutionController taskExecutionController(TaskExplorer explorer, TaskDefinitionRepository taskDefinitionRepository) {
+		return new TaskExecutionController(explorer, taskDefinitionRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -143,8 +143,8 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher(), appRegistry());
 	}
 
-	public TaskExecutionController taskExecutionController(TaskExplorer explorer) {
-		return new TaskExecutionController(explorer);
+	public TaskExecutionController taskExecutionController(TaskExplorer explorer, TaskDefinitionRepository repository) {
+		return new TaskExecutionController(explorer, repository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,10 +74,18 @@ public class TaskCommandTemplate {
 	}
 
 	/**
-	 * Executes a task execution list.
+	 * Lists task executions by predefined name 'foo'.
 	 */
 	public CommandResult taskExecutionListByName() {
 		return shell.executeCommand("task execution list --name foo");
+
+	}
+
+	/**
+	 * Lists task executions by given name.
+	 */
+	public CommandResult taskExecutionListByName(String name) {
+		return shell.executeCommand("task execution list --name "+ name);
 
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,8 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void testTaskExecutionListByName() throws InterruptedException {
 		logger.info("Retrieve Task Execution List By Name Test");
-		CommandResult cr = task().taskExecutionListByName();
+		task().create("mytask", "timestamp");
+		CommandResult cr = task().taskExecutionListByName("mytask");
 		assertTrue("task execution list by name command must be successful",
 				cr.isSuccess());
 		Table table = (Table) cr.getResult();


### PR DESCRIPTION
  - When the task executions are retrieved by the task `name`, check if the task exists
     - If the task doesn't exist, throw NoSuchTaskException

  - Use TaskDefinitionRepository at TaskExecutionController to find task definition by name
  - Update test

Resolves #1089