### PR TITLE
Add search filter to app list

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -154,6 +154,24 @@ public class AppRegistryControllerTests {
 	}
 
 	@Test
+	public void testListApplicationsBySearch() throws Exception {
+		mockMvc.perform(get("/apps?search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(1)));
+		mockMvc.perform(get("/apps?search=time").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(2)));
+	}
+
+	@Test
+	public void testListApplicationsByTypeAndSearch() throws Exception {
+		mockMvc.perform(get("/apps?type=task&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(1)));
+		mockMvc.perform(get("/apps?type=source&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(1)));
+		mockMvc.perform(get("/apps?type=sink&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(0)));
+	}
+
+	@Test
 	public void testFindNonExistentApp() throws Exception {
 		mockMvc.perform(get("/apps/source/foo").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().is4xxClientError()).andReturn().getResponse().getContentAsString()
@@ -190,4 +208,74 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(delete("/apps/processor/blubba").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isNotFound());
 	}
+
+	@Test
+	public void testPagination() throws Exception {
+		mockMvc.perform(get("/apps").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(20)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(1)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=0&size=10").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(10)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(1)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=0&size=1").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(1)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(4)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=1&size=2").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(2)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(1)));
+
+		mockMvc.perform(get("/apps?page=0&size=3").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(3)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=1&size=3").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(3)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(1)));
+
+		mockMvc.perform(get("/apps?page=5&size=2").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(2)))
+				.andExpect(jsonPath("page.totalElements", is(4)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=0&size=10&search=i").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(10)))
+				.andExpect(jsonPath("page.totalElements", is(3)))
+				.andExpect(jsonPath("page.totalPages", is(1)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=0&size=1&search=i").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(1)))
+				.andExpect(jsonPath("page.totalElements", is(3)))
+				.andExpect(jsonPath("page.totalPages", is(3)))
+				.andExpect(jsonPath("page.number", is(0)));
+
+		mockMvc.perform(get("/apps?page=1&size=2&search=i").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(2)))
+				.andExpect(jsonPath("page.totalElements", is(3)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(1)));
+
+		mockMvc.perform(get("/apps?page=5&size=2&search=i").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("page.size", is(2)))
+				.andExpect(jsonPath("page.totalElements", is(3)))
+				.andExpect(jsonPath("page.totalPages", is(2)))
+				.andExpect(jsonPath("page.number", is(0)));
+	}
+
 }


### PR DESCRIPTION
- Add simple search match by apps name. Can't
  really filter by address as it would give
  unrealistic results together with name.
- Fix some issues with pagination i.e. when page
  which doesn't exist is requested. Also make paging
  work with filtered set.
- Fixes #1617