### PR TITLE
Create metrics endpoint for streams

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.cloud.dataflow.server.controller.JobExecutionControll
 import org.springframework.cloud.dataflow.server.controller.JobInstanceController;
 import org.springframework.cloud.dataflow.server.controller.JobStepExecutionController;
 import org.springframework.cloud.dataflow.server.controller.JobStepExecutionProgressController;
+import org.springframework.cloud.dataflow.server.controller.MetricsController;
 import org.springframework.cloud.dataflow.server.controller.RestControllerAdvice;
 import org.springframework.cloud.dataflow.server.controller.RootController;
 import org.springframework.cloud.dataflow.server.controller.RuntimeAppsController;
@@ -150,6 +151,11 @@ public class DataFlowControllerAutoConfiguration {
 			DeploymentIdRepository deploymentIdRepository, AppDeployer appDeployer, MetricStore metricStore) {
 		return new RuntimeAppsController(repository, deploymentIdRepository, appDeployer, metricStore,
 				runtimeAppsStatusFJPFB().getObject());
+	}
+
+	@Bean
+	public MetricsController metricsController(MetricStore metricStore) {
+		return new MetricsController(metricStore);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/MetricsController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/MetricsController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.cloud.dataflow.server.controller.support.ApplicationsMetrics;
+import org.springframework.cloud.dataflow.server.controller.support.MetricStore;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller handling metrics requests for as a passthrough to collector.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RestController
+@RequestMapping("/metrics/streams")
+public class MetricsController {
+
+	private final MetricStore metricStore;
+
+	/**
+	 * Instantiates a new metrics controller.
+	 *
+	 * @param metricStore the metric store
+	 */
+	public MetricsController(MetricStore metricStore) {
+		this.metricStore = metricStore;
+	}
+
+	@RequestMapping(method = RequestMethod.GET)
+	public List<ApplicationsMetrics> list() throws ExecutionException, InterruptedException {
+		return metricStore.getMetrics();
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -13,6 +13,10 @@ spring:
         authorization:
           enabled: true
           rules:
+            # Metrics
+
+            - GET    /metrics/streams                => hasRole('ROLE_VIEW')
+
             # About
 
             - GET    /about                          => hasRole('ROLE_VIEW')

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.dataflow.server.config.MetricsProperties;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
 import org.springframework.cloud.dataflow.server.controller.CompletionController;
+import org.springframework.cloud.dataflow.server.controller.MetricsController;
 import org.springframework.cloud.dataflow.server.controller.RestControllerAdvice;
 import org.springframework.cloud.dataflow.server.controller.RuntimeAppsController;
 import org.springframework.cloud.dataflow.server.controller.StreamDefinitionController;
@@ -149,7 +150,10 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		return new AppRegistryController(registry, metadataResolver, new ForkJoinPool(2));
 	}
 
-
+	@Bean
+	public MetricsController metricsController(MetricStore metricStore) {
+		return new MetricsController(metricStore);
+	}
 
 	@Bean
 	public RuntimeAppsController runtimeAppsController(MetricStore metricStore) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/MetricsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/MetricsControllerTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Tests for metrics controller.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class MetricsControllerTests {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Before
+	public void setupMocks() throws Exception {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+	}
+
+
+	@Test
+	public void testGetResponse() throws Exception {
+		MockHttpServletResponse responseString = mockMvc.perform(
+				get("/metrics/streams").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse();
+		// for now we just get dummy mocked response
+		assertThat(responseString.getContentAsString(), containsString("ticktock1"));
+	}
+}


### PR DESCRIPTION
- Add a simple MetricsController meant to be a proxy
  for collector metrics and used by flo.
- Attatch to security ad VIEW rights
- For now keeping this out from RootController as
  we'd need Resource type and that is not known until
  collector adds hal stuff.
- Fixes #1286