### PR TITLE
gh-1360 REST: Ensure actuator endpoints are secured with OAuth

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
@@ -43,6 +44,7 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
  */
 @EnableOAuth2Sso
 @Configuration
+@EnableWebSecurity
 @Conditional(OnSecurityEnabledAndOAuth2Enabled.class)
 public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
@@ -71,6 +71,30 @@ public class LocalServerSecurityWithOAuth2Tests {
 	}
 
 	@Test
+	public void testThatAccessToActuatorEndpointPromptsSecurity() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/management/env"))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void testAccessToActuatorEndpointWithBasicAuthCredentialsWrongPassword() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/management/env").header("Authorization", basicAuthorizationHeader("user", "wrong-password")))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	public void testThatAccessToActuatorEndpointWithBasicAuthCredentialsSucceeds() throws Exception {
+		localDataflowResource.getMockMvc()
+				.perform(get("/management/env").header("Authorization", basicAuthorizationHeader("user", "secret10")))
+				.andDo(print())
+				.andExpect(status().isOk());
+	}
+
+	@Test
 	public void testAccessRootUrlWithOAuth2AccessToken() throws Exception {
 
 		final ClientCredentialsResourceDetails resourceDetails = new ClientCredentialsResourceDetails();
@@ -91,7 +115,7 @@ public class LocalServerSecurityWithOAuth2Tests {
 	}
 
 	@Test
-	public void testAccessSexurityInfoUrlWithOAuth2AccessToken() throws Exception {
+	public void testAccessSecurityInfoUrlWithOAuth2AccessToken() throws Exception {
 
 		final ClientCredentialsResourceDetails resourceDetails = new ClientCredentialsResourceDetails();
 		resourceDetails.setClientId("myclient");

--- a/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/fileBasedUsers.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/fileBasedUsers.yml
@@ -1,6 +1,3 @@
-management:
-  security:
-    enabled: true
 security:
   basic:
     enabled: true

--- a/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/test/resources/org/springframework/cloud/dataflow/server/local/security/oauthConfig.yml
@@ -1,6 +1,3 @@
-management:
-  security:
-    enabled: true
 security:
   oauth2:
     client:


### PR DESCRIPTION
* Add `@EnableWebSecurity` to `OAuthSecurityConfiguration`
* Add integration tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1360