### PR TITLE
Support providing HTTP credentials from an external process

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.util;
+
+import java.net.URI;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+
+/**
+ * Utility for configuring a {@link CloseableHttpClient}. This class allows for
+ * chained method invocation. If both basic auth credentials and a target host
+ * are provided, the HTTP client will aggressively send the credentials
+ * without having to receive an HTTP 401 response first.
+ *
+ * <p>This class can also be used to configure the client used by
+ * {@link org.springframework.web.client.RestTemplate} using
+ * {@link #buildClientHttpRequestFactory()}.
+ *
+ * @author Mike Heath
+ */
+public class HttpClientConfigurer {
+
+	private final HttpClientBuilder httpClientBuilder;
+
+	private boolean useBasicAuth;
+	private HttpHost targetHost;
+
+	public static HttpClientConfigurer create() {
+		return new HttpClientConfigurer();
+	}
+
+	protected HttpClientConfigurer() {
+		httpClientBuilder = HttpClientBuilder.create();
+	}
+
+	public HttpClientConfigurer basicAuthCredentials(String username, String password) {
+		final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+		credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+		httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+
+		useBasicAuth = true;
+
+		return this;
+	}
+
+	/**
+	 * Sets the client's {@link javax.net.ssl.SSLContext} to use
+	 * {@link HttpUtils#buildCertificateIgnoringSslContext()}.
+	 *
+	 * @return a reference to {@code this} to enable chained method invocation
+	 */
+	public HttpClientConfigurer skipTlsCertificateVerification() {
+		httpClientBuilder.setSSLContext(HttpUtils.buildCertificateIgnoringSslContext());
+		httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+
+		return this;
+	}
+
+	public HttpClientConfigurer skipTlsCertificateVerification(boolean skipTlsCertificateVerification) {
+		if (skipTlsCertificateVerification) {
+			skipTlsCertificateVerification();
+		}
+
+		return this;
+	}
+
+	public HttpClientConfigurer targetHost(URI targetHost) {
+		this.targetHost = new HttpHost(targetHost.getHost(), targetHost.getPort(), targetHost.getScheme());
+
+		return this;
+	}
+
+	public HttpClientConfigurer addInterceptor(HttpRequestInterceptor interceptor) {
+		httpClientBuilder.addInterceptorLast(interceptor);
+
+		return this;
+	}
+
+	public CloseableHttpClient buildHttpClient() {
+		return httpClientBuilder.build();
+	}
+
+	public ClientHttpRequestFactory buildClientHttpRequestFactory() {
+		if (useBasicAuth && targetHost != null) {
+			return new PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory(buildHttpClient(), targetHost);
+		} else {
+			return new HttpComponentsClientHttpRequestFactory(buildHttpClient());
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpUtils.java
@@ -15,30 +15,14 @@
  */
 package org.springframework.cloud.dataflow.rest.util;
 
-import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.apache.http.ssl.TrustStrategy;
-
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Provides utilities for the Apache {@link HttpClient}, used to make REST calls
@@ -48,62 +32,15 @@ import org.springframework.web.client.RestTemplate;
 public class HttpUtils {
 
 	/**
-	 * Ensures that the passed-in {@link RestTemplate} is using the Apache HTTP Client. If
-	 * the optional {@code
-	 * username} AND {@code password} are not empty, then a
-	 * {@link BasicCredentialsProvider} will be added to the {@link CloseableHttpClient}.
-	 * <p>
-	 * Furthermore, you can set the underlying {@link SSLContext} of the
-	 * {@link HttpClient} allowing you to accept self-signed certificates.
-	 *
-	 * @param restTemplate the rest template, must not be null
-	 * @param host the target host URI
-	 * @param username the username for authentication, can be null
-	 * @param password the password for authentication, can be null
-	 * @param skipSslValidation whether to skip ssl validation. Use with caution! If true
-	 * certificate warnings will be ignored.
-	 */
-	public static void prepareRestTemplate(RestTemplate restTemplate, URI host, String username, String password,
-			boolean skipSslValidation) {
-
-		Assert.notNull(restTemplate, "The provided RestTemplate must not be null.");
-
-		final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-		if (StringUtils.hasText(username) && StringUtils.hasText(password)) {
-			final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-			credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
-			httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-		}
-
-		if (skipSslValidation) {
-			httpClientBuilder.setSSLContext(HttpUtils.buildCertificateIgnoringSslContext());
-			httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
-		}
-
-		final CloseableHttpClient httpClient = httpClientBuilder.build();
-		final HttpHost targetHost = new HttpHost(host.getHost(), host.getPort(), host.getScheme());
-
-		final HttpComponentsClientHttpRequestFactory requestFactory = new PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory(
-				httpClient, targetHost);
-		restTemplate.setRequestFactory(requestFactory);
-	}
-
-	/**
 	 * Will create a certificate-ignoring {@link SSLContext}. Please use with utmost
 	 * caution as it undermines security, but may be useful in certain testing or
 	 * development scenarios.
 	 *
-	 * @return The SSLContext
+	 * @return an SSLContext that will ignore peer certificates
 	 */
 	public static SSLContext buildCertificateIgnoringSslContext() {
 		try {
-			return SSLContexts.custom().loadTrustMaterial(new TrustStrategy() {
-				@Override
-				public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-					return true;
-				}
-			}).build();
+			return SSLContexts.custom().loadTrustMaterial((chain, authType) -> true).build();
 		}
 		catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
 			throw new IllegalStateException(

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
@@ -30,6 +30,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
 /**
+ * {@link HttpComponentsClientHttpRequestFactory} extension that aggressively
+ * sends HTTP basic authentication credentials without having to first
+ * receive an HTTP 401 response from the server.
+ *
  * @author Gunnar Hillert
  */
 public class PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory extends HttpComponentsClientHttpRequestFactory {
@@ -43,10 +47,6 @@ public class PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory extends H
 
 	@Override
 	protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
-		return createHttpContext();
-	}
-
-	private HttpContext createHttpContext() {
 		final AuthCache authCache = new BasicAuthCache();
 
 		final BasicScheme basicAuth = new BasicScheme();
@@ -56,4 +56,5 @@ public class PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory extends H
 		localcontext.setAttribute(HttpClientContext.AUTH_CACHE, authCache);
 		return localcontext;
 	}
+
 }

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ProcessOutputResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ProcessOutputResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.util;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.core.io.AbstractResource;
+
+/**
+ * {@link org.springframework.core.io.Resource} implementation to create an
+ * operating system process process and capture its output.
+ *
+ * @author Mike Heath
+ */
+public class ProcessOutputResource extends AbstractResource {
+
+	private final ProcessBuilder processBuilder;
+
+	public ProcessOutputResource(String... command) {
+		processBuilder = new ProcessBuilder(command);
+	}
+
+	@Override
+	public String getDescription() {
+		return processBuilder.toString();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return processBuilder.start().getInputStream();
+	}
+
+	@Override
+	public String toString() {
+		return getDescription();
+	}
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+/**
+ * {@link HttpRequestInterceptor} that adds an {@code Authorization} header
+ * with a value obtained from a {@link Resource}.
+ *
+ * @author Mike Heath
+ */
+public class ResourceBasedAuthorizationInterceptor implements HttpRequestInterceptor {
+
+	private final Resource resource;
+
+	public ResourceBasedAuthorizationInterceptor(Resource resource) {
+		this.resource = resource;
+	}
+
+	@Override
+	public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
+		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+		httpRequest.addHeader(HttpHeaders.AUTHORIZATION, credentials);
+	}
+}

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.resource;
+
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
+import org.springframework.cloud.dataflow.rest.util.ResourceBasedAuthorizationInterceptor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+/**
+ *
+ * @author Mike Heath
+ */
+public class HttpClientTest {
+
+	@Test(expected = Passed.class)
+	public void resourceBasedAuthorizationHeader() throws Exception {
+		final String credentials = "Super Secret Credentials";
+
+		final Resource resource = new ByteArrayResource(credentials.getBytes());
+
+		try (final CloseableHttpClient client = HttpClientConfigurer.create()
+				.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
+				.addInterceptor((request, context) -> {
+					final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
+					Assertions.assertThat(authorization).isEqualTo(credentials);
+
+					// Throw an exception to short-circuit making an HTTP request
+					throw new Passed();
+				})
+				.buildHttpClient()) {
+			client.execute(new HttpGet("http://test.com"));
+		}
+	}
+
+	static final class Passed extends RuntimeException {}
+
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
@@ -46,6 +46,8 @@ public class Target {
 
 	public static final String DEFAULT_UNSPECIFIED_SKIP_SSL_VALIDATION = "false";
 
+	public static final String DEFAULT_CREDENTIALS_PROVIDER_COMMAND = "";
+
 	public static final String DEFAULT_TARGET = DEFAULT_SCHEME + "://" + DEFAULT_HOST + ":" + DEFAULT_PORT + "/";
 
 	private final URI targetUri;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.springframework.cloud.dataflow.rest.util.HttpUtils;
+import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.cloud.dataflow.shell.Target;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -99,7 +99,11 @@ public class HttpCommands implements CommandMarker {
 			outputRequest("POST", requestURI, mediaType, data, buffer);
 			final RestTemplate restTemplate = createRestTemplate(buffer);
 
-			HttpUtils.prepareRestTemplate(restTemplate, requestURI, targetUsername, targetPassword, skipSslValidation);
+			restTemplate.setRequestFactory(HttpClientConfigurer.create()
+					.targetHost(requestURI)
+					.basicAuthCredentials(targetUsername, targetPassword)
+					.skipTlsCertificateVerification(skipSslValidation)
+					.buildClientHttpRequestFactory());
 
 			ResponseEntity<String> response = restTemplate.postForEntity(requestURI, request, String.class);
 			outputResponse(response, buffer);
@@ -137,7 +141,11 @@ public class HttpCommands implements CommandMarker {
 
 			final RestTemplate restTemplate = createRestTemplate(buffer);
 
-			HttpUtils.prepareRestTemplate(restTemplate, requestURI, targetUsername, targetPassword, skipSslValidation);
+			restTemplate.setRequestFactory(HttpClientConfigurer.create()
+					.targetHost(requestURI)
+					.basicAuthCredentials(targetUsername, targetPassword)
+					.skipTlsCertificateVerification(skipSslValidation)
+					.buildClientHttpRequestFactory());
 
 			ResponseEntity<String> response = restTemplate.getForEntity(requestURI, String.class);
 			outputResponse(response, buffer);

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -116,7 +116,7 @@ public class ConfigCommandTests {
 
 		configCommands.onApplicationEvent(null);
 
-		final String targetResult = configCommands.target("http://localhost:9393", null, null, false);
+		final String targetResult = configCommands.target("http://localhost:9393", null, null, null, false);
 		assertThat(targetResult, containsString("Incompatible version of Data Flow server detected"));
 	}
 


### PR DESCRIPTION
This enables use of something like `cf oauth-token` to authenticate the
Shell to a DF server using Oauth2 tokens.

See https://www.pivotaltracker.com/story/show/138282513