### PR TITLE
Use constants for dataflow/stream property keys

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DataFlowPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DataFlowPropertyKeys.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.core;
+
+/**
+ * Spring Cloud Data Flow property keys.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class DataFlowPropertyKeys {
+	
+	public static final String PREFIX = "spring.cloud.dataflow.";
+
+	/**
+	 * Data Flow Stream property key prefix.
+	 */
+	public static final String STREAM_PREFIX = PREFIX + "stream.";
+
+	/**
+	 * Stream name property key.
+	 */
+	public static final String STREAM_NAME = STREAM_PREFIX + "name";
+
+	/**
+	 * Data Flow Stream app key prefix.
+	 */
+	public static final String STREAM_APP_PREFIX = STREAM_PREFIX + "app.";
+
+	/**
+	 * Stream app label property key.
+	 */
+	public static final String STREAM_APP_LABEL = STREAM_APP_PREFIX + "label";
+
+	/**
+	 * Stream app type property key.
+	 */
+	public static final String STREAM_APP_TYPE = STREAM_APP_PREFIX + "type";
+
+
+
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DataFlowPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DataFlowPropertyKeys.java
@@ -28,7 +28,7 @@ public class DataFlowPropertyKeys {
 	/**
 	 * Data Flow Stream property key prefix.
 	 */
-	public static final String STREAM_PREFIX = PREFIX + "stream.";
+	private static final String STREAM_PREFIX = PREFIX + "stream.";
 
 	/**
 	 * Stream name property key.
@@ -38,7 +38,7 @@ public class DataFlowPropertyKeys {
 	/**
 	 * Data Flow Stream app key prefix.
 	 */
-	public static final String STREAM_APP_PREFIX = STREAM_PREFIX + "app.";
+	private static final String STREAM_APP_PREFIX = STREAM_PREFIX + "app.";
 
 	/**
 	 * Stream app label property key.

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
@@ -30,4 +30,19 @@ public class StreamPropertyKeys {
 	 */
 	public static final String INSTANCE_COUNT = PREFIX + "instanceCount";
 
+	/**
+	 * Prefix for Spring Cloud Stream Metrics.
+	 */
+	public static final String METRICS_PREFIX = PREFIX + "metrics.";
+
+	/**
+	 * METRICS Key property key.
+	 */
+	public static final String METRICS_KEY = METRICS_PREFIX + "key";
+
+	/**
+	 * METRICS properties property key.
+	 */
+	public static final String METRICS_PROPERTIES = METRICS_PREFIX + "properties";
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsProperties.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Configuration properties for namespace 'spring.cloud.dataflow.metrics'.
@@ -26,7 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = MetricsProperties.PREFIX)
 public class MetricsProperties {
 
-	public static final String PREFIX = "spring.cloud.dataflow.metrics";
+	public static final String PREFIX = DataFlowPropertyKeys.PREFIX + "metrics";
 
 	private Collector collector = new Collector();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/VersionInfoProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/VersionInfoProperties.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Properties for version information of core dependencies.
@@ -25,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = VersionInfoProperties.VERSION_INFO_PREFIX)
 public class VersionInfoProperties {
 
-	public static final String VERSION_INFO_PREFIX = "spring.cloud.dataflow.version-info";
+	public static final String VERSION_INFO_PREFIX = DataFlowPropertyKeys.PREFIX + "version-info";
 
 	private String dataflowCoreVersion;
 	private String dataflowDashboardVersion;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/apps/CommonApplicationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/apps/CommonApplicationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Common properties for applications deployed via Spring Cloud Data Flow.
  *
  * @author Marius Bogoevici
  */
-@ConfigurationProperties("spring.cloud.dataflow.applicationProperties")
+@ConfigurationProperties(DataFlowPropertyKeys.PREFIX + "applicationProperties")
 public class CommonApplicationProperties {
 
 	private Map<String,String> stream = new ConcurrentHashMap<>();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.config.features;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Configuration properties for all the features that need to be enabled/disabled at the dataflow server.
@@ -25,7 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = FeaturesProperties.FEATURES_PREFIX)
 public class FeaturesProperties {
 
-    public static final String FEATURES_PREFIX = "spring.cloud.dataflow.features";
+    public static final String FEATURES_PREFIX = DataFlowPropertyKeys.PREFIX + "features";
 
     public static final String STREAMS_ENABLED = "streams-enabled";
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/BasicAuthSecurityConfiguration.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -186,7 +187,7 @@ public class BasicAuthSecurityConfiguration extends WebSecurityConfigurerAdapter
 	 * @author Eric Bottard
 	 * @author Gunnar Hillert
 	 */
-	@ConfigurationProperties(prefix = "spring.cloud.dataflow.security.authorization")
+	@ConfigurationProperties(prefix = DataFlowPropertyKeys.PREFIX + "security.authorization")
 	public static class AuthorizationConfig {
 
 		private boolean enabled = true;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/FileAuthenticationConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/FileAuthenticationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.Properties;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
@@ -34,11 +35,11 @@ import org.springframework.util.Assert;
 * @since 1.1.0
 */
 @Configuration
-@ConditionalOnProperty("spring.cloud.dataflow.security.authentication.file.enabled")
+@ConditionalOnProperty(DataFlowPropertyKeys.PREFIX + "security.authentication.file.enabled")
 @ConfigurationProperties(prefix = FileAuthenticationConfiguration.CONFIGURATION_PROPERTIES_PREFIX)
 public class FileAuthenticationConfiguration extends GlobalAuthenticationConfigurerAdapter {
 
-	public static final String CONFIGURATION_PROPERTIES_PREFIX = "spring.cloud.dataflow.security.authentication.file";
+	public static final String CONFIGURATION_PROPERTIES_PREFIX = DataFlowPropertyKeys.PREFIX + "security.authentication.file";
 
 	private Properties users;
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/LdapAuthenticationConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/LdapAuthenticationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.server.config.security.support.LdapSecurityProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.DirContextOperations;
@@ -41,7 +42,7 @@ import org.springframework.util.StringUtils;
 * @since 1.1.0
 */
 @Configuration
-@ConditionalOnProperty("spring.cloud.dataflow.security.authentication.ldap.enabled")
+@ConditionalOnProperty(DataFlowPropertyKeys.PREFIX + "security.authentication.ldap.enabled")
 @EnableConfigurationProperties(LdapSecurityProperties.class)
 public class LdapAuthenticationConfiguration extends GlobalAuthenticationConfigurerAdapter {
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/LdapSecurityProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/LdapSecurityProperties.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Properties for the Ldap security aspects of an application.
@@ -27,7 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Gunnar Hillert
  * @since 1.1.0
  */
-@ConfigurationProperties(prefix = "spring.cloud.dataflow.security.authentication.ldap")
+@ConfigurationProperties(prefix = DataFlowPropertyKeys.PREFIX + "security.authentication.ldap")
 @LdapSecurityPropertiesValid
 public class LdapSecurityProperties {
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
@@ -60,6 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controller for deployment operations on {@link StreamDefinition}.
+ *
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Patrick Peralta
@@ -110,11 +112,12 @@ public class StreamDeploymentController {
 	 * <li>app retrieval to the provided {@link AppRegistry}</li>
 	 * <li>deployment operations to the provided {@link AppDeployer}</li>
 	 * </ul>
+	 *
 	 * @param repository             the repository this controller will use for stream CRUD operations
 	 * @param deploymentIdRepository the repository this controller will use for deployment IDs
 	 * @param registry               the registry this controller will use to lookup apps
 	 * @param deployer               the deployer this controller will use to deploy stream apps
-	 * @param commonProperties         common set of application properties
+	 * @param commonProperties       common set of application properties
 	 */
 	public StreamDeploymentController(StreamDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
@@ -135,6 +138,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Request un-deployment of an existing stream.
+	 *
 	 * @param name the name of an existing stream (required)
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
@@ -160,6 +164,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Request deployment of an existing stream definition.
+	 *
 	 * @param name       the name of an existing stream definition (required)
 	 * @param properties the deployment properties for the stream as a comma-delimited list of key=value pairs
 	 */
@@ -201,6 +206,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Deploy a stream as defined by its {@link StreamDefinition} and optional deployment properties.
+	 *
 	 * @param stream                     the stream to deploy
 	 * @param streamDeploymentProperties the deployment properties for the stream
 	 */
@@ -217,7 +223,7 @@ public class StreamDeploymentController {
 
 			AppRegistration registration = this.registry.find(currentApp.getRegisteredAppName(), type);
 			Assert.notNull(registration, String.format("no application '%s' of type '%s' exists in the registry",
-				currentApp.getName(), type));
+					currentApp.getName(), type));
 
 
 			Map<String, String> appDeployTimeProperties = extractAppProperties(currentApp, streamDeploymentProperties);
@@ -251,18 +257,18 @@ public class StreamDeploymentController {
 			Resource metadataResource = registration.getMetadataResource();
 
 			// add properties needed for metrics system
-			appDeployTimeProperties.put("spring.cloud.dataflow.stream.name", currentApp.getStreamName());
-			appDeployTimeProperties.put("spring.cloud.dataflow.stream.app.label", currentApp.getName());
-			appDeployTimeProperties.put("spring.cloud.dataflow.stream.app.type", type.toString());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_NAME, currentApp.getStreamName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_LABEL, currentApp.getName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_TYPE, type.toString());
 			StringBuilder sb = new StringBuilder()
 					.append(currentApp.getStreamName()).append(".")
 					.append(currentApp.getName()).append(".")
 					.append("${spring.cloud.application.guid}");
-			appDeployTimeProperties.put("spring.cloud.stream.metrics.key", sb.toString());
+			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
 			//TODO allow user to specify SPRING_CLOUD_STREAM_METRICS_PROPERTIES
 			//TODO Default should be spring.application.*,spring.cloud.application.*,spring.cloud.dataflow.*
 			//     Leaving it as spring* for development purposes ATM
-			appDeployTimeProperties.put("spring.cloud.stream.metrics.properties", "spring*");
+			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_PROPERTIES, "spring*");
 
 			// Merge *definition time* app properties with *deployment time* properties
 			// and expand them to their long form if applicable
@@ -296,6 +302,7 @@ public class StreamDeploymentController {
 	/**
 	 * Extract and return a map of properties for a specific app within the
 	 * deployment properties of a stream.
+	 *
 	 * @param appDefinition              the {@link StreamAppDefinition} for which to return a map of properties
 	 * @param streamDeploymentProperties deployment properties for the stream that the app is defined in
 	 * @return map of properties for an app
@@ -343,6 +350,7 @@ public class StreamDeploymentController {
 	/**
 	 * Return {@code true} if the upstream app (the app that appears before
 	 * the provided app) contains partition related properties.
+	 *
 	 * @param stream                     stream for the app
 	 * @param currentApp                 app for which to determine if the upstream app
 	 *                                   has partition properties
@@ -368,6 +376,7 @@ public class StreamDeploymentController {
 	 * Return {@code true} if an app is a consumer of partitioned data.
 	 * This is determined either by the deployment properties for the app
 	 * or whether the previous (upstream) app is publishing partitioned data.
+	 *
 	 * @param appDeploymentProperties      deployment properties for the app
 	 * @param upstreamAppSupportsPartition if true, previous (upstream) app
 	 *                                     in the stream publishes partitioned data
@@ -382,6 +391,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Add app properties for consuming partitioned data to the provided properties.
+	 *
 	 * @param properties properties to update
 	 */
 	private void updateConsumerPartitionProperties(Map<String, String> properties) {
@@ -390,6 +400,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Add app properties for producing partitioned data to the provided properties.
+	 *
 	 * @param properties        properties to update
 	 * @param nextInstanceCount the number of instances for the next (downstream) app in the stream
 	 */
@@ -402,6 +413,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Return the app instance count indicated in the provided properties.
+	 *
 	 * @param properties deployer properties for the app for which to determine the count
 	 * @return instance count indicated in the provided properties;
 	 * if the properties do not contain a count, a value of {@code 1} is returned
@@ -412,6 +424,7 @@ public class StreamDeploymentController {
 
 	/**
 	 * Undeploy the given stream.
+	 *
 	 * @param stream stream to undeploy
 	 */
 	private void undeployStream(StreamDefinition stream) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/DataflowRdbmsInitializer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/DataflowRdbmsInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
@@ -65,7 +66,7 @@ public final class DataflowRdbmsInitializer implements InitializingBean {
 
 	private ResourceLoader resourceLoader;
 
-	@Value("${spring.cloud.dataflow.rdbms.initialize.enable:true}")
+	@Value("${" + DataFlowPropertyKeys.PREFIX + "rdbms.initialize.enable:true}")
 	private boolean definitionInitializationEnable;
 
 	private final FeaturesProperties featuresProperties;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.server.service.impl;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 
 /**
  * Properties used to define the behavior of tasks created by
@@ -27,7 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = TaskConfigurationProperties.COMPOSED_TASK_PREFIX)
 public class TaskConfigurationProperties {
 
-	public static final String COMPOSED_TASK_PREFIX = "spring.cloud.dataflow.task";
+	public static final String COMPOSED_TASK_PREFIX = DataFlowPropertyKeys.PREFIX + "task";
 
 	/**
 	 * The task application name to be used for the composed task runner.


### PR DESCRIPTION
- Define constant prefix/names wherever possible
 - Update `spring.cloud.dataflow.` prefix in other places in the codebase as well

Resolves #1297