### PR TITLE
Make app properties for metrics configurable.

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
@@ -45,4 +45,11 @@ public class StreamPropertyKeys {
 	 */
 	public static final String METRICS_PROPERTIES = METRICS_PREFIX + "properties";
 
+	/**
+	 * This is the spring boot property key that Spring Cloud Stream uses to filter
+	 * the metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is
+	 * fired for metrics export.
+	 */
+	public static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -269,14 +269,12 @@ public class StreamDeploymentController {
 					.append(currentApp.getName()).append(".")
 					.append("${spring.cloud.application.guid}");
 			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
-			//TODO allow user to specify SPRING_CLOUD_STREAM_METRICS_PROPERTIES
-			//TODO Default should be spring.application.*,spring.cloud.application.*,spring.cloud.dataflow.*
-			//     Leaving it as spring* for development purposes ATM
-			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_PROPERTIES, "spring*");
 
 			// Merge *definition time* app properties with *deployment time* properties
 			// and expand them to their long form if applicable
 			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource, appDeployTimeProperties);
+
+
 			AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition, appResource, deployerDeploymentProperties);
 			try {
 				logger.info(String.format(deployLoggingString, request.getDefinition().getName(),
@@ -301,6 +299,12 @@ public class StreamDeploymentController {
 		Map<String, String> merged = new HashMap<>(original.getProperties());
 		merged.putAll(appDeployTimeProperties);
 		merged = whitelistProperties.qualifyProperties(merged, metadataResource);
+
+		merged.putIfAbsent(StreamPropertyKeys.METRICS_PROPERTIES,
+				"spring.application.name,spring.application.index," +
+						"spring.cloud.application.*,spring.cloud.dataflow.*");
+		merged.putIfAbsent(StreamPropertyKeys.METRICS_TRIGGER_INCLUDES, "integration**");
+
 		return new AppDefinition(original.getName(), merged);
 	}
 


### PR DESCRIPTION
Added values to  StreamPropertyKeys and set default values if not already present in application property request.  Added after all expansion/wildcarding taking into account.

Fixes #1298
Tested using
```
stream create --name foostream --definition "time120RS |log120RS"

stream deploy --name foostream --properties "deployer.*.count=2,app.*.security.basic.enabled=false,app.*.management.security.enabled=false,app.*.spring.cloud.stream.bindings.applicationMetrics.destination=metrics"
```

with local deployer and observed default values.

Tested by overrding via

```
stream create --name foostream --definition "time120RS --spring.cloud.stream.metrics.properties=spring* |log120RS"
```

and also
```
stream deploy --name foostream --properties "deployer.*.count=2,app.*.security.basic.enabled=false,app.*.management.security.enabled=false,app.*.spring.cloud.stream.bindings.applicationMetrics.destination=metrics,app.*.spring.cloud.stream.metrics.properties=spring*"

```

The deployed apps had the overriden property values.