### PR TITLE
gh-1216 Expand REST API to Return Version Info

### DIFF
--- a/spring-cloud-dataflow-docs/pom.xml
+++ b/spring-cloud-dataflow-docs/pom.xml
@@ -63,13 +63,11 @@
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-mockmvc</artifactId>
-			<version>1.1.2.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-core</artifactId>
-			<version>1.1.2.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -141,6 +141,32 @@ and execute the desired functionality:
 
 include::{snippets}/api-documentation/index/links.adoc[]
 
+[[resources-about]]
+=== Server Meta Information
+
+A `GET` request will return meta information for Spring Cloud Data Flow. This includes:
+
+* Runtime Environment Information
+* Information regarding which features are enabled
+* Dependency information of Spring Cloud Data Flow Server
+* Security information
+
+==== Request structure
+
+include::{snippets}/about-documentation/get-meta-information/http-request.adoc[]
+
+==== Request parameters
+
+include::{snippets}/about-documentation/get-meta-information/request-parameters.adoc[]
+
+==== Example request
+
+include::{snippets}/about-documentation/get-meta-information/curl-request.adoc[]
+
+==== Response structure
+
+include::{snippets}/about-documentation/get-meta-information/http-response.adoc[]
+
 [[resources-app-registry-list]]
 === Listing Applications
 

--- a/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
+++ b/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.rest.documentation;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class AboutDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getMetaInformation() throws Exception {
+		this.mockMvc.perform(get("/about")
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				responseFields(
+					fieldWithPath("_links.self").description("Link to the runtime environment resource"),
+					fieldWithPath("featureInfo").type(JsonFieldType.OBJECT)
+					.description("Details which features are enabled."),
+
+					fieldWithPath("versionInfo").type(JsonFieldType.OBJECT)
+					.description("Provides details of the Spring Cloud Data Flow Server dependencies."),
+
+					fieldWithPath("securityInfo").type(JsonFieldType.OBJECT)
+					.description("Provides security configuration information."),
+
+					fieldWithPath("runtimeEnvironment").type(JsonFieldType.OBJECT)
+					.description("Provides details of the runtime environment."))
+			));
+	}
+}

--- a/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -76,6 +76,7 @@ public class ApiDocumentation extends BaseDocumentation {
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
 				links(
+					linkWithRel("about").description("Access meta information, including enabled features, security info, version information"),
 					linkWithRel("dashboard").description("Access the dashboard UI"),
 					linkWithRel("apps").description("Handle registered applications"),
 					linkWithRel("completions/stream").description("Exposes the DSL completion features for Stream"),

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/Version.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/Version.java
@@ -26,7 +26,7 @@ public class Version {
 	/**
 	 * Should be incremented each time the API evolves whether it's a breaking change or not.
 	 */
-	public static final int REVISION = 11;
+	public static final int REVISION = 12;
 
 	public static final String REVISION_KEY = "api.revision";
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/AboutResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/AboutResource.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * Provides meta-information about the Spring Cloud Data Flow server.
+ *
+ * @author Gunnar Hillert
+ */
+public class AboutResource extends ResourceSupport {
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public AboutResource() {
+	}
+
+	private FeatureInfo featureInfo;
+	private VersionInfo versionInfo;
+	private SecurityInfo securityInfo;
+	private RuntimeEnvironment runtimeEnvironment;
+
+	public FeatureInfo getFeatureInfo() {
+		return featureInfo;
+	}
+
+	public void setFeatureInfo(FeatureInfo featureInfo) {
+		this.featureInfo = featureInfo;
+	}
+
+	public VersionInfo getVersionInfo() {
+		return versionInfo;
+	}
+
+	public void setVersionInfo(VersionInfo versionInfo) {
+		this.versionInfo = versionInfo;
+	}
+
+	public SecurityInfo getSecurityInfo() {
+		return securityInfo;
+	}
+
+	public void setSecurityInfo(SecurityInfo securityInfo) {
+		this.securityInfo = securityInfo;
+	}
+
+	public RuntimeEnvironment getRuntimeEnvironment() {
+		return runtimeEnvironment;
+	}
+
+	public void setRuntimeEnvironment(RuntimeEnvironment runtimeEnvironment) {
+		this.runtimeEnvironment = runtimeEnvironment;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/Dependency.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/Dependency.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+/**
+ * Holds dependency information of a lbrary used by Spring Cloud Dataflow.
+ *
+ * @author Gunnar Hillert
+ */
+public class Dependency {
+
+	private String name;
+	private String version;
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public Dependency() {
+	}
+
+	public Dependency(String name, String version) {
+		super();
+		this.name = name;
+		this.version = version;
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/FeatureInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/FeatureInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+/**
+ * Provides features information.
+ *
+ * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
+ */
+public class FeatureInfo {
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public FeatureInfo() {
+	}
+
+	private boolean analyticsEnabled = true;
+
+	private boolean streamsEnabled = true;
+
+	private boolean tasksEnabled = true;
+
+	public boolean isAnalyticsEnabled() {
+		return this.analyticsEnabled;
+	}
+
+	public void setAnalyticsEnabled(boolean analyticsEnabled) {
+		this.analyticsEnabled = analyticsEnabled;
+	}
+
+	public boolean isStreamsEnabled() {
+		return this.streamsEnabled;
+	}
+
+	public void setStreamsEnabled(boolean streamsEnabled) {
+		this.streamsEnabled = streamsEnabled;
+	}
+
+	public boolean isTasksEnabled() {
+		return this.tasksEnabled;
+	}
+
+	public void setTasksEnabled(boolean tasksEnabled) {
+		this.tasksEnabled = tasksEnabled;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironment.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironment.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+/**
+ * Provides information about the runtime environment.
+ *
+ * @author Gunnar Hillert
+ */
+public class RuntimeEnvironment {
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public RuntimeEnvironment() {
+	}
+
+	/**
+	 * The {@link RuntimeEnvironmentDetails} of the deployer.
+	 */
+	private RuntimeEnvironmentDetails deployer;
+
+	/**
+	 * The {@link RuntimeEnvironmentDetails} of the task launcher.
+	 */
+	private RuntimeEnvironmentDetails taskLauncher;
+
+	/**
+	 * @return Null, if the stream feature is disabled
+	 */
+	public RuntimeEnvironmentDetails getDeployer() {
+		return deployer;
+	}
+
+	public void setDeployer(RuntimeEnvironmentDetails deployer) {
+		this.deployer = deployer;
+	}
+
+	/**
+	 * @return Null, if the task feature is disabled
+	 */
+	public RuntimeEnvironmentDetails getTaskLauncher() {
+		return taskLauncher;
+	}
+
+	public void setTaskLauncher(RuntimeEnvironmentDetails taskLauncher) {
+		this.taskLauncher = taskLauncher;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironment.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironment.java
@@ -30,9 +30,9 @@ public class RuntimeEnvironment {
 	}
 
 	/**
-	 * The {@link RuntimeEnvironmentDetails} of the deployer.
+	 * The {@link RuntimeEnvironmentDetails} of the app deployer.
 	 */
-	private RuntimeEnvironmentDetails deployer;
+	private RuntimeEnvironmentDetails appDeployer;
 
 	/**
 	 * The {@link RuntimeEnvironmentDetails} of the task launcher.
@@ -42,12 +42,12 @@ public class RuntimeEnvironment {
 	/**
 	 * @return Null, if the stream feature is disabled
 	 */
-	public RuntimeEnvironmentDetails getDeployer() {
-		return deployer;
+	public RuntimeEnvironmentDetails getAppDeployer() {
+		return appDeployer;
 	}
 
-	public void setDeployer(RuntimeEnvironmentDetails deployer) {
-		this.deployer = deployer;
+	public void setAppDeployer(RuntimeEnvironmentDetails appDeployer) {
+		this.appDeployer = appDeployer;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironmentDetails.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/RuntimeEnvironmentDetails.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides runtime environment details for either a deployer or task launcher.
+ *
+ * @author Gunnar Hillert
+ * @see RuntimeEnvironment
+ */
+public class RuntimeEnvironmentDetails {
+
+	/**
+	 * The implementation version of this deployer.
+	 */
+	private String deployerImplementationVersion;
+
+	/**
+	 * The name of this deployer (could be simple class name).
+	 */
+	private String deployerName;
+
+	/**
+	 * The SPI version used by this deployer.
+	 */
+	private String deployerSpiVersion;
+
+	/**
+	 * The Java version used by this deployer.
+	 */
+	private String javaVersion;
+
+	/**
+	 * The deployment platform API for this deployer.
+	 */
+	private String platformApiVersion;
+
+	/**
+	 * The client library version used by this deployer.
+	 */
+	private String platformClientVersion;
+
+	/**
+	 * The version running on the host of the platform used by this deployer.
+	 */
+	private String platformHostVersion;
+
+	/**
+	 * Platform specific properties
+	 */
+	private Map<String, String> platformSpecificInfo = new HashMap<>();
+
+	/**
+	 * The deployment platform for this deployer.
+	 */
+	private String platformType;
+
+	/**
+	 * The Spring Boot version used by this deployer.
+	 */
+	private String springBootVersion;
+
+	/**
+	 * The Spring Framework version used by this deployer.
+	 */
+	private String springVersion;
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public RuntimeEnvironmentDetails() {
+	}
+
+	public String getDeployerImplementationVersion() {
+		return deployerImplementationVersion;
+	}
+
+	public String getDeployerName() {
+		return deployerName;
+	}
+
+	public String getDeployerSpiVersion() {
+		return deployerSpiVersion;
+	}
+
+	public String getJavaVersion() {
+		return javaVersion;
+	}
+
+	public String getPlatformApiVersion() {
+		return platformApiVersion;
+	}
+
+	public String getPlatformClientVersion() {
+		return platformClientVersion;
+	}
+
+	public String getPlatformHostVersion() {
+		return platformHostVersion;
+	}
+
+	public Map<String, String> getPlatformSpecificInfo() {
+		return platformSpecificInfo;
+	}
+
+	public String getPlatformType() {
+		return platformType;
+	}
+
+	public String getSpringBootVersion() {
+		return springBootVersion;
+	}
+
+	public String getSpringVersion() {
+		return springVersion;
+	}
+
+	public void setDeployerImplementationVersion(String deployerImplementationVersion) {
+		this.deployerImplementationVersion = deployerImplementationVersion;
+	}
+
+	public void setDeployerName(String deployerName) {
+		this.deployerName = deployerName;
+	}
+
+	public void setDeployerSpiVersion(String deployerSpiVersion) {
+		this.deployerSpiVersion = deployerSpiVersion;
+	}
+
+	public void setJavaVersion(String javaVersion) {
+		this.javaVersion = javaVersion;
+	}
+
+	public void setPlatformApiVersion(String platformApiVersion) {
+		this.platformApiVersion = platformApiVersion;
+	}
+
+	public void setPlatformClientVersion(String platformClientVersion) {
+		this.platformClientVersion = platformClientVersion;
+	}
+
+	public void setPlatformHostVersion(String platformHostVersion) {
+		this.platformHostVersion = platformHostVersion;
+	}
+
+	public void setPlatformSpecificInfo(Map<String, String> platformSpecificInfo) {
+		this.platformSpecificInfo = platformSpecificInfo;
+	}
+
+	public void setPlatformType(String platformType) {
+		this.platformType = platformType;
+	}
+
+	public void setSpringBootVersion(String springBootVersion) {
+		this.springBootVersion = springBootVersion;
+	}
+
+	public void setSpringVersion(String springVersion) {
+		this.springVersion = springVersion;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/SecurityInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/SecurityInfo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * Provides security related meta-information. E.g. is security enabled, username,
+ * roles etc.
+ *
+ * @author Gunnar Hillert
+ */
+public class SecurityInfo {
+
+	private boolean authenticationEnabled;
+
+	private boolean authorizationEnabled;
+
+	private boolean formLogin;
+
+	private boolean authenticated;
+
+	private String username;
+
+	private List<String> roles = new ArrayList<>(0);
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public SecurityInfo() {
+	}
+
+	/**
+	 * @return true if the authentication feature is enabled, false otherwise
+	 */
+	public boolean isAuthenticationEnabled() {
+		return authenticationEnabled;
+	}
+
+	public void setAuthenticationEnabled(boolean authenticationEnabled) {
+		this.authenticationEnabled = authenticationEnabled;
+	}
+
+	/**
+	 * @return true if the authorization feature is enabled, false otherwise.
+	 */
+	public boolean isAuthorizationEnabled() {
+		return authorizationEnabled;
+	}
+
+	public void setAuthorizationEnabled(boolean authorizationEnabled) {
+		this.authorizationEnabled = authorizationEnabled;
+	}
+
+	/**
+	 * @return True if the user is authenticated
+	 */
+	public boolean isAuthenticated() {
+		return authenticated;
+	}
+
+	public void setAuthenticated(boolean authenticated) {
+		this.authenticated = authenticated;
+	}
+
+	/**
+	 * @return The username of the authenticated user, null otherwise.
+	 */
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	/**
+	 * Will only contain values if {@link #isAuthorizationEnabled()} is {@code true}.
+	 *
+	 * @return List of Roles, if no roles are associated, an empty collection is returned.
+	 */
+	public List<String> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(List<String> roles) {
+		this.roles = roles;
+	}
+
+	/**
+	 * @param role Adds the role to {@link #roles}
+	 */
+	public SecurityInfo addRole(String role) {
+		this.roles.add(role);
+		return this;
+	}
+
+	/**
+	 * Returns {@code true} if form-login is used. In case of OAuth2 authentication,
+	 * {@code false} is returned.
+	 *
+	 * @return True if form-login is, false if OAuth2 authentication is used
+	 * @see OnSecurityEnabledAndOAuth2Enabled
+	 */
+	public boolean isFormLogin() {
+		return formLogin;
+	}
+
+	public void setFormLogin(boolean formLogin) {
+		this.formLogin = formLogin;
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
@@ -18,6 +18,10 @@ package org.springframework.cloud.dataflow.rest.resource.about;
 
 import java.util.Date;
 
+import org.springframework.cloud.dataflow.rest.Version;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Provides version information about core libraries used.
  *
@@ -39,6 +43,12 @@ public class VersionInfo {
 	private String commitId;
 	private Date   commitTime;
 	private String branch;
+
+	private int restApiRevision = Version.REVISION;
+
+	public Integer getRestApiRevision() {
+		return this.restApiRevision;
+	}
 
 	public Dependency getCore() {
 		return core;

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
@@ -20,8 +20,6 @@ import java.util.Date;
 
 import org.springframework.cloud.dataflow.rest.Version;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Provides version information about core libraries used.
  *
@@ -41,6 +39,7 @@ public class VersionInfo {
 	private Dependency shell;
 
 	private String commitId;
+	private String shortCommitId;
 	private Date   commitTime;
 	private String branch;
 
@@ -84,6 +83,14 @@ public class VersionInfo {
 
 	public void setCommitId(String commitId) {
 		this.commitId = commitId;
+	}
+
+	public String getShortCommitId() {
+		return shortCommitId;
+	}
+
+	public void setShortCommitId(String shortCommitId) {
+		this.shortCommitId = shortCommitId;
 	}
 
 	public Date getCommitTime() {

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/VersionInfo.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource.about;
+
+import java.util.Date;
+
+/**
+ * Provides version information about core libraries used.
+ *
+ * @author Gunnar Hillert
+ */
+public class VersionInfo {
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public VersionInfo() {
+	}
+
+	private Dependency implementation;
+	private Dependency core;
+	private Dependency dashboard;
+	private Dependency shell;
+
+	private String commitId;
+	private Date   commitTime;
+	private String branch;
+
+	public Dependency getCore() {
+		return core;
+	}
+
+	public Dependency getImplementation() {
+		return implementation;
+	}
+
+	public void setImplementation(Dependency implementation) {
+		this.implementation = implementation;
+	}
+
+	public void setCore(Dependency core) {
+		this.core = core;
+	}
+	public Dependency getDashboard() {
+		return dashboard;
+	}
+	public void setDashboard(Dependency dashboard) {
+		this.dashboard = dashboard;
+	}
+	public Dependency getShell() {
+		return shell;
+	}
+	public void setShell(Dependency shell) {
+		this.shell = shell;
+	}
+
+	public String getCommitId() {
+		return commitId;
+	}
+
+	public void setCommitId(String commitId) {
+		this.commitId = commitId;
+	}
+
+	public Date getCommitTime() {
+		return commitTime;
+	}
+
+	public void setCommitTime(Date commitTime) {
+		this.commitTime = commitTime;
+	}
+
+	public String getBranch() {
+		return branch;
+	}
+
+	public void setBranch(String branch) {
+		this.branch = branch;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -33,6 +33,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.info.InfoProperties;
 import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
 import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
 import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
@@ -43,6 +46,7 @@ import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationPr
 import org.springframework.cloud.dataflow.server.config.features.ComposedTaskProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.controller.AboutController;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
 import org.springframework.cloud.dataflow.server.controller.ComposedTaskController;
@@ -94,7 +98,7 @@ import org.springframework.scheduling.concurrent.ForkJoinPoolFactoryBean;
 @Configuration
 @Import(CompletionConfiguration.class)
 @ConditionalOnBean({EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class})
-@EnableConfigurationProperties({AuthorizationConfig.class, FeaturesProperties.class, ComposedTaskProperties.class})
+@EnableConfigurationProperties({AuthorizationConfig.class, FeaturesProperties.class, ComposedTaskProperties.class, VersionInfoProperties.class})
 @ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class DataFlowControllerAutoConfiguration {
 
@@ -267,6 +271,17 @@ public class DataFlowControllerAutoConfiguration {
 	@Bean
 	public FeaturesController featuresController(FeaturesProperties featuresProperties) {
 		return new FeaturesController(featuresProperties);
+	}
+
+	@Bean
+	public AboutController aboutController(
+			AppDeployer appDeployer,
+			TaskLauncher taskLauncher,
+			FeaturesProperties featuresProperties,
+			VersionInfoProperties versionInfoProperties,
+			SecurityProperties securityProperties,
+			AuthorizationConfig authorizationConfig) {
+		return new AboutController(appDeployer, taskLauncher, featuresProperties, versionInfoProperties, securityProperties, authorizationConfig);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/VersionInfoProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/VersionInfoProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties for version information of core dependencies.
+ *
+ * @author Gunnar Hillert
+ */
+@ConfigurationProperties(prefix = VersionInfoProperties.VERSION_INFO_PREFIX)
+public class VersionInfoProperties {
+
+	public static final String VERSION_INFO_PREFIX = "spring.cloud.dataflow.version-info";
+
+	private String dataflowCoreVersion;
+	private String dataflowShellVersion;
+	private String dataflowDashboardVersion;
+
+	public String getDataflowCoreVersion() {
+		return dataflowCoreVersion;
+	}
+	public void setDataflowCoreVersion(String dataflowCoreVersion) {
+		this.dataflowCoreVersion = dataflowCoreVersion;
+	}
+	public String getDataflowShellVersion() {
+		return dataflowShellVersion;
+	}
+	public void setDataflowShellVersion(String dataflowShellVersion) {
+		this.dataflowShellVersion = dataflowShellVersion;
+	}
+	public String getDataflowDashboardVersion() {
+		return dataflowDashboardVersion;
+	}
+	public void setDataflowDashboardVersion(String dataflowDashboardVersion) {
+		this.dataflowDashboardVersion = dataflowDashboardVersion;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,6 +117,8 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 					dashboard("/**"),
 					"/authenticate",
 					"/security/info",
+					"/dashboard",
+					"/about",
 					"/features",
 					"/assets/**").permitAll();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -165,7 +165,7 @@ public class AboutController {
 			deployerInfo.setSpringBootVersion(deployerEnvironmentInfo.getSpringBootVersion());
 			deployerInfo.setSpringVersion(deployerEnvironmentInfo.getSpringVersion());
 
-			runtimeEnvironment.setDeployer(deployerInfo);
+			runtimeEnvironment.setAppDeployer(deployerInfo);
 		}
 
 		if (this.taskLauncher != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -21,9 +21,9 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.cloud.dataflow.rest.resource.about.Dependency;
-import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironmentDetails;
 import org.springframework.cloud.dataflow.rest.resource.about.FeatureInfo;
 import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironment;
+import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironmentDetails;
 import org.springframework.cloud.dataflow.rest.resource.about.SecurityInfo;
 import org.springframework.cloud.dataflow.rest.resource.about.VersionInfo;
 import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
@@ -41,12 +41,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * REST controller that provides features that are enabled/disabled on the dataflow server.
+ * REST controller that provides meta information regarding the dataflow server and
+ * its deployers.
  *
  * @author Gunnar Hillert
  */
@@ -92,9 +92,8 @@ public class AboutController {
 	}
 
 	/**
-	 * Return features that are enabled/disabled on the dataflow server.
+	 * Return meta information about the dataflow server.
 	 */
-	@ResponseBody
 	@RequestMapping(method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public AboutResource getAboutResource() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
+import org.springframework.cloud.dataflow.rest.resource.about.Dependency;
+import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironmentDetails;
+import org.springframework.cloud.dataflow.rest.resource.about.FeatureInfo;
+import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironment;
+import org.springframework.cloud.dataflow.rest.resource.about.SecurityInfo;
+import org.springframework.cloud.dataflow.rest.resource.about.VersionInfo;
+import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller that provides features that are enabled/disabled on the dataflow server.
+ *
+ * @author Gunnar Hillert
+ */
+@RestController
+@RequestMapping("/about")
+@ExposesResourceFor(AboutResource.class)
+public class AboutController {
+
+	private final FeaturesProperties featuresProperties;
+	private final VersionInfoProperties versionInfoProperties;
+
+	@Autowired(required=false)
+	private GitProperties gitProperties;
+
+	private final SecurityProperties securityProperties;
+	private final AuthorizationConfig authorizationConfig;
+
+	@Value("${security.oauth2.client.client-id:#{null}}")
+	private String oauthClientId;
+
+	@Value("${info.app.name:#{null}}")
+	private String implementationName;
+
+	@Value("${info.app.version:#{null}}")
+	private String implementationVersion;
+
+	private AppDeployer appDeployer;
+	private TaskLauncher taskLauncher;
+
+	public AboutController(
+			AppDeployer appDeployer,
+			TaskLauncher taskLauncher,
+			FeaturesProperties featuresProperties,
+			VersionInfoProperties versionInfoProperties,
+			SecurityProperties securityProperties,
+			AuthorizationConfig authorizationConfig) {
+		this.appDeployer = appDeployer;
+		this.taskLauncher = taskLauncher;
+		this.featuresProperties = featuresProperties;
+		this.versionInfoProperties = versionInfoProperties;
+		this.securityProperties = securityProperties;
+		this.authorizationConfig = authorizationConfig;
+	}
+
+	/**
+	 * Return features that are enabled/disabled on the dataflow server.
+	 */
+	@ResponseBody
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public AboutResource getAboutResource() {
+		final AboutResource aboutResource = new AboutResource();
+		final FeatureInfo featureInfo = new FeatureInfo();
+		featureInfo.setAnalyticsEnabled(featuresProperties.isAnalyticsEnabled());
+		featureInfo.setStreamsEnabled(featuresProperties.isStreamsEnabled());
+		featureInfo.setTasksEnabled(featuresProperties.isTasksEnabled());
+
+		final VersionInfo versionInfo = new VersionInfo();
+
+		versionInfo.setImplementation(new Dependency(this.implementationName, this.implementationVersion));
+		versionInfo.setCore(new Dependency("Spring Cloud Data Flow Core", versionInfoProperties.getDataflowCoreVersion()));
+		versionInfo.setShell(new Dependency("Spring Cloud Data Flow Shell",versionInfoProperties.getDataflowShellVersion()));
+		versionInfo.setDashboard(new Dependency("Spring Cloud Dataflow UI", versionInfoProperties.getDataflowDashboardVersion()));
+
+		versionInfo.setBranch(this.gitProperties.getBranch());
+		versionInfo.setCommitId(this.gitProperties.getCommitId());
+		versionInfo.setCommitTime(this.gitProperties.getCommitTime());
+
+		aboutResource.setFeatureInfo(featureInfo);
+		aboutResource.setVersionInfo(versionInfo);
+
+		final boolean authenticationEnabled = securityProperties.getBasic().isEnabled();
+		final boolean authorizationEnabled = this.authorizationConfig.isEnabled();
+
+		final SecurityInfo securityInfo = new SecurityInfo();
+		securityInfo.setAuthenticationEnabled(authenticationEnabled);
+		securityInfo.setAuthorizationEnabled(authorizationEnabled);
+
+		if (authenticationEnabled && SecurityContextHolder.getContext() != null) {
+			final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			if (!(authentication instanceof AnonymousAuthenticationToken)) {
+				securityInfo.setAuthenticated(authentication.isAuthenticated());
+				securityInfo.setUsername(authentication.getName());
+
+				if (authorizationEnabled) {
+					for (GrantedAuthority authority : authentication.getAuthorities()) {
+						securityInfo.addRole(authority.getAuthority());
+					}
+				}
+				if (this.oauthClientId == null) {
+					securityInfo.setFormLogin(true);
+				}
+				else {
+					securityInfo.setFormLogin(false);
+				}
+			}
+		}
+
+		aboutResource.setSecurityInfo(securityInfo);
+
+		final RuntimeEnvironment runtimeEnvironment = new RuntimeEnvironment();
+
+		if (this.appDeployer != null) {
+			final RuntimeEnvironmentInfo deployerEnvironmentInfo = this.appDeployer.environmentInfo();
+			final RuntimeEnvironmentDetails deployerInfo = new RuntimeEnvironmentDetails();
+
+			deployerInfo.setDeployerImplementationVersion(deployerEnvironmentInfo.getImplementationVersion());
+			deployerInfo.setDeployerName(deployerEnvironmentInfo.getImplementationName());
+			deployerInfo.setDeployerSpiVersion(deployerEnvironmentInfo.getSpiVersion());
+			deployerInfo.setJavaVersion(deployerEnvironmentInfo.getJavaVersion());
+			deployerInfo.setPlatformApiVersion(deployerEnvironmentInfo.getPlatformApiVersion());
+			deployerInfo.setPlatformClientVersion(deployerEnvironmentInfo.getPlatformClientVersion());
+			deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
+			deployerInfo.setPlatformSpecificInfo(deployerEnvironmentInfo.getPlatformSpecificInfo());
+			deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
+			deployerInfo.setPlatformType(deployerEnvironmentInfo.getPlatformType());
+			deployerInfo.setSpringBootVersion(deployerEnvironmentInfo.getSpringBootVersion());
+			deployerInfo.setSpringVersion(deployerEnvironmentInfo.getSpringVersion());
+
+			runtimeEnvironment.setDeployer(deployerInfo);
+		}
+
+		if (this.taskLauncher != null) {
+			final RuntimeEnvironmentInfo taskLauncherEnvironmentInfo = this.taskLauncher.environmentInfo();
+			final RuntimeEnvironmentDetails taskLauncherInfo = new RuntimeEnvironmentDetails();
+
+			taskLauncherInfo.setDeployerImplementationVersion(taskLauncherEnvironmentInfo.getImplementationVersion());
+			taskLauncherInfo.setDeployerName(taskLauncherEnvironmentInfo.getImplementationName());
+			taskLauncherInfo.setDeployerSpiVersion(taskLauncherEnvironmentInfo.getSpiVersion());
+			taskLauncherInfo.setJavaVersion(taskLauncherEnvironmentInfo.getJavaVersion());
+			taskLauncherInfo.setPlatformApiVersion(taskLauncherEnvironmentInfo.getPlatformApiVersion());
+			taskLauncherInfo.setPlatformClientVersion(taskLauncherEnvironmentInfo.getPlatformClientVersion());
+			taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
+			taskLauncherInfo.setPlatformSpecificInfo(taskLauncherEnvironmentInfo.getPlatformSpecificInfo());
+			taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
+			taskLauncherInfo.setPlatformType(taskLauncherEnvironmentInfo.getPlatformType());
+			taskLauncherInfo.setSpringBootVersion(taskLauncherEnvironmentInfo.getSpringBootVersion());
+			taskLauncherInfo.setSpringVersion(taskLauncherEnvironmentInfo.getSpringVersion());
+
+			runtimeEnvironment.setTaskLauncher(taskLauncherInfo);
+		}
+
+		aboutResource.setRuntimeEnvironment(runtimeEnvironment);
+		aboutResource.add(ControllerLinkBuilder.linkTo(AboutController.class).withSelfRel());
+
+		return aboutResource;
+	}
+}
+

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -112,6 +112,7 @@ public class AboutController {
 
 		versionInfo.setBranch(this.gitProperties.getBranch());
 		versionInfo.setCommitId(this.gitProperties.getCommitId());
+		versionInfo.setShortCommitId(this.gitProperties.getShortCommitId());
 		versionInfo.setCommitTime(this.gitProperties.getCommitTime());
 
 		aboutResource.setFeatureInfo(featureInfo);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/FeaturesController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/FeaturesController.java
@@ -1,10 +1,21 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.rest.resource.FeaturesInfoResource;
-import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.http.HttpStatus;
@@ -18,6 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
  * REST controller that provides features that are enabled/disabled on the dataflow server.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
+ * @deprecated Functionality now provided by {@link AboutController}
  */
 @RestController
 @RequestMapping("/features")

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionResource;
+import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -129,6 +130,8 @@ public class RootController {
 					.linkToSingleResource(AggregateCounterResource.class, "{name}").withRel("aggregate-counters/counter")));
 		}
 		root.add(entityLinks.linkToCollectionResource(AppRegistrationResource.class).withRel("apps"));
+		root.add(entityLinks.linkToCollectionResource(AboutResource.class).withRel("about"));
+
 		String completionStreamTemplated = entityLinks.linkFor(CompletionProposalsResource.class).withSelfRel().getHref() + ("/stream{?start,detailLevel}");
 		root.add(new Link(completionStreamTemplated).withRel("completions/stream"));
 		String completionTaskTemplated = entityLinks.linkFor(CompletionProposalsResource.class).withSelfRel().getHref() + ("/task{?start,detailLevel}");

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
 import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.controller.AboutController;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  * @since 1.0
+ * @deprecated Functionality now provided by {@link AboutController}
  */
 @RestController
 @RequestMapping("/security/info")

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -6,6 +6,10 @@ spring:
     exclude: org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
   cloud:
     dataflow:
+      version-info:
+        dataflow-shell-version: "@spring-shell.version@"
+        dataflow-dashboard-version: "@spring-cloud-dataflow-ui.version@"
+        dataflow-core-version: "@project.version@"
       security:
         authorization:
           enabled: true

--- a/spring-cloud-dataflow-server-local/pom.xml
+++ b/spring-cloud-dataflow-server-local/pom.xml
@@ -19,6 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<spring-cloud-dataflow.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
 		<spring-cloud-task.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-task.version>
 		<spring-cloud.version>Dalston.BUILD-SNAPSHOT</spring-cloud.version>
 	</properties>
@@ -85,7 +86,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-dependencies</artifactId>
-				<version>1.2.0.BUILD-SNAPSHOT</version>
+				<version>${spring-cloud-dataflow.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-dataflow-server-local/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server-local/src/main/resources/application.yml
@@ -3,7 +3,6 @@ info:
     name: "@project.artifactId@"
     description: "@project.name@"
     version: "@project.version@"
-
 #server:
 #  port: 8443
 #  ssl:

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
@@ -45,8 +45,19 @@ public class LocalDataflowResource extends ExternalResource {
 
 	private WebApplicationContext configurableApplicationContext;
 
+	final boolean streamsEnabled;
+	final boolean tasksEnabled;
+
 	public LocalDataflowResource(String configurationLocation) {
 		this.configurationLocation = configurationLocation;
+		this.streamsEnabled = true;
+		this.tasksEnabled = true;
+	}
+
+	public LocalDataflowResource(String configurationLocation, boolean streamsEnabled, boolean tasksEnabled) {
+		this.configurationLocation = configurationLocation;
+		this.streamsEnabled = streamsEnabled;
+		this.tasksEnabled = tasksEnabled;
 	}
 
 	@Override
@@ -58,7 +69,8 @@ public class LocalDataflowResource extends ExternalResource {
 
 		app = new SpringApplication(LocalTestDataFlowServer.class);
 		configurableApplicationContext = (WebApplicationContext) app.run(new String[]{"--server.port=0",
-				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.STREAMS_ENABLED + "=true",
+				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.STREAMS_ENABLED + "=" + this.streamsEnabled,
+				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.TASKS_ENABLED + "=" + this.tasksEnabled,
 				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.ANALYTICS_ENABLED + "=true"});
 
 		Collection<Filter> filters = configurableApplicationContext.getBeansOfType(Filter.class).values();


### PR DESCRIPTION
This PR unifies multiple pre-existing rest-endpoints into one:

* `/security/info`
* `/features`

* Add API documentations
* Add tests
  - Make `LocalDataflowResource` more dynamic so that features (Task & Stream) can be toggled
  - Add test suite that runs security REST tests with disabled task feature

Resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1216