### PR TITLE
Add Metrics system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<spring-cloud-dataflow-ui.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
 
 		<spring-cloud-deployer.version>1.2.0.M3</spring-cloud-deployer.version>
-		<spring-cloud-deployer-local.version>1.2.0.M3</spring-cloud-deployer-local.version>
+		<spring-cloud-deployer-local.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-boot.version -->
 		<spring-boot.version>1.5.2.RELEASE</spring-boot.version>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppMetricResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppMetricResource.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * Rest resources for runtime metrics response.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class AppMetricResource extends ResourceSupport {
+
+	private MetricsHolder entity;
+
+	/**
+	 * Instantiates a new app metric resource.
+	 *
+	 * @param entity the entity
+	 */
+	public AppMetricResource(MetricsHolder entity) {
+		this.entity = entity;
+	}
+
+	/**
+	 * Gets the guid.
+	 *
+	 * @return the guid
+	 */
+	public String getGuid() {
+		return entity.getGuid();
+	}
+
+	/**
+	 * Gets the deployment id.
+	 *
+	 * @return the deployment id
+	 */
+	public String getDeploymentId() {
+		return entity.getDeploymentId();
+	}
+
+	/**
+	 * Gets the instance id.
+	 *
+	 * @return the instance id
+	 */
+	public String getInstanceId() {
+		return entity.getInstanceId();
+	}
+
+	/**
+	 * Gets the metrics.
+	 *
+	 * @return the metrics
+	 */
+	public Map<String, Number> getMetrics() {
+		return entity.getMetrics();
+	}
+
+	/**
+	 * Entity class for metrics.
+	 */
+	public static class MetricsHolder {
+
+		private String guid;
+		private String deploymentId;
+		private String instanceId;
+		private final Map<String, Number> metrics = new HashMap<>();
+
+		/**
+		 * Instantiates a new metrics holder.
+		 *
+		 * @param guid the guid
+		 * @param deploymentId the deployment id
+		 * @param instanceId the instance id
+		 */
+		public MetricsHolder(String guid, String deploymentId, String instanceId) {
+			this.guid = guid;
+			this.deploymentId = deploymentId;
+			this.instanceId = instanceId;
+		}
+
+		/**
+		 * Gets the guid.
+		 *
+		 * @return the guid
+		 */
+		public String getGuid() {
+			return guid;
+		}
+
+		/**
+		 * Gets the deployment id.
+		 *
+		 * @return the deployment id
+		 */
+		public String getDeploymentId() {
+			return deploymentId;
+		}
+
+		/**
+		 * Gets the instance id.
+		 *
+		 * @return the instance id
+		 */
+		public String getInstanceId() {
+			return instanceId;
+		}
+
+		/**
+		 * Gets the metrics.
+		 *
+		 * @return the metrics
+		 */
+		public Map<String, Number> getMetrics() {
+			return metrics;
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -133,6 +133,10 @@
 			<artifactId>spring-cloud-starter-config</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-hystrix</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.batch</groupId>
 			<artifactId>spring-batch-admin-manager</artifactId>
 			<exclusions>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -33,6 +33,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.info.InfoProperties;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
 import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
 import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
@@ -50,6 +54,7 @@ import org.springframework.cloud.dataflow.server.controller.JobExecutionControll
 import org.springframework.cloud.dataflow.server.controller.JobInstanceController;
 import org.springframework.cloud.dataflow.server.controller.JobStepExecutionController;
 import org.springframework.cloud.dataflow.server.controller.JobStepExecutionProgressController;
+import org.springframework.cloud.dataflow.server.controller.MetricsController;
 import org.springframework.cloud.dataflow.server.controller.RestControllerAdvice;
 import org.springframework.cloud.dataflow.server.controller.RootController;
 import org.springframework.cloud.dataflow.server.controller.RuntimeAppsController;
@@ -62,6 +67,7 @@ import org.springframework.cloud.dataflow.server.controller.ToolsController;
 import org.springframework.cloud.dataflow.server.controller.UiController;
 import org.springframework.cloud.dataflow.server.controller.security.LoginController;
 import org.springframework.cloud.dataflow.server.controller.security.SecurityController;
+import org.springframework.cloud.dataflow.server.controller.support.MetricStore;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
@@ -94,8 +100,10 @@ import org.springframework.scheduling.concurrent.ForkJoinPoolFactoryBean;
 @Configuration
 @Import(CompletionConfiguration.class)
 @ConditionalOnBean({EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class})
-@EnableConfigurationProperties({AuthorizationConfig.class, FeaturesProperties.class, VersionInfoProperties.class})
+@EnableConfigurationProperties({ AuthorizationConfig.class, FeaturesProperties.class,
+		VersionInfoProperties.class, MetricsProperties.class })
 @ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableCircuitBreaker
 public class DataFlowControllerAutoConfiguration {
 
 	@Bean
@@ -116,6 +124,16 @@ public class DataFlowControllerAutoConfiguration {
 	@Bean
 	public AppInstanceController appInstanceController(AppDeployer appDeployer) {
 		return new AppInstanceController(appDeployer);
+	}
+
+	@Bean
+	public MetricStore metricStore(MetricsProperties metricsProperties) {
+		return new MetricStore(metricsProperties);
+	}
+
+	@Bean
+	public MetricsController metricsController(MetricStore metricStore) {
+		return new MetricsController(metricStore);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for namespace 'spring.cloud.dataflow.metrics'.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(prefix = MetricsProperties.PREFIX)
+public class MetricsProperties {
+
+	public static final String PREFIX = "spring.cloud.dataflow.metrics";
+
+	private Collector collector = new Collector();
+
+	public Collector getCollector() {
+		return collector;
+	}
+
+	public void setCollector(Collector collector) {
+		this.collector = collector;
+	}
+
+	public static class Collector {
+		private String url;
+
+		public String getUrl() {
+			return url;
+		}
+
+		public void setUrl(String url) {
+			this.url = url;
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/MetricsController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/MetricsController.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.cloud.dataflow.rest.resource.AppMetricResource;
+import org.springframework.cloud.dataflow.rest.resource.AppMetricResource.MetricsHolder;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics.Application;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics.Instance;
+import org.springframework.cloud.dataflow.server.controller.support.MetricStore;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceAssembler;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller handling metrics requests for 'runtime apps'.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RestController
+@RequestMapping("/metrics/runtime")
+@ExposesResourceFor(AppMetricResource.class)
+public class MetricsController {
+
+	private final ResourceAssembler<MetricsHolder, AppMetricResource> statusAssembler = new Assembler();
+	private final MetricStore metricStore;
+
+	public MetricsController(MetricStore metricStore) {
+		this.metricStore = metricStore;
+	}
+
+	@RequestMapping(method = RequestMethod.POST)
+	public PagedResources<AppMetricResource> list(@RequestBody(required = true) Map<String, Map<String, String>> instanceIdToGuid,
+			PagedResourcesAssembler<MetricsHolder> assembler) throws ExecutionException, InterruptedException {
+		// instanceIdToGuid maps deploymentId's to maps of its instanceId/guid and have format
+		// {"foostream.log120RS":{"foostream.log120RS-0":"56575"},"foostream.time120RS":{"foostream.time120RS-0":"61998"}}
+		// this allows us to rely of what UI currently needs and we don't need to re-query
+		// deployers to get same map. It's essentially same info what RuntimeAppsController returns to UI.
+
+		// logic for this response is. UI builds its 'runtime apps' structure based on
+		// deploymentId(s)/instanced(s). instance attributes have guid added by a deployer.
+		// UI passes in this structure and we build matching metrics response
+		// so that UI can backmap metrics into correct positions in UI.
+		// this is needed because response from collector only knows about stream and
+		// label names and here we're working on deploymentId/instanceId level.
+
+		List<ApplicationsMetrics> metricsIn = metricStore.getMetrics();
+
+		// build response structure
+		Map<String, MetricsHolder> guidToHolderMap = new HashMap<>();
+		for (Entry<String, Map<String, String>> deploymentIdEntry : instanceIdToGuid.entrySet()) {
+			for (Entry<String, String> instanceIdEntry : deploymentIdEntry.getValue().entrySet()) {
+				guidToHolderMap.put(instanceIdEntry.getValue(),
+						new MetricsHolder(instanceIdEntry.getValue(), deploymentIdEntry.getKey(), instanceIdEntry.getKey()));
+			}
+		}
+
+		// update metrics to response
+		for (ApplicationsMetrics am : metricsIn) {
+			for (Application a : am.getApplications()) {
+				for (Instance i : a.getInstances()) {
+					MetricsHolder holder = guidToHolderMap.get(i.getGuid());
+					if (holder != null) {
+						holder.getMetrics().put("incomingRate", i.getIncomingRate());
+						holder.getMetrics().put("outgoingRate", i.getOutgoingRate());
+					}
+				}
+			}
+		}
+
+		// build hal response
+		List<MetricsHolder> holders = new ArrayList<>(guidToHolderMap.values());
+		return assembler.toResource(new PageImpl<>(holders), statusAssembler);
+	}
+
+	private static class Assembler extends ResourceAssemblerSupport<MetricsHolder, AppMetricResource> {
+
+		public Assembler() {
+			super(MetricsController.class, AppMetricResource.class);
+		}
+
+		@Override
+		public AppMetricResource toResource(MetricsHolder entity) {
+			return new AppMetricResource(entity);
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.rest.Version;
 import org.springframework.cloud.dataflow.rest.resource.AppInstanceStatusResource;
+import org.springframework.cloud.dataflow.rest.resource.AppMetricResource;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.CompletionProposalsResource;
@@ -99,6 +100,7 @@ public class RootController {
 			root.add(entityLinks.linkToCollectionResource(AppStatusResource.class).withRel("runtime/apps"));
 			root.add(unescapeTemplateVariables(entityLinks.linkForSingleResource(AppStatusResource.class, "{appId}").withRel("runtime/apps/app")));
 			root.add(unescapeTemplateVariables(entityLinks.linkFor(AppInstanceStatusResource.class, UriComponents.UriTemplateVariables.SKIP_VALUE).withRel("runtime/apps/instances")));
+			root.add(entityLinks.linkToCollectionResource(AppMetricResource.class).withRel("metrics/runtime"));
 		}
 		if (featuresProperties.isTasksEnabled()) {
 			root.add(entityLinks.linkToCollectionResource(TaskDefinitionResource.class).withRel("tasks/definitions"));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -250,6 +250,11 @@ public class StreamDeploymentController {
 			Resource appResource = registration.getResource();
 			Resource metadataResource = registration.getMetadataResource();
 
+			// add properties needed for metrics system
+			appDeployTimeProperties.put("spring.cloud.dataflow.stream.name", currentApp.getStreamName());
+			appDeployTimeProperties.put("spring.cloud.dataflow.stream.app.label", currentApp.getName());
+			appDeployTimeProperties.put("spring.cloud.dataflow.stream.app.type", type.toString());
+
 			// Merge *definition time* app properties with *deployment time* properties
 			// and expand them to their long form if applicable
 			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource, appDeployTimeProperties);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ApplicationsMetrics.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ApplicationsMetrics.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Support domain class to map metrics response from a collector.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ApplicationsMetrics {
+
+	private String name;
+	private List<Application> applications;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<Application> getApplications() {
+		return applications;
+	}
+
+	public void setApplications(List<Application> applications) {
+		this.applications = applications;
+	}
+
+	public static class Application {
+
+		private String name;
+		private List<Instance> instances;
+		private double incomingRate;
+		private double outgoingRate;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public List<Instance> getInstances() {
+			return instances;
+		}
+
+		public void setInstances(List<Instance> instances) {
+			this.instances = instances;
+		}
+
+		public double getIncomingRate() {
+			return incomingRate;
+		}
+
+		public void setIncomingRate(double incomingRate) {
+			this.incomingRate = incomingRate;
+		}
+
+		public double getOutgoingRate() {
+			return outgoingRate;
+		}
+
+		public void setOutgoingRate(double outgoingRate) {
+			this.outgoingRate = outgoingRate;
+		}
+	}
+
+	public static class Instance {
+
+		private String guid;
+		private int index;
+		private Map<String, Object> properties;
+		private double incomingRate;
+		private double outgoingRate;
+
+		public String getGuid() {
+			return guid;
+		}
+
+		public void setGuid(String guid) {
+			this.guid = guid;
+		}
+
+		public int getIndex() {
+			return index;
+		}
+
+		public void setIndex(int index) {
+			this.index = index;
+		}
+
+		public Map<String, Object> getProperties() {
+			return properties;
+		}
+
+		public void setProperties(Map<String, Object> properties) {
+			this.properties = properties;
+		}
+
+		public double getIncomingRate() {
+			return incomingRate;
+		}
+
+		public void setIncomingRate(double incomingRate) {
+			this.incomingRate = incomingRate;
+		}
+
+		public double getOutgoingRate() {
+			return outgoingRate;
+		}
+
+		public void setOutgoingRate(double outgoingRate) {
+			this.outgoingRate = outgoingRate;
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/MetricStore.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/MetricStore.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.dataflow.server.config.MetricsProperties;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+
+/**
+ * Store implementation returning metrics info from a collector application.
+ * Implemented via hystrix command having a fallback to empty response.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Component
+public class MetricStore {
+
+	private static Log logger = LogFactory.getLog(MetricStore.class);
+	private final RestTemplate restTemplate;
+	private final MetricsProperties metricsProperties;
+	private final static List<ApplicationsMetrics> EMPTY_RESPONSE = new ArrayList<ApplicationsMetrics>();
+
+	/**
+	 * Instantiates a new metric store.
+	 *
+	 * @param metricsProperties the metrics properties
+	 */
+	public MetricStore(MetricsProperties metricsProperties) {
+		this.metricsProperties = metricsProperties;
+		restTemplate = new RestTemplate();
+	}
+
+	@HystrixCommand(fallbackMethod = "defaultMetrics")
+	public List<ApplicationsMetrics> getMetrics() {
+		List<ApplicationsMetrics> metrics = null;
+		if (StringUtils.hasText(metricsProperties.getCollector().getUrl())) {
+			try {
+				metrics = restTemplate.exchange(metricsProperties.getCollector().getUrl(), HttpMethod.GET, null,
+						new ParameterizedTypeReference<List<ApplicationsMetrics>>() {
+						}).getBody();
+			} catch (Exception e) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Error requesting metrics from url " + metricsProperties.getCollector().getUrl(), e);
+				}
+				throw e;
+			}
+		} else {
+			metrics = defaultMetrics();
+		}
+		return metrics;
+	}
+
+	public List<ApplicationsMetrics> defaultMetrics() {
+		return EMPTY_RESPONSE;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.dataflow.server.configuration;
 import static org.mockito.Mockito.mock;
 import static org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType.HAL;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 
@@ -32,9 +34,11 @@ import org.springframework.cloud.dataflow.completion.StreamCompletionProvider;
 import org.springframework.cloud.dataflow.completion.TaskCompletionProvider;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.server.config.MetricsProperties;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
+import org.springframework.cloud.dataflow.server.controller.MetricsController;
 import org.springframework.cloud.dataflow.server.controller.RestControllerAdvice;
 import org.springframework.cloud.dataflow.server.controller.RuntimeAppsController;
 import org.springframework.cloud.dataflow.server.controller.StreamDefinitionController;
@@ -42,6 +46,10 @@ import org.springframework.cloud.dataflow.server.controller.StreamDeploymentCont
 import org.springframework.cloud.dataflow.server.controller.TaskDefinitionController;
 import org.springframework.cloud.dataflow.server.controller.TaskExecutionController;
 import org.springframework.cloud.dataflow.server.controller.ToolsController;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics.Application;
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics.Instance;
+import org.springframework.cloud.dataflow.server.controller.support.MetricStore;
 import org.springframework.cloud.dataflow.server.registry.DataFlowAppRegistryPopulator;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentIdRepository;
@@ -84,7 +92,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupp
 @EnableHypermediaSupport(type = HAL)
 @Import(CompletionConfiguration.class)
 @EnableWebMvc
-@EnableConfigurationProperties({CommonApplicationProperties.class})
+@EnableConfigurationProperties({CommonApplicationProperties.class, MetricsProperties.class})
 public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
@@ -150,6 +158,39 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	@Bean
 	public RuntimeAppsController.AppInstanceController appInstanceController() {
 		return new RuntimeAppsController.AppInstanceController(appDeployer());
+	}
+
+	@Bean
+	public MetricStore metricStore(MetricsProperties metricsProperties) {
+		return new MetricStore(metricsProperties) {
+			@Override
+			public List<ApplicationsMetrics> getMetrics() {
+				List<ApplicationsMetrics> metrics = new ArrayList<>();
+				ApplicationsMetrics am = new ApplicationsMetrics();
+				am.setName("ticktock1");
+				List<Application> applications = new ArrayList<>();
+				Application a = new Application();
+				a.setName("time");
+				a.setIncomingRate(111);
+				a.setOutgoingRate(222);
+				List<Instance> instances = new ArrayList<>();
+				Instance i = new Instance();
+				i.setIncomingRate(333);
+				i.setOutgoingRate(444);
+				i.setGuid("34215");
+				instances.add(i);
+				a.setInstances(instances);
+				applications.add(a);
+				am.setApplications(applications);
+				metrics.add(am);
+				return metrics;
+			}
+		};
+	}
+
+	@Bean
+	public MetricsController metricsController(MetricStore metricStore) {
+		return new MetricsController(metricStore);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/MetricsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/MetricsControllerTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Tests for metrics controller.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class MetricsControllerTests {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Autowired
+	private StreamDefinitionRepository streamDefinitionRepository;
+
+	@Autowired
+	private DeploymentIdRepository deploymentIdRepository;
+
+	@Autowired
+	private AppRegistry appRegistry;
+
+	@Autowired
+	private AppDeployer appDeployer;
+
+	@Before
+	public void setupMocks() throws Exception {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(
+				get("/").accept(MediaType.APPLICATION_JSON)).build();
+		for (AppRegistration appRegistration : this.appRegistry.findAll()) {
+			this.appRegistry.delete(appRegistration.getName(), appRegistration.getType());
+		}
+
+
+		StreamDefinition streamDefinition1 = new StreamDefinition("ticktock1", "time|log");
+		streamDefinitionRepository.save(streamDefinition1);
+
+		deploymentIdRepository.save("ticktock1.time", "ticktock1.time");
+		deploymentIdRepository.save("ticktock1.log", "ticktock1.log");
+
+		when(appDeployer.status("ticktock1.time")).thenReturn(AppStatus.of("ticktock1.time").generalState(DeploymentState.deployed).build());
+		when(appDeployer.status("ticktock1.log")).thenReturn(AppStatus.of("ticktock1.log").generalState(DeploymentState.deployed).build());
+
+		when(appDeployer.status("foo")).thenReturn(AppStatus.of("foo").generalState(DeploymentState.unknown).build());
+		AppStatus validAppStatus = AppStatus.of("a1.valid").generalState(DeploymentState.failed).build();
+		when(appDeployer.status("valid")).thenReturn(validAppStatus);
+	}
+
+	@Test
+	public void testSimpleMetricsResponseNoMetrics() throws Exception {
+		String content = "{\"ticktock1\":{\"ticktock1.time-0\":\"34215\"},\"ticktock1\":{\"ticktock1.log-0\":\"39729\"}}";
+		MockHttpServletResponse responseString = mockMvc.perform(
+				post("/metrics/runtime").accept(MediaType.APPLICATION_JSON).content(content).contentType("application/json")).andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse();
+		Assert.assertTrue(responseString.getContentAsString().contains("ticktock1"));
+		Assert.assertTrue(responseString.getContentAsString().contains("metrics\":{}"));
+	}
+
+	@Test
+	public void testPostNoContentBody() throws Exception {
+		mockMvc.perform(
+				post("/metrics/runtime").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().is5xxServerError()).andReturn().getResponse();
+	}
+
+	@Test
+	public void testSimpleMetricsResponseMetrics() throws Exception {
+		String content = "{\"ticktock1.time\":{\"ticktock1.time-0\":\"34215\"},\"ticktock1.log\":{\"ticktock1.log-0\":\"39729\"}}";
+		MockHttpServletResponse responseString = mockMvc.perform(
+				post("/metrics/runtime").accept(MediaType.APPLICATION_JSON).content(content).contentType("application/json")).andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse();
+		Assert.assertTrue(responseString.getContentAsString().contains("ticktock1"));
+		Assert.assertTrue(responseString.getContentAsString().contains("333"));
+		Assert.assertTrue(responseString.getContentAsString().contains("444"));
+	}
+
+}


### PR DESCRIPTION
- Add hystrix dependency used by MetricStore
- New AppMetricResource in rest-resource
- ApplicationsMetrics is a simple domain class mapping
  collector response as I didn't want to pull any
  deps from collector into scdf for now.

- Fixes #1225
- Fixes #1260
- Fixes #1261

This is a 3 stage PR, one in each spring-cloud-dataflow, spring-cloud-deployer-local and spring-cloud-dataflow-ui. These can go in independently but nothing really works until all are merged and metrics collector is running.
https://github.com/spring-cloud/spring-cloud-dataflow-ui/pull/189
https://github.com/spring-cloud/spring-cloud-deployer-local/pull/38
```
# java -jar spring-cloud-dataflow-server-local/target/spring-cloud-dataflow-server-local-1.2.0.BUILD-SNAPSHOT.jar --spring.cloud.dataflow.metrics.collector.url=http://localhost:8080/collector/metrics

# java -jar target/metrics-collector-rabbit-1.0.0.BUILD-SNAPSHOT.jar --spring.cloud.stream.bindings.input.destination=metrics --spring.cloud.stream.default.contentType=application/json --security.basic.enabled=false --management.security.enabled=false

# shell
dataflow:>app register --name time120RS --type source --uri maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.0.BUILD-SNAPSHOT

dataflow:>app register --name log120RS --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.BUILD-SNAPSHOT

dataflow:>stream create --name foostream --definition "time120RS --spring.cloud.stream.bindings.applicationMetricsChannel.destination=metrics --spring.cloud.stream.metrics.properties=spring*|log120RS --spring.cloud.stream.bindings.applicationMetricsChannel.destination=metrics --spring.cloud.stream.metrics.properties=spring*"

dataflow:>stream deploy --name foostream --properties "deployer.*.count=2"
```