### PR TITLE
gh-1470 Docs: Remove `security.basic.enabled` from GitHub example

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -796,8 +796,6 @@ Configure Spring Cloud Data Flow with the GitHub relevant Client Id and Secret:
 [source,yaml]
 ----
 security:
-  basic:
-    enabled: true
   oauth2:
     client:
       client-id: your-github-client-id


### PR DESCRIPTION
resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1470