### PR TITLE
Updating versions for Spring Boot and Spring Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,17 +27,17 @@
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<spring-cloud-dataflow-ui.version>1.3.0.BUILD-SNAPSHOT</spring-cloud-dataflow-ui.version>
 
-		<spring-cloud-deployer.version>1.2.2.RELEASE</spring-cloud-deployer.version>
-		<spring-cloud-deployer-local.version>1.2.2.RELEASE</spring-cloud-deployer-local.version>
+		<spring-cloud-deployer.version>1.3.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer-local.version>1.3.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-boot.version -->
-		<spring-boot.version>1.5.4.RELEASE</spring-boot.version>
+		<spring-boot.version>1.5.7.RELEASE</spring-boot.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud-task.version -->
 		<spring-cloud-task.version>1.2.1.RELEASE</spring-cloud-task.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud.version -->
-		<spring-cloud.version>Dalston.SR2</spring-cloud.version>
+		<spring-cloud.version>Dalston.SR3</spring-cloud.version>
 
 		<spring-cloud-common-security-config.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-common-security-config.version>
 

--- a/spring-cloud-dataflow-server-local/pom.xml
+++ b/spring-cloud-dataflow-server-local/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.4.RELEASE</version>
+		<version>1.5.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -20,7 +20,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<spring-cloud-task.version>1.2.1.RELEASE</spring-cloud-task.version>
-		<spring-cloud.version>Dalston.SR2</spring-cloud.version>
+		<spring-cloud.version>Dalston.SR3</spring-cloud.version>
 		<checkstyle.config.location>../src/checkstyle/checkstyle.xml</checkstyle.config.location>
 	</properties>
 


### PR DESCRIPTION
- Spring Boot 1.5.7

- Spring Cloud Dalston.SR3

- also setting deployer version to 1.3.0.BUILD-SNAPSHOT

Resolves #1649