### PR TITLE
Add paging to RuntimeAppController

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/RuntimeTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,9 @@ public class RuntimeTemplate implements RuntimeOperations {
 
 	@Override
 	public PagedResources<AppStatusResource> status() {
-		return restTemplate.getForObject(appStatusesUriTemplate.expand().getHref(), AppStatusResource.Page.class);
+		String uriTemplate = appStatusesUriTemplate.expand().getHref();
+		uriTemplate = uriTemplate + "?size=10000";
+		return restTemplate.getForObject(uriTemplate, AppStatusResource.Page.class);
 	}
 
 	@Override


### PR DESCRIPTION
- list method now understand Pageable.
- modified stream handling to only return current page
- modified RuntimeTemplate to request 10000 items which is
  a same value what StreamTemplate is using. For some
  reason Pageable defaults to size 20 so shell need to request
  more to get past 20 items is shell doesn't use paging.
- fixes #1251
- this also is a root cause for spring-cloud/spring-cloud-dataflow-ui#176