### PR TITLE
Fix access to oauth logout notify page

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -23,7 +23,7 @@ spring:
       security:
         authorization:
           enabled: true
-          permit-all-paths: "/authenticate,/security/info,/features,/assets/**"
+          permit-all-paths: "/authenticate,/security/info,/features,/assets/**,/dashboard/logout-success-oauth.html"
           rules:
             # Metrics
 


### PR DESCRIPTION
- Add logout-success-oauth.html to permitted pages.
- Fixes #1659