### PR TITLE
Fix NPE at config command

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/test/resources/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests-testInfo.txt
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests-testInfo.txt
@@ -1,42 +1,38 @@
-╔═════════╤═══════════════════════════════════════════════════════════════════╗
-║ Target  │                       http://localhost:9393                       ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║ Result  │  Unable to contact Data Flow Server at 'http://localhost:9393':   ║
-║         │   'org.springframework.web.client.RestClientException: FooBar'.   ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║         │Analytics Enabled: true                                            ║
-║Features │  Streams Enabled: true                                            ║
-║         │    Tasks Enabled: false                                           ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║Versions │Foo Core: 1.2.3.BUILD-SNAPSHOT                                     ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║         │         Authenticated: false                                      ║
-║Security │Authentication Enabled: true                                       ║
-║         │ Authorization Enabled: false                                      ║
-║         │            Form Login: false                                      ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║         │Deployer Implementation Version: null                              ║
-║         │                  Deployer Name: null                              ║
-║         │           Deployer Spi Version: null                              ║
-║         │                   Java Version: 1.8                               ║
-║   App   │           Platform Api Version: null                              ║
-║Deployer │        Platform Client Version: null                              ║
-║         │          Platform Host Version: null                              ║
-║         │                  Platform Type: null                              ║
-║         │            Spring Boot Version: null                              ║
-║         │                 Spring Version: null                              ║
-╟┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
-║Platform │Some: Stuff                                                        ║
-║Specific │                                                                   ║
-╟─────────┼───────────────────────────────────────────────────────────────────╢
-║         │Deployer Implementation Version: null                              ║
-║         │                  Deployer Name: null                              ║
-║         │           Deployer Spi Version: 6.4                               ║
-║         │                   Java Version: null                              ║
-║  Task   │           Platform Api Version: null                              ║
-║Launcher │        Platform Client Version: null                              ║
-║         │          Platform Host Version: null                              ║
-║         │                  Platform Type: null                              ║
-║         │            Spring Boot Version: null                              ║
-║         │                 Spring Version: null                              ║
-╚═════════╧═══════════════════════════════════════════════════════════════════╝
+╔═════════════════╤═════════════════════════════════════╗
+║     Target      │        http://localhost:9393        ║
+╟─────────────────┼─────────────────────────────────────╢
+║                 │Analytics Enabled: true              ║
+║    Features     │  Streams Enabled: true              ║
+║                 │    Tasks Enabled: false             ║
+╟─────────────────┼─────────────────────────────────────╢
+║    Versions     │Foo Core: 1.2.3.BUILD-SNAPSHOT       ║
+╟─────────────────┼─────────────────────────────────────╢
+║                 │         Authenticated: false        ║
+║    Security     │Authentication Enabled: true         ║
+║                 │ Authorization Enabled: false        ║
+║                 │            Form Login: false        ║
+╟─────────────────┼─────────────────────────────────────╢
+║                 │Deployer Implementation Version: null║
+║                 │                  Deployer Name: null║
+║                 │           Deployer Spi Version: null║
+║                 │                   Java Version: 1.8 ║
+║  App Deployer   │           Platform Api Version: null║
+║                 │        Platform Client Version: null║
+║                 │          Platform Host Version: null║
+║                 │                  Platform Type: null║
+║                 │            Spring Boot Version: null║
+║                 │                 Spring Version: null║
+╟┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┼┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈╢
+║Platform Specific│Some: Stuff                          ║
+╟─────────────────┼─────────────────────────────────────╢
+║                 │Deployer Implementation Version: null║
+║                 │                  Deployer Name: null║
+║                 │           Deployer Spi Version: 6.4 ║
+║                 │                   Java Version: null║
+║  Task Launcher  │           Platform Api Version: null║
+║                 │        Platform Client Version: null║
+║                 │          Platform Host Version: null║
+║                 │                  Platform Type: null║
+║                 │            Spring Boot Version: null║
+║                 │                 Spring Version: null║
+╚═════════════════╧═════════════════════════════════════╝


### PR DESCRIPTION
- When security is enabled and `dataflow config info` is invoked without user credentials, the NPE is thrown
   - Handle exceptions inside `dataflow config info` command
   - Fix ConfigCommandTests class to avoid NPE
 - Fix DataFlowTemplate NPE on RootResource

Resolves #1295