### PR TITLE
Initial support to delegate to skipper to deploy a stream.

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -46,6 +46,17 @@ public interface StreamOperations {
 	public StreamDefinitionResource createStream(String name, String definition, boolean deploy);
 
 	/**
+	 * Create a new stream, optionally deploying it, using skipper.
+	 *
+	 * @param name the name of the stream
+	 * @param definition the stream definition DSL
+	 * @param deploy whether to deploy the stream after creating its definition
+	 * @param useSkipper delegate the deployment of the stream to skipper
+	 * @return the new stream definition
+	 */
+	public StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper);
+
+	/**
 	 * Deploy an already created stream.
 	 *
 	 * @param name the name of the stream

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -75,14 +75,21 @@ public class StreamTemplate implements StreamOperations {
 
 	@Override
 	public StreamDefinitionResource createStream(String name, String definition, boolean deploy) {
+		return createStream(name, definition, deploy, false);
+	}
+
+	@Override
+	public StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		values.add("name", name);
 		values.add("definition", definition);
 		values.add("deploy", Boolean.toString(deploy));
+		values.add("useSkipper", Boolean.toString(useSkipper));
 		StreamDefinitionResource stream = restTemplate.postForObject(definitionsLink.expand().getHref(), values,
 				StreamDefinitionResource.class);
 		return stream;
 	}
+
 
 	@Override
 	public void deploy(String name, Map<String, String> properties) {

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -150,6 +150,11 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-skipper-client</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -52,7 +52,7 @@ import org.springframework.cloud.dataflow.server.repository.DuplicateStreamDefin
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
+import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.support.CannotDetermineApplicationTypeException;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
@@ -98,7 +98,7 @@ public class StreamDefinitionController {
 	/**
 	 * The service that is responsible for deploying streams.
 	 */
-	private final DefaultStreamService defaultStreamService;
+	private final StreamService streamService;
 
 	/**
 	 * The repository this controller will use for stream CRUD operations.
@@ -144,19 +144,19 @@ public class StreamDefinitionController {
 	 */
 	public StreamDefinitionController(StreamDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController,
-			AppDeployer deployer, AppRegistry appRegistry, DefaultStreamService defaultStreamService) {
+			AppDeployer deployer, AppRegistry appRegistry, StreamService streamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(deploymentController, "StreamDeploymentController must not be null");
 		Assert.notNull(deployer, "AppDeployer must not be null");
 		Assert.notNull(appRegistry, "AppRegistry must not be null");
-		Assert.notNull(defaultStreamService, "StreamDeploymentService must not be null");
+		Assert.notNull(streamService, "StreamDeploymentService must not be null");
 		this.deploymentController = deploymentController;
 		this.deploymentIdRepository = deploymentIdRepository;
 		this.repository = repository;
 		this.deployer = deployer;
 		this.appRegistry = appRegistry;
-		this.defaultStreamService = defaultStreamService;
+		this.streamService = streamService;
 	}
 
 	/**
@@ -280,7 +280,7 @@ public class StreamDefinitionController {
 			if (useSkipper) {
 				streamDeploymentProperties.put(SKIPPER_ENABLED_PROPERTY_KEY, "true");
 			}
-			defaultStreamService.deployStream(name, streamDeploymentProperties);
+			this.streamService.deployStream(name, streamDeploymentProperties);
 		}
 		return new Assembler(new PageImpl<>(Collections.singletonList(stream))).toResource(stream);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -16,38 +16,29 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.cloud.dataflow.core.ApplicationType;
-import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
-import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
-import org.springframework.cloud.dataflow.registry.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
-import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
-import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
-import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.Resource;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.http.HttpStatus;
@@ -74,19 +65,14 @@ import org.springframework.web.bind.annotation.RestController;
 @ExposesResourceFor(StreamDeploymentResource.class)
 public class StreamDeploymentController {
 
-	private static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";
-
 	/**
 	 * This is the spring boot property key that Spring Cloud Stream uses to filter the
-	 * metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is
-	 * fired for metrics export.
+	 * metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is fired
+	 * for metrics export.
 	 */
 	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
-
 	private static Log logger = LogFactory.getLog(StreamDeploymentController.class);
-
-	private static String deployLoggingString = "Deploying application named [%s] as part of stream named [%s] "
-			+ "with resource URI [%s]";
+	private final DefaultStreamService defaultStreamService;
 
 	/**
 	 * The repository this controller will use for stream CRUD operations.
@@ -123,30 +109,32 @@ public class StreamDeploymentController {
 	 * <li>deployment operations to the provided {@link AppDeployer}</li>
 	 * </ul>
 	 *
-	 * @param repository the repository this controller will use for stream CRUD
-	 * operations
-	 * @param deploymentIdRepository the repository this controller will use for
-	 * deployment IDs
+	 * @param repository the repository this controller will use for stream CRUD operations
+	 * @param deploymentIdRepository the repository this controller will use for deployment
+	 * IDs
 	 * @param registry the registry this controller will use to lookup apps
 	 * @param deployer the deployer this controller will use to deploy stream apps
 	 * @param metadataResolver the application metadata resolver
 	 * @param commonProperties common set of application properties
 	 */
 	public StreamDeploymentController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
-			ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties) {
+									  DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
+									  ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties,
+									  DefaultStreamService defaultStreamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(registry, "AppRegistry must not be null");
 		Assert.notNull(deployer, "AppDeployer must not be null");
 		Assert.notNull(metadataResolver, "MetadataResolver must not be null");
 		Assert.notNull(commonProperties, "CommonApplicationProperties must not be null");
+		Assert.notNull(defaultStreamService, "StreamDeploymentService must not be null");
 		this.repository = repository;
 		this.deploymentIdRepository = deploymentIdRepository;
 		this.registry = registry;
 		this.deployer = deployer;
 		this.whitelistProperties = new WhitelistProperties(metadataResolver);
 		this.commonApplicationProperties = commonProperties;
+		this.defaultStreamService = defaultStreamService;
 	}
 
 	/**
@@ -179,135 +167,20 @@ public class StreamDeploymentController {
 	 * Request deployment of an existing stream definition.
 	 *
 	 * @param name the name of an existing stream definition (required)
-	 * @param properties the deployment properties for the stream as a comma-delimited
-	 * list of key=value pairs
+	 * @param properties the deployment properties for the stream as a comma-delimited list of
+	 * key=value pairs
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public void deploy(@PathVariable("name") String name,
-			@RequestBody(required = false) Map<String, String> properties) {
-		StreamDefinition stream = this.repository.findOne(name);
-		if (stream == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
-		String status = calculateStreamState(name);
-		if (DeploymentState.deployed.equals(DeploymentState.valueOf(status))) {
-			throw new StreamAlreadyDeployedException(name);
-		}
-		else if (DeploymentState.deploying.equals(DeploymentState.valueOf(status))) {
-			throw new StreamAlreadyDeployingException(name);
-		}
-		DeploymentPropertiesUtils.ensureJustDeploymentProperties(properties);
-		deployStream(stream, properties);
-	}
-
-	private String calculateStreamState(String name) {
-		Set<DeploymentState> appStates = EnumSet.noneOf(DeploymentState.class);
-		StreamDefinition stream = this.repository.findOne(name);
-		for (StreamAppDefinition appDefinition : stream.getAppDefinitions()) {
-			String key = DeploymentKey.forStreamAppDefinition(appDefinition);
-			String id = this.deploymentIdRepository.findOne(key);
-			if (id != null) {
-				AppStatus status = this.deployer.status(id);
-				appStates.add(status.getState());
-			}
-			else {
-				appStates.add(DeploymentState.undeployed);
-			}
-		}
-		return StreamDefinitionController.aggregateState(appStates).toString();
+					   @RequestBody(required = false) Map<String, String> properties) {
+		defaultStreamService.deployStream(name, properties);
 	}
 
 	/**
-	 * Deploy a stream as defined by its {@link StreamDefinition} and optional deployment
-	 * properties.
-	 *
-	 * @param stream the stream to deploy
-	 * @param streamDeploymentProperties the deployment properties for the stream
-	 */
-	private void deployStream(StreamDefinition stream, Map<String, String> streamDeploymentProperties) {
-		if (streamDeploymentProperties == null) {
-			streamDeploymentProperties = Collections.emptyMap();
-		}
-		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
-		int nextAppCount = 0;
-		boolean isDownStreamAppPartitioned = false;
-		while (iterator.hasNext()) {
-			StreamAppDefinition currentApp = iterator.next();
-			ApplicationType type = DataFlowServerUtil.determineApplicationType(currentApp);
-
-			AppRegistration registration = this.registry.find(currentApp.getRegisteredAppName(), type);
-			Assert.notNull(registration, String.format("no application '%s' of type '%s' exists in the registry",
-					currentApp.getName(), type));
-
-			Map<String, String> appDeployTimeProperties = extractAppProperties(currentApp, streamDeploymentProperties);
-			Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
-					.extractAndQualifyDeployerProperties(streamDeploymentProperties, currentApp.getName());
-			deployerDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
-
-			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp,
-					streamDeploymentProperties);
-			// Set instance count property
-			if (deployerDeploymentProperties.containsKey(AppDeployer.COUNT_PROPERTY_KEY)) {
-				appDeployTimeProperties.put(StreamPropertyKeys.INSTANCE_COUNT,
-						deployerDeploymentProperties.get(AppDeployer.COUNT_PROPERTY_KEY));
-			}
-			if (!type.equals(ApplicationType.source)) {
-				deployerDeploymentProperties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
-			}
-
-			// consumer app partition properties
-			if (upstreamAppSupportsPartition) {
-				updateConsumerPartitionProperties(appDeployTimeProperties);
-			}
-
-			// producer app partition properties
-			if (isDownStreamAppPartitioned) {
-				updateProducerPartitionProperties(appDeployTimeProperties, nextAppCount);
-			}
-
-			nextAppCount = getInstanceCount(deployerDeploymentProperties);
-			isDownStreamAppPartitioned = isPartitionedConsumer(appDeployTimeProperties, upstreamAppSupportsPartition);
-
-			logger.info(String.format("Downloading resource URI [%s]", registration.getUri()));
-			Resource appResource = registration.getResource();
-			Resource metadataResource = registration.getMetadataResource();
-
-			// add properties needed for metrics system
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_NAME, currentApp.getStreamName());
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_LABEL, currentApp.getName());
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_TYPE, type.toString());
-			StringBuilder sb = new StringBuilder().append(currentApp.getStreamName()).append(".")
-					.append(currentApp.getName()).append(".").append("${spring.cloud.application.guid}");
-			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
-
-			// Merge *definition time* app properties with *deployment time* properties
-			// and expand them to their long form if applicable
-			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource,
-					appDeployTimeProperties);
-
-			AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition, appResource,
-					deployerDeploymentProperties);
-			try {
-				logger.info(String.format(deployLoggingString, request.getDefinition().getName(),
-						currentApp.getStreamName(), registration.getUri()));
-				String id = this.deployer.deploy(request);
-				this.deploymentIdRepository.save(DeploymentKey.forStreamAppDefinition(currentApp), id);
-			}
-			// If the deployer implementation handles the deployment request
-			// synchronously, log error message if
-			// any exception is thrown out of the deployment and proceed to the next
-			// deployment.
-			catch (Exception e) {
-				logger.error(String.format("Exception when deploying the app %s: %s", currentApp, e.getMessage()), e);
-			}
-		}
-	}
-
-	/**
-	 * Return a new app definition where definition-time and deploy-time properties have
-	 * been merged and short form parameters have been expanded to their long form
-	 * (amongst the whitelisted supported properties of the app) if applicable.
+	 * Return a new app definition where definition-time and deploy-time properties have been
+	 * merged and short form parameters have been expanded to their long form (amongst the
+	 * whitelisted supported properties of the app) if applicable.
 	 */
 	/* default */ AppDefinition mergeAndExpandAppProperties(StreamAppDefinition original, Resource metadataResource,
 			Map<String, String> appDeployTimeProperties) {
@@ -320,134 +193,6 @@ public class StreamDeploymentController {
 		merged.putIfAbsent(METRICS_TRIGGER_INCLUDES, "integration**");
 
 		return new AppDefinition(original.getName(), merged);
-	}
-
-	/**
-	 * Extract and return a map of properties for a specific app within the deployment
-	 * properties of a stream.
-	 *
-	 * @param appDefinition the {@link StreamAppDefinition} for which to return a map of
-	 * properties
-	 * @param streamDeploymentProperties deployment properties for the stream that the app
-	 * is defined in
-	 * @return map of properties for an app
-	 */
-	private Map<String, String> extractAppProperties(StreamAppDefinition appDefinition,
-			Map<String, String> streamDeploymentProperties) {
-		Map<String, String> appDeploymentProperties = new HashMap<>();
-		// add common properties first
-		appDeploymentProperties.putAll(this.commonApplicationProperties.getStream());
-		// add properties with wild card prefix
-		String wildCardProducerPropertyPrefix = "app.*.producer.";
-		String wildCardConsumerPropertyPrefix = "app.*.consumer.";
-		String wildCardPrefix = "app.*.";
-		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, wildCardProducerPropertyPrefix,
-				wildCardConsumerPropertyPrefix, wildCardPrefix);
-		// add application specific properties
-		String producerPropertyPrefix = String.format("app.%s.producer.", appDefinition.getName());
-		String consumerPropertyPrefix = String.format("app.%s.consumer.", appDefinition.getName());
-		String appPrefix = String.format("app.%s.", appDefinition.getName());
-		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, producerPropertyPrefix,
-				consumerPropertyPrefix, appPrefix);
-		return appDeploymentProperties;
-	}
-
-	private void parseAndPopulateProperties(Map<String, String> streamDeploymentProperties,
-			Map<String, String> appDeploymentProperties, String producerPropertyPrefix, String consumerPropertyPrefix,
-			String appPrefix) {
-		for (Map.Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
-			if (entry.getKey().startsWith(appPrefix)) {
-				if (entry.getKey().startsWith(producerPropertyPrefix)) {
-					appDeploymentProperties.put(BindingPropertyKeys.OUTPUT_BINDING_KEY_PREFIX
-							+ entry.getKey().substring(appPrefix.length()), entry.getValue());
-				}
-				else if (entry.getKey().startsWith(consumerPropertyPrefix)) {
-					appDeploymentProperties.put(
-							BindingPropertyKeys.INPUT_BINDING_KEY_PREFIX + entry.getKey().substring(appPrefix.length()),
-							entry.getValue());
-				}
-				else {
-					appDeploymentProperties.put(entry.getKey().substring(appPrefix.length()), entry.getValue());
-				}
-			}
-		}
-	}
-
-	/**
-	 * Return {@code true} if the upstream app (the app that appears before the provided
-	 * app) contains partition related properties.
-	 *
-	 * @param stream stream for the app
-	 * @param currentApp app for which to determine if the upstream app has partition
-	 * properties
-	 * @param streamDeploymentProperties deployment properties for the stream
-	 * @return true if the upstream app has partition properties
-	 */
-	private boolean upstreamAppHasPartitionInfo(StreamDefinition stream, StreamAppDefinition currentApp,
-			Map<String, String> streamDeploymentProperties) {
-		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
-		while (iterator.hasNext()) {
-			StreamAppDefinition app = iterator.next();
-			if (app.equals(currentApp) && iterator.hasNext()) {
-				StreamAppDefinition prevApp = iterator.next();
-				Map<String, String> appDeploymentProperties = extractAppProperties(prevApp, streamDeploymentProperties);
-				return appDeploymentProperties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)
-						|| appDeploymentProperties
-								.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXTRACTOR_CLASS);
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Return {@code true} if an app is a consumer of partitioned data. This is determined
-	 * either by the deployment properties for the app or whether the previous (upstream)
-	 * app is publishing partitioned data.
-	 *
-	 * @param appDeploymentProperties deployment properties for the app
-	 * @param upstreamAppSupportsPartition if true, previous (upstream) app in the stream
-	 * publishes partitioned data
-	 * @return true if the app consumes partitioned data
-	 */
-	private boolean isPartitionedConsumer(Map<String, String> appDeploymentProperties,
-			boolean upstreamAppSupportsPartition) {
-		return upstreamAppSupportsPartition
-				|| (appDeploymentProperties.containsKey(BindingPropertyKeys.INPUT_PARTITIONED)
-						&& appDeploymentProperties.get(BindingPropertyKeys.INPUT_PARTITIONED).equalsIgnoreCase("true"));
-	}
-
-	/**
-	 * Add app properties for consuming partitioned data to the provided properties.
-	 *
-	 * @param properties properties to update
-	 */
-	private void updateConsumerPartitionProperties(Map<String, String> properties) {
-		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
-	}
-
-	/**
-	 * Add app properties for producing partitioned data to the provided properties.
-	 *
-	 * @param properties properties to update
-	 * @param nextInstanceCount the number of instances for the next (downstream) app in
-	 * the stream
-	 */
-	private void updateProducerPartitionProperties(Map<String, String> properties, int nextInstanceCount) {
-		properties.put(BindingPropertyKeys.OUTPUT_PARTITION_COUNT, String.valueOf(nextInstanceCount));
-		if (!properties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)) {
-			properties.put(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION, DEFAULT_PARTITION_KEY_EXPRESSION);
-		}
-	}
-
-	/**
-	 * Return the app instance count indicated in the provided properties.
-	 *
-	 * @param properties deployer properties for the app for which to determine the count
-	 * @return instance count indicated in the provided properties; if the properties do
-	 * not contain a count, a value of {@code 1} is returned
-	 */
-	private int getInstanceCount(Map<String, String> properties) {
-		return Integer.valueOf(properties.getOrDefault(AppDeployer.COUNT_PROPERTY_KEY, "1"));
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentKey.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentKey.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.repository;
 
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.util.Assert;
 
 /**
@@ -37,6 +38,12 @@ public abstract class DeploymentKey {
 	public static String forStreamAppDefinition(StreamAppDefinition streamAppDefinition) {
 		Assert.notNull(streamAppDefinition, "streamAppDefinition must not be null");
 		return String.format("%s.%s", streamAppDefinition.getStreamName(), streamAppDefinition.getName());
+	}
+
+	public static String forAppDeploymentRequest(String streamName, AppDefinition appDefinition) {
+		Assert.notNull(streamName, "streamName must not be null");
+		Assert.notNull(appDefinition, "appDefinition must not be null");
+		return String.format("%s.%s", streamName, appDefinition.getName());
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service;
+
+import java.util.Map;
+
+/**
+ * Deploys the specified stream. Implementations are resonsible for expanding deployment
+ * wildcard expressions.
+ * @author Mark Pollack
+ */
+public interface StreamService {
+	/**
+	 * Deploys the stream with the user provided deployment properites.
+	 * @param name the name of the stream
+	 * @param deploymentProperties deployment properties to use as passed in from the client.
+	 */
+	void deployStream(String name, Map<String, String> deploymentProperties);
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -41,19 +41,19 @@ import org.springframework.data.domain.Pageable;
 public interface TaskJobService {
 
 	/**
-	 * Retrieves Pageable list of {@link JobExecution}s from the JobRepository and matches
-	 * the data with a task id.
+	 * Retrieves Pageable list of {@link JobExecution}s from the JobRepository and matches the
+	 * data with a task id.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @return List containing {@link TaskJobExecution}s.
-	 * @throws NoSuchJobExecutionException in the event that a job execution id specified
-	 * is not present when looking up stepExecutions for the result.
+	 * @throws NoSuchJobExecutionException in the event that a job execution id specified is
+	 * not present when looking up stepExecutions for the result.
 	 */
 	List<TaskJobExecution> listJobExecutions(Pageable pageable) throws NoSuchJobExecutionException;
 
 	/**
-	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a
-	 * specific jobName and matches the data with a task id.
+	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a specific
+	 * jobName and matches the data with a task id.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @param jobName the name of the job for which to search.
@@ -67,14 +67,14 @@ public interface TaskJobService {
 	 *
 	 * @param id the id of the {@link JobExecution}
 	 * @return the {@link TaskJobExecution}s associated with the id.
-	 * @throws NoSuchJobExecutionException if the specified job execution for the id does
-	 * not exist.
+	 * @throws NoSuchJobExecutionException if the specified job execution for the id does not
+	 * exist.
 	 */
 	TaskJobExecution getJobExecution(long id) throws NoSuchJobExecutionException;
 
 	/**
-	 * Retrieves Pageable list of {@link JobInstanceExecutions} from the JobRepository
-	 * with a specific jobName and matches the data with the associated JobExecutions.
+	 * Retrieves Pageable list of {@link JobInstanceExecutions} from the JobRepository with a
+	 * specific jobName and matches the data with the associated JobExecutions.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @param jobName the name of the job for which to search.
@@ -125,8 +125,8 @@ public interface TaskJobService {
 	 * deemed restartable. Otherwise a {@link JobNotRestartableException} is being thrown.
 	 *
 	 * @param jobExecutionId The id of the JobExecution to restart.
-	 * @throws NoSuchJobExecutionException if the JobExecution for the provided id does
-	 * not exist.
+	 * @throws NoSuchJobExecutionException if the JobExecution for the provided id does not
+	 * exist.
 	 */
 	void restartJobExecution(long jobExecutionId) throws NoSuchJobExecutionException;
 
@@ -134,14 +134,12 @@ public interface TaskJobService {
 	 * Requests a {@link JobExecution} to stop.
 	 * <p>
 	 * Please remember, that calling this method only requests a job execution to stop
-	 * processing. This method does not guarantee a {@link JobExecution} to stop. It is
-	 * the responsibility of the implementor of the {@link Job} to react to that request.
-	 * Furthermore, this method does not interfere with the associated
-	 * {@link TaskExecution}.
+	 * processing. This method does not guarantee a {@link JobExecution} to stop. It is the
+	 * responsibility of the implementor of the {@link Job} to react to that request.
+	 * Furthermore, this method does not interfere with the associated {@link TaskExecution}.
 	 *
 	 * @param jobExecutionId The id of the {@link JobExecution} to stop
-	 * @throws NoSuchJobExecutionException if no job execution exists for the
-	 * jobExecutionId.
+	 * @throws NoSuchJobExecutionException if no job execution exists for the jobExecutionId.
 	 * @throws JobExecutionNotRunningException if a stop is requested on a job that is not
 	 * running.
 	 * @see org.springframework.batch.admin.service.JobService#stop(Long)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskService.java
@@ -41,16 +41,15 @@ public interface TaskService {
 	long executeTask(String taskName, Map<String, String> taskDeploymentProperties, List<String> commandLineArgs);
 
 	/**
-	 * Cleanup the resources that resulted from running the task with the given execution
-	 * id.
+	 * Cleanup the resources that resulted from running the task with the given execution id.
 	 *
 	 * @param id the execution id
 	 */
 	void cleanupExecution(long id);
 
 	/**
-	 * Saves the task definition. If it is a Composed Task then the task definitions
-	 * required for a ComposedTaskRunner task are also created.
+	 * Saves the task definition. If it is a Composed Task then the task definitions required
+	 * for a ComposedTaskRunner task are also created.
 	 *
 	 * @param name The name of the task.
 	 * @param dsl The dsl that comprises the task.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployedException;
+import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployingException;
+import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
+import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.StreamService;
+import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeployer;
+import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
+import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPERTY_KEY;
+
+/**
+ * Performs manipulation on application and deployment properties, expanding shorthand
+ * application property values, resolving wildcard deployment properties, and creates a
+ * {@link StreamDeploymentRequest}.
+ * </p>
+ * If the deployment uses Skipper, delegate to {@link SkipperStreamDeployer}, otherwise
+ * use {@link AppDeployerStreamDeployer}.
+ * </p>
+ * @author Mark Pollack
+ */
+@Service
+public class DefaultStreamService implements StreamService {
+
+	/**
+	 * This is the spring boot property key that Spring Cloud Stream uses to filter the
+	 * metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is fired
+	 * for metrics export.
+	 */
+	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
+	private static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";
+	private static Log logger = LogFactory.getLog(DefaultStreamService.class);
+	private final WhitelistProperties whitelistProperties;
+
+	/**
+	 * The repository this controller will use for stream CRUD operations.
+	 */
+	private final StreamDefinitionRepository streamDefinitionRepository;
+
+	/**
+	 * The app registry this controller will use to lookup apps.
+	 */
+	private final AppRegistry appRegistry;
+
+	private final AppDeployerStreamDeployer appDeployerStreamDeployer;
+
+	private final SkipperStreamDeployer skipperStreamDeployer;
+
+	/**
+	 * General properties to be applied to applications on deployment.
+	 */
+	private final CommonApplicationProperties commonApplicationProperties;
+
+	public DefaultStreamService(AppRegistry appRegistry,
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver,
+			StreamDefinitionRepository streamDefinitionRepository,
+			AppDeployerStreamDeployer appDeployerStreamDeployer,
+			SkipperStreamDeployer skipperStreamDeployer) {
+		Assert.notNull(appRegistry, "AppRegistry must not be null");
+		Assert.notNull(commonApplicationProperties, "CommonApplicationProperties must not be null");
+		Assert.notNull(metadataResolver, "MetadataResolver must not be null");
+		Assert.notNull(streamDefinitionRepository, "StreamDefinitionRepository must not be null");
+		Assert.notNull(appDeployerStreamDeployer, "AppDeployerStreamDeployer must not be null");
+		Assert.notNull(skipperStreamDeployer, "SkipperStreamDeployer must not be null");
+		this.appRegistry = appRegistry;
+		this.commonApplicationProperties = commonApplicationProperties;
+		this.whitelistProperties = new WhitelistProperties(metadataResolver);
+		this.streamDefinitionRepository = streamDefinitionRepository;
+		this.appDeployerStreamDeployer = appDeployerStreamDeployer;
+		this.skipperStreamDeployer = skipperStreamDeployer;
+	}
+
+	@Override
+	public void deployStream(String name, Map<String, String> deploymentProperties) {
+		if (deploymentProperties == null) {
+			deploymentProperties = new HashMap<>();
+		}
+		deployStreamWithDefinition(createStreamDefinitionForDeploy(name, deploymentProperties), deploymentProperties);
+	}
+
+	private StreamDefinition createStreamDefinitionForDeploy(String name,
+			Map<String, String> deploymentProperties) {
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(name);
+		if (streamDefinition == null) {
+			throw new NoSuchStreamDefinitionException(name);
+		}
+
+		Map<String, String> skipperDeploymentProperties = getSkipperProperties(deploymentProperties);
+		String status;
+		if (skipperDeploymentProperties.containsKey(SkipperStreamDeployer.SKIPPER_ENABLED_PROPERTY_KEY)) {
+			status = skipperStreamDeployer.calculateStreamState(name);
+		}
+		else {
+			status = appDeployerStreamDeployer.calculateStreamState(name);
+		}
+
+		if (DeploymentState.deployed.equals(DeploymentState.valueOf(status))) {
+			throw new StreamAlreadyDeployedException(name);
+		}
+		else if (DeploymentState.deploying.equals(DeploymentState.valueOf(status))) {
+			throw new StreamAlreadyDeployingException(name);
+		}
+		return streamDefinition;
+	}
+
+	private Map<String, String> getSkipperProperties(Map<String, String> deploymentProperties) {
+		// Extract skipper properties
+		return deploymentProperties.entrySet().stream()
+				.filter(mapEntry -> mapEntry.getKey().startsWith(SkipperStreamDeployer.SKIPPER_KEY_PREFIX))
+				.collect(Collectors.toMap(mapEntry -> mapEntry.getKey(), mapEntry -> mapEntry.getValue()));
+	}
+
+	/**
+	 * Deploy a stream as defined by its {@link StreamDefinition} and optional deployment
+	 * properties.
+	 *
+	 * @param streamDefinition the stream to deploy
+	 * @param streamDeploymentProperties the deployment properties for the stream
+	 */
+	private void deployStreamWithDefinition(StreamDefinition streamDefinition,
+			Map<String, String> streamDeploymentProperties) {
+
+		// Extract skipper properties
+		Map<String, String> skipperDeploymentProperties = getSkipperProperties(streamDeploymentProperties);
+		// Create map without any skipper properties
+		Map<String, String> deploymentPropertiesToUse = streamDeploymentProperties.entrySet().stream()
+				.filter(mapEntry -> !mapEntry.getKey().startsWith(SkipperStreamDeployer.SKIPPER_KEY_PREFIX))
+				.collect(Collectors.toMap(mapEntry -> mapEntry.getKey(), mapEntry -> mapEntry.getValue()));
+
+		List<AppDeploymentRequest> appDeploymentRequests = createRequests(streamDefinition,
+				deploymentPropertiesToUse);
+
+		if (skipperDeploymentProperties.containsKey(SkipperStreamDeployer.SKIPPER_ENABLED_PROPERTY_KEY)) {
+			skipperStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
+					streamDefinition.getDslText(), appDeploymentRequests, skipperDeploymentProperties));
+		}
+		else {
+			appDeployerStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
+					streamDefinition.getDslText(), appDeploymentRequests, new HashMap<>()));
+		}
+	}
+
+	private List<AppDeploymentRequest> createRequests(StreamDefinition stream,
+			Map<String, String> streamDeploymentProperties) {
+		List<AppDeploymentRequest> appDeploymentRequests = new ArrayList<>();
+		if (streamDeploymentProperties == null) {
+			streamDeploymentProperties = Collections.emptyMap();
+		}
+		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
+		int nextAppCount = 0;
+		boolean isDownStreamAppPartitioned = false;
+		while (iterator.hasNext()) {
+			StreamAppDefinition currentApp = iterator.next();
+			ApplicationType type = DataFlowServerUtil.determineApplicationType(currentApp);
+
+			AppRegistration registration = this.appRegistry.find(currentApp.getRegisteredAppName(), type);
+			Assert.notNull(registration, String.format("no application '%s' of type '%s' exists in the registry",
+					currentApp.getName(), type));
+
+			Map<String, String> appDeployTimeProperties = extractAppProperties(currentApp, streamDeploymentProperties);
+			Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
+					.extractAndQualifyDeployerProperties(streamDeploymentProperties, currentApp.getName());
+			deployerDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
+
+			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp,
+					streamDeploymentProperties);
+			// Set instance count property
+			if (deployerDeploymentProperties.containsKey(COUNT_PROPERTY_KEY)) {
+				appDeployTimeProperties.put(StreamPropertyKeys.INSTANCE_COUNT,
+						deployerDeploymentProperties.get(COUNT_PROPERTY_KEY));
+			}
+			if (!type.equals(ApplicationType.source)) {
+				deployerDeploymentProperties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
+			}
+
+			// consumer app partition properties
+			if (upstreamAppSupportsPartition) {
+				updateConsumerPartitionProperties(appDeployTimeProperties);
+			}
+
+			// producer app partition properties
+			if (isDownStreamAppPartitioned) {
+				updateProducerPartitionProperties(appDeployTimeProperties, nextAppCount);
+			}
+
+			nextAppCount = getInstanceCount(deployerDeploymentProperties);
+			isDownStreamAppPartitioned = isPartitionedConsumer(appDeployTimeProperties, upstreamAppSupportsPartition);
+
+			logger.info(String.format("Downloading resource URI [%s]", registration.getUri()));
+			Resource appResource = registration.getResource();
+			Resource metadataResource = registration.getMetadataResource();
+
+			// add properties needed for metrics system
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_NAME, currentApp.getStreamName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_LABEL, currentApp.getName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_TYPE, type.toString());
+			StringBuilder sb = new StringBuilder().append(currentApp.getStreamName()).append(".")
+					.append(currentApp.getName()).append(".").append("${spring.cloud.application.guid}");
+			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
+
+			// Merge *definition time* app properties with *deployment time* properties
+			// and expand them to their long form if applicable
+			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource,
+					appDeployTimeProperties);
+
+			AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition, appResource,
+					deployerDeploymentProperties);
+
+			appDeploymentRequests.add(request);
+		}
+		DeploymentPropertiesUtils.ensureJustDeploymentProperties(streamDeploymentProperties);
+		return appDeploymentRequests;
+	}
+
+	/**
+	 * Extract and return a map of properties for a specific app within the deployment
+	 * properties of a stream.
+	 *
+	 * @param appDefinition the {@link StreamAppDefinition} for which to return a map of
+	 * properties
+	 * @param streamDeploymentProperties deployment properties for the stream that the app is
+	 * defined in
+	 * @return map of properties for an app
+	 */
+	private Map<String, String> extractAppProperties(StreamAppDefinition appDefinition,
+			Map<String, String> streamDeploymentProperties) {
+		Map<String, String> appDeploymentProperties = new HashMap<>();
+		// add common properties first
+		appDeploymentProperties.putAll(this.commonApplicationProperties.getStream());
+		// add properties with wild card prefix
+		String wildCardProducerPropertyPrefix = "app.*.producer.";
+		String wildCardConsumerPropertyPrefix = "app.*.consumer.";
+		String wildCardPrefix = "app.*.";
+		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, wildCardProducerPropertyPrefix,
+				wildCardConsumerPropertyPrefix, wildCardPrefix);
+		// add application specific properties
+		String producerPropertyPrefix = String.format("app.%s.producer.", appDefinition.getName());
+		String consumerPropertyPrefix = String.format("app.%s.consumer.", appDefinition.getName());
+		String appPrefix = String.format("app.%s.", appDefinition.getName());
+		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, producerPropertyPrefix,
+				consumerPropertyPrefix, appPrefix);
+		return appDeploymentProperties;
+	}
+
+	/**
+	 * Return {@code true} if the upstream app (the app that appears before the provided app)
+	 * contains partition related properties.
+	 *
+	 * @param stream stream for the app
+	 * @param currentApp app for which to determine if the upstream app has partition
+	 * properties
+	 * @param streamDeploymentProperties deployment properties for the stream
+	 * @return true if the upstream app has partition properties
+	 */
+	private boolean upstreamAppHasPartitionInfo(StreamDefinition stream, StreamAppDefinition currentApp,
+			Map<String, String> streamDeploymentProperties) {
+		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
+		while (iterator.hasNext()) {
+			StreamAppDefinition app = iterator.next();
+			if (app.equals(currentApp) && iterator.hasNext()) {
+				StreamAppDefinition prevApp = iterator.next();
+				Map<String, String> appDeploymentProperties = extractAppProperties(prevApp, streamDeploymentProperties);
+				return appDeploymentProperties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)
+						|| appDeploymentProperties
+								.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXTRACTOR_CLASS);
+			}
+		}
+		return false;
+	}
+
+	private void parseAndPopulateProperties(Map<String, String> streamDeploymentProperties,
+			Map<String, String> appDeploymentProperties, String producerPropertyPrefix,
+			String consumerPropertyPrefix,
+			String appPrefix) {
+		for (Map.Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
+			if (entry.getKey().startsWith(appPrefix)) {
+				if (entry.getKey().startsWith(producerPropertyPrefix)) {
+					appDeploymentProperties.put(BindingPropertyKeys.OUTPUT_BINDING_KEY_PREFIX
+							+ entry.getKey().substring(appPrefix.length()), entry.getValue());
+				}
+				else if (entry.getKey().startsWith(consumerPropertyPrefix)) {
+					appDeploymentProperties.put(
+							BindingPropertyKeys.INPUT_BINDING_KEY_PREFIX + entry.getKey().substring(appPrefix.length()),
+							entry.getValue());
+				}
+				else {
+					appDeploymentProperties.put(entry.getKey().substring(appPrefix.length()), entry.getValue());
+				}
+			}
+		}
+	}
+
+	/**
+	 * Return a new app definition where definition-time and deploy-time properties have been
+	 * merged and short form parameters have been expanded to their long form (amongst the
+	 * whitelisted supported properties of the app) if applicable.
+	 */
+	/* default */ AppDefinition mergeAndExpandAppProperties(StreamAppDefinition original, Resource metadataResource,
+			Map<String, String> appDeployTimeProperties) {
+		Map<String, String> merged = new HashMap<>(original.getProperties());
+		merged.putAll(appDeployTimeProperties);
+		merged = whitelistProperties.qualifyProperties(merged, metadataResource);
+
+		merged.putIfAbsent(StreamPropertyKeys.METRICS_PROPERTIES, "spring.application.name,spring.application.index,"
+				+ "spring.cloud.application.*,spring.cloud.dataflow.*");
+		merged.putIfAbsent(METRICS_TRIGGER_INCLUDES, "integration**");
+
+		return new AppDefinition(original.getName(), merged);
+	}
+
+	/**
+	 * Add app properties for producing partitioned data to the provided properties.
+	 *
+	 * @param properties properties to update
+	 * @param nextInstanceCount the number of instances for the next (downstream) app in the
+	 * stream
+	 */
+	private void updateProducerPartitionProperties(Map<String, String> properties, int nextInstanceCount) {
+		properties.put(BindingPropertyKeys.OUTPUT_PARTITION_COUNT, String.valueOf(nextInstanceCount));
+		if (!properties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)) {
+			properties.put(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION, DEFAULT_PARTITION_KEY_EXPRESSION);
+		}
+	}
+
+	/**
+	 * Add app properties for consuming partitioned data to the provided properties.
+	 *
+	 * @param properties properties to update
+	 */
+	private void updateConsumerPartitionProperties(Map<String, String> properties) {
+		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
+	}
+
+	/**
+	 * Return the app instance count indicated in the provided properties.
+	 *
+	 * @param properties deployer properties for the app for which to determine the count
+	 * @return instance count indicated in the provided properties; if the properties do not
+	 * contain a count, a value of {@code 1} is returned
+	 */
+	private int getInstanceCount(Map<String, String> properties) {
+		return Integer.valueOf(properties.getOrDefault(COUNT_PROPERTY_KEY, "1"));
+	}
+
+	/**
+	 * Return {@code true} if an app is a consumer of partitioned data. This is determined
+	 * either by the deployment properties for the app or whether the previous (upstream) app
+	 * is publishing partitioned data.
+	 *
+	 * @param appDeploymentProperties deployment properties for the app
+	 * @param upstreamAppSupportsPartition if true, previous (upstream) app in the stream
+	 * publishes partitioned data
+	 * @return true if the app consumes partitioned data
+	 */
+	private boolean isPartitionedConsumer(Map<String, String> appDeploymentProperties,
+			boolean upstreamAppSupportsPartition) {
+		return upstreamAppSupportsPartition
+				|| (appDeploymentProperties.containsKey(BindingPropertyKeys.INPUT_PARTITIONED)
+						&& appDeploymentProperties.get(BindingPropertyKeys.INPUT_PARTITIONED).equalsIgnoreCase("true"));
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -79,8 +79,8 @@ public class DefaultTaskJobService implements TaskJobService {
 	}
 
 	/**
-	 * Retrieves Pageable list of {@link JobExecution}s from the JobRepository and matches
-	 * the data with a task id.
+	 * Retrieves Pageable list of {@link JobExecution}s from the JobRepository and matches the
+	 * data with a task id.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @return List containing {@link TaskJobExecution}s.
@@ -104,8 +104,8 @@ public class DefaultTaskJobService implements TaskJobService {
 	}
 
 	/**
-	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a
-	 * specific jobName and matches the data with a task id.
+	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a specific
+	 * jobName and matches the data with a task id.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @param jobName the name of the job for which to search.
@@ -132,8 +132,8 @@ public class DefaultTaskJobService implements TaskJobService {
 	}
 
 	/**
-	 * Retrieves Pageable list of {@link JobInstanceExecutions} from the JobRepository
-	 * with a specific jobName and matches the data with the associated JobExecutions.
+	 * Retrieves Pageable list of {@link JobInstanceExecutions} from the JobRepository with a
+	 * specific jobName and matches the data with the associated JobExecutions.
 	 *
 	 * @param pageable enumerates the data to be returned.
 	 * @param jobName the name of the job for which to search.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -108,18 +108,16 @@ public class DefaultTaskService implements TaskService {
 	 * Initializes the {@link DefaultTaskService}.
 	 *
 	 * @param dataSourceProperties the data source properties.
-	 * @param taskDefinitionRepository the {@link TaskDefinitionRepository} this service
-	 * will use for task CRUD operations.
-	 * @param taskExecutionRepository the repository this service will use for deployment
-	 * IDs.
+	 * @param taskDefinitionRepository the {@link TaskDefinitionRepository} this service will
+	 * use for task CRUD operations.
+	 * @param taskExecutionRepository the repository this service will use for deployment IDs.
 	 * @param taskExplorer the explorer this service will use to lookup task executions
 	 * @param registry URI registry this service will use to look up app URIs.
 	 * @param resourceLoader the {@link ResourceLoader} that will resolve URIs to
 	 * {@link Resource}s.
 	 * @param taskLauncher the launcher this service will use to launch task apps.
 	 * @param metaDataResolver the metadata resolver
-	 * @param taskConfigurationProperties the properties used to define the behavior of
-	 * tasks
+	 * @param taskConfigurationProperties the properties used to define the behavior of tasks
 	 * @param deploymentIdRepository the repository that maps deployment keys to IDs
 	 * @param dataflowServerUri the data flow server URI
 	 */
@@ -247,9 +245,9 @@ public class DefaultTaskService implements TaskService {
 	}
 
 	/**
-	 * Return a copy of a given task definition where short form parameters have been
-	 * expanded to their long form (amongst the whitelisted supported properties of the
-	 * app) if applicable.
+	 * Return a copy of a given task definition where short form parameters have been expanded
+	 * to their long form (amongst the whitelisted supported properties of the app) if
+	 * applicable.
 	 */
 	private AppDefinition mergeAndExpandAppProperties(TaskDefinition original, Resource resource,
 			Map<String, String> appDeploymentProperties) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ManualOAuthAuthenticationProvider.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ManualOAuthAuthenticationProvider.java
@@ -102,7 +102,8 @@ public class ManualOAuthAuthenticationProvider implements AuthenticationProvider
 					String.format("Unable to perform OAuth authentication for user '%s'.", username), e);
 		}
 
-		final OAuth2Authentication auth2Authentication = userInfoTokenServices.loadAuthentication(accessToken.getValue());
+		final OAuth2Authentication auth2Authentication = userInfoTokenServices
+				.loadAuthentication(accessToken.getValue());
 		return auth2Authentication;
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.stream;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.server.controller.StreamDefinitionController;
+import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
+import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.util.Assert;
+
+/**
+ * Uses an AppDeployer instance to deploy the stream.
+ *
+ * @author Mark Pollack
+ */
+public class AppDeployerStreamDeployer implements StreamDeployer {
+
+	private static Log logger = LogFactory.getLog(AppDeployerStreamDeployer.class);
+
+	private static String deployLoggingString = "Deploying application named [%s] as part of stream named [%s] "
+			+ "with resource URI [%s]";
+
+	/**
+	 * The deployer this controller will use to deploy stream apps.
+	 */
+	private final AppDeployer appDeployer;
+
+	/**
+	 * The repository this controller will use for deployment IDs.
+	 */
+	private final DeploymentIdRepository deploymentIdRepository;
+
+	/**
+	 * The repository this controller will use for stream CRUD operations.
+	 */
+	private final StreamDefinitionRepository streamDefinitionRepository;
+
+	public AppDeployerStreamDeployer(AppDeployer appDeployer, DeploymentIdRepository deploymentIdRepository,
+			StreamDefinitionRepository streamDefinitionRepository) {
+		Assert.notNull(appDeployer, "AppDeployer must not be null");
+		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
+		Assert.notNull(streamDefinitionRepository, "StreamDefinitionRepository must not be null");
+		this.appDeployer = appDeployer;
+		this.deploymentIdRepository = deploymentIdRepository;
+		this.streamDefinitionRepository = streamDefinitionRepository;
+	}
+
+	@Override
+	public void deployStream(StreamDeploymentRequest streamDeploymentRequest) {
+
+		for (AppDeploymentRequest appDeploymentRequest : streamDeploymentRequest.getAppDeploymentRequests()) {
+			try {
+				logger.info(String.format(deployLoggingString, appDeploymentRequest.getDefinition().getName(),
+						streamDeploymentRequest.getStreamName(), appDeploymentRequest.getResource().getURI()));
+				String id = this.appDeployer.deploy(appDeploymentRequest);
+				this.deploymentIdRepository.save(DeploymentKey
+						.forAppDeploymentRequest(streamDeploymentRequest.getStreamName(),
+								appDeploymentRequest.getDefinition()),
+						id);
+			}
+			catch (Exception e) {
+				String errorMessage = String.format(
+						"[stream name = %s, application name = %s, application properties = %s",
+						streamDeploymentRequest.getStreamName(),
+						appDeploymentRequest.getDefinition().getName(),
+						appDeploymentRequest.getDefinition().getProperties());
+				logger.error(
+						String.format("Exception when deploying the app %s: %s", errorMessage, e.getMessage()),
+						e);
+			}
+		}
+	}
+
+	@Override
+	public String calculateStreamState(String streamName) {
+		Set<DeploymentState> appStates = EnumSet.noneOf(DeploymentState.class);
+		StreamDefinition stream = this.streamDefinitionRepository.findOne(streamName);
+		for (StreamAppDefinition appDefinition : stream.getAppDefinitions()) {
+			String key = DeploymentKey.forStreamAppDefinition(appDefinition);
+			String id = this.deploymentIdRepository.findOne(key);
+			if (id != null) {
+				AppStatus status = this.appDeployer.status(id);
+				appStates.add(status.getState());
+			}
+			else {
+				appStates.add(DeploymentState.undeployed);
+			}
+		}
+		return StreamDefinitionController.aggregateState(appStates).toString();
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -207,7 +207,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 			template.setName(resource.getURL().toString());
 		}
 		catch (IOException e) {
-			e.printStackTrace();
+			logger.error("Could not get URL of resource " + resource.getDescription(), e);
 		}
 		List<Template> templateList = new ArrayList<>();
 		templateList.add(template);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.stream;
+
+/**
+ * @author Mark Pollack
+ */
+public interface StreamDeployer {
+
+	// TODO return 'stream handle' stream name for AppDeployer impl, release name for Skipper
+	// impl.
+	// TODO store releaseName in SCDF for stream name?
+	void deployStream(StreamDeploymentRequest streamDeploymentRequest);
+
+	String calculateStreamState(String streamName);
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -16,6 +16,8 @@
 package org.springframework.cloud.dataflow.server.stream;
 
 /**
+ * SPI for deploying the apps in a stream and providing information about the status of
+ * those deployed apps.
  * @author Mark Pollack
  */
 public interface StreamDeployer {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeploymentRequest.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeploymentRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.stream;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Pollack
+ */
+public class StreamDeploymentRequest {
+
+	/**
+	 * Name of stream.
+	 */
+	private final String streamName;
+
+	/**
+	 * DSL definition for stream.
+	 */
+	private final String dslText;
+
+	/**
+	 * The list of app deployment requests for the stream.
+	 */
+	private final List<AppDeploymentRequest> appDeploymentRequests;
+
+	/**
+	 * The set of properties for the {@link StreamDeployer} implementation to use.
+	 */
+	private final Map<String, String> streamDeployerProperties;
+
+	public StreamDeploymentRequest(String streamName, String dslText, List<AppDeploymentRequest> appDeploymentRequests,
+			Map<String, String> streamDeployerProperties) {
+		Assert.hasText(streamName, "stream name is required");
+		Assert.hasText(dslText, "dslText is required");
+		Assert.notNull(appDeploymentRequests, "appDeploymentRequests can not be null");
+		Assert.notNull(streamDeployerProperties, "streamDeployerProperties can not be null");
+		this.streamName = streamName;
+		this.dslText = dslText;
+		this.appDeploymentRequests = appDeploymentRequests;
+		this.streamDeployerProperties = streamDeployerProperties;
+	}
+
+	/**
+	 * Return the name of this stream.
+	 *
+	 * @return stream name
+	 */
+	public String getStreamName() {
+		return streamName;
+	}
+
+	/**
+	 * Return the DSL definition for this stream.
+	 *
+	 * @return stream definition DSL
+	 */
+	public String getDslText() {
+		return dslText;
+	}
+
+	/**
+	 * Return the list of {@link AppDeploymentRequest} for the stream.
+	 * @return list of app requests
+	 */
+	public List<AppDeploymentRequest> getAppDeploymentRequests() {
+		return appDeploymentRequests;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.InMemoryStreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResource;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
@@ -122,6 +123,9 @@ public class StreamControllerTests {
 	@Autowired
 	private CommonApplicationProperties appsProperties;
 
+	@Autowired
+	private DefaultStreamService defaultStreamService;
+
 	@Before
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
@@ -139,23 +143,23 @@ public class StreamControllerTests {
 	public void testConstructorMissingRepository() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(
 				new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), appRegistry,
-				appDeployer, metadataResolver, new CommonApplicationProperties());
-		new StreamDefinitionController(null, null, deploymentController, appDeployer, appRegistry);
+				appDeployer, metadataResolver, new CommonApplicationProperties(), defaultStreamService);
+		new StreamDefinitionController(null, null, deploymentController, appDeployer, appRegistry, defaultStreamService);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingDeploymentController() {
 		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(),
-				null, appDeployer, appRegistry);
+				null, appDeployer, appRegistry, defaultStreamService);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingDeployer() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(
 				new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), appRegistry,
-				appDeployer, metadataResolver, new CommonApplicationProperties());
+				appDeployer, metadataResolver, new CommonApplicationProperties(), defaultStreamService);
 		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(),
-				deploymentController, null, appRegistry);
+				deploymentController, null, appRegistry, defaultStreamService);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionControllerTests.java
@@ -45,7 +45,7 @@ public class StreamDefinitionControllerTests {
 		when(uriRegistry.find("sink.bar")).thenReturn(new URI("file://bar"));
 
 		StreamDefinitionController controller = buildStreamDefinitionControllerStub(uriRegistry);
-		controller.save("foo", "foo|bar", false);
+		controller.save("foo", "foo|bar", false, false);
 	}
 
 	private static StreamDefinitionController buildStreamDefinitionControllerStub(UriRegistry uriRegistry)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.core.io.ClassPathResource;
@@ -72,10 +73,13 @@ public class StreamDeploymentControllerTests {
 	@Mock
 	private CommonApplicationProperties commonApplicationProperties;
 
+	@Mock
+	private DefaultStreamService defaultStreamService;
+
 	@Before
 	public void setup() {
 		controller = new StreamDeploymentController(streamDefinitionRepository, deploymentIdRepository, appRegistry,
-				appDeployer, metadataResolver, commonApplicationProperties);
+				appDeployer, metadataResolver, commonApplicationProperties, defaultStreamService);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -107,8 +107,9 @@ public class StreamCommands implements CommandMarker {
 			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
 			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
 					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
-			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
-		streamOperations().createStream(name, dsl, deploy);
+			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy,
+			@CliOption(key = "useSkipper", help = "whether to deploy the stream using skipper", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean useSkipper) {
+		streamOperations().createStream(name, dsl, deploy, useSkipper);
 		String message = String.format("Created new stream '%s'", name);
 		if (deploy) {
 			message += "\nDeployment request has been sent";


### PR DESCRIPTION
- Use Skipper's PackageWriter
- Refactor code out of StreamDeployment controller
- Create StreamService that manages resolution of app/deployment props
- Create StreamDeployer interface with Skipper and AppDeployer impls
- Update stream create command to add --useSkipper option
- Avoid database lookup to get application resource URI for logging

Fixes #1643