### PR TITLE
Add new reference guide experience

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-dataflow-template.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-dataflow-template.adoc
@@ -1,12 +1,11 @@
+[appendix]
 [[dataflow-template]]
-= Data Flow Template
+== Data Flow Template
 
 As described in the previous chapter, Spring Cloud Data Flow's functionality is completely
 exposed via REST endpoints. While you can use those endpoints directly, Spring Cloud
 Data Flow also provides a Java-based API, which makes using those REST endpoints
 even easier.
-
-== Overview
 
 The central entrypoint is the `DataFlowTemplate` class in package `org.springframework.cloud.dataflow.rest.client`.
 
@@ -51,7 +50,7 @@ IMPORTANT: If a resource cannot be resolved, the respective sub-template will re
 in being _NULL_. A common cause is that Spring Cloud Data Flow offers for specific
 sets of features to be enabled/disabled when launching. For more information see <<enable-disable-specific-features>>.
 
-== Using the Data Flow Template
+=== Using the Data Flow Template
 
 When using the Data Flow Template the only needed Data Flow dependency is the
 Spring Cloud Data Flow Rest Client:

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-howto.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-howto.adoc
@@ -1,5 +1,6 @@
+[appendix]
 [[howto]]
-= '`How-to`' guides
+== '`How-to`' guides
 
 [partintro]
 --
@@ -15,7 +16,7 @@ We're also more than happy to extend this section; If you want to add a '`how-to
 can send us a {github-code}[pull request].
 --
 
-== Configure Maven Properties
+=== Configure Maven Properties
 
 You can set the maven properties such as local maven repository location, remote maven repositories and their authentication credentials including
 the proxy server properties via commandline properties when starting the Dataflow server or using the `SPRING_APPLICATION_JSON` environment property
@@ -81,8 +82,7 @@ NOTE: Depending on Spring Cloud Data Flow server implementation, you may have to
 environment properties using the platform specific environment-setting capabilities. For instance,
 in Cloud Foundry, you'd be passing them as `cf set-env SPRING_APPLICATION_JSON`.
 
-
-== Logging
+=== Logging
 
 Spring Cloud Data Flow is built upon several Spring projects, but ultimately the dataflow-server is a
 Spring Boot app, so the logging techniques that apply to any link:http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot]
@@ -207,10 +207,10 @@ NOTE: Log redirect is only supported with link:https://github.com/spring-cloud/s
 
 
 [[faqs]]
-== Frequently asked questions
+=== Frequently asked questions
 In this section, we will review the frequently discussed questions in Spring Cloud Data Flow.
 
-=== Advanced SpEL expressions
+==== Advanced SpEL expressions
 
 One of the powerful features of SpEL expressions is http://docs.spring.io/spring/docs/current/spring-framework-reference/html/expressions.html#expressions-ref-functions[functions].
 Spring Integration provides `jsonPath()` and `xpath()` out-of-the-box http://docs.spring.io/spring-integration/reference/html/spel.html#spel-functions[SpEL-functions], if appropriate libraries are in the classpath.
@@ -239,7 +239,7 @@ Any other custom SpEL-function can also be used, but for this purpose you should
 The target Spring Cloud Stream application starter should be re-packaged to supply such a custom extension via built-in Spring Boot `@ComponentScan` mechanism or auto-configuration hook.
 
 [[dataflow-jdbc-sink]]
-=== How to use JDBC-sink?
+==== How to use JDBC-sink?
 The JDBC-sink can be used to insert message payload data into a relational database table. By default,
 it inserts the entire payload into a table named after the `jdbc.table-name` property, and if it is not set,
 by default the application expects to use a table with the name `messages`. To alter this behavior, the
@@ -292,7 +292,7 @@ mysql> select * from test.messages;
 ----
 
 [[dataflow-multiple-brokers]]
-=== How to use multiple message-binders?
+==== How to use multiple message-binders?
 For situations where the data is consumed and processed between two different message brokers, Spring
 Cloud Data Flow provides easy to override global configurations, out-of-the-box link:https://github.com/spring-cloud-stream-app-starters/bridge[`bridge-processor`],
 and DSL primitives to build these type of topologies.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
@@ -1,12 +1,8 @@
 [appendix]
-[[migration-guide]]
-== Migrating from Spring XD to Spring Cloud Data Flow
-
-[partintro]
---
+[[migrationguide]]
+== Spring XD to SCDF
 In this section you will learn all about the migration path from Spring XD to Spring Cloud Data Flow
 along with the tips and tricks.
---
 
 === Terminology Changes
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-migration-guide.adoc
@@ -41,7 +41,7 @@ follow the procedure link:http://docs.spring.io/spring-cloud-stream-app-starters
 CF implementations or as docker images, when deploying to Kubernetes and Mesos. Other than maven and
 docker resolution, you can also resolve application artifacts from `http`, `file`, or as `hdfs`
 coordinates
-* Unlike Spring XD, you do not have to upload the application bits while registering custom applications anymore; instead, you’re expected to <<spring-cloud-dataflow-register-apps, register>> the application coordinates that are hosted in the maven repository or by other means as discussed in the previous bullet
+* Unlike Spring XD, you do not have to upload the application bits while registering custom applications anymore; instead, you’re expected to <<spring-cloud-dataflow-register-stream-apps, register>> the application coordinates that are hosted in the maven repository or by other means as discussed in the previous bullet
 * By default, none of the out-of-the-box applications are preloaded already. It is intentionally designed to
 provide the flexibility to register app(s), as you find appropriate for the given use-case requirement
 * Depending on the binder choice, you can manually add the appropriate binder dependency to build

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix.adoc
@@ -1,7 +1,18 @@
 [[appendix]]
 = Appendices
 
-include::appendix-migration-guide.adoc[]
+[partintro]
+--
+Having trouble with Spring Cloud Data Flow, We'd like to help!
+
+* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
+  tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
+--
+
+include::appendix-dataflow-template.adoc[]
+include::appendix-howto.adoc[]
 include::appendix-building.adoc[]
 include::appendix-contributing.adoc[]
+include::appendix-migration-guide.adoc[]
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix.adoc
@@ -12,7 +12,7 @@ Having trouble with Spring Cloud Data Flow, We'd like to help!
 
 include::appendix-dataflow-template.adoc[]
 include::appendix-howto.adoc[]
+include::appendix-migration-guide.adoc[]
 include::appendix-building.adoc[]
 include::appendix-contributing.adoc[]
-include::appendix-migration-guide.adoc[]
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -1,0 +1,8 @@
+[[applications]]
+= Applications
+
+[partintro]
+--
+A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] starter apps for various data integration and processing scenarios facilitate learning and experimentation. For more details, review how to <<streams.adoc#spring-cloud-dataflow-register-stream-apps, register applications>>
+--
+

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/docinfo.html
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/docinfo.html
@@ -1,0 +1,74 @@
+<!-- Generate a nice TOC -->
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
+<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we neeed -->
+
+<style>
+.tocify-header {
+    font-style: italic;
+}
+
+.tocify-subheader {
+    font-style: normal;
+}
+
+.tocify ul {
+    margin: 0;
+ }
+
+.tocify-focus {
+    color: #7a2518; 
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.tocify-focus > a {
+    color: #7a2518; 
+}
+</style>
+
+<script type="text/javascript">
+    $(function () {
+        // Add a new container for the tocify toc into the existing toc so we can re-use its
+        // styling
+        $("#toc").append("<div id='generated-toc'></div>");
+        $("#generated-toc").tocify({
+            extendPage: false,
+            context: "#content",
+            highlightOnScroll: false,
+            hideEffect: "slideUp",
+            // Use the IDs that asciidoc already provides so that TOC links and intra-document
+            // links are the same. Anything else might confuse users when they create bookmarks.
+            hashGenerator: function(text, element) {
+                return $(element).attr("id");
+            },
+            // Smooth scrolling doesn't work properly if we use the asciidoc IDs
+            smoothScroll: false,
+            // Set to 'none' to use the tocify classes
+            theme: "none",
+            // Handle book (may contain h1) and article (only h2 deeper)
+            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5",
+            ignoreSelector: ".discrete"
+        });
+
+        // Switch between static asciidoc toc and dynamic tocify toc based on browser size
+        // This is set to match the media selectors in the asciidoc CSS
+        // Without this, we keep the dynamic toc even if it is moved from the side to preamble
+        // position which will cause odd scrolling behavior
+        var handleTocOnResize = function() {
+            if ($(document).width() < 768) {
+                $("#generated-toc").hide();
+                $(".sectlevel0").show();
+                $(".sectlevel1").show();
+            }
+            else {
+                $("#generated-toc").show();
+                $(".sectlevel0").hide();
+                $(".sectlevel1").hide();
+            }
+        }
+
+        $(window).resize(handleTocOnResize);
+        handleTocOnResize();
+    });
+</script>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -58,7 +58,7 @@ Successfully targeted http://198.51.100.0
 dataflow:>
 ----
 +
-By default, the application registry will be empty. If you would like to register all out-of-the-box stream applications built with the Kafka binder in bulk, you can with the following command. For more details, review how to <<streams.adoc#spring-cloud-dataflow-register-apps, register applications>>.
+By default, the application registry will be empty. If you would like to register all out-of-the-box stream applications built with the Kafka binder in bulk, you can with the following command. For more details, review how to <<streams.adoc#spring-cloud-dataflow-register-stream-apps, register applications>>.
 +
 [source,bash,subs=attributes]
 ----

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -1,12 +1,13 @@
 = Spring Cloud Data Flow Reference Guide
 Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Patrick Peralta; Glenn Renfro; Thomas Risberg; Dave Syer; David Turanski; Janne Valkealahti; Oleg Zhurakousky
 :doctype: book
-:toc:
+:toc: left
 :toclevels: 4
 :source-highlighter: prettify
 :numbered:
 :icons: font
 :hide-uri-scheme:
+:docinfo: shared
 
 :spring-cloud-dataflow-docs: http://docs.spring.io/spring-cloud-dataflow/docs/{project-version}/reference
 :spring-cloud-dataflow-docs-current: http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/
@@ -31,18 +32,14 @@ endif::backend-html5[]
 
 // ======================================================================================
 
-include::preface.adoc[]
-include::spring-cloud-dataflow-overview.adoc[]
-include::architecture.adoc[]
 include::getting-started.adoc[]
+include::applications.adoc[]
+include::architecture.adoc[]
 include::configuration.adoc[]
 include::streams.adoc[]
 include::tasks.adoc[]
 include::dashboard.adoc[]
-include::howto.adoc[]
 include::api-guide.adoc[]
-include::dataflow-template.adoc[]
 include::appendix.adoc[]
-
 
 // ======================================================================================

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -33,8 +33,11 @@ The shell provides tab completion for application properties and also the shell 
 
 NOTE: Supported Stream <appType>'s are: source, processor, and sink
 
+[[spring-cloud-dataflow-stream-lifecycle]]
+== Lifecycle of Streams
+
 [[spring-cloud-dataflow-register-stream-apps]]
-== Register a Stream App
+=== Register a Stream App
 
 Register a Stream App with the App Registry using the Spring Cloud Data Flow Shell
 `app register` command. You must provide a unique name, application type, and a URI that can be
@@ -166,7 +169,7 @@ URI will be passed to a runtime container instance where it is resolved. Consult
 the specific documentation of each Data Flow Server for more detail.
 
 [[spring-cloud-dataflow-stream-app-whitelisting]]
-=== Whitelisting application properties
+==== Whitelisting application properties
 
 Stream and Task applications are Spring Boot applications which are aware of many <<spring-cloud-dataflow-global-properties>>, e.g. `server.port` but also families of properties such as those with the prefix `spring.jmx` and `logging`.  When creating your own application it is desirable to whitelist properties so that the shell and the UI can display them first as primary properties when presenting options via TAB completion or in drop-down boxes.
 
@@ -201,7 +204,7 @@ Make sure to add 'spring-boot-configuration-processor' as an optional dependency
 
 
 [[spring-cloud-dataflow-stream-app-metadata-artifact]]
-=== Creating and using a dedicated metadata artifact
+==== Creating and using a dedicated metadata artifact
 You can go a step further in the process of describing the main properties that your stream or task app supports by
 creating a so-called metadata companion artifact. This simple jar file contains only the Spring boot JSON file about
 configuration properties metadata, as well as the whitelisting file described in the previous section.
@@ -283,7 +286,7 @@ source.http.metadata=maven://org.springframework.cloud.stream.app:http-source-ra
 ----
 
 [[custom-applications]]
-== Creating custom applications
+=== Creating custom applications
 
 While there are out of the box source, processor, sink applications available, one can extend these applications or write a custom link:https://github.com/spring-cloud/spring-cloud-stream[Spring Cloud Stream] application.
 
@@ -317,7 +320,7 @@ Once a custom application has been created, it can be registered as described in
 
 
 [[spring-cloud-dataflow-create-stream]]
-== Creating a Stream
+=== Creating a Stream
 
 The Spring Cloud Data Flow Server exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use is it is via the Spring Cloud Data Flow shell. Start the shell as described in the xref:getting-started#getting-started[Getting Started] section.
 
@@ -351,12 +354,12 @@ $ tail -f /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow
 2016-06-01 09:45:12.250  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:12
 2016-06-01 09:45:13.251  INFO 79194 --- [  kafka-binder-] log.sink    : 06/01/16 09:45:13
 ```
-=== Application properties
+==== Application properties
 
 Application properties are the properties associated with each application in the stream. When the application is deployed, the application properties are applied to the application via
 command line arguments or environment variables based on the underlying deployment implementation.
 
-==== Passing application properties when creating a stream
+===== Passing application properties when creating a stream
 
 The following stream
 
@@ -419,12 +422,12 @@ dataflow:> stream create --definition "time --fixed-delay=5 | log --level=WARN" 
 Note that the properties `fixed-delay` and `level` defined above for the apps `time` and `log` are the 'short-form' property names provided by the shell completion.
 These 'short-form' property names are applicable only for the white-listed properties and in all other cases, only _fully qualified_ property names should be used.
 
-=== Deployment properties
+==== Deployment properties
 
 When deploying the stream, properties that control the deployment of the apps into the target platform are known as `deployment` properties.
 For instance, one can specify how many instances need to be deployed for the specific application defined in the stream using the deployment property called `count`.
 
-==== Application properties versus Deployer properties
+===== Application properties versus Deployer properties
 
 Starting with version 1.2, the distinction between properties that are meant for the _deployed app_ and properties that
 govern _how_ this app is deployed (thanks to some implementation of a
@@ -456,7 +459,7 @@ The following table recaps the difference in behavior between the two.
 |===
 
 
-==== Passing instance count as deployment property
+===== Passing instance count as deployment property
 
 If you would like to have multiple instances of an application in the stream, you
 can include a deployer property with the deploy command:
@@ -473,7 +476,7 @@ Note that `count` is the *reserved* property name used by the underlying deploye
 
 IMPORTANT: See <<spring-cloud-dataflow-stream-app-labels>>.
 
-==== Inline vs file reference properties
+===== Inline vs file reference properties
 
 When using the Spring Cloud Data Flow Shell, there are two ways to provide deployment
 properties: either *inline* or via a *file reference*. Those two ways are exclusive
@@ -531,7 +534,7 @@ app:
       partitionKeyExpression: payload
 ```
 
-==== Passing application properties when deploying a stream
+===== Passing application properties when deploying a stream
 
 The application properties can also be specified when deploying a stream. When specified during deployment, these application properties can either be specified as
  'short-form' property names (applicable for white-listed properties) or _fully qualified_ property names. The application properties should have the prefix "app.<appName/label>".
@@ -565,7 +568,7 @@ stream deploy ticktock --properties "app.a.fixed-delay=4,app.b.level=ERROR"
 ----
 
 [[passing_producer_consumer_properties]]
-==== Passing Spring Cloud Stream properties for the application
+===== Passing Spring Cloud Stream properties for the application
 Spring Cloud Data Flow sets the `required` Spring Cloud Stream properties for the applications inside the stream. Most importantly, the `spring.cloud.stream.bindings.<input/output>.destination` is set internally for the apps to bind.
 
 If someone wants to override any of the Spring Cloud Stream properties, they can be set via deployment properties.
@@ -586,7 +589,7 @@ dataflow:>stream deploy ticktock --properties "app.time.spring.cloud.stream.bind
 
 NOTE: Overriding the destination names is not recommended as Spring Cloud Data Flow takes care of setting this internally.
 
-==== Passing per-binding producer consumer properties
+===== Passing per-binding producer consumer properties
 A Spring Cloud Stream application can have producer and consumer properties set `per-binding` basis.
 While Spring Cloud Data Flow supports specifying short-hand notation for per binding producer properties such as `partitionKeyExpression`, `partitionKeyExtractorClass` as described in <<passing_stream_partition_properties>>, all the supported Spring Cloud Stream producer/consumer properties can be set as Spring Cloud Stream properties for the app directly as well.
 
@@ -615,7 +618,7 @@ dataflow:>stream deploy ticktock --properties "app.time.spring.cloud.stream.rabb
 ----
 
 [[passing_stream_partition_properties]]
-==== Passing stream partition properties during stream deployment
+===== Passing stream partition properties during stream deployment
 A common pattern in stream processing is to partition the data as it is streamed.
 This entails deploying multiple instances of a message consuming app and using
 content-based routing so that messages with a given key (as determined at runtime)
@@ -654,7 +657,7 @@ If neither a `partitionSelectorClass` nor a `partitionSelectorExpression` is
 present the result is `key.hashCode() % partitionCount`.
 
 [[passing_content_type_properties]]
-==== Passing application content type properties
+===== Passing application content type properties
 In a stream definition you can specify that the input or the output of an application need to be converted to a different type.
 You can use the `inputType` and `outputType` properties to specify the content type for the incoming data and outgoing data, respectively.
 
@@ -688,7 +691,7 @@ For instance, in the above stream, instead of specifying the `--inputType` on th
 
 For the complete list of message conversion and message converters, please refer to Spring Cloud Stream {spring-cloud-stream-docs}#contenttypemanagement[documentation].
 
-==== Overriding application properties during stream deployment
+===== Overriding application properties during stream deployment
 
 Application properties that are defined during deployment override the same properties defined during the stream creation.
 
@@ -707,7 +710,7 @@ dataflow:>stream deploy ticktock --properties "app.time.fixed-delay=4,app.log.le
 ----
 
 [[spring-cloud-dataflow-global-properties]]
-=== Common application properties
+==== Common application properties
 
 In addition to configuration via DSL, Spring Cloud Data Flow provides a mechanism for setting common properties to all
 the streaming applications that are launched by it.
@@ -732,7 +735,7 @@ They will be overridden if a property with the same key is specified at stream d
 `app.http.spring.cloud.stream.kafka.binder.brokers` will override the common property).
 
 [[spring-cloud-dataflow-destroy-stream]]
-== Destroying a Stream
+=== Destroying a Stream
 
 You can delete a stream by issuing the `stream destroy` command from the shell:
 
@@ -743,123 +746,13 @@ dataflow:> stream destroy --name ticktock
 If the stream was deployed, it will be undeployed before the stream definition is deleted.
 
 [[spring-cloud-dataflow-deploy-undeploy-stream]]
-== Deploying and Undeploying Streams
+=== Deploying and Undeploying Streams
 
 Often you will want to stop a stream, but retain the name and definition for future use. In that case you can `undeploy` the stream by name and issue the `deploy` command at a later time to restart it.
 ```
 dataflow:> stream undeploy --name ticktock
 dataflow:> stream deploy --name ticktock
 ```
-
-[[spring-cloud-dataflow-stream-app-types]]
-== Other Source and Sink Application Types
-
-Let's try something a bit more complicated and swap out the `time` source for something else. Another supported source type is `http`, which accepts data for ingestion over HTTP POSTs. Note that the `http` source accepts data on a different port from the Data Flow Server (default 8080). By default the port is randomly assigned.
-
-To create a stream using an `http` source, but still using the same `log` sink, we would change the original command above to
-
-```
-dataflow:> stream create --definition "http | log" --name myhttpstream --deploy
-```
-which will produce the following output from the server
-
-```
-2016-06-01 09:47:58.920  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.log instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788878747/myhttpstream.log
-2016-06-01 09:48:06.396  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.http instance 0
-   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788886383/myhttpstream.http
-```
-
-Note that we don't see any other output this time until we actually post some data (using a shell command). In order to see the randomly assigned port on which the http source is listening, execute:
-
-```
-dataflow:> runtime apps
-```
-You should see that the corresponding http source has a `url` property containing the host and port information on which it is listening. You are now ready to post to that url, e.g.:
-```
-dataflow:> http post --target http://localhost:1234 --data "hello"
-dataflow:> http post --target http://localhost:1234 --data "goodbye"
-```
-and the stream will then funnel the data from the http source to the output log implemented by the log sink
-
-```
-2016-06-01 09:50:22.121  INFO 79654 --- [  kafka-binder-] log.sink    : hello
-2016-06-01 09:50:26.810  INFO 79654 --- [  kafka-binder-] log.sink    : goodbye
-```
-
-Of course, we could also change the sink implementation. You could pipe the output to a file (`file`), to hadoop (`hdfs`) or to any of the other sink apps which are available. You can also define your own apps.
-
-[[spring-cloud-dataflow-simple-stream]]
-== Simple Stream Processing
-
-As an example of a simple processing step, we can transform the payload of the HTTP posted data to upper case using the stream definitions
-```
-http | transform --expression=payload.toUpperCase() | log
-```
-To create this stream enter the following command in the shell
-```
-dataflow:> stream create --definition "http | transform --expression=payload.toUpperCase() | log" --name mystream --deploy
-```
-Posting some data (using a shell command)
-```
-dataflow:> http post --target http://localhost:1234 --data "hello"
-```
-Will result in an uppercased 'HELLO' in the log
-
-```
-2016-06-01 09:54:37.749  INFO 80083 --- [  kafka-binder-] log.sink    : HELLO
-```
-
-[[spring-cloud-dataflow-stream-partitions]]
-== Stateful Stream Processing
-
-To demonstrate the data partitioning functionality, let's deploy the following stream with Kafka as the binder.
-
-```
-dataflow:>stream create --name words --definition "http --server.port=9900 | splitter --expression=payload.split(' ') | log"
-Created new stream 'words'
-
-dataflow:>stream deploy words --properties "app.splitter.producer.partitionKeyExpression=payload,deployer.log.count=2"
-Deployed stream 'words'
-
-dataflow:>http post --target http://localhost:9900 --data "How much wood would a woodchuck chuck if a woodchuck could chuck wood"
-> POST (text/plain;Charset=UTF-8) http://localhost:9900 How much wood would a woodchuck chuck if a woodchuck could chuck wood
-> 202 ACCEPTED
-```
-
-You'll see the following in the server logs.
-
-```
-2016-06-05 18:33:24.982  INFO 58039 --- [nio-9393-exec-9] o.s.c.d.spi.local.LocalAppDeployer       : deploying app words.log instance 0
-   Logs will be in /var/folders/c3/ctx7_rns6x30tq7rb76wzqwr0000gp/T/spring-cloud-dataflow-694182453710731989/words-1465176804970/words.log
-2016-06-05 18:33:24.988  INFO 58039 --- [nio-9393-exec-9] o.s.c.d.spi.local.LocalAppDeployer       : deploying app words.log instance 1
-   Logs will be in /var/folders/c3/ctx7_rns6x30tq7rb76wzqwr0000gp/T/spring-cloud-dataflow-694182453710731989/words-1465176804970/words.log
-```
-
-Review the `words.log instance 0` logs:
-
-```
-2016-06-05 18:35:47.047  INFO 58638 --- [  kafka-binder-] log.sink                                 : How
-2016-06-05 18:35:47.066  INFO 58638 --- [  kafka-binder-] log.sink                                 : chuck
-2016-06-05 18:35:47.066  INFO 58638 --- [  kafka-binder-] log.sink                                 : chuck
-```
-
-Review the `words.log instance 1` logs:
-
-```
-2016-06-05 18:35:47.047  INFO 58639 --- [  kafka-binder-] log.sink                                 : much
-2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : wood
-2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : would
-2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : a
-2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : woodchuck
-2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : if
-2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : a
-2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : woodchuck
-2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : could
-2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : wood
-```
-
-This shows that payload splits that contain the same word are routed to the same application instance.
 
 [[spring-cloud-dataflow-stream-tap-dsl]]
 == Tap a Stream
@@ -982,3 +875,116 @@ app.transform.spring.cloud.stream.bindings.output.binder=kafka1,app.log.spring.c
 ```
 
 One can override any of the binder configuration properties by specifying them via deployment properties.
+
+[[spring-cloud-dataflow-stream-examples]]
+== Examples
+
+[[spring-cloud-dataflow-simple-stream]]
+=== Simple Stream Processing
+
+As an example of a simple processing step, we can transform the payload of the HTTP posted data to upper case using the stream definitions
+```
+http | transform --expression=payload.toUpperCase() | log
+```
+To create this stream enter the following command in the shell
+```
+dataflow:> stream create --definition "http | transform --expression=payload.toUpperCase() | log" --name mystream --deploy
+```
+Posting some data (using a shell command)
+```
+dataflow:> http post --target http://localhost:1234 --data "hello"
+```
+Will result in an uppercased 'HELLO' in the log
+
+```
+2016-06-01 09:54:37.749  INFO 80083 --- [  kafka-binder-] log.sink    : HELLO
+```
+
+[[spring-cloud-dataflow-stream-partitions]]
+=== Stateful Stream Processing
+
+To demonstrate the data partitioning functionality, let's deploy the following stream with Kafka as the binder.
+
+```
+dataflow:>stream create --name words --definition "http --server.port=9900 | splitter --expression=payload.split(' ') | log"
+Created new stream 'words'
+
+dataflow:>stream deploy words --properties "app.splitter.producer.partitionKeyExpression=payload,deployer.log.count=2"
+Deployed stream 'words'
+
+dataflow:>http post --target http://localhost:9900 --data "How much wood would a woodchuck chuck if a woodchuck could chuck wood"
+> POST (text/plain;Charset=UTF-8) http://localhost:9900 How much wood would a woodchuck chuck if a woodchuck could chuck wood
+> 202 ACCEPTED
+```
+
+You'll see the following in the server logs.
+
+```
+2016-06-05 18:33:24.982  INFO 58039 --- [nio-9393-exec-9] o.s.c.d.spi.local.LocalAppDeployer       : deploying app words.log instance 0
+   Logs will be in /var/folders/c3/ctx7_rns6x30tq7rb76wzqwr0000gp/T/spring-cloud-dataflow-694182453710731989/words-1465176804970/words.log
+2016-06-05 18:33:24.988  INFO 58039 --- [nio-9393-exec-9] o.s.c.d.spi.local.LocalAppDeployer       : deploying app words.log instance 1
+   Logs will be in /var/folders/c3/ctx7_rns6x30tq7rb76wzqwr0000gp/T/spring-cloud-dataflow-694182453710731989/words-1465176804970/words.log
+```
+
+Review the `words.log instance 0` logs:
+
+```
+2016-06-05 18:35:47.047  INFO 58638 --- [  kafka-binder-] log.sink                                 : How
+2016-06-05 18:35:47.066  INFO 58638 --- [  kafka-binder-] log.sink                                 : chuck
+2016-06-05 18:35:47.066  INFO 58638 --- [  kafka-binder-] log.sink                                 : chuck
+```
+
+Review the `words.log instance 1` logs:
+
+```
+2016-06-05 18:35:47.047  INFO 58639 --- [  kafka-binder-] log.sink                                 : much
+2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : wood
+2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : would
+2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : a
+2016-06-05 18:35:47.066  INFO 58639 --- [  kafka-binder-] log.sink                                 : woodchuck
+2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : if
+2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : a
+2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : woodchuck
+2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : could
+2016-06-05 18:35:47.067  INFO 58639 --- [  kafka-binder-] log.sink                                 : wood
+```
+
+This shows that payload splits that contain the same word are routed to the same application instance.
+
+[[spring-cloud-dataflow-stream-app-types]]
+=== Other Source and Sink Application Types
+
+Let's try something a bit more complicated and swap out the `time` source for something else. Another supported source type is `http`, which accepts data for ingestion over HTTP POSTs. Note that the `http` source accepts data on a different port from the Data Flow Server (default 8080). By default the port is randomly assigned.
+
+To create a stream using an `http` source, but still using the same `log` sink, we would change the original command above to
+
+```
+dataflow:> stream create --definition "http | log" --name myhttpstream --deploy
+```
+which will produce the following output from the server
+
+```
+2016-06-01 09:47:58.920  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.log instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788878747/myhttpstream.log
+2016-06-01 09:48:06.396  INFO 79016 --- [io-9393-exec-10] o.s.c.d.spi.local.LocalAppDeployer       : deploying app myhttpstream.http instance 0
+   Logs will be in /var/folders/wn/8jxm_tbd1vj28c8vj37n900m0000gn/T/spring-cloud-dataflow-912434582726479179/myhttpstream-1464788886383/myhttpstream.http
+```
+
+Note that we don't see any other output this time until we actually post some data (using a shell command). In order to see the randomly assigned port on which the http source is listening, execute:
+
+```
+dataflow:> runtime apps
+```
+You should see that the corresponding http source has a `url` property containing the host and port information on which it is listening. You are now ready to post to that url, e.g.:
+```
+dataflow:> http post --target http://localhost:1234 --data "hello"
+dataflow:> http post --target http://localhost:1234 --data "goodbye"
+```
+and the stream will then funnel the data from the http source to the output log implemented by the log sink
+
+```
+2016-06-01 09:50:22.121  INFO 79654 --- [  kafka-binder-] log.sink    : hello
+2016-06-01 09:50:26.810  INFO 79654 --- [  kafka-binder-] log.sink    : goodbye
+```
+
+Of course, we could also change the sink implementation. You could pipe the output to a file (`file`), to hadoop (`hdfs`) or to any of the other sink apps which are available. You can also define your own apps.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -33,7 +33,7 @@ The shell provides tab completion for application properties and also the shell 
 
 NOTE: Supported Stream <appType>'s are: source, processor, and sink
 
-[[spring-cloud-dataflow-register-apps]]
+[[spring-cloud-dataflow-register-stream-apps]]
 == Register a Stream App
 
 Register a Stream App with the App Registry using the Spring Cloud Data Flow Shell
@@ -313,7 +313,7 @@ The plugin is necesary for creating the executable jar that will be registered w
 Spring Initialzr will include the plugin in the generated POM.
 ====
 
-Once a custom application has been created, it can be registered as described in <<spring-cloud-dataflow-register-apps>>.
+Once a custom application has been created, it can be registered as described in <<spring-cloud-dataflow-register-stream-apps>>.
 
 
 [[spring-cloud-dataflow-create-stream]]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -61,6 +61,7 @@ Boot (there is one for running batch jobs for example).
   Boot conventions.
 .  The packaged application can be registered and deployed as noted below.
 
+[[spring-cloud-dataflow-register-task-apps]]
 === Registering a Task Application
 Register a Task App with the App Registry using the Spring Cloud Data Flow Shell
 `app register` command. You must provide a unique name and a URI that can be


### PR DESCRIPTION
- Use http://gregfranko.com/jquery.tocify.js/ for a simplified TOC experience (see: docinfo.html)
- Reorder doc sections
- Move relevant bits to Appendix
- Rename files to be consistent with rest of the Appendix includes
- Add "Applications" file (points to stream and task project sites for docs)

This change was tested locally with:

> ./mvnw package -DskipTests=true -P full -pl spring-cloud-dataflow-docs -am

Resolves spring-cloud/spring-cloud-dataflow#1597