### PR TITLE
gh-ui-158 Add property `formLogin` to `SecurityInfoResource`

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/security/SecurityInfoResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/security/SecurityInfoResource.java
@@ -30,6 +30,7 @@ import org.springframework.hateoas.ResourceSupport;
 public class SecurityInfoResource extends ResourceSupport {
 
 	private boolean authenticationEnabled;
+	private boolean formLogin;
 
 	private boolean authenticated;
 
@@ -94,4 +95,20 @@ public class SecurityInfoResource extends ResourceSupport {
 		this.roles.add(role);
 		return this;
 	}
+
+	/**
+	 * Returns {@code true} if form-login is used. In case of OAuth2 authentication,
+	 * {@code false} is returned.
+	 *
+	 * @return True if form-login is, false if OAuth2 authentication is used
+	 * @see OnSecurityEnabledAndOAuth2Enabled
+	 */
+	public boolean isFormLogin() {
+		return formLogin;
+	}
+
+	public void setFormLogin(boolean formLogin) {
+		this.formLogin = formLogin;
+	}
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.controller.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -47,6 +48,9 @@ public class SecurityController {
 
 	private final SecurityProperties securityProperties;
 
+	@Value("${security.oauth2.client.client-id:#{null}}")
+	private String oauthClientId;
+
 	public SecurityController(SecurityProperties securityProperties) {
 		this.securityProperties = securityProperties;
 	}
@@ -72,6 +76,12 @@ public class SecurityController {
 				securityInfo.setUsername(authentication.getName());
 				for (GrantedAuthority authority : authentication.getAuthorities()) {
 					securityInfo.addRole(authority.getAuthority());
+				}
+				if (this.oauthClientId == null) {
+					securityInfo.setFormLogin(true);
+				}
+				else {
+					securityInfo.setFormLogin(false);
 				}
 			}
 		}


### PR DESCRIPTION
Expand the `SecurityInfoResource` by a property `formLogin` that indicates that formLogin is being used. This is needed in cases where the application needs to be "reccreated" using the xauth-token and the `SecurityInfoResource` (aka the user presses refresh) only. If Outh2 authentication is being used, this property will be `false`.

Is depended on by https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/158