### PR TITLE
Support newline Characters in Quoted Strings

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AbstractTokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AbstractTokenizer.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  * subclasses.
  *
  * @author Andy Clement
+ * @author Gary Russell
  */
 public abstract class AbstractTokenizer {
 
@@ -214,7 +215,8 @@ public abstract class AbstractTokenizer {
 	 */
 	protected boolean isArgValueIdentifierTerminator(char ch, boolean quoteOpen) {
 		return (ch == '|' && !quoteOpen) || (ch == ';' && !quoteOpen) || ch == '\0' || (ch == ' ' && !quoteOpen)
-				|| (ch == '\t' && !quoteOpen) || (ch == '>' && !quoteOpen) || ch == '\r' || ch == '\n';
+				|| (ch == '\t' && !quoteOpen) || (ch == '>' && !quoteOpen) || (ch == '\r' && !quoteOpen)
+				|| (ch == '\n' && !quoteOpen);
 	}
 
 	/**


### PR DESCRIPTION
Certain properties are mapped to `Properties` objects using Spring's `PropertiesEditor`.

The sytax for such properties is `someProp='foo=bar \n baz=qux'`.

Currently the abstract tokenizer terminates a quoted token when `\n` or `\r` is found.

Change the `isArgValueIdentifierTerminator` to only terminate on such characters if we are
not parsing a quoted token.