### PR TITLE
Reworded READMEs to allow for limited production use cases

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ The Data Flow Server is a Spring Boot application that provides a common REST AP
 runtime environment there is a different version of the Data Flow Server that depends upon a
 deployer SPI implementation for that environment. The github locations for these Data Flow Servers are:
 
-* https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-server-local[Local] (intended for development use only)
+* https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-server-local[Local]
 * https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry[Cloud Foundry]
 * https://github.com/spring-cloud/spring-cloud-dataflow-server-yarn[Apache YARN]
 * https://github.com/spring-cloud/spring-cloud-dataflow-server-mesos[Apache Mesos]

--- a/spring-cloud-dataflow-server-local/README.adoc
+++ b/spring-cloud-dataflow-server-local/README.adoc
@@ -2,7 +2,11 @@
 
 The Data Flow Server implementation for deploying https://github.com/spring-cloud/spring-cloud-stream[Spring Cloud Stream]
 and https://github.com/spring-cloud/spring-cloud-task[Spring Cloud Task] apps locally by spawning
-a new JVM process on the local machine. This server is intended for development use only.
+a new JVM process on the local machine.
+
+NOTE: The local version of the Data Flow server should only be used for development as
+well as in environments where production grade resilience is provided via means other than
+Data Flow itself.
 
 == Getting Started
 


### PR DESCRIPTION
This commit removes the statements that the local version of the server
is for development only and calls out the limitations of using the local
server in a production environment.