### PR TITLE
Fix RDBMS registry find method

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
@@ -89,11 +89,13 @@ public class RdbmsUriRegistry implements UriRegistry {
 		Assert.hasText(uri.getSchemeSpecificPart(), "Error when registering " + name + " with URI " + uri +
 				": URI scheme-specific part must be specified");
 		String uriString = uri.toString();
-		if (find(name) != null) {
-			jdbcTemplate.update(UPDATE_SQL, new Object[] { uriString, name },
-					new int[] { Types.VARCHAR, Types.VARCHAR });
+		try {
+			if (find(name) != null) {
+				jdbcTemplate.update(UPDATE_SQL, new Object[]{uriString, name},
+						new int[]{Types.VARCHAR, Types.VARCHAR});
+			}
 		}
-		else {
+		catch (IllegalArgumentException e) {
 			jdbcTemplate.update(INSERT_SQL, new Object[] { name, uriString },
 					new int[] { Types.VARCHAR, Types.VARCHAR });
 		}

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/RdbmsUriRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * RDBMS implementation of {@link UriRegistry}.
@@ -65,9 +66,9 @@ public class RdbmsUriRegistry implements UriRegistry {
 			uriString = jdbcTemplate.queryForObject(SELECT_URI_SQL, String.class, name);
 		}
 		catch (EmptyResultDataAccessException e) {
-			return null;
+			throw new IllegalArgumentException("No URI is registered for ["+ name + "] "+ e);
 		}
-		return uriString != null ? toUri(uriString) : null;
+		return toUri(uriString);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/registry/RdbmsUriRegistryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/registry/RdbmsUriRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.server.registry;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -71,6 +73,17 @@ public class RdbmsUriRegistryTests {
 		registry.register("sink.test2", test2URI);
 		assertEquals(test1URI, registry.find("source.test1"));
 		assertEquals(test2URI, registry.find("sink.test2"));
+	}
+
+	@Test
+	public void testFindNonRegisteredURI() throws Exception {
+		try {
+			registry.find("source.foo");
+			fail("IllegalArgumentException is expected when finding non registered app.");
+		}
+		catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().contains("No URI is registered for [source.foo]"));
+		}
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/registry/RdbmsUriRegistryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/registry/RdbmsUriRegistryTests.java
@@ -116,7 +116,12 @@ public class RdbmsUriRegistryTests {
 		registry.register("sink.test2", test2URI);
 		assertEquals(test1URI, registry.find("source.test1"));
 		registry.unregister("source.test1");
-		assertNull(registry.find("source.test1"));
+		try {
+			registry.find("source.test1");
+			fail("[source.test1] should have been unregistered");
+		}
+		catch (IllegalArgumentException e) {
+		}
 		assertEquals(test2URI, registry.find("sink.test2"));
 	}
 


### PR DESCRIPTION
- Throw IllegalArgumentException when the URI for the given app name is not found

Resolves #1126