### PR TITLE
gh-1294 Add support for OAUTH authorization

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -699,10 +699,6 @@ security:
 
 <1> Providing the Client Id in the OAuth Configuration Section will activate OAuth2 security
 
-NOTE: As of the current version, Spring Cloud Data Flow does not provide
-finer-grained authorization when OAUTH is used as authentication mechanism. Thus,
-once you are logged in, you have full access to all functionality.
-
 You can verify that basic authentication is working properly using _curl_:
 
 [source,bash]
@@ -720,6 +716,28 @@ the REST Api using the **Authorization** Http header:
 ```
 $ curl -H "Authorization: Bearer <ACCESS_TOKEN>" http://localhost:9393/
 ```
+
+[[configuration-security-oauth2-authorization]]
+==== OAuth REST Endpoint Authorization
+
+The OAuth2 authentication option uses the same authorization rules as used by the
+<<configuration-security-basic-authentication, Traditional Authentication>> option.
+
+[TIP]
+====
+The authorization rules are defined in `dataflow-server-defaults.yml` (Part of
+the Spring Cloud Data Flow Core Module). Please see the chapter on
+<<customizing-authorization, customizing authorization>> for more details.
+====
+
+Due to fact that the determination of security roles is very environment-specific,
+_Spring Cloud Data Flow_ will by default assign all roles to authenticated OAuth2
+users using the `DefaultDataflowAuthoritiesExtractor` class.
+
+You can customize that behavior by providing your own Spring bean definition that
+extends Spring Security OAuth's `AuthoritiesExtractor` interface. In that case,
+the custom bean definition will take precedence over the default one provided by
+_Spring Cloud Data Flow_
 
 [[configuration-security-oauth2-shell]]
 ==== OAuth Authentication using the Spring Cloud Data Flow Shell

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
-import org.springframework.cloud.dataflow.server.config.security.BasicAuthSecurityConfiguration.AuthorizationConfig;
+import org.springframework.cloud.dataflow.server.config.security.AuthorizationConfig;
 import org.springframework.cloud.dataflow.server.config.security.support.OnSecurityEnabledAndOAuth2Disabled;
 import org.springframework.cloud.dataflow.server.config.security.support.SecurityStateBean;
 import org.springframework.cloud.dataflow.server.controller.AboutController;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/AuthorizationConfig.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/AuthorizationConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+
+/**
+ * Holds configuration for the authorization aspects of security.
+ *
+ * @author Eric Bottard
+ * @author Gunnar Hillert
+ */
+@ConfigurationProperties(prefix = DataFlowPropertyKeys.PREFIX + "security.authorization")
+public class AuthorizationConfig {
+
+	private boolean enabled = true;
+
+	private List<String> rules = new ArrayList<>();
+
+	public List<String> getRules() {
+		return rules;
+	}
+
+	public void setRules(List<String> rules) {
+		this.rules = rules;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/DefaultDataflowAuthoritiesExtractor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/DefaultDataflowAuthoritiesExtractor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor;
+import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default Spring Cloud Data Flow {@link AuthoritiesExtractor}. Will assign ALL
+ * {@link CoreSecurityRoles} to the authenticated OAuth2 user.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class DefaultDataflowAuthoritiesExtractor implements AuthoritiesExtractor {
+
+	private static final org.slf4j.Logger logger = LoggerFactory.getLogger(DefaultDataflowAuthoritiesExtractor.class);
+
+	/**
+	 * The returned {@link List} of {@link GrantedAuthority}s contains all roles from
+	 * {@link CoreSecurityRoles}. The roles are prefixed with the value specified in
+	 * {@link GrantedAuthorityDefaults}.
+	 *
+	 *
+	 * @param Must not be null. Is only used for logging
+	 */
+	@Override
+	public List<GrantedAuthority> extractAuthorities(Map<String, Object> map) {
+		Assert.notNull(map, "The map argument must not be null.");
+
+		final List<String> rolesAsStrings = new ArrayList<>();
+		final List<GrantedAuthority> grantedAuthorities =
+			Stream.of(CoreSecurityRoles.values())
+				.map(roleEnum -> {
+					final String roleName = SecurityConfigUtils.ROLE_PREFIX + roleEnum.getKey();
+					rolesAsStrings.add(roleName);
+					return new SimpleGrantedAuthority(roleName);
+				})
+				.collect(Collectors.toList());
+		logger.info("Adding ALL roles {} to user {}", StringUtils.collectionToCommaDelimitedString(rolesAsStrings), map);
+		return grantedAuthorities;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/SecurityConfigUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/security/support/SecurityConfigUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.dataflow.server.config.security.AuthorizationConfig;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * State-holder for computed security meta-information.
+ *
+ * @author Gunnar Hillert
+ */
+public class SecurityConfigUtils {
+
+	private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SecurityConfigUtils.class);
+
+	public static final String ROLE_PREFIX = "ROLE_";
+
+	public static final Pattern AUTHORIZATION_RULE;
+
+	static {
+		String methodsRegex = StringUtils.arrayToDelimitedString(HttpMethod.values(), "|");
+		AUTHORIZATION_RULE = Pattern.compile("(" + methodsRegex + ")\\s+(.+)\\s+=>\\s+(.+)");
+	}
+
+	/**
+	 * Read the configuration for "simple" (that is, not ACL based) security and apply it.
+	 */
+	public static ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry configureSimpleSecurity(
+			ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry security,
+			AuthorizationConfig authorizationConfig) {
+		for (String rule : authorizationConfig.getRules()) {
+			Matcher matcher = AUTHORIZATION_RULE.matcher(rule);
+			Assert.isTrue(matcher.matches(),
+					String.format("Unable to parse security rule [%s], expected format is 'HTTP_METHOD ANT_PATTERN => "
+							+ "SECURITY_ATTRIBUTE(S)'", rule));
+
+			HttpMethod method = HttpMethod.valueOf(matcher.group(1).trim());
+			String urlPattern = matcher.group(2).trim();
+			String attribute = matcher.group(3).trim();
+
+			logger.info("Authorization '{}' | '{}' | '{}'", method, attribute, urlPattern);
+			security = security.antMatchers(method, urlPattern).access(attribute);
+		}
+		return security;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/support/DefaultDataflowAuthoritiesExtractorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/security/support/DefaultDataflowAuthoritiesExtractorTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config.security.support;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class DefaultDataflowAuthoritiesExtractorTests {
+
+	@Test
+	public void testNullMapParameter() throws Exception {
+		final DefaultDataflowAuthoritiesExtractor authoritiesExtractor = new DefaultDataflowAuthoritiesExtractor();
+		try {
+			authoritiesExtractor.extractAuthorities(null);
+		}
+		catch (IllegalArgumentException e) {
+			Assert.assertEquals("The map argument must not be null.", e.getMessage());
+			return;
+		}
+		Assert.fail("Expected an IllegalStateException to be thrown.");
+	}
+
+	@Test
+	public void testThat3AuthoritiesAreReturned() throws Exception {
+		final DefaultDataflowAuthoritiesExtractor authoritiesExtractor = new DefaultDataflowAuthoritiesExtractor();
+
+		final List<GrantedAuthority> authorities = authoritiesExtractor.extractAuthorities(new HashMap<>());
+		assertThat(authorities, hasSize(3));
+
+		assertThat(authorities.stream().map(authority -> authority.getAuthority()).collect(Collectors.toList()),
+			containsInAnyOrder("ROLE_MANAGE", "ROLE_CREATE", "ROLE_VIEW"));
+	}
+
+}

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithOAuth2Tests.java
@@ -26,7 +26,8 @@ import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.cloud.dataflow.server.local.security.SecurityTestUtils.basicAuthorizationHeader;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -123,9 +124,10 @@ public class LocalServerSecurityWithOAuth2Tests {
 
 		localDataflowResource.getMockMvc()
 				.perform(get("/security/info").header("Authorization", "bearer " + accessTokenAsString)).andDo(print())
-				.andExpect(status().isOk()).andExpect(jsonPath("$.authorizationEnabled", is(Boolean.FALSE)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.authorizationEnabled", is(Boolean.TRUE)))
 				.andExpect(jsonPath("$.authenticated", is(Boolean.TRUE)))
-				.andExpect(jsonPath("$.authenticationEnabled", is(Boolean.TRUE)));
+				.andExpect(jsonPath("$.authenticationEnabled", is(Boolean.TRUE)))
+				.andExpect(jsonPath("$.roles", hasSize(3)));
 	}
 
 	@Test


### PR DESCRIPTION
* Add role support to OAuth2-enabled security
  - Uses same rules (matchers) as traditional security
* Add `DefaultDataflowAuthoritiesExtractor`
  - Assigns all roles by default
  - Allows for user-customization, if providing own `AuthoritiesExtractor` bean
* Add tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1294