### PR TITLE
gh-1279 Implement OAUTH2 "Acess Token" support for REST-APIs

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.controller.AboutController;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
@@ -263,8 +264,8 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	public SecurityController securityController(SecurityProperties securityProperties, AuthorizationConfig authorizationConfig) {
-		return new SecurityController(securityProperties, authorizationConfig);
+	public SecurityController securityController(SecurityStateBean securityStateBean) {
+		return new SecurityController(securityStateBean);
 	}
 
 	@Bean
@@ -284,9 +285,9 @@ public class DataFlowControllerAutoConfiguration {
 			TaskLauncher taskLauncher,
 			FeaturesProperties featuresProperties,
 			VersionInfoProperties versionInfoProperties,
-			SecurityProperties securityProperties,
-			AuthorizationConfig authorizationConfig) {
-		return new AboutController(appDeployer, taskLauncher, featuresProperties, versionInfoProperties, securityProperties, authorizationConfig);
+			SecurityStateBean securityStateBean) {
+		return new AboutController(appDeployer, taskLauncher, featuresProperties, versionInfoProperties,
+			securityStateBean);
 	}
 
 	@Bean
@@ -306,5 +307,10 @@ public class DataFlowControllerAutoConfiguration {
 
 	@ConfigurationProperties(prefix = "maven")
 	static class MavenConfigurationProperties extends MavenProperties {
+	}
+
+	@Bean
+	SecurityStateBean securityStateBean() {
+		return new SecurityStateBean();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
+import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -96,6 +97,9 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 	@Autowired
 	private AuthorizationConfig authorizationConfig;
 
+	@Autowired
+	private SecurityStateBean securityStateBean;
+
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		final RequestMatcher textHtmlMatcher = new MediaTypeRequestMatcher(
@@ -157,6 +161,9 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 		http.addFilterBefore(sessionRepositoryFilter,
 				ChannelProcessingFilter.class).csrf().disable();
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
+
+		securityStateBean.setAuthenticationEnabled(true);
+		securityStateBean.setAuthorizationEnabled(true);
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
@@ -20,6 +20,7 @@ import static org.springframework.cloud.dataflow.server.controller.UiController.
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Enabled;
+import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.service.impl.ManualOAuthAuthenticationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -48,6 +49,9 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private ResourceServerTokenServices tokenServices;
 
+	@Autowired
+	private SecurityStateBean securityStateBean;
+
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.addFilterBefore(oAuth2AuthenticationProcessingFilter(), AbstractPreAuthenticatedProcessingFilter.class);
@@ -66,6 +70,9 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		.and().httpBasic()
 		.and().logout().logoutSuccessUrl(dashboard("/logout-success-oauth.html"))
 		.and().csrf().disable();
+
+		securityStateBean.setAuthenticationEnabled(true);
+		securityStateBean.setAuthorizationEnabled(false);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,6 @@ public class OnSecurityEnabledAndOAuth2Enabled extends AllNestedConditions {
 	public OnSecurityEnabledAndOAuth2Enabled() {
 		super(ConfigurationPhase.REGISTER_BEAN);
 	}
-
-	@ConditionalOnProperty(name = "security.basic.enabled", havingValue = "true")
-	static class SecurityEnabled { }
 
 	@ConditionalOnProperty(name = "security.oauth2.client.client-id")
 	static class OAuth2Enabled { }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnSecurityEnabledAndOAuth2Enabled.java
@@ -20,8 +20,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Condition;
 
 /**
- * {@link Condition} that is only valid if {@code security.basic.enabled} is
- * {@code true} and the property {@code security.oauth2.client.client-id} exists.
+ * {@link Condition} that is only valid if the property
+ * {@code security.oauth2.client.client-id} exists.
  *
  * @author Gunnar Hillert
  * @since 1.1.0

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/SecurityStateBean.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/SecurityStateBean.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+/**
+ * State-holder for computed security meta-information.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class SecurityStateBean {
+
+	private boolean authenticationEnabled;
+	private boolean authorizationEnabled;
+
+	public SecurityStateBean() {
+		super();
+	}
+
+	public boolean isAuthenticationEnabled() {
+		return authenticationEnabled;
+	}
+
+	public boolean isAuthorizationEnabled() {
+		return authorizationEnabled;
+	}
+
+	public void setAuthenticationEnabled(boolean authenticationEnabled) {
+		this.authenticationEnabled = authenticationEnabled;
+	}
+
+	public void setAuthorizationEnabled(boolean authorizationEnabled) {
+		this.authorizationEnabled = authorizationEnabled;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -16,7 +16,6 @@
 package org.springframework.cloud.dataflow.server.controller;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.cloud.dataflow.rest.resource.about.Dependency;
 import org.springframework.cloud.dataflow.rest.resource.about.FeatureInfo;
@@ -26,7 +25,7 @@ import org.springframework.cloud.dataflow.rest.resource.about.SecurityInfo;
 import org.springframework.cloud.dataflow.rest.resource.about.VersionInfo;
 import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
-import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -56,8 +55,7 @@ public class AboutController {
 	private final FeaturesProperties featuresProperties;
 	private final VersionInfoProperties versionInfoProperties;
 
-	private final SecurityProperties securityProperties;
-	private final AuthorizationConfig authorizationConfig;
+	private final SecurityStateBean securityStateBean;
 
 	@Value("${security.oauth2.client.client-id:#{null}}")
 	private String oauthClientId;
@@ -76,14 +74,12 @@ public class AboutController {
 			TaskLauncher taskLauncher,
 			FeaturesProperties featuresProperties,
 			VersionInfoProperties versionInfoProperties,
-			SecurityProperties securityProperties,
-			AuthorizationConfig authorizationConfig) {
+			SecurityStateBean securityStateBean) {
 		this.appDeployer = appDeployer;
 		this.taskLauncher = taskLauncher;
 		this.featuresProperties = featuresProperties;
 		this.versionInfoProperties = versionInfoProperties;
-		this.securityProperties = securityProperties;
-		this.authorizationConfig = authorizationConfig;
+		this.securityStateBean = securityStateBean;
 	}
 
 	/**
@@ -107,8 +103,8 @@ public class AboutController {
 		aboutResource.setFeatureInfo(featureInfo);
 		aboutResource.setVersionInfo(versionInfo);
 
-		final boolean authenticationEnabled = securityProperties.getBasic().isEnabled();
-		final boolean authorizationEnabled = this.authorizationConfig.isEnabled();
+		final boolean authenticationEnabled = securityStateBean.isAuthenticationEnabled();
+		final boolean authorizationEnabled = securityStateBean.isAuthorizationEnabled();
 
 		final SecurityInfo securityInfo = new SecurityInfo();
 		securityInfo.setAuthenticationEnabled(authenticationEnabled);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
@@ -17,9 +17,8 @@
 package org.springframework.cloud.dataflow.server.controller.security;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
-import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.controller.AboutController;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
@@ -48,15 +47,13 @@ import org.springframework.web.bind.annotation.RestController;
 @ExposesResourceFor(SecurityInfoResource.class)
 public class SecurityController {
 
-	private final SecurityProperties securityProperties;
-	private final AuthorizationConfig authorizationConfig;
+	private final SecurityStateBean securityStateBean;
 
 	@Value("${security.oauth2.client.client-id:#{null}}")
 	private String oauthClientId;
 
-	public SecurityController(SecurityProperties securityProperties, AuthorizationConfig authorizationConfig) {
-		this.securityProperties = securityProperties;
-		this.authorizationConfig = authorizationConfig;
+	public SecurityController(SecurityStateBean securityStateBean) {
+		this.securityStateBean = securityStateBean;
 	}
 
 	/**
@@ -67,8 +64,8 @@ public class SecurityController {
 	@ResponseStatus(HttpStatus.OK)
 	public SecurityInfoResource getSecurityInfo() {
 
-		final boolean authenticationEnabled = securityProperties.getBasic().isEnabled();
-		final boolean authorizationEnabled = this.authorizationConfig.isEnabled();
+		final boolean authenticationEnabled = securityStateBean.isAuthenticationEnabled();
+		final boolean authorizationEnabled = securityStateBean.isAuthorizationEnabled();
 
 		final SecurityInfoResource securityInfo = new SecurityInfoResource();
 		securityInfo.setAuthenticationEnabled(authenticationEnabled);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/OnSecurityEnabledAndOAuth2DisabledTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/OnSecurityEnabledAndOAuth2DisabledTests.java
@@ -48,8 +48,15 @@ public class OnSecurityEnabledAndOAuth2DisabledTests {
 	}
 
 	@Test
-	public void basicSecurityEnabledAndOauth2Enabled() throws Exception {
+	public void basicSecurityDefaultAndOauth2Enabled() throws Exception {
 		AnnotationConfigApplicationContext context = load(Config.class, "security.oauth2.client.client-id:12345");
+		assertThat(context.containsBean("myBean"), equalTo(false));
+		context.close();
+	}
+
+	@Test
+	public void basicSecurityEnabledAndOauth2Enabled() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class, "security.basic.enabled:true", "security.oauth2.client.client-id:12345");
 		assertThat(context.containsBean("myBean"), equalTo(false));
 		context.close();
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/OnSecurityEnabledAndOAuth2EnabledTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/OnSecurityEnabledAndOAuth2EnabledTests.java
@@ -71,6 +71,22 @@ public class OnSecurityEnabledAndOAuth2EnabledTests {
 	}
 
 	@Test
+	public void clientIdOnly() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class,
+			"security.oauth2.client.client-id:12345");
+		assertThat(context.containsBean("myBean"), equalTo(true));
+		context.close();
+	}
+
+	@Test
+	public void clientIdOnlyWithNoValue() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class,
+			"security.oauth2.client.client-id");
+		assertThat(context.containsBean("myBean"), equalTo(true));
+		context.close();
+	}
+
+	@Test
 	public void both3() throws Exception {
 		AnnotationConfigApplicationContext context = load(Config.class,
 			"security.basic.enabled:true", "security.oauth2.client.client-id");
@@ -83,6 +99,14 @@ public class OnSecurityEnabledAndOAuth2EnabledTests {
 		AnnotationConfigApplicationContext context = load(Config.class,
 			"security.basic.enabled:false", "security.oauth2");
 		assertThat(context.containsBean("myBean"), equalTo(false));
+		context.close();
+	}
+
+	@Test
+	public void oneTrueOneFalse2() throws Exception {
+		AnnotationConfigApplicationContext context = load(Config.class,
+			"security.basic.enabled:false", "security.oauth2.client.client-id:12345");
+		assertThat(context.containsBean("myBean"), equalTo(true));
 		context.close();
 	}
 

--- a/spring-cloud-dataflow-server-local/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server-local/src/main/resources/application.yml
@@ -26,8 +26,6 @@ info:
 # Oauth 2 support:
 
 #security:
-#  basic:
-#    enabled: true
 #  oauth2:
 #    client:
 #      client-id: myclient

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/LocalDataflowResource.java
@@ -68,6 +68,7 @@ public class LocalDataflowResource extends ExternalResource {
 		}
 
 		app = new SpringApplication(LocalTestDataFlowServer.class);
+
 		configurableApplicationContext = (WebApplicationContext) app.run(new String[]{"--server.port=0",
 				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.STREAMS_ENABLED + "=" + this.streamsEnabled,
 				"--" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.TASKS_ENABLED + "=" + this.tasksEnabled,

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.local.security;
+
+import static org.springframework.cloud.dataflow.server.local.security.SecurityTestUtils.basicAuthorizationHeader;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.springframework.cloud.dataflow.server.local.LocalDataflowResource;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+/**
+ * @author Gunnar Hillert
+ */
+public class LocalServerSecurityWithOAuth2Tests {
+
+	private final static OAuth2ServerResource oAuth2ServerResource =
+			new OAuth2ServerResource();
+
+	private final static LocalDataflowResource localDataflowResource =
+		new LocalDataflowResource("classpath:org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml");
+
+	@ClassRule
+	public static TestRule springDataflowAndLdapServer = RuleChain
+			.outerRule(oAuth2ServerResource)
+			.around(localDataflowResource);
+
+	@Test
+	public void testAccessRootUrlWithoutCredentials() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/"))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void testAccessRootUrlWithBasicAuthCredentials() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/").header("Authorization", basicAuthorizationHeader("user", "secret10")))
+				.andDo(print())
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testAccessRootUrlWithBasicAuthCredentialsWrongPassword() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/").header("Authorization", basicAuthorizationHeader("user", "wrong-password")))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void testAccessRootUrlWithOauth2AccessToken() throws Exception {
+
+		final ClientCredentialsResourceDetails resourceDetails = new ClientCredentialsResourceDetails();
+		resourceDetails.setClientId("myclient");
+		resourceDetails.setClientSecret("mysecret");
+		resourceDetails.setGrantType("client_credentials");
+		resourceDetails.setAccessTokenUri("http://localhost:" + oAuth2ServerResource.getOauth2ServerPort() + "/oauth/token");
+
+		final OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(resourceDetails);
+		final OAuth2AccessToken accessToken = oAuth2RestTemplate.getAccessToken();
+
+		final String accessTokenAsString = accessToken.getValue();
+
+		localDataflowResource.getMockMvc()
+				.perform(get("/").header("Authorization", "bearer " + accessTokenAsString))
+				.andDo(print())
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void testAccessRootUrlWithWrongOauth2AccessToken() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/").header("Authorization", "bearer 123456"))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
+	}
+
+}

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/OAuth2ServerResource.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/OAuth2ServerResource.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.local.security;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.rules.ExternalResource;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.dataflow.server.local.security.support.OAuth2TestServer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.SocketUtils;
+
+/**
+ * Bootstraps an embedded OAuth2 server using {@link OAuth2TestServer}.
+ *
+ * @author Gunnar Hillert
+ */
+public class OAuth2ServerResource extends ExternalResource {
+
+	private final Log LOGGER = LogFactory.getLog(OAuth2ServerResource.class);
+
+	private String originalOAuth2Port;
+
+	private int oauth2ServerPort;
+
+	private static final String OAUTH2_PORT_PROPERTY = "oauth2.port";
+
+	public OAuth2ServerResource() {
+		super();
+	}
+
+	private ConfigurableApplicationContext application;
+
+	@Override
+	protected void before() throws Throwable {
+
+		originalOAuth2Port = System.getProperty(OAUTH2_PORT_PROPERTY);
+
+		this.oauth2ServerPort = SocketUtils.findAvailableTcpPort();
+
+		LOGGER.info("Setting OAuth2 Server port to " + this.oauth2ServerPort);
+
+		System.setProperty(OAUTH2_PORT_PROPERTY, String.valueOf(this.oauth2ServerPort));
+
+		this.application = new SpringApplicationBuilder(OAuth2TestServer.class)
+			.build()
+			.run("--spring.config.location=classpath:/org/springframework/cloud/dataflow/server/local/security/support/oauth2TestServerConfig.yml");
+
+	}
+
+	@Override
+	protected void after() {
+		try {
+			application.stop();
+		}
+		finally {
+			if (originalOAuth2Port != null) {
+				System.setProperty(OAUTH2_PORT_PROPERTY, originalOAuth2Port);
+			}
+			else {
+				System.clearProperty(OAUTH2_PORT_PROPERTY);
+			}
+		}
+	}
+
+	public int getOauth2ServerPort() {
+		return oauth2ServerPort;
+	}
+
+}

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/support/OAuth2TestServer.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/support/OAuth2TestServer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.local.security.support;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.authserver.AuthorizationServerProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.authserver.OAuth2AuthorizationServerConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.util.SocketUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+@RestController
+@SpringBootApplication(exclude={
+		DataSourceAutoConfiguration.class,
+		DataSourceTransactionManagerAutoConfiguration.class,
+		JmxAutoConfiguration.class,
+		IntegrationAutoConfiguration.class})
+public class OAuth2TestServer {
+
+	public static void main(String[] args) {
+		new SpringApplicationBuilder(OAuth2TestServer.class)
+		.properties("server.port:" + SocketUtils.findAvailableTcpPort())
+		.build()
+		.run("--debug --spring.config.location=classpath:/org/springframework/cloud/dataflow/server/local/security/support/oauth2TestServerConfig.yml");
+	}
+
+	@RequestMapping({"/user", "/me"})
+	public Map<String, String> user(Principal principal) {
+		return Collections.singletonMap("name", principal.getName());
+	}
+
+	@Configuration
+	@EnableAuthorizationServer
+	protected static class MyOAuth2AuthorizationServerConfiguration extends OAuth2AuthorizationServerConfiguration {
+		public MyOAuth2AuthorizationServerConfiguration(BaseClientDetails details,
+				AuthenticationManager authenticationManager, ObjectProvider<TokenStore> tokenStore,
+				ObjectProvider<AccessTokenConverter> tokenConverter, AuthorizationServerProperties properties) {
+			super(details, authenticationManager, tokenStore, tokenConverter, properties);
+		}
+
+		@Override
+		public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+			super.configure(security);
+			security.allowFormAuthenticationForClients();
+		}
+	}
+
+	@Configuration
+	@EnableResourceServer
+	protected static class ResourceServerConfiguration
+			extends ResourceServerConfigurerAdapter {
+		@Override
+		public void configure(HttpSecurity http) throws Exception {
+			http.antMatcher("/me").authorizeRequests().anyRequest().authenticated();
+		}
+	}
+
+}

--- a/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
@@ -1,0 +1,21 @@
+management:
+  security:
+    enabled: true
+security:
+  oauth2:
+    authorization:
+      check-token-access: isAuthenticated()
+    client:
+      client-id: myclient
+      client-secret: mysecret
+      access-token-uri: http://127.0.0.1:${oauth2.port}/oauth/token
+      user-authorization-uri: http://127.0.0.1:${oauth2.port}/oauth/authorize
+    resource:
+      user-info-uri: http://127.0.0.1:${oauth2.port}/me
+      filter-order: 1
+spring:
+  cloud:
+    dataflow:
+      security:
+        authorization:
+          enabled: false

--- a/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
@@ -3,8 +3,6 @@ management:
     enabled: true
 security:
   oauth2:
-    authorization:
-      check-token-access: isAuthenticated()
     client:
       client-id: myclient
       client-secret: mysecret
@@ -12,10 +10,5 @@ security:
       user-authorization-uri: http://127.0.0.1:${oauth2.port}/oauth/authorize
     resource:
       user-info-uri: http://127.0.0.1:${oauth2.port}/me
-      filter-order: 1
-spring:
-  cloud:
-    dataflow:
-      security:
-        authorization:
-          enabled: false
+    authorization:
+      check-token-access: isAuthenticated()

--- a/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/support/oauth2TestServerConfig.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/support/oauth2TestServerConfig.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: my-app-name
+  jmx:
+    default-domain: my-app-name
+server:
+  port: ${oauth2.port}
+security:
+  user:
+    password: secret10
+  oauth2:
+    client:
+      clientId: myclient
+      clientSecret: mysecret
+      scope: access
+      auto-approve-scopes: '.*'
+    authorization:
+      checkTokenAccess: permitAll()


### PR DESCRIPTION
* Relax security configuration: `security.basic.enabled=true` is not required for OAuth2 any longer
* Add `OAuth2ServerResource` for creating JUnit integration tests using an embedded OAuth2 server instance
* Add tests

resolves spring-cloud/spring-cloud-dataflow#1279