### PR TITLE
gh-1045 Doc: Add Version + Copyright notice for HTML5 backend

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index-docinfo.xml
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index-docinfo.xml
@@ -1,7 +1,7 @@
 <productname>Spring Cloud Data Flow</productname>
 <releaseinfo>{project-version}</releaseinfo>
 <copyright>
-	<year>2013-2016</year>
+	<year>2013-2017</year>
 	<holder>Pivotal Software, Inc.</holder>
 </copyright>
 <legalnotice>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,6 @@
 = Spring Cloud Data Flow Reference Guide
 Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Patrick Peralta; Glenn Renfro; Thomas Risberg; Dave Syer; David Turanski; Janne Valkealahti
+
 :doctype: book
 :toc:
 :toclevels: 4
@@ -15,6 +16,19 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :github-code: http://github.com/{github-repo}
 
 :dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/asciidoc
+
+ifdef::backend-html5[]
+
+Version {project-version}
+
+(C) 2012-2017 Pivotal Software, Inc.
+
+Copies of this document may be made for your own use and for distribution to
+others, provided that you do not charge any fee for such copies and further
+provided that each copy contains this Copyright Notice, whether distributed in
+print or electronically.
+
+endif::[]
 
 // ======================================================================================
 


### PR DESCRIPTION
* Add the version and copyright notice to the `HTML5` documentation
  - This is done conditionally using `ifdef` tags in the Asciidoc `index.adoc` file
  - For PDF and multi-page HTML we use Docbook as the tool-chain, which adds that information in `index-docinfo.xml`)
* Update copyright year

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1045