### PR TITLE
gh-1285 Fix: Simplest secured setup is unusable

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationPr
 import org.springframework.cloud.dataflow.server.config.features.FeaturesConfiguration;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration;
+import org.springframework.cloud.dataflow.server.config.security.DefaultBootUserAuthenticationConfiguration;
 import org.springframework.cloud.dataflow.server.config.security.FileAuthenticationConfiguration;
 import org.springframework.cloud.dataflow.server.config.security.LdapAuthenticationConfiguration;
 import org.springframework.cloud.dataflow.server.config.security.OAuthSecurityConfiguration;
@@ -68,6 +69,7 @@ import org.springframework.util.StringUtils;
 @Configuration
 @Import({CompletionConfiguration.class, FeaturesConfiguration.class, WebConfiguration.class,
 		BasicAuthSecurityConfiguration.class, FileAuthenticationConfiguration.class,
+		DefaultBootUserAuthenticationConfiguration.class,
 		LdapAuthenticationConfiguration.class, OAuthSecurityConfiguration.class})
 @EnableConfigurationProperties({BatchProperties.class, CommonApplicationProperties.class})
 public class DataFlowServerConfiguration {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/DefaultBootUserAuthenticationConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/DefaultBootUserAuthenticationConfiguration.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.cloud.dataflow.server.config.security.support.CoreSecurityRoles;
+import org.springframework.cloud.dataflow.server.config.security.support.OnDefaultBootUserAuthenticationEnabled;
+import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.util.StringUtils;
+
+/**
+* Activated if basic authentication is enabled and
+* neither {@link FileAuthenticationConfiguration}
+* nor {@link LdapAuthenticationConfiguration} are loaded. In that case the Spring Boot default user is used and if that
+* user was not explicitly customized by the user, the user will get full access to the application, assigning her all
+* applicable roles.
+*
+* @author Gunnar Hillert
+*
+* @since 1.2.0
+*/
+@Configuration
+@Conditional({OnDefaultBootUserAuthenticationEnabled.class, OnSecurityEnabledAndOAuth2Disabled.class})
+public class DefaultBootUserAuthenticationConfiguration extends GlobalAuthenticationConfigurerAdapter {
+
+	private static final org.slf4j.Logger logger = LoggerFactory.getLogger(BasicAuthSecurityConfiguration.class);
+
+	@Autowired
+	private SecurityProperties securityProperties;
+
+	@Autowired(required=false)
+	private ManagementServerProperties managementServerProperties;
+
+	/**
+	 * Initializes the {@link AuthenticationManagerBuilder}. Creates an
+	 * {@link InMemoryUserDetailsManager} with the provided {@link DefaultBootUserAuthenticationConfiguration#getUsers()}.
+	 * {@link DefaultBootUserAuthenticationConfiguration#getUsers()} must contain at least 1 user.
+	 */
+	@Override
+	public void init(AuthenticationManagerBuilder auth) throws Exception {
+
+		final User user = this.securityProperties.getUser();
+
+		final User defaultSpringBootUser = new SecurityProperties().getUser();
+
+		final String[] rolesToPopulate;
+
+		final boolean hasDefaultRoles;
+
+		if (this.managementServerProperties != null
+			&& this.managementServerProperties.getSecurity().getRoles().size() == 1
+			&& "ADMIN".equals(this.managementServerProperties.getSecurity().getRoles().get(0))) {
+			defaultSpringBootUser.getRole().add("ADMIN");
+		}
+
+		if (defaultSpringBootUser.getName().equals(user.getName())
+			&& user.getRole().size() == defaultSpringBootUser.getRole().size()
+			&& defaultSpringBootUser.getRole().equals(user.getRole())) {
+			hasDefaultRoles = true;
+		}
+		else {
+			hasDefaultRoles = false;
+		}
+
+		if (hasDefaultRoles) {
+			rolesToPopulate = CoreSecurityRoles.getAllRolesAsStringArray();
+		}
+		else {
+			rolesToPopulate = user.getRole().toArray(new String[user.getRole().size()]);
+		}
+
+		if (user.isDefaultPassword()) {
+			logger.info(String.format("%n%nUsing default security password: %s with roles '%s'%n",
+					user.getPassword(), StringUtils.arrayToCommaDelimitedString(rolesToPopulate)));
+		}
+
+		auth.inMemoryAuthentication()
+			.withUser(user.getName()).password(user.getPassword()).roles(rolesToPopulate);
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/FileAuthenticationConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/FileAuthenticationConfiguration.java
@@ -64,7 +64,6 @@ public class FileAuthenticationConfiguration extends GlobalAuthenticationConfigu
 	 */
 	@Override
 	public void init(AuthenticationManagerBuilder auth) throws Exception {
-
 		Assert.notEmpty(this.users,
 			String.format("No user specified. Please specify at least 1 user (e.g. via '%s')",
 				CONFIGURATION_PROPERTIES_PREFIX + ".users"));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/CoreSecurityRoles.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/CoreSecurityRoles.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+import java.util.Arrays;
+
+import org.springframework.util.Assert;
+
+/**
+ * Defines the core security roles supported by Spring Cloud Data Flow.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public enum CoreSecurityRoles {
+
+	VIEW("VIEW", "view role"),
+	CREATE("CREATE", "role for create operations"),
+	MANAGE("MANAGE", "role for the boot management endpoints");
+
+	private String key;
+	private String name;
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	CoreSecurityRoles(final String key, final String name) {
+		this.key = key;
+		this.name = name;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public static CoreSecurityRoles fromKey(String role) {
+
+		Assert.hasText(role, "Parameter role must not be null or empty.");
+
+		for (CoreSecurityRoles roleType : CoreSecurityRoles.values()) {
+			if (roleType.getKey().equals(role)) {
+				return roleType;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Helper class that will return all role names as a string array.
+	 * @return Never null
+	 */
+	public static String[] getAllRolesAsStringArray() {
+		return Arrays.stream(CoreSecurityRoles.values())
+			.map(CoreSecurityRoles::getKey).toArray(size -> new String[size]);
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnDefaultBootUserAuthenticationEnabled.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/OnDefaultBootUserAuthenticationEnabled.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.context.annotation.Condition;
+
+/**
+ * {@link Condition} that is valid if neither file authentication nor Ldap authentication are enabled.
+ *
+ * @author Gunnar Hillert
+ * @since 1.2.0
+ *
+ */
+public class OnDefaultBootUserAuthenticationEnabled extends NoneNestedConditions {
+
+	public OnDefaultBootUserAuthenticationEnabled() {
+		super(ConfigurationPhase.REGISTER_BEAN);
+	}
+
+	@ConditionalOnProperty("spring.cloud.dataflow.security.authentication.file.enabled")
+	static class fileAuthenticationEnabled { }
+
+	@ConditionalOnProperty("spring.cloud.dataflow.security.authentication.ldap.enabled")
+	static class ldapAuthenticationEnabled { }
+}


### PR DESCRIPTION
* Carefully determine what a "default-user" is
* Ensure that a default user is only setup if neither Ldap- nor file-based authentication are setup
* Add new conditional annotation `OnDefaultBootUserAuthenticationEnabled`

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1285