### PR TITLE
gh-1105 Make the Shell Role-aware

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/security/SecurityInfoResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/security/SecurityInfoResource.java
@@ -30,6 +30,7 @@ import org.springframework.hateoas.ResourceSupport;
 public class SecurityInfoResource extends ResourceSupport {
 
 	private boolean authenticationEnabled;
+	private boolean authorizationEnabled;
 
 	private boolean authenticated;
 
@@ -55,6 +56,17 @@ public class SecurityInfoResource extends ResourceSupport {
 	}
 
 	/**
+	 * @return true if the authorization feature is enabled, false otherwise.
+	 */
+	public boolean isAuthorizationEnabled() {
+		return authorizationEnabled;
+	}
+
+	public void setAuthorizationEnabled(boolean authorizationEnabled) {
+		this.authorizationEnabled = authorizationEnabled;
+	}
+
+	/**
 	 * @return True if the user is authenticated
 	 */
 	public boolean isAuthenticated() {
@@ -77,6 +89,8 @@ public class SecurityInfoResource extends ResourceSupport {
 	}
 
 	/**
+	 * Will only contain values if {@link #isAuthorizationEnabled()} is {@code true}.
+	 *
 	 * @return List of Roles, if no roles are associated, an empty collection is returned.
 	 */
 	public List<String> getRoles() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
 import org.springframework.cloud.dataflow.server.controller.FeaturesController;
@@ -91,7 +92,7 @@ import org.springframework.scheduling.concurrent.ForkJoinPoolFactoryBean;
 @Configuration
 @Import(CompletionConfiguration.class)
 @ConditionalOnBean({EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class})
-@EnableConfigurationProperties({FeaturesProperties.class})
+@EnableConfigurationProperties({AuthorizationConfig.class, FeaturesProperties.class})
 @ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class DataFlowControllerAutoConfiguration {
 
@@ -228,8 +229,8 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public SecurityController securityController(SecurityProperties securityProperties) {
-		return new SecurityController(securityProperties);
+	public SecurityController securityController(SecurityProperties securityProperties, AuthorizationConfig authorizationConfig) {
+		return new SecurityController(securityProperties, authorizationConfig);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.dataflow.server.config.DataFlowServerConfiguration.H2ServerConfiguration;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -95,11 +94,6 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 
 	@Autowired
 	private AuthorizationConfig authorizationConfig;
-
-	@Bean
-	public AuthorizationConfig config() {
-		return new AuthorizationConfig();
-	}
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
@@ -35,42 +35,6 @@ public class Target {
 		SUCCESS, ERROR
 	}
 
-	public class Credentials {
-
-		String username;
-
-		String password;
-
-		// for serialization/persistence
-		public Credentials() {
-		}
-
-		public Credentials(String username, String password) {
-			this.username = username;
-			this.password = password;
-		}
-
-		public String getUsername() {
-			return username;
-		}
-
-		public void setUsername(String username) {
-			this.username = username;
-		}
-
-		public String getPassword() {
-			return password;
-		}
-
-		public void setPassword(String password) {
-			this.password = password;
-		}
-
-		public String getDisplayableContents() {
-			return "[username='" + username +", password=****']";
-		}
-	}
-
 	public static final String DEFAULT_SCHEME = "http";
 
 	public static final String DEFAULT_HOST = "localhost";
@@ -93,13 +57,17 @@ public class Target {
 
 	private final boolean skipSslValidation;
 
-	private final Credentials targetCredentials;
+	private TargetCredentials targetCredentials;
 
 	private Exception targetException;
 
 	private String targetResultMessage;
 
 	private TargetStatus status;
+
+	private boolean authenticationEnabled;
+	private boolean authorizationEnabled = true;
+	private boolean authenticated;
 
 	/**
 	 * Construct a new Target. The passed in <code>targetUriAsString</code> String parameter will be converted to a {@link URI}.
@@ -119,8 +87,12 @@ public class Target {
 		if (StringUtils.isEmpty(targetUsername)) {
 			this.targetCredentials = null;
 		} else {
-			this.targetCredentials = new Credentials(targetUsername, targetPassword);
+			this.targetCredentials = new TargetCredentials(targetUsername, targetPassword);
 		}
+	}
+
+	public void setTargetCredentials(TargetCredentials targetCredentials) {
+		this.targetCredentials = targetCredentials;
 	}
 
 	/**
@@ -191,7 +163,7 @@ public class Target {
 	 *
 	 * @return The target credentials. May be null if there is no authentication
 	 */
-	public Credentials getTargetCredentials() {
+	public TargetCredentials getTargetCredentials() {
 		return targetCredentials;
 	}
 
@@ -215,6 +187,52 @@ public class Target {
 	public void setTargetResultMessage(String targetResultMessage) {
 		Assert.hasText(targetResultMessage, "The provided targetResultMessage must neither be null nor empty.");
 		this.targetResultMessage = targetResultMessage;
+	}
+
+	/**
+	 * Indicates whether authentication is enabled for this target.
+	 *
+	 * @return True if authentication is enabled, false otherwise
+	 */
+	public boolean isAuthenticationEnabled() {
+		return authenticationEnabled;
+	}
+
+	/**
+	 * @param authenticationEnabled False by default
+	 */
+	public void setAuthenticationEnabled(boolean authenticationEnabled) {
+		this.authenticationEnabled = authenticationEnabled;
+	}
+
+	/**
+	 * @return True if authorization is enabled, false otherwise
+	 */
+	public boolean isAuthorizationEnabled() {
+		return authorizationEnabled;
+	}
+
+	/**
+	 *
+	 * @param authorizationEnabled If not set, it defaults to true
+	 */
+	public void setAuthorizationEnabled(boolean authorizationEnabled) {
+		this.authorizationEnabled = authorizationEnabled;
+	}
+
+	/**
+	 *
+	 * @return True if the user is successfully authenticated with this Target
+	 */
+	public boolean isAuthenticated() {
+		return authenticated;
+	}
+
+	/**
+	 * Indicates whether a user is successfully authenticated with the Target
+	 */
+	public void setAuthenticated(boolean authenticated) {
+		this.authenticated = authenticated;
 	}
 
 	@Override

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetCredentials.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetCredentials.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+
+/**
+ * Encapsulates the credentials to the Data Flow Server Target, such as
+ * {@link #username} and {@link #password}. Maybe also, depending on security settings,
+ * include a list of {@link #roles}s that are associated with the user account.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public class TargetCredentials {
+
+	private final String username;
+	private final String password;
+
+	final List<RoleType> roles = new ArrayList<>(0);
+
+	public TargetCredentials(String username, String password) {
+		this.username = username;
+		this.password = password;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public String getDisplayableContents() {
+		return "[username='" + username +", password=****']";
+	}
+
+	public List<RoleType> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(List<String> roles) {
+		this.roles.clear();
+		for (String roleAsString : roles) {
+			this.roles.add(RoleType.fromKey(roleAsString));
+		}
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Credentials [username=");
+		builder.append(username);
+		builder.append(", password=");
+		builder.append("*********");
+		builder.append(", roles=");
+		builder.append(roles);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AggregateCounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AggregateCounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 
 import org.joda.time.DateTimeConstants;
-
 import org.springframework.analytics.rest.domain.AggregateCounterResource;
 import org.springframework.analytics.rest.domain.MetricResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.client.AggregateCounterOperations;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.cloud.dataflow.shell.converter.NumberFormatConverter;
 import org.springframework.hateoas.PagedResources;
@@ -49,6 +49,7 @@ import org.springframework.stereotype.Component;
  * Commands for interacting with aggregate counter analytics.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Component
 public class AggregateCounterCommands extends AbstractMetricsCommands implements CommandMarker {
@@ -66,10 +67,14 @@ public class AggregateCounterCommands extends AbstractMetricsCommands implements
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
-	@CliAvailabilityIndicator({ DISPLAY_AGGR_COUNTER, LIST_AGGR_COUNTERS, DELETE_AGGR_COUNTER })
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.aggregateCounterOperations() != null;
+	@CliAvailabilityIndicator({ DISPLAY_AGGR_COUNTER, LIST_AGGR_COUNTERS })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER);
+	}
+
+	@CliAvailabilityIndicator({ DELETE_AGGR_COUNTER })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.AGGREGATE_COUNTER);
 	}
 
 	@CliCommand(value = DISPLAY_AGGR_COUNTER, help = "Display aggregate counter values by chosen interval and resolution(minute, hour)")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
@@ -26,9 +26,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.rest.client.AppRegistryOperations;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
 import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationResource;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -59,6 +60,7 @@ import org.springframework.util.Assert;
  * @author Patrick Peralta
  * @author Mark Fisher
  * @author Thomas Risberg
+ * @author Gunnar Hillert
  */
 @Component
 public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
@@ -88,11 +90,14 @@ public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
 		this.resourceLoader = resourceLoader;
 	}
 
-	@CliAvailabilityIndicator({LIST_APPLICATIONS, APPLICATION_INFO, UNREGISTER_APPLICATION,
-		REGISTER_APPLICATION, IMPORT_APPLICATIONS})
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.appRegistryOperations() != null;
+	@CliAvailabilityIndicator({ LIST_APPLICATIONS, APPLICATION_INFO })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.APP_REGISTRY);
+	}
+
+	@CliAvailabilityIndicator({ UNREGISTER_APPLICATION, REGISTER_APPLICATION, IMPORT_APPLICATIONS })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.APP_REGISTRY);
 	}
 
 	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
@@ -23,22 +23,22 @@ import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.dataflow.rest.client.DataFlowServerException;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
+import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
 import org.springframework.cloud.dataflow.shell.Target;
 import org.springframework.cloud.dataflow.shell.TargetHolder;
 import org.springframework.cloud.dataflow.shell.command.support.HttpClientUtils;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.env.Environment;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
@@ -65,9 +65,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 public class ConfigCommands implements CommandMarker,
-		InitializingBean,
-		ApplicationListener<ApplicationReadyEvent>,
-		ApplicationContextAware
+		ApplicationListener<ApplicationEvent>
 {
 
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -96,8 +94,6 @@ public class ConfigCommands implements CommandMarker,
 	private UserInput userInput;
 
 	private TargetHolder targetHolder;
-
-	private ApplicationContext applicationContext;
 
 	private volatile boolean initialized;
 
@@ -163,11 +159,24 @@ public class ConfigCommands implements CommandMarker,
 		try {
 			this.targetHolder.setTarget(new Target(targetUriString, targetUsername, targetPassword, skipSslValidation));
 
-			HttpClientUtils.prepareRestTemplate(this.restTemplate,
+			HttpClientUtils.prepareRestTemplate(this.restTemplate, this.targetHolder.getTarget().getTargetUri(),
 					targetUsername, targetPassword, skipSslValidation);
 
 			this.shell.setDataFlowOperations(new DataFlowTemplate(targetHolder.getTarget().getTargetUri(), this.restTemplate));
 			this.targetHolder.getTarget().setTargetResultMessage(String.format("Successfully targeted %s", targetUriString));
+
+			final SecurityInfoResource securityInfoResource = restTemplate.getForObject(targetUriString + "/security/info", SecurityInfoResource.class);
+
+			if (securityInfoResource.isAuthenticated() && this.targetHolder.getTarget().getTargetCredentials() != null) {
+				for (String roleAsString : securityInfoResource.getRoles()) {
+					this.targetHolder.getTarget().getTargetCredentials().getRoles().add(RoleType.fromKey(roleAsString));
+				}
+			}
+
+			this.targetHolder.getTarget().setAuthenticated(securityInfoResource.isAuthenticated());
+			this.targetHolder.getTarget().setAuthenticationEnabled(securityInfoResource.isAuthenticationEnabled());
+			this.targetHolder.getTarget().setAuthorizationEnabled(securityInfoResource.isAuthorizationEnabled());
+
 		}
 		catch (Exception e) {
 			this.targetHolder.getTarget().setTargetException(e);
@@ -187,7 +196,9 @@ public class ConfigCommands implements CommandMarker,
 				this.targetHolder.getTarget().setTargetResultMessage(String.format("Unable to contact Data Flow Server at '%s': '%s'.",
 						targetUriString, e.toString()));
 			}
+
 		}
+
 		return(this.targetHolder.getTarget().getTargetResultMessage());
 
 	}
@@ -234,25 +245,15 @@ public class ConfigCommands implements CommandMarker,
 	}
 
 	@Override
-	public void onApplicationEvent(ApplicationReadyEvent event) {
-		//Only invoke if the shell is executing in the same application context as the data flow server.
+	public void onApplicationEvent(ApplicationEvent event) {
 		if (!initialized) {
-			target(this.serverUri, this.userName, this.password, this.skipSslValidation);
+			if (event instanceof ContextRefreshedEvent) {
+				target(this.serverUri, this.userName, this.password, this.skipSslValidation);
+			}
+			else if (event instanceof ApplicationReadyEvent) {
+				target(this.serverUri, this.userName, this.password, this.skipSslValidation);
+			}
 		}
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		//Only invoke this lifecycle method if the shell is executing in stand-alone mode.
-		if (applicationContext != null && !applicationContext.containsBean("streamDefinitionRepository")) {
-			initialized = true;
-			target(this.serverUri, this.userName, this.password, this.skipSslValidation);
-		}
-	}
-
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		this.applicationContext = applicationContext;
 	}
 
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/CounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/CounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,7 +21,8 @@ import org.springframework.analytics.rest.domain.CounterResource;
 import org.springframework.analytics.rest.domain.MetricResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.client.CounterOperations;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.cloud.dataflow.shell.converter.NumberFormatConverter;
 import org.springframework.hateoas.PagedResources;
@@ -34,9 +35,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * Commands for interacting with Counter analytics.
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Component
 public class CounterCommands extends AbstractMetricsCommands implements CommandMarker {
@@ -54,10 +56,14 @@ public class CounterCommands extends AbstractMetricsCommands implements CommandM
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
-	@CliAvailabilityIndicator({ LIST_COUNTERS, DISPLAY_COUNTER, DELETE_COUNTER })
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.counterOperations() != null;
+	@CliAvailabilityIndicator({ LIST_COUNTERS, DISPLAY_COUNTER })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.COUNTER);
+	}
+
+	@CliAvailabilityIndicator({ DELETE_COUNTER })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.COUNTER);
 	}
 
 	@CliCommand(value = DISPLAY_COUNTER, help = "Display the value of a counter")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/FieldValueCounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/FieldValueCounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ import java.util.List;
 import org.springframework.analytics.rest.domain.FieldValueCounterResource;
 import org.springframework.analytics.rest.domain.MetricResource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.FieldValueCounterOperations;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.cloud.dataflow.shell.converter.NumberFormatConverter;
 import org.springframework.hateoas.PagedResources;
@@ -44,9 +45,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * Commands for interacting with Field Value Counter analytics.
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Component
 public class FieldValueCounterCommands extends AbstractMetricsCommands implements CommandMarker {
@@ -64,10 +66,14 @@ public class FieldValueCounterCommands extends AbstractMetricsCommands implement
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
-	@CliAvailabilityIndicator({ LIST_COUNTERS, DISPLAY_COUNTER, RESET_COUNTER})
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.fieldValueCounterOperations() != null;
+	@CliAvailabilityIndicator({ LIST_COUNTERS, DISPLAY_COUNTER })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.FIELD_VALUE_COUNTER);
+	}
+
+	@CliAvailabilityIndicator({ RESET_COUNTER })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.FIELD_VALUE_COUNTER);
 	}
 
 	@CliCommand(value = DISPLAY_COUNTER, help = "Display the value of a field value counter")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
@@ -104,7 +104,7 @@ public class HttpCommands implements CommandMarker {
 			outputRequest("POST", requestURI, mediaType, data, buffer);
 			final RestTemplate restTemplate = createRestTemplate(buffer);
 
-			HttpClientUtils.prepareRestTemplate(restTemplate, targetUsername, targetPassword, skipSslValidation);
+			HttpClientUtils.prepareRestTemplate(restTemplate, requestURI, targetUsername, targetPassword, skipSslValidation);
 
 			ResponseEntity<String> response = restTemplate.postForEntity(requestURI, request, String.class);
 			outputResponse(response, buffer);
@@ -143,7 +143,7 @@ public class HttpCommands implements CommandMarker {
 
 			final RestTemplate restTemplate = createRestTemplate(buffer);
 
-			HttpClientUtils.prepareRestTemplate(restTemplate, targetUsername, targetPassword, skipSslValidation);
+			HttpClientUtils.prepareRestTemplate(restTemplate, requestURI, targetUsername, targetPassword, skipSslValidation);
 
 			ResponseEntity<String> response = restTemplate.getForEntity(requestURI, String.class);
 			outputResponse(response, buffer);

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import java.util.Map;
 
 import org.springframework.batch.core.JobParameter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.JobOperations;
 import org.springframework.cloud.dataflow.rest.resource.JobExecutionResource;
 import org.springframework.cloud.dataflow.rest.resource.JobInstanceResource;
 import org.springframework.cloud.dataflow.rest.resource.StepExecutionProgressInfoResource;
 import org.springframework.cloud.dataflow.rest.resource.StepExecutionResource;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.core.CommandMarker;
@@ -42,6 +43,7 @@ import org.springframework.stereotype.Component;
  *
  * @author Glenn Renfro
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Component
 public class JobCommands implements CommandMarker {
@@ -61,11 +63,10 @@ public class JobCommands implements CommandMarker {
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
-	@CliAvailabilityIndicator({EXECUTION_DISPLAY, EXECUTION_LIST, STEP_EXECUTION_LIST, INSTANCE_DISPLAY,
-			STEP_EXECUTION_PROGRESS, STEP_EXECUTION_DISPLAY})
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.jobOperations() != null;
+	@CliAvailabilityIndicator({ EXECUTION_DISPLAY, EXECUTION_LIST, STEP_EXECUTION_LIST, INSTANCE_DISPLAY,
+		STEP_EXECUTION_PROGRESS, STEP_EXECUTION_DISPLAY })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.JOB);
 	}
 
 	@CliCommand(value = EXECUTION_LIST,

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.RuntimeOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppInstanceStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
@@ -54,12 +55,13 @@ import org.springframework.util.Assert;
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @Component
 public class RuntimeCommands implements CommandMarker {
 
 	private static final String LIST_APPS = "runtime apps";
-	
+
 	private final DataFlowShell dataFlowShell;
 
 	@Autowired
@@ -68,10 +70,9 @@ public class RuntimeCommands implements CommandMarker {
 		this.dataFlowShell = dataFlowShell;
 	}
 
-	@CliAvailabilityIndicator({LIST_APPS})
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.runtimeOperations() != null;
+	@CliAvailabilityIndicator({ LIST_APPS })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.RUNTIME);
 	}
 
 	@CliCommand(value = LIST_APPS, help = "List runtime apps")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,14 +25,13 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.io.FilenameUtils;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.boot.env.YamlPropertySourceLoader;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.StreamOperations;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.hateoas.PagedResources;
@@ -50,6 +49,7 @@ import org.springframework.stereotype.Component;
  *
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @Component
 // todo: reenable optionContext attributes
@@ -79,11 +79,15 @@ public class StreamCommands implements CommandMarker {
 	@Autowired
 	private UserInput userInput;
 
-	@CliAvailabilityIndicator({ LIST_STREAM, CREATE_STREAM, DEPLOY_STREAM, UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL,
+	@CliAvailabilityIndicator({ LIST_STREAM })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM);
+	}
+
+	@CliAvailabilityIndicator({ CREATE_STREAM, DEPLOY_STREAM, UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL,
 		DESTROY_STREAM, DESTROY_STREAM_ALL })
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.streamOperations() != null;
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
 	}
 
 	@CliCommand(value = LIST_STREAM, help = "List created streams")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -27,11 +27,12 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.core.CommandMarker;
@@ -81,10 +82,14 @@ public class TaskCommands implements CommandMarker {
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
-	@CliAvailabilityIndicator({ LIST, CREATE, LAUNCH, TASK_EXECUTION_STATUS, TASK_EXECUTION_CLEANUP,  DESTROY, EXECUTION_LIST })
-	public boolean available() {
-		DataFlowOperations dataFlowOperations = dataFlowShell.getDataFlowOperations();
-		return dataFlowOperations != null && dataFlowOperations.taskOperations() != null;
+	@CliAvailabilityIndicator({ LIST, TASK_EXECUTION_STATUS, EXECUTION_LIST })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.TASK);
+	}
+
+	@CliAvailabilityIndicator({ CREATE, LAUNCH, TASK_EXECUTION_CLEANUP, DESTROY })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.TASK);
 	}
 
 	@CliCommand(value = LIST, help = "List created tasks")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/HttpClientUtils.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/HttpClientUtils.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.shell.command.support;
 
+import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -23,10 +24,14 @@ import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
 
+import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -59,6 +64,7 @@ public class HttpClientUtils {
 	 */
 	public static void prepareRestTemplate(
 			RestTemplate restTemplate,
+			URI host,
 			String username,
 			String password,
 			boolean skipSslValidation) {
@@ -82,7 +88,9 @@ public class HttpClientUtils {
 		}
 
 		final CloseableHttpClient httpClient = httpClientBuilder.build();
-		final HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+		final HttpHost targetHost = new HttpHost(host.getHost(), host.getPort(), host.getScheme());
+
+		final HttpComponentsClientHttpRequestFactory requestFactory = new PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory(httpClient, targetHost);
 		restTemplate.setRequestFactory(requestFactory);
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/OpsType.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/OpsType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.command.support;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public enum OpsType {
+	STREAM,
+	COUNTER,
+	FIELD_VALUE_COUNTER,
+	AGGREGATE_COUNTER,
+	TASK,
+	JOB,
+	APP_REGISTRY,
+	COMPLETION,
+	RUNTIME;
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.command.support;
+
+import java.net.URI;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+
+/**
+ * @author Gunnar Hillert
+ *
+ */
+public class PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory
+	extends HttpComponentsClientHttpRequestFactory {
+
+	private final HttpHost host;
+
+	public PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory(HttpClient httpClient, HttpHost host) {
+		super(httpClient);
+		this.host = host;
+	}
+
+	@Override
+	protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
+		return createHttpContext();
+	}
+
+	private HttpContext createHttpContext() {
+		final AuthCache authCache = new BasicAuthCache();
+
+		final BasicScheme basicAuth = new BasicScheme();
+		authCache.put(host, basicAuth);
+
+		final BasicHttpContext localcontext = new BasicHttpContext();
+		localcontext.setAttribute(HttpClientContext.AUTH_CACHE, authCache);
+		return localcontext;
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/RoleType.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/RoleType.java
@@ -1,0 +1,48 @@
+package org.springframework.cloud.dataflow.shell.command.support;
+
+import org.springframework.util.Assert;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public enum RoleType {
+
+	VIEW("ROLE_VIEW", "view role"),
+	CREATE("ROLE_CREATE", "role for create operations"),
+	MANAGE("ROLE_MANAGE", "role for the boot management endpoints");
+
+	private String key;
+	private String name;
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	RoleType(final String key, final String name) {
+		this.key = key;
+		this.name = name;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public static RoleType fromKey(String role) {
+
+		Assert.hasText(role, "Parameter role must not be null or empty.");
+
+		for (RoleType roleType : RoleType.values()) {
+			if (roleType.getKey().equals(role)) {
+				return roleType;
+			}
+		}
+
+		return null;
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/config/DataFlowShell.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/config/DataFlowShell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,13 @@
 
 package org.springframework.cloud.dataflow.shell.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.shell.Target;
+import org.springframework.cloud.dataflow.shell.TargetCredentials;
+import org.springframework.cloud.dataflow.shell.TargetHolder;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.stereotype.Component;
 
 /**
@@ -24,17 +30,111 @@ import org.springframework.stereotype.Component;
  * communicating with the Spring Cloud Data Flow REST server.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Component
 public class DataFlowShell {
 
 	private DataFlowOperations dataFlowOperations;
 
+	private TargetHolder targetHolder;
+
 	public DataFlowOperations getDataFlowOperations() {
 		return dataFlowOperations;
 	}
 
+	@Autowired
+	public void setTargetHolder(TargetHolder targetHolder) {
+		this.targetHolder = targetHolder;
+	}
+
 	public void setDataFlowOperations(DataFlowOperations dataFlowOperations) {
 		this.dataFlowOperations = dataFlowOperations;
+	}
+
+	/**
+	 * This method performs various access checks and only if {@code true} is returned, the shell should show the associated
+	 * commands. 2 checks are performed:
+	 *
+	 * <ul>
+	 *   <li>Does the desired operation indicated by the {@link OpsType} exist?
+	 *   <li>If the operation exist, does the user have the necessary credentials?
+	 * </ul>
+	 *
+	 * <b>What are valid credentials?</b>
+	 *
+	 * The way the passed-in {@link RoleType}s are treated depends on the servers security settings:
+	 *
+	 *<ul>
+	 *   <li>{@link Target#isAuthenticationEnabled()} Is authentication enabled?
+	 *   <li>{@link Target#isAuthorizationEnabled()} If authentication is enabled, is authorization enabled?
+	 *   <li>{@link Target#isAuthenticated()} Is the user authenticated?
+	 *   <li>Only if {@link Target#isAuthorizationEnabled()} and {@link Target#isAuthenticated()} is {@code true}
+	 *   will the {@link RoleType} checked against {@link TargetCredentials#getRoles()}.
+	 * </ul>
+	 *
+	 * @param role Can be null.
+	 * @param opsType Must not be null.
+	 * @return If true the indicated operation is accessible and the user has all credentials to execute the operation.
+	 */
+	public boolean hasAccess(RoleType role, OpsType opsType) {
+		if (this.dataFlowOperations != null) {
+			boolean operationsAvailable = false;
+			switch(opsType) {
+				case AGGREGATE_COUNTER:
+					operationsAvailable = this.dataFlowOperations.aggregateCounterOperations() != null;
+					break;
+				case APP_REGISTRY:
+					operationsAvailable = this.dataFlowOperations.appRegistryOperations() != null;
+					break;
+				case COMPLETION:
+					operationsAvailable = this.dataFlowOperations.completionOperations() != null;
+					break;
+				case COUNTER:
+					operationsAvailable = this.dataFlowOperations.counterOperations() != null;
+					break;
+				case FIELD_VALUE_COUNTER:
+					operationsAvailable = this.dataFlowOperations.fieldValueCounterOperations() != null;
+					break;
+				case JOB:
+					operationsAvailable = this.dataFlowOperations.jobOperations() != null;
+					break;
+				case RUNTIME:
+					operationsAvailable = this.dataFlowOperations.runtimeOperations() != null;
+					break;
+				case STREAM:
+					operationsAvailable = this.dataFlowOperations.streamOperations() != null;
+					break;
+				case TASK:
+					operationsAvailable = this.dataFlowOperations.taskOperations() != null;
+					break;
+				default:
+					throw new IllegalArgumentException("Unsupported OpsType " + opsType);
+			}
+
+			boolean passesSecurityChecks = false;
+			final Target target = targetHolder.getTarget();
+
+			if (target.isAuthenticationEnabled()) {
+				if (target.isAuthenticated()) {
+					if (target.isAuthorizationEnabled() && role != null) {
+						passesSecurityChecks = target.getTargetCredentials().getRoles().contains(role);
+					}
+					else {
+						passesSecurityChecks = true;
+					}
+				}
+				else {
+					passesSecurityChecks = false;
+				}
+			}
+			else {
+				passesSecurityChecks = true;
+			}
+			return operationsAvailable && passesSecurityChecks;
+		}
+		else {
+			return false;
+		}
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -21,33 +21,18 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.dataflow.shell.TargetHolder;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.MessageSourceResolvable;
-import org.springframework.context.NoSuchMessageException;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.core.ResolvableType;
-import org.springframework.core.env.Environment;
-import org.springframework.core.io.Resource;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -89,7 +74,7 @@ public class ConfigCommandTests {
 		configCommands.setRestTemplate(restTemplate);
 		configCommands.setDataFlowShell(dataFlowShell);
 		configCommands.setServerUri("http://localhost:9393");
-		configCommands.onApplicationEvent(mock(ContextRefreshedEvent.class));
+		configCommands.onApplicationEvent(mock(ApplicationReadyEvent.class));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -18,19 +18,36 @@ package org.springframework.cloud.dataflow.shell.command;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.cloud.dataflow.shell.TargetHolder;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -72,7 +89,7 @@ public class ConfigCommandTests {
 		configCommands.setRestTemplate(restTemplate);
 		configCommands.setDataFlowShell(dataFlowShell);
 		configCommands.setServerUri("http://localhost:9393");
-		configCommands.onApplicationEvent(null);
+		configCommands.onApplicationEvent(mock(ContextRefreshedEvent.class));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/config/DataFlowShellTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/config/DataFlowShellTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.cloud.dataflow.rest.client.AggregateCounterOperations;
+import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.shell.Target;
+import org.springframework.cloud.dataflow.shell.TargetHolder;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class DataFlowShellTests {
+
+	@Test
+	public void testHasAccessWithNoOperation() {
+		final DataFlowShell dataFlowShell = new DataFlowShell();
+		dataFlowShell.setDataFlowOperations(null);
+
+		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+
+	}
+
+	@Test
+	public void testHasAccessWithOperations() {
+		final Target target = new Target("http://myUri");
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+
+	}
+
+	@Test
+	public void testHasAccessWithOperationsAndNullRole() {
+		final Target target = new Target("http://myUri");
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertTrue(dataFlowShell.hasAccess(null, OpsType.AGGREGATE_COUNTER));
+
+	}
+
+	@Test
+	public void testHasAccessWithOperationsAndAuthenticationEnabledButNotAuthenticated() {
+		final Target target = new Target("http://myUri");
+		target.setAuthenticationEnabled(true);
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+
+	}
+
+	@Test
+	public void testHasAccessWithOperationsAndAuthenticationEnabledAndAuthenticated() {
+		final Target target = new Target("http://myUri", "username", "password", true);
+		target.getTargetCredentials().getRoles().add(RoleType.VIEW);
+		target.setAuthenticationEnabled(true);
+		target.setAuthenticated(true);
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+	}
+
+	@Test
+	public void testHasWrongRoleWithOperationsAndAuthenticationEnabledAndAuthenticated() {
+
+		final Target target = new Target("http://myUri", "username", "password", true);
+		target.getTargetCredentials().getRoles().add(RoleType.CREATE);
+		target.setAuthenticationEnabled(true);
+		target.setAuthenticated(true);
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+	}
+
+	@Test
+	public void testHasNullRoleWithOperationsAndAuthenticationEnabledAndAuthenticated() {
+
+		final Target target = new Target("http://myUri", "username", "password", true);
+		target.getTargetCredentials().getRoles().add(RoleType.CREATE);
+		target.setAuthenticationEnabled(true);
+		target.setAuthenticated(true);
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertTrue(dataFlowShell.hasAccess(null, OpsType.AGGREGATE_COUNTER));
+	}
+
+	@Test
+	public void testHasAccessWithOperationsAndAuthenticationEnabledAndAuthenticatedAndAuthorizationDisabled() {
+		final Target target = new Target("http://myUri", "username", "password", true);
+		target.getTargetCredentials().getRoles().add(RoleType.CREATE);
+		target.setAuthenticationEnabled(true);
+		target.setAuthenticated(true);
+		target.setAuthorizationEnabled(false);
+
+		final DataFlowShell dataFlowShell = prepareDataFlowShellWithAggregateCounterOperations(target);
+		Assert.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.AGGREGATE_COUNTER));
+	}
+
+	private DataFlowShell prepareDataFlowShellWithAggregateCounterOperations(Target target) {
+		final DataFlowShell dataFlowShell = new DataFlowShell();
+
+		final DataFlowOperations dataFlowOperations = Mockito.mock(DataFlowOperations.class);
+		final AggregateCounterOperations aggregateCounterOperations = Mockito.mock(AggregateCounterOperations.class);
+		Mockito.when(dataFlowOperations.aggregateCounterOperations()).thenReturn(aggregateCounterOperations);
+		dataFlowShell.setDataFlowOperations(dataFlowOperations);
+
+		final TargetHolder targetHolder = new TargetHolder();
+		targetHolder.setTarget(target);
+		dataFlowShell.setTargetHolder(targetHolder);
+		return dataFlowShell;
+	}
+}


### PR DESCRIPTION
* Add role handling to methods annotated with `@CliAvailabilityIndicator`
* Add access handling rules to `DataFlowShell#hasAccess`
* Add tests
* Improve slightly handling of `403` (Forbidden) error responses in `VndErrorResponseErrorHandler`
  - See also https://github.com/spring-cloud/spring-cloud-dataflow/issues/1175

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1105
Depends on https://github.com/spring-projects/spring-shell/issues/115