### PR TITLE
Set dataFlowUri for composed task definition

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -29,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
-import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
@@ -37,7 +34,6 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.util.StringUtils;
 
 /**
  * Contributes the values from {@code META-INF/dataflow-server-defaults.yml} and
@@ -64,17 +60,6 @@ public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor
 
 		contributeDefaults(internalDefaults, serverDefaultsResource);
 		contributeDefaults(defaults, serverResource);
-		String hostName = null;
-		try {
-			hostName = InetAddress.getLocalHost().getHostAddress();
-		}
-		catch (UnknownHostException e) {
-			// ignore
-		}
-		String dataflowServerPort = environment.getProperty("server.port");
-		if (StringUtils.hasText(hostName) && StringUtils.hasText(dataflowServerPort)) {
-			defaults.put(DataFlowPropertyKeys.PREFIX + "server.uri", String.format("http://%s:%s", hostName, dataflowServerPort));
-		}
 		String defaultPropertiesKey = "defaultProperties";
 
 		if (!existingPropertySources.contains(defaultPropertiesKey) ||

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
@@ -44,7 +44,6 @@ import org.springframework.core.io.Resource;
  *
  * @author Josh Long
  * @author Janne Valkealahti
- * @author Ilayaperumal Gopinathan
  */
 public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -73,7 +73,7 @@ public class TaskConfiguration {
 	@Autowired
 	DataSourceProperties dataSourceProperties;
 
-	@Value("${spring.cloud.dataflow.server.uri}")
+	@Value("${spring.cloud.dataflow.server.uri:}")
 	private String dataFlowUri;
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.batch.BatchDatabaseInitializer;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -72,6 +73,9 @@ public class TaskConfiguration {
 	@Autowired
 	DataSourceProperties dataSourceProperties;
 
+	@Value("${spring.cloud.dataflow.server.uri}")
+	private String dataFlowUri;
+
 	@Bean
 	public TaskExplorerFactoryBean taskExplorerFactoryBean(DataSource dataSource) {
 		return new TaskExplorerFactoryBean(dataSource);
@@ -91,7 +95,7 @@ public class TaskConfiguration {
 			DeploymentIdRepository deploymentIdRepository) {
 		return new DefaultTaskService(dataSourceProperties, repository, taskExplorer, taskExecutionRepository,
 				registry, resourceLoader, taskLauncher, metadataResolver,
-				taskConfigurationProperties, deploymentIdRepository);
+				taskConfigurationProperties, deploymentIdRepository, this.dataFlowUri);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -180,7 +180,7 @@ public class DefaultTaskService implements TaskService {
 
 		Map<String, String> appDeploymentProperties = extractAppProperties(taskDefinition.getRegisteredAppName(), taskDeploymentProperties);
 		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils.extractAndQualifyDeployerProperties(taskDeploymentProperties, taskDefinition.getRegisteredAppName());
-		if (StringUtils.hasText(this.dataFlowUri)) {
+		if (StringUtils.hasText(this.dataFlowUri) && taskNode.isComposed()) {
 			updateDataFlowUriIfNeeded(appDeploymentProperties, commandLineArgs);
 		}
 		AppDefinition revisedDefinition = mergeAndExpandAppProperties(taskDefinition, metadataResource, appDeploymentProperties);
@@ -318,8 +318,8 @@ public class DefaultTaskService implements TaskService {
 	}
 
 	private String createComposedTaskDefinition(String graph) {
-		return String.format(String.format("%s --graph=\"%s\""),
-				taskConfigurationProperties.getComposedTaskRunnerName(), graph);
+		return String.format(String.format("%s --graph=\"%s\"",
+				taskConfigurationProperties.getComposedTaskRunnerName(), graph));
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Janne Valkealahti
  * @author Gunnar Hillert
  * @author Thomas Risberg
+ * @author Ilayaperumal Gopinathan
  */
 public class DefaultTaskService implements TaskService {
 
@@ -100,6 +101,8 @@ public class DefaultTaskService implements TaskService {
 
 	private final DeploymentIdRepository deploymentIdRepository;
 
+	private final String dataFlowUri;
+
 	/**
 	 * Initializes the {@link DefaultTaskService}.
 	 *
@@ -113,6 +116,7 @@ public class DefaultTaskService implements TaskService {
 	 * @param resourceLoader the {@link ResourceLoader} that will resolve URIs to
 	 * {@link Resource}s.
 	 * @param taskLauncher the launcher this service will use to launch task apps.
+	 * @param dataFlowUri the data flow server URI
 	 */
 	public DefaultTaskService(DataSourceProperties dataSourceProperties,
 			TaskDefinitionRepository taskDefinitionRepository,
@@ -121,7 +125,8 @@ public class DefaultTaskService implements TaskService {
 			ResourceLoader resourceLoader, TaskLauncher taskLauncher,
 			ApplicationConfigurationMetadataResolver metaDataResolver,
 			TaskConfigurationProperties taskConfigurationProperties,
-			DeploymentIdRepository deploymentIdRepository) {
+			DeploymentIdRepository deploymentIdRepository,
+			String dataFlowUri) {
 		Assert.notNull(dataSourceProperties, "DataSourceProperties must not be null");
 		Assert.notNull(taskDefinitionRepository, "TaskDefinitionRepository must not be null");
 		Assert.notNull(taskExecutionRepository, "TaskExecutionRepository must not be null");
@@ -142,6 +147,7 @@ public class DefaultTaskService implements TaskService {
 		this.whitelistProperties = new WhitelistProperties(metaDataResolver);
 		this.taskConfigurationProperties = taskConfigurationProperties;
 		this.deploymentIdRepository = deploymentIdRepository;
+		this.dataFlowUri = dataFlowUri;
 	}
 
 	@Override
@@ -285,8 +291,9 @@ public class DefaultTaskService implements TaskService {
 	}
 
 	private String createComposedTaskDefinition(String graph) {
-		return String.format("%s --graph=\"%s\"",
-				taskConfigurationProperties.getComposedTaskRunnerName(), graph);
+		String composedTaskDefinition = StringUtils.hasText(this.dataFlowUri) ? "%s --graph=\"%s\" --dataFlowUri=%s" : "%s --graph=\"%s\"";
+		return String.format(composedTaskDefinition,
+				taskConfigurationProperties.getComposedTaskRunnerName(), graph, this.dataFlowUri);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -133,7 +133,7 @@ public class JobDependencies {
 		return new DefaultTaskService(new DataSourceProperties(), repository,
 				explorer, taskRepository(),
 				registry, resourceLoader, taskLauncher, metadataResolver,
-				new TaskConfigurationProperties(), deploymentIdRepository);
+				new TaskConfigurationProperties(), deploymentIdRepository, null);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -257,7 +257,7 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 				taskDefinitionRepository(), taskExplorer(), taskExecutionRepository,
 				appRegistry(), resourceLoader(), taskLauncher(),
 				metadataResolver, new TaskConfigurationProperties(),
-				deploymentIdRepository);
+				deploymentIdRepository, null);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/services/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/services/impl/DefaultTaskServiceTests.java
@@ -18,8 +18,10 @@ package org.springframework.cloud.dataflow.server.services.impl;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -266,28 +268,37 @@ public class DefaultTaskServiceTests {
 						this.resourceLoader, this.taskLauncher,
 						this.metadataResolver, new TaskConfigurationProperties(),
 						new InMemoryDeploymentIdRepository(), "http://myserver:9191");
-		String graph = "AAA && BBB && CCC";
-		Method method = ReflectionUtils.findMethod(DefaultTaskService.class, "updateDataFlowUriIfNeeded", Map.class);
+		List<String> cmdLineArgs = new ArrayList<>();
+		Method method = ReflectionUtils.findMethod(DefaultTaskService.class, "updateDataFlowUriIfNeeded", Map.class, List.class);
 		ReflectionUtils.makeAccessible(method);
 		Map<String, String> appDeploymentProperties = new HashMap<>();
-		method.invoke(taskService, appDeploymentProperties);
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
 		assertTrue(appDeploymentProperties.containsKey("dataFlowUri"));
 		assertTrue("dataFlowURI is expected to be in the app deployment properties", appDeploymentProperties.get("dataFlowUri").equals("http://myserver:9191"));
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("data-flow-uri", "http://localhost:8080");
-		method.invoke(taskService, appDeploymentProperties);
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
 		assertTrue(!appDeploymentProperties.containsKey("dataFlowUri"));
 		assertTrue("dataFlowURI is incorrect", appDeploymentProperties.get("data-flow-uri").equals("http://localhost:8080"));
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("dataFlowUri", "http://localhost:8191");
-		method.invoke(taskService, appDeploymentProperties);
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
 		assertTrue(appDeploymentProperties.containsKey("dataFlowUri"));
 		assertTrue("dataFlowURI is incorrect", appDeploymentProperties.get("dataFlowUri").equals("http://localhost:8191"));
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("DATA_FLOW_URI", "http://localhost:9000");
-		method.invoke(taskService, appDeploymentProperties);
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
 		assertTrue(!appDeploymentProperties.containsKey("dataFlowUri"));
 		assertTrue("dataFlowURI is incorrect", appDeploymentProperties.get("DATA_FLOW_URI").equals("http://localhost:9000"));
+		appDeploymentProperties.clear();
+		cmdLineArgs.add("--dataFlowUri=http://localhost:8383");
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
+		assertTrue(!appDeploymentProperties.containsKey("dataFlowUri"));
+		cmdLineArgs.clear();
+		cmdLineArgs.add("DATA_FLOW_URI=http://localhost:8383");
+		method.invoke(taskService, appDeploymentProperties, cmdLineArgs);
+		assertTrue(!appDeploymentProperties.containsKey("dataFlowUri"));
+		assertTrue(!appDeploymentProperties.containsKey("DATA-FLOW-URI"));
 	}
 
 


### PR DESCRIPTION
 - Infer data flow server URI and update as default property
 - Inject this property into DefaultTaskService to set `--dataFlowUri`
 - Add test

Resolves #1323