### PR TITLE
Ensure consistency with quoted wildcard handling for composed tasks

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
@@ -349,16 +349,11 @@ public class Graph {
 				// capture the target of this link as a simple transition
 				String transitionName = l.getTransitionName();
 				boolean isStatusText = true;
-				if (transitionName.equals("*")) {
+				try {
+					Integer.parseInt(transitionName);
 					isStatusText = false;
-				}
-				else {
-					try {
-						Integer.parseInt(transitionName);
-						isStatusText = false;
-					} catch (NumberFormatException nfe) {
-						// it is text
-					}
+				} catch (NumberFormatException nfe) {
+					// it is text
 				}
 				if (isStatusText && !transitionName.startsWith("'")) {
 					transitionName = "'"+transitionName+"'";


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-dataflow-ui/issues/197

With this change if you quote wildcards in the DSL box they will get unquoted when the graph is built and if you leave them unquoted in the graph building, they will get quoted when the DSL is built - as expected by composed-task-runner. This will need revisiting when we think about how to handle exit codes (vs exit statuses).