### PR TITLE
Trim whitespace from external credentials

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
@@ -43,7 +43,7 @@ public class ResourceBasedAuthorizationInterceptor implements HttpRequestInterce
 
 	@Override
 	public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
-		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8).trim();
 		httpRequest.addHeader(HttpHeaders.AUTHORIZATION, credentials);
 	}
 }


### PR DESCRIPTION
The Apache HTTP client doesn't recognize invalid characters (such as
`\r\n`) in header values. This commit explictly trims white space
eliminating common causes of this problem.