### PR TITLE
Redact sensitive info in Task definitions

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -409,7 +409,7 @@ public class StreamDefinitionController {
 		@Override
 		public StreamDefinitionResource instantiateResource(StreamDefinition stream) {
 			final StreamDefinitionResource resource = new StreamDefinitionResource(stream.getName(),
-					ArgumentSanitizer.sanitizeStream(stream.getDslText()));
+					ArgumentSanitizer.sanitizeDefinition(stream.getDslText()));
 			final DeploymentStateResource deploymentStateResource = ControllerUtils
 					.mapState(streamDeploymentStates.get(stream));
 			resource.setStatus(deploymentStateResource.getKey());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.server.controller;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
+import org.springframework.cloud.dataflow.server.controller.support.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
@@ -190,7 +191,7 @@ public class TaskDefinitionController {
 			}
 			String state = (status != null) ? status.getState().name() : "unknown";
 			TaskDefinitionResource taskDefinitionResource = new TaskDefinitionResource(taskDefinition.getName(),
-					taskDefinition.getDslText());
+					ArgumentSanitizer.sanitizeDefinition(taskDefinition.getDslText()));
 			taskDefinitionResource.setComposed(composed);
 			taskDefinitionResource.setStatus(state);
 			return taskDefinitionResource;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
@@ -41,7 +41,7 @@ public class ArgumentSanitizer {
 			//that match the following strings from the KEYS_TO_SANITIZE array
 					+ StringUtils.arrayToDelimitedString(KEYS_TO_SANITIZE, "|")
 			//Following the equal sign (group1) accept any number of unicode characters(letters, open punctuation, close punctuation etc) for the value to be sanitized for group 3.
-					+ ")[\\p{L}]*[\\p{Z}]*=[\\p{Z}]*)((\"[\\p{L}|\\p{Pd}|\\p{Ps}|\\p{Pe}|\\p{Pc}|\\p{S}|\\p{N}|\\p{Z}]*\")|([\\p{N}|\\p{L}|\\p{Po}|\\p{Pc}|\\p{S}]*))",
+					+ ")[\\p{L}]*[\\p{Z}]*=[\\p{Z}]*)((\"[\\p{L}|\\p{Pd}|\\p{Ps}|\\p{Pe}|\\p{Pc}|\\p{S}|\\p{N}|\\p{Z}]*\")|([\\p{N}|\\p{L}|\\p{Pd}|\\p{Po}|\\p{Pc}|\\p{S}]*))",
 			Pattern.UNICODE_CASE);
 
 
@@ -98,7 +98,7 @@ public class ArgumentSanitizer {
 	 * @param definition the definition to sanitize
 	 * @return Stream definition that has sensitive data redacted.
 	 */
-	public static String sanitizeStream(String definition) {
+	public static String sanitizeDefinition(String definition) {
 		Assert.hasText(definition, "definition must not be null nor empty");
 		final StringBuffer output = new StringBuffer();
 		final Matcher matcher = passwordParameterPatternForStreams.matcher(definition);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -241,7 +241,7 @@ public class StreamControllerTests {
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
 		mockMvc.perform(post("/streams/definitions/").param("name", "myStream6")
-				.param("definition", ":myStream5.time > log --password=bar").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.param("definition", ":myStream5.time > log --password=b-ar").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isCreated());
 
 		assertEquals(10, repository.count());
@@ -316,7 +316,7 @@ public class StreamControllerTests {
 		mockMvc.perform(post("/streams/definitions/").param("name", "nameChannelPassword")
 				.param("definition", "time --password='foo'> :foobar")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "twoParam").param("definition", "time --password=foo --arg=foo | log")
+		mockMvc.perform(post("/streams/definitions/").param("name", "twoParam").param("definition", "time --password=fo-o --arg=foo | log")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		mockMvc.perform(post("/streams/definitions/").param("name", "twoPipeInQuotes").param("definition", "time --password='fo|o' --arg=bar | log")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());


### PR DESCRIPTION
Also added support for embedded hyphens in passwords.

resolves #1546