### PR TITLE
task destroy calls TaskLauncher#destroy()

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -16,21 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
-import org.springframework.cloud.dataflow.core.dsl.ComposedTaskNode;
-import org.springframework.cloud.dataflow.core.dsl.ComposedTaskParser;
-import org.springframework.cloud.dataflow.core.dsl.ComposedTaskValidationException;
-import org.springframework.cloud.dataflow.core.dsl.ComposedTaskValidationProblem;
-import org.springframework.cloud.dataflow.core.dsl.DSLMessage;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.cloud.dataflow.server.config.features.ComposedTaskProperties;
-import org.springframework.cloud.dataflow.server.controller.support.ComposedTaskValidator;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
@@ -144,6 +134,7 @@ public class TaskDefinitionController {
 			throw new NoSuchTaskDefinitionException(name);
 		}
 		repository.delete(name);
+		taskLauncher.destroy(name);
 		deploymentIdRepository.delete(DeploymentKey.forTaskDefinition(taskDefinition));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -40,6 +40,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.ApplicationType;
@@ -55,7 +57,6 @@ import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -381,6 +382,7 @@ public class TaskControllerTests {
 				.andExpect(status().isOk());
 
 		assertEquals(0, repository.count());
+		Mockito.verify(taskLauncher).destroy("myTask");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-dataflow/issues/1238