### PR TITLE
Remove ':' from the channel names in the router config in example

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
@@ -125,7 +125,7 @@ _for instance, in Spring Cloud Data Flow:_
 ----
 stream create f --definition ":foo > transform --expression=payload+'-foo' | log" --deploy
 stream create b --definition ":bar > transform --expression=payload+'-bar' | log" --deploy
-stream create r --definition "http | router --expression=payload.contains('a')?':foo':':bar'" --deploy
+stream create r --definition "http | router --expression=payload.contains('a')?'foo':'bar'" --deploy
 ----
 
 === Batch to Tasks


### PR DESCRIPTION
Resolves #1451