### PR TITLE
Update spring-cloud-deployer to 1.2.0.BUILD-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
 		<spring-cloud-dataflow-ui.version>1.1.0.RELEASE</spring-cloud-dataflow-ui.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud-deployer.version -->
-		<spring-cloud-deployer.version>1.1.4.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 
-		<spring-cloud-deployer-local.version>1.1.4.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
+		<spring-cloud-deployer-local.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud-task.version -->
 		<spring-cloud-task.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-task.version>

--- a/spring-cloud-dataflow-server-local/pom.xml
+++ b/spring-cloud-dataflow-server-local/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud-deployer.version>1.1.4.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-task.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-task.version>
 		<spring-cloud.version>Camden.SR3</spring-cloud.version>
 	</properties>


### PR DESCRIPTION
 - Also update spring-cloud-deployer-local to use 1.2.0.BUILD-SNAPSHOT

Resolves #1170