### PR TITLE
Update existing docs using the new 'deployer' prefix

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
@@ -143,8 +143,8 @@ To use a simple partitioning strategy in Spring Cloud Data Flow, you only need s
 
 [source,bash]
 ----
-app.http.count=3
-app.averageprocessor.count=2
+deployer.http.count=3
+deployer.averageprocessor.count=2
 app.http.producer.partitionKeyExpression=payload.sensorId
 ----
 will deploy the stream such that all the input and output destinations are configured for data to flow through the applications but also ensure that a unique set of data is always delivered to each averageprocessor instance.  In this case the default algorithm is to evaluate `payload.sensorId % partitionCount` where the `partitionCount` is the application count in the case of RabbitMQ and the partition count of the topic in the case of Kafka.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -72,15 +72,13 @@ Maven repository location or configure proxy settings.  See <<getting-started-ma
 +
 [source,bash]
 ----
-dataflow:> stream create --name httptest --definition "http --server.port=9000 | log" 
-dataflow:> stream deploy --name httptest --properties "app.http.security.basic.enabled=false" 
+dataflow:> stream create --name httptest --definition "http --server.port=9000 | log" --deploy
 ----
 +
 NOTE: You will need to wait a little while until the apps are actually deployed successfully
 before posting data.  Look in the log file of the Data Flow server for the location of the log
 files for the `http` and `log` applications.  Tail the log file for each application to verify
-the application has started.  The security is disabled due to a small bug in the http source that
-secures all endpoints, not only Spring Boot Actuator endpoints, by default.
+the application has started.
 +
 Now post some data
 [source,bash]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -160,18 +160,18 @@ spring.cloud.deployer.local.shutdownTimeout=30 # Max number of seconds to wait f
 spring.cloud.deployer.local.javaOpts= # The Java options to pass to the JVM
 ----
 
-When deploying the application you can also set deployer properties prefixed with `app.<name of application>`, So for example to set Java options for the time application in the `ticktock` stream, use the following stream deployment properties.
+When deploying the application you can also set deployer properties prefixed with `deployer.<name of application>`, So for example to set Java options for the time application in the `ticktock` stream, use the following stream deployment properties.
 [source,bash]
 ----
 dataflow:> stream create --name ticktock --definition "time --server.port=9000 | log"
-dataflow:> stream deploy --name ticktock --properties "app.time.spring.cloud.deployer.local.javaOpts=-Xmx2048m -Dtest=foo"
+dataflow:> stream deploy --name ticktock --properties "deployer.time.local.javaOpts=-Xmx2048m -Dtest=foo"
 ----
 
-As a convenience you can set the property `spring.cloud.deployer.local.memory` to set the Java option `-Xmx`.  So for example, 
+As a convenience you can set the property `deployer.memory` to set the Java option `-Xmx`.  So for example, 
 
 [source,bash]
 ----
-dataflow:> stream deploy --name ticktock --properties "app.time.spring.cloud.deployer.local.memory=2048m"
+dataflow:> stream deploy --name ticktock --properties "deployer.time.memory=2048m"
 ----
 
-At deployment time, if you specify an `-Xmx` option in the `javaOpts` property in addition to a value of the `memory` option, the value in the `javaOpts` property has precedence.  Also, the `javaOpts` property set when deploying the application has precedence over the Data Flow server's `javaOpts` property.
+At deployment time, if you specify an `-Xmx` option in the `deployer.<app>.local.javaOpts` property in addition to a value of the `deployer.<app>.local.memory` option, the value in the `javaOpts` property has precedence.  Also, the `javaOpts` property set when deploying the application has precedence over the Data Flow server's `spring.cloud.deployer.local.javaOpts` property.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -309,11 +309,11 @@ For instance, one can specify how many instances need to be deployed for the spe
 ==== Passing instance count as deployment property
 
 If you would like to have multiple instances of an application in the stream, you
-can include a property with the deploy command:
+can include a deployer property with the deploy command:
 
 [source,bash,subs=attributes]
 ----
-dataflow:> stream deploy --name ticktock --properties "app.time.count=3"
+dataflow:> stream deploy --name ticktock --properties "deployer.time.count=3"
 ----
 
 Note that `count` is the *reserved* property name used by the underlying deployer. Hence, if the application also has a custom property named `count`, it is *not* supported
@@ -337,7 +337,7 @@ and documented below:
 [source,bash]
 ----
 stream deploy foo
-    --properties "app.transform.count=2,app.transform.producer.partitionKeyExpression=payload"
+    --properties "deployer.transform.count=2,app.transform.producer.partitionKeyExpression=payload"
 ----
 
 *Using a file reference*::
@@ -356,7 +356,7 @@ stream deploy foo --propertiesFile myprops.properties
 where `myprops.properties` contains:
 
 ```
-app.transform.count=2
+deployer.transform.count=2
 app.transform.producer.partitionKeyExpression=payload
 ```
 
@@ -642,7 +642,7 @@ To demonstrate the data partitioning functionality, let's deploy the following s
 dataflow:>stream create --name words --definition "http --server.port=9900 | splitter --expression=payload.split(' ') | log"
 Created new stream 'words'
 
-dataflow:>stream deploy words --properties "app.splitter.producer.partitionKeyExpression=payload,app.log.count=2"
+dataflow:>stream deploy words --properties "app.splitter.producer.partitionKeyExpression=payload,deployer.log.count=2"
 Deployed stream 'words'
 
 dataflow:>http post --target http://localhost:9900 --data "How much wood would a woodchuck chuck if a woodchuck could chuck wood"

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -342,11 +342,11 @@ stream deploy foo
 
 *Using a file reference*::
 
-  use the `--propertiesFile` option and point it to a local Java `.properties` file or 
-  `.yaml` or `.yml` file.  The file should be on the file system of the machine running the 
-  shell.  If using a `.properties` file, normal rules apply (ISO 8859-1 encoding, `=`, `<space>` or
+  use the `--propertiesFile` option and point it to a local `.properties`, `.yaml` or `.yml` file
+  (i.e. that lives in the filesystem of the machine running the shell). Being read
+  as a `.properties` file, normal rules apply (ISO 8859-1 encoding, `=`, `<space>` or
   `:` delimiter, etc.) although we recommend using `=` as a key-value pair delimiter
-  for consistency.
+  for consistency:
 
 [source,bash]
 ----
@@ -361,6 +361,23 @@ app.transform.producer.partitionKeyExpression=payload
 ```
 
 Both the above properties will be passed as deployment properties for the stream `foo` above.
+
+In case of using YAML as the format for the deployment properties, use the `.yaml` or `.yml` file extention when deploying the stream,
+
+[source,bash]
+----
+stream deploy foo --propertiesFile myprops.yaml
+----
+
+where `myprops.yaml` contains:
+
+```
+app:
+  transform:
+    count: 2
+    producer:
+      partitionKeyExpression: payload
+```
 
 ==== Passing application properties when deploying a stream
 
@@ -536,83 +553,6 @@ To override these application properties, one can specify the new property value
 ----
 dataflow:>stream deploy ticktock --properties "app.time.fixed-delay=4,app.log.level=ERROR"
 ----
-
-=== Deployment properties
-
-When deploying the stream, properties that control the deployment of the apps into the target platform are known as `deployment` properties.
-For instance, one can specify how many instances need to be deployed for the specific application defined in the stream using the deployment property called `count`.
-
-==== Passing instance count as deployment property
-
-If you would like to have multiple instances of an application in the stream, you
-can include a property with the deploy command:
-
-[source,bash,subs=attributes]
-----
-dataflow:> stream deploy --name ticktock --properties "app.time.count=3"
-----
-
-Note that `count` is the *reserved* property name used by the underlying deployer. Hence, if the application also has a custom property named `count`, it is *not* supported
- when specified in 'short-form' form during stream _deployment_ as it could conflict with the _instance_ count deployer property. Instead, the `count` as a custom application property can be
- specified in its _fully qualified_ form (example: `app.foo.bar.count`) during stream _deployment_ or it can be specified using 'short-form' or _fully qualified_ form during the stream _creation_
- where it will be considered as an app property.
-
-IMPORTANT: See <<spring-cloud-dataflow-stream-app-labels>>.
-
-==== Inline vs file reference properties
-
-When using the Spring Cloud Data Flow Shell, there are two ways to provide deployment
-properties: either *inline* or via a *file reference*. Those two ways are exclusive
-and documented below:
-
-*Inline properties*::
-
-  use the `--properties` shell option and list properties as a comma separated
-  list of key=value pairs, like so:
-
-[source,bash]
-----
-stream deploy foo
-    --properties "app.transform.count=2,app.transform.producer.partitionKeyExpression=payload"
-----
-
-*Using a file reference*::
-
-  use the `--propertiesFile` option and point it to a local `.properties`, `.yaml` or `.yml` file
-  (i.e. that lives in the filesystem of the machine running the shell). Being read
-  as a `.properties` file, normal rules apply (ISO 8859-1 encoding, `=`, `<space>` or
-  `:` delimiter, etc.) although we recommend using `=` as a key-value pair delimiter
-  for consistency:
-
-[source,bash]
-----
-stream deploy foo --propertiesFile myprops.properties
-----
-
-where `myprops.properties` contains:
-
-```
-app.transform.count=2
-app.transform.producer.partitionKeyExpression=payload
-```
-Both the above properties will be passed as deployment properties for the stream `foo` above.
-
-In case of using YAML as the format for the deployment properties, use the `.yaml` or `.yml` file extention when deploying the stream,
-
-[source,bash]
-----
-stream deploy foo --propertiesFile myprops.yaml
-----
-
-where `myprops.yaml` contains:
-
-```
-app:
-  transform:
-    count: 2
-    producer:
-      partitionKeyExpression: payload
-```
 
 [[spring-cloud-dataflow-destroy-stream]]
 == Destroying a Stream

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -372,9 +372,11 @@ stream deploy foo --propertiesFile myprops.yaml
 where `myprops.yaml` contains:
 
 ```
-app:
+deployer:
   transform:
     count: 2
+app:
+  transform:
     producer:
       partitionKeyExpression: payload
 ```

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -163,17 +163,15 @@ dataflow:>task launch mytask --arguments "--server.port=8080,--foo=bar"
 Additional properties meant for a `TaskLauncher` itself can be passed
 in using a `--properties` option. Format of this option is a comma
 delimited string of properties prefixed with `app.<task definition
-name>.<property>`.
-
-If actual property is prefixed with `spring.cloud.deployer` it is
-passed to `TaskLauncher` as a deployment property and its meaning may
-be `TaskLauncher` implementation specific. Other properties are passed
+name>.<property>`. Properties are passed
 to `TaskLauncher` as application properties and it is up to an
 implementation to choose how those are passed into an actual task
-application.
+application. If the property is prefixed with `deployer` instead of `app` it is
+passed to `TaskLauncher` as a deployment property and its meaning may
+be `TaskLauncher` implementation specific. 
 
 ```
-dataflow:>task launch mytask --properties "app.timestamp.spring.cloud.deployer.foo1=bar1,app.timestamp.foo2=bar2"
+dataflow:>task launch mytask --properties "deployer.timestamp.foo1=bar1,app.timestamp.foo2=bar2"
 ```
 
 === Reviewing Task Executions


### PR DESCRIPTION
- Also some additional changes
1.  Removing getting started doc change for disabling security for http
2.  Removing duplicated content of using YAML for the deployment properties

Resolves #1182 