### PR TITLE
gh-1133 Provide `/app-starters` rest endpoint

### DIFF
--- a/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -103,7 +103,9 @@ public class ApiDocumentation extends BaseDocumentation {
 					linkWithRel("aggregate-counters").description("Provides the resource for dealing with aggregate counters"),
 					linkWithRel("aggregate-counters/counter").description("Handle a specific aggregate counter"),
 					linkWithRel("field-value-counters").description("Provides the resource for dealing with field-value-counters"),
-					linkWithRel("field-value-counters/counter").description("Handle a specific field-value-counter")),
+					linkWithRel("field-value-counters/counter").description("Handle a specific field-value-counter"),
+					linkWithRel("app-starters").description("Provides links to App Starters")),
+
 				responseFields(
 					fieldWithPath("_links").description("Links to other resources"))));
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppStarter.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppStarter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.resource;
+
+/**
+ * Provides meta information for an App Starter, such as name and a uri.
+ *
+ * @author Gunnar Hillert
+ */
+public class AppStarter {
+
+	private String name;
+	private String uri;
+
+	public AppStarter() {
+		super();
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public String getUri() {
+		return uri;
+	}
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	@Override
+	public String toString() {
+		return "AppStarter [name=" + name + ", uri=" + uri + "]";
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppStartersInfoResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppStartersInfoResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ *
+ * Provides information (uris) for App Starters.
+ *
+ * @author Gunnar Hillert
+ */
+public class AppStartersInfoResource extends ResourceSupport {
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public AppStartersInfoResource() {
+	}
+
+	private List<AppStarter> streamAppStarters = new ArrayList<>(0);
+	private List<AppStarter> taskAppStarters = new ArrayList<>(0);
+
+	public List<AppStarter> getStreamAppStarters() {
+		return streamAppStarters;
+	}
+	public void setStreamAppStarters(List<AppStarter> streamAppStarters) {
+		this.streamAppStarters = streamAppStarters;
+	}
+	public List<AppStarter> getTaskAppStarters() {
+		return taskAppStarters;
+	}
+	public void setTaskAppStarters(List<AppStarter> taskAppStarters) {
+		this.taskAppStarters = taskAppStarters;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -41,8 +41,10 @@ import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConf
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.config.features.AppStartersProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
+import org.springframework.cloud.dataflow.server.controller.AppStartersController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
 import org.springframework.cloud.dataflow.server.controller.FeaturesController;
 import org.springframework.cloud.dataflow.server.controller.JobExecutionController;
@@ -90,7 +92,7 @@ import org.springframework.hateoas.EntityLinks;
 @Configuration
 @Import(CompletionConfiguration.class)
 @ConditionalOnBean({EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class})
-@EnableConfigurationProperties({FeaturesProperties.class})
+@EnableConfigurationProperties({FeaturesProperties.class, AppStartersProperties.class})
 @ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class DataFlowControllerAutoConfiguration {
 
@@ -226,6 +228,12 @@ public class DataFlowControllerAutoConfiguration {
 	@ConditionalOnProperty("security.basic.enabled")
 	public LoginController loginController() {
 		return new LoginController();
+	}
+
+	@Bean
+	public AppStartersController appStartersController(AppStartersProperties appStartersProperties,
+			FeaturesProperties featuresProperties) {
+		return new AppStartersController(appStartersProperties, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/AppStartersProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/AppStartersProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.features;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.rest.resource.AppStarter;
+
+/**
+ * Configuration properties for the stream and task app starters.
+ *
+ * @author Gunnar Hillert
+ */
+@ConfigurationProperties(prefix = AppStartersProperties.APP_STARTERS_PREFIX)
+public class AppStartersProperties {
+
+	public static final String APP_STARTERS_PREFIX = "spring.cloud.dataflow.app-starters";
+
+	private List<AppStarter> stream;
+	private List<AppStarter> task;
+
+	public List<AppStarter> getStream() {
+		return stream;
+	}
+
+	public void setStream(List<AppStarter> stream) {
+		this.stream = stream;
+	}
+
+	public List<AppStarter> getTask() {
+		return task;
+	}
+
+	public void setTask(List<AppStarter> task) {
+		this.task = task;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppStartersController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppStartersController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import org.springframework.cloud.dataflow.rest.resource.AppStarter;
+import org.springframework.cloud.dataflow.rest.resource.AppStartersInfoResource;
+import org.springframework.cloud.dataflow.server.config.features.AppStartersProperties;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller that provides a list of app starter uris.
+ *
+ * @author Gunnar Hillert
+ */
+@RestController
+@RequestMapping("/app-starters")
+@ExposesResourceFor(AppStartersInfoResource.class)
+public class AppStartersController {
+
+	private final AppStartersProperties appStartersProperties;
+	private final FeaturesProperties featuresProperties;
+
+	public AppStartersController(AppStartersProperties appStartersProperties, FeaturesProperties featuresProperties) {
+		this.appStartersProperties = appStartersProperties;
+		this.featuresProperties = featuresProperties;
+	}
+
+	/**
+	 * Returns an {@link AppStartersInfoResource} containing a list of {@link AppStarter}.
+	 * Depending on {@link FeaturesProperties}, Stream App Starters and/or Task App Starters
+	 * will be returned.
+	 *
+	 */
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public AppStartersInfoResource getAppStarters() {
+		final AppStartersInfoResource appStarterInfoResource = new AppStartersInfoResource();
+
+		if (featuresProperties.isTasksEnabled()) {
+			appStarterInfoResource.setTaskAppStarters(appStartersProperties.getTask());
+		}
+
+		if (featuresProperties.isStreamsEnabled()) {
+			appStarterInfoResource.setStreamAppStarters(appStartersProperties.getStream());
+		}
+
+		return appStarterInfoResource;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.rest.resource.AppInstanceStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
+import org.springframework.cloud.dataflow.rest.resource.AppStartersInfoResource;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.CompletionProposalsResource;
 import org.springframework.cloud.dataflow.rest.resource.JobExecutionResource;
@@ -120,6 +121,7 @@ public class RootController {
 			resourceSupport.add(unescapeTemplateVariables(entityLinks
 					.linkToSingleResource(AggregateCounterResource.class, "{name}").withRel("aggregate-counters/counter")));
 		}
+		resourceSupport.add(entityLinks.linkToCollectionResource(AppStartersInfoResource.class).withRel("app-starters"));
 		resourceSupport.add(entityLinks.linkToCollectionResource(AppRegistrationResource.class).withRel("apps"));
 		String completionStreamTemplated = entityLinks.linkFor(CompletionProposalsResource.class).withSelfRel().getHref() + ("/stream{?start,detailLevel}");
 		resourceSupport.add(new Link(completionStreamTemplated).withRel("completions/stream"));

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,3 +1,20 @@
 spring:
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
+  cloud:
+    dataflow:
+      app-starters:
+        stream:
+          - name: "Maven based Stream Applications with RabbitMQ Binder"
+            uri:  "http://bit.ly/1-0-2-GA-stream-applications-rabbit-maven"
+          - name: "Maven based Stream Applications with Kafka Binder"
+            uri:  "http://bit.ly/1-0-2-GA-stream-applications-kafka-maven"
+          - name: "Docker based Stream Applications with RabbitMQ Binder"
+            uri:  "http://bit.ly/1-0-2-GA-stream-applications-rabbit-docker"
+          - name: "Docker based Stream Applications with Kafka Binder"
+            uri:  "http://bit.ly/1-0-2-GA-stream-applications-kafka-docker"
+        task:
+          - name: "Maven based Task Applications"
+            uri:  "http://bit.ly/1-0-1-GA-task-applications-maven"
+          - name: "Docker based Task Applications"
+            uri:  "http://bit.ly/1-0-1-GA-task-applications-docker"

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -32,7 +32,10 @@ import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.config.features.AppStartersProperties;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
+import org.springframework.cloud.dataflow.server.controller.AppStartersController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
 import org.springframework.cloud.dataflow.server.controller.RestControllerAdvice;
 import org.springframework.cloud.dataflow.server.controller.StreamDefinitionController;
@@ -78,7 +81,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @EnableHypermediaSupport(type = HAL)
 @Import(CompletionConfiguration.class)
 @EnableWebMvc
-@EnableConfigurationProperties(CommonApplicationProperties.class)
+@EnableConfigurationProperties({CommonApplicationProperties.class, FeaturesProperties.class,
+	AppStartersProperties.class})
 public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
@@ -124,6 +128,12 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	@Bean
 	public CompletionController completionController(StreamCompletionProvider streamCompletionProvider, TaskCompletionProvider taskCompletionProvider) {
 		return new CompletionController(streamCompletionProvider, taskCompletionProvider);
+	}
+
+	@Bean
+	public AppStartersController appStartersController(AppStartersProperties appStartersProperties,
+			FeaturesProperties featuresProperties) {
+		return new AppStartersController(appStartersProperties, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppStartersControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppStartersControllerTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * @author Gunnar Hillert
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class AppStartersControllerTests {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Autowired
+	private FeaturesProperties featuresProperties;
+
+	@Before
+	public void setupMocks() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(
+				get("/").accept(MediaType.APPLICATION_JSON)).build();
+	}
+
+	@Test
+	public void testGetAppStarters() throws Exception {
+		mockMvc.perform(get("/app-starters").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andDo(print())
+				.andExpect(jsonPath("$.streamAppStarters", hasSize(4)))
+				.andExpect(jsonPath("$.taskAppStarters", hasSize(2)));
+	}
+
+	@Test
+	public void testGetAppStartersTasksDisabled() throws Exception {
+		this.featuresProperties.setTasksEnabled(false);
+		mockMvc.perform(get("/app-starters").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andDo(print())
+				.andExpect(jsonPath("$.streamAppStarters", hasSize(4)))
+				.andExpect(jsonPath("$.taskAppStarters", hasSize(0)));
+	}
+
+	@Test
+	public void testGetAppStartersStreamsDisabled() throws Exception {
+		this.featuresProperties.setStreamsEnabled(false);
+		mockMvc.perform(get("/app-starters").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andDo(print())
+				.andExpect(jsonPath("$.streamAppStarters", hasSize(0)))
+				.andExpect(jsonPath("$.taskAppStarters", hasSize(2)));
+	}
+
+}


### PR DESCRIPTION
* Ensure that the rest endpoint is `features-aware` - E.g. if tasks are disabled, then don't return the task-specific app starters
* Add tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1133

Is depended on by https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/146