### PR TITLE
Add stream update command in shell and server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<spring-cloud-deployer.version>1.3.0.M1</spring-cloud-deployer.version>
 		<spring-cloud-deployer-local.version>1.3.0.M1</spring-cloud-deployer-local.version>
 
+		<spring-cloud-skipper.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-skipper.version>
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-boot.version -->
 		<spring-boot.version>1.5.7.RELEASE</spring-boot.version>
 

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -39,5 +39,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-skipper</artifactId>
+			<version>${spring-cloud-skipper.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.rest.client;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
+import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.hateoas.PagedResources;
 
 /**
@@ -33,7 +34,7 @@ public interface StreamOperations {
 	/**
 	 * @return the list streams known to the system.
 	 */
-	public PagedResources<StreamDefinitionResource> list();
+	PagedResources<StreamDefinitionResource> list();
 
 	/**
 	 * Create a new stream, optionally deploying it.
@@ -43,7 +44,7 @@ public interface StreamOperations {
 	 * @param deploy whether to deploy the stream after creating its definition
 	 * @return the new stream definition
 	 */
-	public StreamDefinitionResource createStream(String name, String definition, boolean deploy);
+	StreamDefinitionResource createStream(String name, String definition, boolean deploy);
 
 	/**
 	 * Create a new stream, optionally deploying it, using skipper.
@@ -54,7 +55,7 @@ public interface StreamOperations {
 	 * @param useSkipper delegate the deployment of the stream to skipper
 	 * @return the new stream definition
 	 */
-	public StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper);
+	StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper);
 
 	/**
 	 * Deploy an already created stream.
@@ -62,30 +63,39 @@ public interface StreamOperations {
 	 * @param name the name of the stream
 	 * @param properties the deployment properties
 	 */
-	public void deploy(String name, Map<String, String> properties);
+	void deploy(String name, Map<String, String> properties);
 
 	/**
 	 * Undeploy a deployed stream, retaining its definition.
 	 *
 	 * @param name the name of the stream
 	 */
-	public void undeploy(String name);
+	void undeploy(String name);
 
 	/**
 	 * Undeploy all currently deployed streams.
 	 */
-	public void undeployAll();
+	void undeployAll();
 
 	/**
 	 * Destroy an existing stream.
 	 *
 	 * @param name the name of the stream
 	 */
-	public void destroy(String name);
+	void destroy(String name);
 
 	/**
 	 * Destroy all streams known to the system.
 	 */
-	public void destroyAll();
+	void destroyAll();
 
+	/**
+	 * Update the stream given its corresponding releaseName in Skipper using the specified
+	 * package and updated yaml config.
+	 * @param streamName the name of the stream to update
+	 * @param releaseName the corresponding release name of the stream in skipper
+	 * @param packageIdentifier the package that corresponds to this stream
+	 * @param yaml the values to change in the update
+	 */
+	void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier, String yaml);
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.dataflow.rest.client;
 
 import java.util.Map;
 
+import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
+import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.util.Assert;
@@ -114,5 +116,16 @@ public class StreamTemplate implements StreamOperations {
 	@Override
 	public void destroyAll() {
 		restTemplate.delete(definitionsLink.getHref());
+	}
+
+	@Override
+	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier, String yaml) {
+		Assert.hasText(streamName, "Stream name cannot be null or empty");
+		Assert.notNull(packageIdentifier, "PackageIdentifier cannot be null");
+		Assert.hasText(packageIdentifier.getPackageName(), "Package Name cannot be null or empty");
+		Assert.hasText(releaseName, "Release name cannot be null or empty");
+		UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest(releaseName, packageIdentifier, yaml);
+		String url = deploymentsLink.getHref() + "/update/" + streamName;
+		restTemplate.postForObject(url, updateStreamRequest, Object.class);
 	}
 }

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -73,5 +73,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-skipper</artifactId>
+            <version>${spring-cloud-skipper.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/UpdateStreamRequest.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/UpdateStreamRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest;
+
+import org.springframework.cloud.skipper.domain.PackageIdentifier;
+
+/**
+ * Caputures the required data for updating a stream using Skipper.
+ * @author Mark Pollack
+ */
+public class UpdateStreamRequest {
+
+	private String releaseName;
+
+	private PackageIdentifier packageIdentifier;
+
+	private String yaml;
+
+	public UpdateStreamRequest() {
+	}
+
+	public UpdateStreamRequest(String releaseName, PackageIdentifier packageIdentifier, String yaml) {
+		this.releaseName = releaseName;
+		this.packageIdentifier = packageIdentifier;
+		this.yaml = yaml;
+	}
+
+	public String getReleaseName() {
+		return releaseName;
+	}
+
+	public void setReleaseName(String releaseName) {
+		this.releaseName = releaseName;
+	}
+
+	public PackageIdentifier getPackageIdentifier() {
+		return packageIdentifier;
+	}
+
+	public void setPackageIdentifier(PackageIdentifier packageIdentifier) {
+		this.packageIdentifier = packageIdentifier;
+	}
+
+	public String getYaml() {
+		return yaml;
+	}
+
+	public void setYaml(String yaml) {
+		this.yaml = yaml;
+	}
+
+	@Override
+	public String toString() {
+		return "UpdateStreamRequest{" +
+				"releaseName='" + releaseName + '\'' +
+				", packageIdentifier=" + packageIdentifier +
+				", yaml='" + yaml + '\'' +
+				'}';
+	}
+}

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -153,9 +153,14 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-skipper-client</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<version>${spring-cloud-skipper.version}</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-skipper</artifactId>
+            <version>${spring-cloud-skipper.version}</version>
+        </dependency>
+    </dependencies>
 	<build>
 		<resources>
 			<resource>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -20,14 +20,12 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
@@ -71,7 +69,7 @@ public class StreamDeploymentController {
 	 * for metrics export.
 	 */
 	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
-	private static Log logger = LogFactory.getLog(StreamDeploymentController.class);
+
 	private final DefaultStreamService defaultStreamService;
 
 	/**
@@ -118,9 +116,9 @@ public class StreamDeploymentController {
 	 * @param commonProperties common set of application properties
 	 */
 	public StreamDeploymentController(StreamDefinitionRepository repository,
-									  DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
-									  ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties,
-									  DefaultStreamService defaultStreamService) {
+			DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
+			ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties,
+			DefaultStreamService defaultStreamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(registry, "AppRegistry must not be null");
@@ -168,13 +166,21 @@ public class StreamDeploymentController {
 	 *
 	 * @param name the name of an existing stream definition (required)
 	 * @param properties the deployment properties for the stream as a comma-delimited list of
-	 * key=value pairs
+	 * key=value pairsef
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public void deploy(@PathVariable("name") String name,
-					   @RequestBody(required = false) Map<String, String> properties) {
+			@RequestBody(required = false) Map<String, String> properties) {
 		defaultStreamService.deployStream(name, properties);
+	}
+
+	@RequestMapping(value = "/update/{name}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public void update(@PathVariable("name") String name,
+			@RequestBody UpdateStreamRequest updateStreamRequest) {
+		defaultStreamService.upgradeStream(name, updateStreamRequest.getReleaseName(),
+				updateStreamRequest.getPackageIdentifier(), updateStreamRequest.getYaml());
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -35,4 +35,5 @@ public interface StreamService {
 	void deployStream(String name, Map<String, String> deploymentProperties);
 
 	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -51,6 +51,7 @@ import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -420,6 +421,14 @@ public class DefaultStreamService implements StreamService {
 			return this.skipperStreamDeployer.state(streamDefinitions);
 		} else {
 			return this.appDeployerStreamDeployer.state(streamDefinitions);
+		}
+	}
+
+	public void upgradeStream(String name, String releaseName, PackageIdentifier packageIdenfier, String yaml) {
+		if (System.getProperty("USE_SKIPPER") != null) {
+			this.skipperStreamDeployer.upgradeStream(name, releaseName, packageIdenfier, yaml);
+		} else {
+			throw new IllegalStateException("Can only update stream when using the Skipper deployer.");
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -76,8 +76,11 @@ public class DefaultStreamService implements StreamService {
 	 * for metrics export.
 	 */
 	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
+
 	private static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";
+
 	private static Log logger = LogFactory.getLog(DefaultStreamService.class);
+
 	private final WhitelistProperties whitelistProperties;
 
 	/**
@@ -408,4 +411,15 @@ public class DefaultStreamService implements StreamService {
 						&& appDeploymentProperties.get(BindingPropertyKeys.INPUT_PARTITIONED).equalsIgnoreCase("true"));
 	}
 
+	// State
+
+	@Override
+	public Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> streamDefinitions) {
+
+		if (System.getProperty("USE_SKIPPER") != null) {
+			return this.skipperStreamDeployer.state(streamDefinitions);
+		} else {
+			return this.appDeployerStreamDeployer.state(streamDefinitions);
+		}
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppInstanceStatusImpl.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppInstanceStatusImpl.java
@@ -13,26 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.service;
+package org.springframework.cloud.dataflow.server.stream;
 
-import java.util.List;
 import java.util.Map;
 
-import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 
 /**
- * Deploys the specified stream. Implementations are resonsible for expanding deployment
- * wildcard expressions.
  * @author Mark Pollack
  */
-public interface StreamService {
-	/**
-	 * Deploys the stream with the user provided deployment properites.
-	 * @param name the name of the stream
-	 * @param deploymentProperties deployment properties to use as passed in from the client.
-	 */
-	void deployStream(String name, Map<String, String> deploymentProperties);
+public class AppInstanceStatusImpl implements AppInstanceStatus {
 
-	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+	private String id;
+
+	private DeploymentState state;
+
+	private Map<String, String> attributes;
+
+	public AppInstanceStatusImpl() {
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public DeploymentState getState() {
+		return state;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		return attributes;
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppStatusMixin.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppStatusMixin.java
@@ -13,26 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.service;
+package org.springframework.cloud.dataflow.server.stream;
 
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 
 /**
- * Deploys the specified stream. Implementations are resonsible for expanding deployment
- * wildcard expressions.
  * @author Mark Pollack
  */
-public interface StreamService {
-	/**
-	 * Deploys the stream with the user provided deployment properites.
-	 * @param name the name of the stream
-	 * @param deploymentProperties deployment properties to use as passed in from the client.
-	 */
-	void deployStream(String name, Map<String, String> deploymentProperties);
+public abstract class AppStatusMixin extends AppStatus {
 
-	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+	@JsonCreator
+	AppStatusMixin(@JsonProperty("deploymentId") String deploymentId,
+			@JsonProperty("state") DeploymentState deploymentState) {
+		super(deploymentId, deploymentState);
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -53,6 +53,8 @@ import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Template;
+import org.springframework.cloud.skipper.domain.UpgradeProperties;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
 import org.springframework.cloud.skipper.io.PackageWriter;
@@ -277,4 +279,15 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		return templateList;
 	}
 
+	public void upgradeStream(String name, String releaseName, PackageIdentifier packageIdentifier, String yaml) {
+		UpgradeRequest upgradeRequest = new UpgradeRequest();
+		upgradeRequest.setPackageIdentifier(packageIdentifier);
+		UpgradeProperties upgradeProperties = new UpgradeProperties();
+		ConfigValues configValues = new ConfigValues();
+		configValues.setRaw(yaml);
+		upgradeProperties.setConfigValues(configValues);
+		upgradeProperties.setReleaseName(releaseName);
+		upgradeRequest.setUpgradeProperties(upgradeProperties);
+		this.skipperClient.upgrade(upgradeRequest);
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -15,6 +15,12 @@
  */
 package org.springframework.cloud.dataflow.server.stream;
 
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
 /**
  * SPI for deploying the apps in a stream and providing information about the status of
  * those deployed apps.
@@ -28,4 +34,6 @@ public interface StreamDeployer {
 	void deployStream(StreamDeploymentRequest streamDeploymentRequest);
 
 	String calculateStreamState(String streamName);
+
+	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -36,4 +36,5 @@ public interface StreamDeployer {
 	String calculateStreamState(String streamName);
 
 	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+
 }

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -48,6 +48,15 @@
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.codearte.props2yaml</groupId>
+			<artifactId>props2yaml</artifactId>
+			<version>0.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-server-local</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/YmlUtils.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/support/YmlUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.command.support;
+
+import io.codearte.props2yaml.Props2YAML;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Utility for converting a String of comma delimited property values to YAML.
+ * @author Ilayaperumal Gopinathan
+ * @author Mark Pollack
+ */
+public abstract class YmlUtils {
+
+	public static String convertFromCsvToYaml(String propertiesAsString) {
+		String stringToConvert = propertiesAsString.replaceAll(",", "\n");
+		String yamlString = Props2YAML.fromContent(stringToConvert).convert();
+		// validate the yaml can be parsed
+		Yaml yaml = new Yaml();
+		yaml.load(yamlString);
+		return yamlString;
+	}
+}
+


### PR DESCRIPTION
Test by starting up SCDF server/shell and Skipper server/shell - no args/options
The registration of the Bacon apps brings in log v 1.2.0.RELEASE.  Will 'update' to use 1.1.1.RELEASE
    
    ```
    dataflow:>app import --uri http://bit.ly/Bacon-RELEASE-stream-applications-rabbit-maven
    
    dataflow:>stream create --name ticktock --definition "time | log" --deploy --useSkipper
    Created new stream 'ticktock'
    Deployment request has been sent
    dataflow:>stream list
    ╔═══════════╤═════════════════╤════════════════════════════════════════╗
    ║Stream Name│Stream Definition│                 Status                 ║
    ╠═══════════╪═════════════════╪════════════════════════════════════════╣
    ║ticktock   │time | log       │All apps have been successfully deployed║
    ╚═══════════╧═════════════════╧════════════════════════════════════════╝
    
    dataflow:>stream update --name ticktock --yaml log.version=1.1.1.RELEASE
    Update request has been sent for stream 'ticktock'
    dataflow:>stream list
    ╔═══════════╤═════════════════╤════════════════════════════════════════╗
    ║Stream Name│Stream Definition│                 Status                 ║
    ╠═══════════╪═════════════════╪════════════════════════════════════════╣
    ║ticktock   │time | log       │All apps have been successfully deployed║
    ╚═══════════╧═════════════════╧════════════════════════════════════════╝
    
    ```
    Simultaneous commands in skipper
    
    ```
    skipper:>list
    ╔══════════╤═══════╤════════════════════════╤════════╤═══════════╤═════════════╤════════════╤═════════════╗
    ║   Name   │Version│      Last updated      │ Status │  Package  │   Package   │  Platform  │  Platform   ║
    ║          │       │                        │        │   Name    │   Version   │    Name    │   Status    ║
    ╠══════════╪═══════╪════════════════════════╪════════╪═══════════╪═════════════╪════════════╪═════════════╣
    ║myticktock│1      │Wed Oct 11 02:02:35 EDT │DEPLOYED│ticktock   │1.0.0        │default     │             ║
    ║          │       │2017                    │        │           │             │            │             ║
    ╚══════════╧═══════╧════════════════════════╧════════╧═══════════╧═════════════╧════════════╧═════════════╝
    
    skipper:>status --release-name myticktock
    ╔═══════════════╤══════════════════════════════════════════════╗
    ║Last Deployed  │Wed Oct 11 02:02:35 EDT 2017                  ║
    ║Status         │DEPLOYED                                      ║
    ║Platform Status│The applications are being deployed.          ║
    ║               │ticktock.log-v1[ticktock.log-v1-0=deploying]  ║
    ║               │ticktock.time-v1[ticktock.time-v1-0=deploying]║
    ╚═══════════════╧══════════════════════════════════════════════╝
    
    skipper:>status --release-name myticktock
    ╔═══════════════╤═════════════════════════════════════════════════╗
    ║Last Deployed  │Wed Oct 11 02:03:17 EDT 2017                     ║
    ║Status         │DEPLOYED                                         ║
    ║Platform Status│All applications have been successfully deployed.║
    ║               │ticktock.log-v2[ticktock.log-v2-0=deployed]      ║
    ║               │ticktock.time-v1[ticktock.time-v1-0=deployed]    ║
    ╚═══════════════╧═════════════════════════════════════════════════╝
    
    skipper:>get manifest --release-name myticktock --release-version 2
    
    ---
    apiVersion: skipper/v1
    kind: SpringBootApp
    metadata:
      count: 1
      name: log
    spec:
      resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.1.1.RELEASE
      resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.1.1.RELEASE
      applicationProperties:
        spring.metrics.export.triggers.application.includes: integration**
        spring.cloud.dataflow.stream.app.label: log
        spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
        spring.cloud.stream.bindings.input.group: ticktock
        spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
        spring.cloud.dataflow.stream.name: ticktock
        spring.cloud.dataflow.stream.app.type: sink
        spring.cloud.stream.bindings.input.destination: ticktock.time
      deploymentProperties:
        spring.cloud.deployer.indexed: true
        spring.cloud.deployer.group: ticktock
    
    ---
    apiVersion: skipper/v1
    kind: SpringBootApp
    metadata:
      count: 1
      name: time
    spec:
      resource: maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.0.RELEASE
      resourceMetadata: maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:1.2.0.RELEASE
      applicationProperties:
        spring.metrics.export.triggers.application.includes: integration**
        spring.cloud.dataflow.stream.app.label: time
        spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
        spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
        spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
        spring.cloud.stream.bindings.output.destination: ticktock.time
        spring.cloud.dataflow.stream.name: ticktock
        spring.cloud.dataflow.stream.app.type: source
      deploymentProperties:
        spring.cloud.deployer.group: ticktock
    
    ```
    
    Fixes #154
