### PR TITLE
Tools polish

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/GraphGeneratorVisitor.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/GraphGeneratorVisitor.java
@@ -498,11 +498,11 @@ public class GraphGeneratorVisitor extends TaskVisitor {
 			if (transition.isSpecialTransition()) {
 				if (transition.isFailTransition()) {
 					Node failNode = findOrMakeNode("$FAIL");
-					addLink(new Link(currentTaskAppId, failNode.id, transition.getStatusToCheckInDSLForm()));
+					addLink(new Link(currentTaskAppId, failNode.id, transition.getStatusToCheck()));
 				}
 				else if (transition.isEndTransition()) {
 					Node endNode = findOrMakeNode("$END");
-					addLink(new Link(currentTaskAppId, endNode.id, transition.getStatusToCheckInDSLForm()));
+					addLink(new Link(currentTaskAppId, endNode.id, transition.getStatusToCheck()));
 				}
 			}
 			else {
@@ -519,7 +519,7 @@ public class GraphGeneratorVisitor extends TaskVisitor {
 					addNode(n);
 					isCreated = true;
 				}
-				addLink(new Link(currentTaskAppId, n.id, transition.getStatusToCheckInDSLForm()));
+				addLink(new Link(currentTaskAppId, n.id, transition.getStatusToCheck()));
 				if (isCreated) {
 					if (currentContext().isFlow) {
 						currentContext().addOtherExit(n.id);
@@ -534,11 +534,11 @@ public class GraphGeneratorVisitor extends TaskVisitor {
 			// Check if it is a transition to something labeled earlier in this flow
 			Node existingNode = currentContext().getNodeLabeled(transition.getTargetLabel());
 			if (existingNode != null) {
-				addLink(new Link(currentTaskAppId, existingNode.id, transition.getStatusToCheckInDSLForm()));
+				addLink(new Link(currentTaskAppId, existingNode.id, transition.getStatusToCheck()));
 			}
 			else {
 				// Record a new transition attempted
-				currentContext().addTransitionTarget(currentTaskAppId, transition.getStatusToCheckInDSLForm(),
+				currentContext().addTransitionTarget(currentTaskAppId, transition.getStatusToCheck(),
 						transition.getTargetLabel());
 			}
 		}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskApp.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskApp.java
@@ -29,9 +29,6 @@ import org.springframework.util.Assert;
  */
 public class TaskApp {
 
-	// Used when building the executable dsl name for a task app
-	private final static String EXECUTABLE_DSL_JOIN_CHAR = "_";
-
 	private String taskDefinitionName;
 
 	private String name;
@@ -81,7 +78,7 @@ public class TaskApp {
 
 	public String getExecutableDSLName() {
 		StringBuilder s = new StringBuilder();
-		s.append(EXECUTABLE_DSL_JOIN_CHAR).append(taskDefinitionName).append(EXECUTABLE_DSL_JOIN_CHAR);
+		s.append(TaskNode.getTaskPrefix(taskDefinitionName));
 		s.append(label == null ? name : label);
 		return s.toString();
 	}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskNode.java
@@ -215,7 +215,6 @@ public class TaskNode extends AstNode {
 
 	static class ExecutableDSLVisitor extends TaskVisitor {
 
-		private final String EXECUTABLE_DSL_JOIN_CHAR = "_";
 		private final static int START_OF_FLOW = 0;
 		private final static int START_OF_SPLIT = 1;
 		private final static int IN_FLOW = 2;
@@ -303,7 +302,7 @@ public class TaskNode extends AstNode {
 
 		private String toExecutableDSLTaskName(TaskAppNode taskApp) {
 			StringBuilder taskDefName = new StringBuilder();
-			taskDefName.append(EXECUTABLE_DSL_JOIN_CHAR).append(taskName).append(EXECUTABLE_DSL_JOIN_CHAR);
+			taskDefName.append(getTaskPrefix(taskName));
 			if (taskApp.hasLabel()) {
 				taskDefName.append(taskApp.getLabelString());
 			}
@@ -317,6 +316,16 @@ public class TaskNode extends AstNode {
 			return dsl.toString();
 		}
 
+	}
+	
+	/**
+	 * Create the prefix to be added to task names created for task app references
+	 * in composed task DSL.
+	 * @param taskName the name of the composed task
+	 * @return a prefix to include ahead of the name/label of an app name
+	 */
+	public static String getTaskPrefix(String taskName) {
+		return taskName + "-";
 	}
 
 	/**

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
@@ -125,6 +125,29 @@ public class TaskValidatorVisitor extends TaskVisitor {
 		if (!transition.isTargetApp()) {
 			transitionsTargetingLabels.add(transition);
 		}
+		if (transition.isTargetApp()) {
+			TaskAppNode taskApp = transition.getTargetApp();
+			if (taskApp.hasLabel()) {
+				String labelString = taskApp.getLabelString();
+				if (labelsDefined.contains(labelString)) {
+					pushProblem(taskApp.getLabel().startPos, DSLMessage.TASK_VALIDATION_DUPLICATE_LABEL);
+				}
+				labelsDefined.add(labelString);
+				if (taskAppNamesWithoutLabels.contains(labelString)) {
+					pushProblem(taskApp.getLabel().startPos,DSLMessage.TASK_VALIDATION_LABEL_CLASHES_WITH_TASKAPP_NAME);
+				}
+			}
+			else {
+				String name = taskApp.getName();
+				if (labelsDefined.contains(name)) {
+					pushProblem(taskApp.startPos,DSLMessage.TASK_VALIDATION_APP_NAME_CLASHES_WITH_LABEL);
+				}
+				if (taskAppNamesWithoutLabels.contains(name)) {
+					pushProblem(taskApp.startPos,DSLMessage.TASK_VALIDATION_APP_NAME_ALREADY_IN_USE);
+				}
+				taskAppNamesWithoutLabels.add(taskApp.getName());
+			}
+		}
 	}
 	
 	@Override

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
@@ -63,7 +63,11 @@ public class Graph {
 	public String toVerboseString() {
 		StringBuilder s = new StringBuilder();
 		for (Node n: nodes) {
-			s.append("[").append(n.id).append(":").append(n.name);
+			s.append("[").append(n.id).append(":");
+			if (n.getLabel() != null) {
+				s.append(n.getLabel()).append(":");
+			}
+			s.append(n.name);
 			if (n.properties != null) {
 				for (Map.Entry<String,String> property: n.properties.entrySet()) {
 					s.append(":").append(property.getKey()).append("=").append(property.getValue());
@@ -318,7 +322,11 @@ public class Graph {
 		if (node.properties != null) {
 			for (Map.Entry<String, String> entry : node.properties.entrySet()) {
 				graphText.append(" ");
-				graphText.append("--").append(entry.getKey()).append("=").append(entry.getValue());
+				String propertyValue = entry.getValue();
+				if (propertyValue.contains(" ") && !propertyValue.startsWith("'")) {
+					propertyValue = "'" + propertyValue + "'";
+				}
+				graphText.append("--").append(entry.getKey()).append("=").append(propertyValue);
 			}
 		}
 	}
@@ -340,6 +348,21 @@ public class Graph {
 			if (l.hasTransitionSet()) {
 				// capture the target of this link as a simple transition
 				String transitionName = l.getTransitionName();
+				boolean isStatusText = true;
+				if (transitionName.equals("*")) {
+					isStatusText = false;
+				}
+				else {
+					try {
+						Integer.parseInt(transitionName);
+						isStatusText = false;
+					} catch (NumberFormatException nfe) {
+						// it is text
+					}
+				}
+				if (isStatusText && !transitionName.startsWith("'")) {
+					transitionName = "'"+transitionName+"'";
+				}
 				Node transitionTarget = findNodeById(l.to);
 				String transitionTargetName = transitionTarget.name;
 				if (transitionTargetName.equals("FAIL")) {
@@ -349,7 +372,7 @@ public class Graph {
 					transitionTargetName = TransitionNode.END;
 				}
 				else if (transitionTarget.getLabel()!=null) {
-					transitionTargetName = ":"+transitionTarget.getLabel();
+					transitionTargetName = transitionTarget.getLabel()+": "+transitionTargetName;
 				}
 				graphText.append(" ").append(transitionName).append("->").append(transitionTargetName);
 				unfollowedLinks.remove(l);

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -291,60 +291,60 @@ public class TaskParserTests {
 		TaskNode ctn = parse("foo","appA && appB",true);
 		List<TaskApp> taskApps = ctn.getTaskApps();
 		assertEquals("appA",taskApps.get(0).getName());
-		assertEquals("_foo_appA",taskApps.get(0).getExecutableDSLName());
+		assertEquals("foo-appA",taskApps.get(0).getExecutableDSLName());
 		assertEquals("appB",taskApps.get(1).getName());
-		assertEquals("_foo_appB",taskApps.get(1).getExecutableDSLName());
+		assertEquals("foo-appB",taskApps.get(1).getExecutableDSLName());
 		
 		ctn = parse("bar","appC && goo: appC",true);
 		taskApps = ctn.getTaskApps();
 		assertEquals("appC",taskApps.get(0).getName());
-		assertEquals("_bar_appC",taskApps.get(0).getExecutableDSLName());
+		assertEquals("bar-appC",taskApps.get(0).getExecutableDSLName());
 		assertEquals("appC",taskApps.get(1).getName());
-		assertEquals("_bar_goo",taskApps.get(1).getExecutableDSLName());
+		assertEquals("bar-goo",taskApps.get(1).getExecutableDSLName());
 
 		// flows
-		assertEquals("_foo_appA",parse("foo","appA",true).toExecutableDSL());
-		assertEquals("_foo_appA && _foo_appB",parse("foo","appA && appB",true).toExecutableDSL());
-		assertEquals("_foo_appA && _foo_appB && _foo_appC",parse("foo","appA && appB && appC",true).toExecutableDSL());
+		assertEquals("foo-appA",parse("foo","appA",true).toExecutableDSL());
+		assertEquals("foo-appA && foo-appB",parse("foo","appA && appB",true).toExecutableDSL());
+		assertEquals("foo-appA && foo-appB && foo-appC",parse("foo","appA && appB && appC",true).toExecutableDSL());
 
-		assertTaskApps("foo","appA","_foo_appA");
-		assertTaskApps("foo","appA && appB","_foo_appA","_foo_appB");
-		assertTaskApps("foo","appA && appB && appC","_foo_appA","_foo_appB","_foo_appC");
+		assertTaskApps("foo","appA","foo-appA");
+		assertTaskApps("foo","appA && appB","foo-appA","foo-appB");
+		assertTaskApps("foo","appA && appB && appC","foo-appA","foo-appB","foo-appC");
 		
 		// arguments
-		assertEquals("_foo_appA",parse("foo","appA --p1=v1 --p2=v2",true).toExecutableDSL());
-		assertEquals("_foo_appA && _foo_appB",parse("foo","appA --p2=v2 && appB --p3=v3",true).toExecutableDSL());
-		assertTaskApps("foo","appA --p1=v2","_foo_appA:p1=v2");
-		assertTaskApps("foo","appA --p1=v2 && goo: appB --p2=v2","_foo_appA:p1=v2","_foo_goo:p2=v2");
-		assertTaskApps("foo","appA 0->x:appA --p1=v1","_foo_appA","_foo_x:p1=v1");
+		assertEquals("foo-appA",parse("foo","appA --p1=v1 --p2=v2",true).toExecutableDSL());
+		assertEquals("foo-appA && foo-appB",parse("foo","appA --p2=v2 && appB --p3=v3",true).toExecutableDSL());
+		assertTaskApps("foo","appA --p1=v2","foo-appA:p1=v2");
+		assertTaskApps("foo","appA --p1=v2 && goo: appB --p2=v2","foo-appA:p1=v2","foo-goo:p2=v2");
+		assertTaskApps("foo","appA 0->x:appA --p1=v1","foo-appA","foo-x:p1=v1");
 		
 		// labels
-		assertEquals("_bar_goo",parse("bar","goo:appA",true).toExecutableDSL());
-		assertEquals("_fo_aaa && _fo_bbb",parse("fo","aaa: appA && bbb: appA",true).toExecutableDSL());
+		assertEquals("bar-goo",parse("bar","goo:appA",true).toExecutableDSL());
+		assertEquals("fo-aaa && fo-bbb",parse("fo","aaa: appA && bbb: appA",true).toExecutableDSL());
 
-		assertTaskApps("bar","goo:appA","_bar_goo");
-		assertTaskApps("bar","appA && goo: appA","_bar_appA","_bar_goo");
+		assertTaskApps("bar","goo:appA","bar-goo");
+		assertTaskApps("bar","appA && goo: appA","bar-appA","bar-goo");
 
 		// transitions
-		assertEquals("_foo_appA 'c'->_foo_appC && _foo_appB",parse("foo","appA 'c'->appC && appB",true).toExecutableDSL());
-		assertEquals("_foo_appA 'c'->_foo_appC 'd'->_foo_appD && _foo_appB",parse("foo","appA 'c'->appC 'd'->appD && appB",true).toExecutableDSL());
-		assertEquals("_foo_appA 1->_foo_appC 2->_foo_appD && _foo_appB",parse("foo","appA 1->appC 2->appD && appB",true).toExecutableDSL());
-		assertEquals("_foo_aaa 1->_foo_appC 2->:aaa",parse("foo","aaa: appA 1->appC 2->:aaa",true).toExecutableDSL());
+		assertEquals("foo-appA 'c'->foo-appC && foo-appB",parse("foo","appA 'c'->appC && appB",true).toExecutableDSL());
+		assertEquals("foo-appA 'c'->foo-appC 'd'->foo-appD && foo-appB",parse("foo","appA 'c'->appC 'd'->appD && appB",true).toExecutableDSL());
+		assertEquals("foo-appA 1->foo-appC 2->foo-appD && foo-appB",parse("foo","appA 1->appC 2->appD && appB",true).toExecutableDSL());
+		assertEquals("foo-aaa 1->foo-appC 2->:aaa",parse("foo","aaa: appA 1->appC 2->:aaa",true).toExecutableDSL());
 
 		// splits
-		assertEquals("<_foo_appA || _foo_appB>",parse("foo","<appA || appB>",true).toExecutableDSL());
-		assertEquals("<_foo_appA || _foo_appB && _foo_appC>",parse("foo","<appA || appB && appC>",true).toExecutableDSL());
-		assertEquals("<<_foo_appA && _foo_appD || _foo_appE> || _foo_appB>",parse("foo","<<appA && appD || appE> || appB>",true).toExecutableDSL());
-		assertEquals("<<_foo_appA || _foo_x> || _foo_appB>",parse("foo","<<appA || x: appA> || appB>",true).toExecutableDSL());
+		assertEquals("<foo-appA || foo-appB>",parse("foo","<appA || appB>",true).toExecutableDSL());
+		assertEquals("<foo-appA || foo-appB && foo-appC>",parse("foo","<appA || appB && appC>",true).toExecutableDSL());
+		assertEquals("<<foo-appA && foo-appD || foo-appE> || foo-appB>",parse("foo","<<appA && appD || appE> || appB>",true).toExecutableDSL());
+		assertEquals("<<foo-appA || foo-x> || foo-appB>",parse("foo","<<appA || x: appA> || appB>",true).toExecutableDSL());
 		
 		// splits and flows
-		assertEquals("_foo_AAA && _foo_FFF 'FAILED'->_foo_EEE && <_foo_BBB || _foo_CCC> && _foo_DDD",parse("foo","AAA && FFF 'FAILED' -> EEE && <BBB||CCC> && DDD",true).toExecutableDSL());
-		assertTaskApps("foo","AAA && FFF 'FAILED' -> EEE && <BBB||CCC> && DDD","_foo_AAA","_foo_FFF","_foo_EEE","_foo_BBB","_foo_CCC","_foo_DDD");
-		assertEquals("<_test_A || _test_B> && <_test_C || _test_D>",parse("<A || B> && <C||D>",true).toExecutableDSL());
-		assertEquals("<_test_A || _test_B || _test_C> && <_test_D || _test_E>",parse("<A || B || C> && <D||E>",true).toExecutableDSL());
-		assertEquals("<_test_A || _test_B || _test_C> && _test_D",parse("<A || B || C> && D",true).toExecutableDSL());
-		assertEquals("<_test_A || <_test_B && _test_C || _test_D>>",parse("<A || <B && C || D>>",true).toExecutableDSL());
-		assertEquals("<_test_A || <_test_B || _test_D && _test_E>>",parse("<A || <B || D && E>>",true).toExecutableDSL());
+		assertEquals("foo-AAA && foo-FFF 'FAILED'->foo-EEE && <foo-BBB || foo-CCC> && foo-DDD",parse("foo","AAA && FFF 'FAILED' -> EEE && <BBB||CCC> && DDD",true).toExecutableDSL());
+		assertTaskApps("foo","AAA && FFF 'FAILED' -> EEE && <BBB||CCC> && DDD","foo-AAA","foo-FFF","foo-EEE","foo-BBB","foo-CCC","foo-DDD");
+		assertEquals("<test-A || test-B> && <test-C || test-D>",parse("<A || B> && <C||D>",true).toExecutableDSL());
+		assertEquals("<test-A || test-B || test-C> && <test-D || test-E>",parse("<A || B || C> && <D||E>",true).toExecutableDSL());
+		assertEquals("<test-A || test-B || test-C> && test-D",parse("<A || B || C> && D",true).toExecutableDSL());
+		assertEquals("<test-A || <test-B && test-C || test-D>>",parse("<A || <B && C || D>>",true).toExecutableDSL());
+		assertEquals("<test-A || <test-B || test-D && test-E>>",parse("<A || <B || D && E>>",true).toExecutableDSL());
 		
 		ctn = parse("AAA 0->BBB");
 		List<TransitionNode> transitions = ((TaskAppNode)((FlowNode)ctn.getSequences().get(0)).getSeriesElement(0)).getTransitions();
@@ -359,9 +359,9 @@ public class TaskParserTests {
 		assertEquals("*",transitions.get(0).getStatusToCheckInDSLForm());
 		assertEquals("'*'",transitions.get(1).getStatusToCheckInDSLForm());
 
-		assertEquals("_test_AAA 'failed'->_test_BBB *->_test_CCC",parse("AAA 'failed' -> BBB * -> CCC").toExecutableDSL());
-		assertEquals("_test_AAA 'failed'->_test_BBB '*'->_test_CCC",parse("AAA 'failed' -> BBB '*' -> CCC").toExecutableDSL());
-		assertEquals("_test_AAA 1->_test_BBB 2->_test_CCC",parse("AAA 1 -> BBB 2 -> CCC").toExecutableDSL());
+		assertEquals("test-AAA 'failed'->test-BBB *->test-CCC",parse("AAA 'failed' -> BBB * -> CCC").toExecutableDSL());
+		assertEquals("test-AAA 'failed'->test-BBB '*'->test-CCC",parse("AAA 'failed' -> BBB '*' -> CCC").toExecutableDSL());
+		assertEquals("test-AAA 1->test-BBB 2->test-CCC",parse("AAA 1 -> BBB 2 -> CCC").toExecutableDSL());
 	}
 
 	@Test

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -889,6 +889,10 @@ public class TaskParserTests {
 		checkDSLToGraphAndBackToDSL("<foojob || bbb && ccc>");
 		checkDSLToGraphAndBackToDSL("<a || b> && c");
 		checkDSLToGraphAndBackToDSL("a && <b || c>");
+		// Test that even though two transitions specify the same app and are in the same flow, the
+		// targets are different because the 'names' (i.e. labels) make them different.
+		assertGraph("[0:START][1:AppA][2:AppB][3:x:AppC][4:AppD][5:y:AppC][6:END][0-1][1-2][0:2-3][2-4][0:4-5][4-6][3-6][5-6]",
+				"AppA && AppB 0->x: AppC && AppD 0->y: AppC");
 	}
 	
 	@Test

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -285,7 +285,7 @@ public class DefaultTaskService implements TaskService {
 		//if composed-task-runner definition then destroy all child tasks associated with it.
 		if(taskDefinition.getDslText().startsWith(taskConfigurationProperties.getComposedTaskRunnerName()))
 		{
-			String childTaskPrefix = String.format("_%s_",name);
+			String childTaskPrefix = String.format("%s-",name);
 			taskDefinitionRepository.findAll().forEach(
 					childDefinition -> {
 						if(childDefinition.getName().startsWith(childTaskPrefix)) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/services/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/services/impl/DefaultTaskServiceTests.java
@@ -183,10 +183,10 @@ public class DefaultTaskServiceTests {
 	public void createSequenceComposedTask() {
 		taskService.saveTaskDefinition("seqTask", "AAA && BBB");
 		verifyTaskExistsInRepo("seqTask",
-				"composed-task-runner --graph=\"_seqTask_AAA && _seqTask_BBB\"");
+				"composed-task-runner --graph=\"seqTask-AAA && seqTask-BBB\"");
 
-		verifyTaskExistsInRepo("_seqTask_AAA", "AAA");
-		verifyTaskExistsInRepo("_seqTask_BBB", "BBB");
+		verifyTaskExistsInRepo("seqTask-AAA", "AAA");
+		verifyTaskExistsInRepo("seqTask-BBB", "BBB");
 	}
 
 	@Test
@@ -194,10 +194,10 @@ public class DefaultTaskServiceTests {
 	public void createSplitComposedTask() {
 		taskService.saveTaskDefinition("splitTask", "<AAA || BBB>");
 		verifyTaskExistsInRepo("splitTask",
-				"composed-task-runner --graph=\"<_splitTask_AAA || _splitTask_BBB>\"");
+				"composed-task-runner --graph=\"<splitTask-AAA || splitTask-BBB>\"");
 
-		verifyTaskExistsInRepo("_splitTask_AAA", "AAA");
-		verifyTaskExistsInRepo("_splitTask_BBB", "BBB");
+		verifyTaskExistsInRepo("splitTask-AAA", "AAA");
+		verifyTaskExistsInRepo("splitTask-BBB", "BBB");
 	}
 
 	@Test
@@ -205,10 +205,10 @@ public class DefaultTaskServiceTests {
 	public void createTransitionComposedTask() {
 		taskService.saveTaskDefinition("transitionTask", "AAA 'FAILED' -> BBB '*' -> CCC");
 		verifyTaskExistsInRepo("transitionTask",
-				"composed-task-runner --graph=\"_transitionTask_AAA 'FAILED'->_transitionTask_BBB '*'->_transitionTask_CCC\"");
+				"composed-task-runner --graph=\"transitionTask-AAA 'FAILED'->transitionTask-BBB '*'->transitionTask-CCC\"");
 
-		verifyTaskExistsInRepo("_transitionTask_AAA", "AAA");
-		verifyTaskExistsInRepo("_transitionTask_BBB", "BBB");
+		verifyTaskExistsInRepo("transitionTask-AAA", "AAA");
+		verifyTaskExistsInRepo("transitionTask-BBB", "BBB");
 	}
 
 	@Test
@@ -222,10 +222,10 @@ public class DefaultTaskServiceTests {
 	@DirtiesContext
 	public void deleteComposedTask() {
 		taskService.saveTaskDefinition("deleteTask", "AAA && BBB && CCC");
-		verifyTaskExistsInRepo("_deleteTask_AAA", "AAA");
-		verifyTaskExistsInRepo("_deleteTask_BBB", "BBB");
-		verifyTaskExistsInRepo("_deleteTask_CCC", "CCC");
-		verifyTaskExistsInRepo("deleteTask", "composed-task-runner --graph=\"_deleteTask_AAA && _deleteTask_BBB && _deleteTask_CCC\"");
+		verifyTaskExistsInRepo("deleteTask-AAA", "AAA");
+		verifyTaskExistsInRepo("deleteTask-BBB", "BBB");
+		verifyTaskExistsInRepo("deleteTask-CCC", "CCC");
+		verifyTaskExistsInRepo("deleteTask", "composed-task-runner --graph=\"deleteTask-AAA && deleteTask-BBB && deleteTask-CCC\"");
 
 		long preDeleteSize = taskDefinitionRepository.count();
 		taskService.deleteTaskDefinition("deleteTask");


### PR DESCRIPTION
Key things in here:

- changed composed task 'executable dsl' task names from _taskname_appname to taskname-appname
- altered tests to cope with the change above
- altered graph to text so that it will quote any graph values that may need it when being put into the dsl: exit statuses for transitions and property values
- removed some tests that deal with move advanced DSL constructs that we don't care about yet
- altered text to graph to remove quotes so the user doesn't have to worry about them when editing graph properties
- added validation to ensure apps targeted by transitions are also unique across the composed task def