### PR TITLE
gh-1464 OAuth2 - Fix Authorization Code Grant Type Not Working

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
 import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.controller.AboutController;
 import org.springframework.cloud.dataflow.server.controller.AppRegistryController;
@@ -79,6 +80,7 @@ import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
@@ -270,7 +272,7 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty("security.basic.enabled")
+	@Conditional(OnSecurityEnabledAndOAuth2Disabled.class)
 	public LoginController loginController() {
 		return new LoginController();
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/OAuthSecurityConfiguration.java
@@ -15,23 +15,47 @@
  */
 package org.springframework.cloud.dataflow.server.config.security;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.Filter;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Enabled;
 import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.service.impl.ManualOAuthAuthenticationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.client.OAuth2ClientContext;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
-import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
-import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.accept.ContentNegotiationStrategy;
+import org.springframework.web.accept.HeaderContentNegotiationStrategy;
+import org.springframework.web.context.request.NativeWebRequest;
 
 import static org.springframework.cloud.dataflow.server.controller.UiController.dashboard;
 
@@ -41,34 +65,97 @@ import static org.springframework.cloud.dataflow.server.controller.UiController.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
-@EnableOAuth2Sso
-@Configuration
+@EnableOAuth2Client
 @EnableWebSecurity
+@Configuration
 @Conditional(OnSecurityEnabledAndOAuth2Enabled.class)
 public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired
-	private ResourceServerTokenServices tokenServices;
+	private SecurityStateBean securityStateBean;
 
 	@Autowired
-	private SecurityStateBean securityStateBean;
+	private SecurityProperties securityProperties;
+
+	@Autowired
+	private OAuth2ClientContext oauth2ClientContext;
+
+	@Autowired
+	private AuthorizationCodeResourceDetails authorizationCodeResourceDetails;
+
+	@Autowired
+	private ResourceServerProperties resourceServerProperties;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
-		http.addFilterBefore(oAuth2AuthenticationProcessingFilter(), AbstractPreAuthenticatedProcessingFilter.class);
-		http.authorizeRequests().antMatchers("/security/info**", "/login**", dashboard("/logout-success-oauth.html"),
-				dashboard("/styles/**"), dashboard("/images/**"), dashboard("/fonts/**"), dashboard("/lib/**")
 
-		).permitAll().anyRequest().authenticated().and().httpBasic().and().logout()
-				.logoutSuccessUrl(dashboard("/logout-success-oauth.html")).and().csrf().disable();
+		final RequestMatcher textHtmlMatcher = new MediaTypeRequestMatcher(new BrowserDetectingContentNegotiationStrategy(),
+				MediaType.TEXT_HTML);
+
+		final BasicAuthenticationEntryPoint basicAuthenticationEntryPoint = new BasicAuthenticationEntryPoint();
+		basicAuthenticationEntryPoint.setRealmName(securityProperties.getBasic().getRealm());
+		basicAuthenticationEntryPoint.afterPropertiesSet();
+
+		final Filter oauthFilter = oauthFilter();
+		BasicAuthenticationFilter basicAuthenticationFilter = new BasicAuthenticationFilter(
+				providerManager(), basicAuthenticationEntryPoint);
+
+		http.addFilterAfter(oauthFilter, basicAuthenticationFilter.getClass());
+		http.addFilterBefore(basicAuthenticationFilter, oauthFilter.getClass());
+		http.addFilterBefore(oAuth2AuthenticationProcessingFilter(), basicAuthenticationFilter.getClass());
+
+		http.authorizeRequests()
+			.antMatchers(
+				"/security/info**", "/login**", dashboard("/logout-success-oauth.html"),
+				dashboard("/styles/**"), dashboard("/images/**"), dashboard("/fonts/**"), dashboard("/lib/**")
+			).permitAll().anyRequest()
+			.authenticated().and()
+			.httpBasic().and()
+			.logout()
+			.logoutSuccessUrl(dashboard("/logout-success-oauth.html"))
+			.and().csrf().disable()
+			.exceptionHandling()
+			.defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint("/login"), textHtmlMatcher)
+			.defaultAuthenticationEntryPointFor(basicAuthenticationEntryPoint, AnyRequestMatcher.INSTANCE);
 
 		securityStateBean.setAuthenticationEnabled(true);
 		securityStateBean.setAuthorizationEnabled(false);
 	}
 
 	@Bean
+	public UserInfoTokenServices tokenServices() {
+		final UserInfoTokenServices tokenServices = new UserInfoTokenServices(resourceServerProperties.getUserInfoUri(),
+				authorizationCodeResourceDetails.getClientId());
+		tokenServices.setRestTemplate(oAuth2RestTemplate());
+		return tokenServices;
+
+	}
+
+	@Bean
+	public OAuth2RestTemplate oAuth2RestTemplate() {
+		final OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(authorizationCodeResourceDetails, oauth2ClientContext);
+		return oAuth2RestTemplate;
+	}
+
+	@Bean
 	public AuthenticationProvider authenticationProvider() {
 		return new ManualOAuthAuthenticationProvider();
+	}
+
+	@Bean
+	public ProviderManager providerManager() {
+		List<AuthenticationProvider> providers = new ArrayList<>();
+		providers.add(this.authenticationProvider());
+		ProviderManager providerManager = new ProviderManager(providers);
+		return providerManager;
+	}
+
+	private Filter oauthFilter() {
+		final OAuth2ClientAuthenticationProcessingFilter oauthFilter = new OAuth2ClientAuthenticationProcessingFilter(
+				"/login");
+		oauthFilter.setRestTemplate(oAuth2RestTemplate());
+		oauthFilter.setTokenServices(tokenServices());
+		return oauthFilter;
 	}
 
 	private OAuth2AuthenticationProcessingFilter oAuth2AuthenticationProcessingFilter() {
@@ -78,9 +165,27 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		return oAuth2AuthenticationProcessingFilter;
 	}
 
-	private AuthenticationManager oauthAuthenticationManager() {
+	@Bean
+	public AuthenticationManager oauthAuthenticationManager() {
 		final OAuth2AuthenticationManager oauthAuthenticationManager = new OAuth2AuthenticationManager();
-		oauthAuthenticationManager.setTokenServices(tokenServices);
+		oauthAuthenticationManager.setTokenServices(tokenServices());
 		return oauthAuthenticationManager;
+	}
+
+	private static class BrowserDetectingContentNegotiationStrategy extends HeaderContentNegotiationStrategy {
+
+		@Override
+		public List<MediaType> resolveMediaTypes(NativeWebRequest request)
+				throws HttpMediaTypeNotAcceptableException {
+			final List<MediaType> supportedMediaTypes = super.resolveMediaTypes(request);
+
+			final String userAgent = request.getHeader(HttpHeaders.USER_AGENT);
+			if (userAgent != null && userAgent.contains("Mozilla/5.0")
+				&& !supportedMediaTypes.contains(MediaType.APPLICATION_JSON)) {
+
+				return Collections.singletonList(MediaType.TEXT_HTML);
+			}
+			return Collections.singletonList(MediaType.APPLICATION_JSON);
+		}
 	}
 }


### PR DESCRIPTION
* Minimize Boot's AutoConfiguration for Security
* Maintain full backwards compatibility - no test changes
* Trigger OAuth2 Authorization Code Grant Type only for Browsers and only if they don't send a `application/json` Accept header

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1464