### PR TITLE
Fixes a bug where stepExecutionId is used instead of jobExecutionId

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionResourceBuilder.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionResourceBuilder.java
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
 public class StepExecutionResourceBuilder {
 
 	static public StepExecutionResource toResource(StepExecution entity) {
-		return new StepExecutionResource(entity.getId(), entity, generateStepType(entity));
+		return new StepExecutionResource(entity.getJobExecution().getId(), entity, generateStepType(entity));
 	}
 
 	private static String generateStepType(StepExecution stepExecution) {


### PR DESCRIPTION
StepExecutionResourceBuilder has been updated to resolve this issue
resolves #1633