### PR TITLE
Fix app importAll overwrite

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
@@ -99,7 +99,7 @@ public class AppRegistry {
 
 	public List<AppRegistration> importAll(boolean overwrite, Resource... resources) {
 
-		Set<String> keysAlreadyThere = overwrite ? uriRegistry.findAll().keySet() : Collections.emptySet();
+		Set<String> keysAlreadyThere = overwrite ? Collections.emptySet() : uriRegistry.findAll().keySet();
 
 		List<AppRegistration> apps = new ArrayList<>();
 		for (Resource resource : resources) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.registry.DataFlowAppRegistryPopulator;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -109,6 +110,24 @@ public class AppRegistryControllerTests {
 				post("/apps").param("apps", "sink.foo=file:///bar").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isCreated());
 		assertThat(appRegistry.find("foo", ApplicationType.sink).getUri().toString(), is("file:///bar"));
+	}
+
+	@Test
+	public void testRegisterAllWithoutForce() throws Exception {
+		appRegistry.importAll(false, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
+		assertThat(appRegistry.find("time", ApplicationType.source).getUri().toString(), is("maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("filter", ApplicationType.processor).getUri().toString(), is("maven://org.springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("log", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("timestamp", ApplicationType.task).getUri().toString(), is("maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT"));
+	}
+
+	@Test
+	public void testRegisterAllWithForce() throws Exception {
+		appRegistry.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
+		assertThat(appRegistry.find("time", ApplicationType.source).getUri().toString(), is("maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("filter", ApplicationType.processor).getUri().toString(), is("maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("log", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT"));
+		assertThat(appRegistry.find("timestamp", ApplicationType.task).getUri().toString(), is("maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
@@ -1,0 +1,4 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT
+processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT


### PR DESCRIPTION
 - When overwrite is set to true, the existingKey collection should be empty so that all the apps get registered and if `overwrite` is false the collection would return the non-empty collection so that only those apps that have unavailable keys get registered

Resolves #1195