### PR TITLE
Upgrade spring-cloud-build to 1.3.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.springframework.cloud</groupId>
 	<artifactId>spring-cloud-dataflow-parent</artifactId>
 	<version>1.3.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
@@ -13,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.3.RELEASE</version>
+		<version>1.3.5.RELEASE</version>
 		<relativePath />
 	</parent>
 	<scm>

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamPropertyKeys.java
@@ -42,5 +42,5 @@ public class StreamPropertyKeys {
 	 */
 	public static final String INSTANCE_COUNT = PREFIX + "instanceCount";
 
-    // @formatter:on
+	// @formatter:on
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -119,9 +119,9 @@ public class StreamDeploymentController {
 	 * @param defaultStreamService the underlying StreamService to deploy the stream
 	 */
 	public StreamDeploymentController(StreamDefinitionRepository repository,
-									  DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
-									  ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties,
-									  DefaultStreamService defaultStreamService) {
+									DeploymentIdRepository deploymentIdRepository, AppRegistry registry, AppDeployer deployer,
+									ApplicationConfigurationMetadataResolver metadataResolver, CommonApplicationProperties commonProperties,
+									DefaultStreamService defaultStreamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(registry, "AppRegistry must not be null");

--- a/spring-cloud-starter-dataflow-server-local/pom.xml
+++ b/spring-cloud-starter-dataflow-server-local/pom.xml
@@ -33,11 +33,6 @@
 			<version>1.5.5</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/TestUtils.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/TestUtils.java
@@ -18,6 +18,10 @@ package org.springframework.cloud.dataflow.server.local;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.springframework.util.ReflectionUtils;
 
@@ -93,6 +97,16 @@ public class TestUtils {
 					"Cannot find method '" + method + "' in the class hierarchy of " + target.getClass());
 		method.setAccessible(true);
 		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+	public static Map<String, String> toImmutableMap(
+			String... entries) {
+		if(entries.length % 2 == 1)
+			throw new IllegalArgumentException("Invalid entries");
+		return Collections.unmodifiableMap(IntStream.range(0, entries.length / 2).map(i -> i * 2)
+				.collect(HashMap::new,
+						(m, i) -> m.put(entries[i], entries[i + 1]),
+						Map::putAll));
 	}
 
 }

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -32,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.server.local.LocalDataflowResource;
+import org.springframework.cloud.dataflow.server.local.TestUtils;
 import org.springframework.data.authentication.UserCredentials;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -85,6 +85,7 @@ public class LocalServerSecurityWithSingleUserTests {
 
 	@Parameters(name = "Authentication Test {index} - {0} {2} - Returns: {1}")
 	public static Collection<Object[]> data() {
+
 		return Arrays.asList(new Object[][] {
 
 				{ HttpMethod.GET, HttpStatus.OK, "/", singleUser, null },
@@ -100,8 +101,7 @@ public class LocalServerSecurityWithSingleUserTests {
 
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/apps/task/taskname", singleUser, null },
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps/task/taskname", singleUser,
-						ImmutableMap.of("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
-								"force", "false") },
+						TestUtils.toImmutableMap("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT","force", "false")},
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
 				{ HttpMethod.DELETE, HttpStatus.OK, "/apps/task/taskname", singleUser, null }, // Should
@@ -112,39 +112,39 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", singleUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
 								"app=is_ignored", "force", "false") },
 				// Should be 400 -
 				// See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", singleUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
 								"false") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps", null,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 
 				/* CompletionController */
 
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", singleUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", singleUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", singleUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null, null },
 
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", singleUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", singleUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", singleUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null, null },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", singleUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", singleUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", singleUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", singleUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				/* ToolsController */
 
@@ -155,14 +155,14 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", singleUser,
-						ImmutableMap.of("definition", "fooApp") },
+						TestUtils.toImmutableMap("definition", "fooApp") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null,
-						ImmutableMap.of("definition", "fooApp") },
+						TestUtils.toImmutableMap("definition", "fooApp") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", singleUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				/* FeaturesController */
 
@@ -175,44 +175,44 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/jobs/executions", singleUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", singleUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", singleUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null, null },
 
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", singleUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", singleUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 
 				/* JobInstanceController */
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", singleUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", singleUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/instances", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null, null },
@@ -229,9 +229,9 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/abc/steps", null, null },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", singleUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps/1", null, null },
@@ -261,24 +261,24 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", singleUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", singleUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", singleUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", singleUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/streams/definitions/delete-me", singleUser, null },
 				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/definitions/delete-me", null, null },
@@ -287,9 +287,9 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null, null },
 
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/streams/definitions/my-stream/related", singleUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream", null, null },
@@ -311,12 +311,12 @@ public class LocalServerSecurityWithSingleUserTests {
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", singleUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 
 				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tasks/definitions", singleUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") }, // Should
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") }, // Should
 																					// be
 																					// a
 																					// `400`
@@ -325,7 +325,7 @@ public class LocalServerSecurityWithSingleUserTests {
 																					// See
 				// also: https://github.com/spring-cloud/spring-cloud-dataflow/issues/1075
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 
 				/* TaskExecutionController */
 
@@ -333,14 +333,14 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.OK, "/tasks/executions", singleUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", singleUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions/123", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null },
@@ -352,9 +352,9 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions", singleUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				/* UiController */
 

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -32,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.server.local.LocalDataflowResource;
+import org.springframework.cloud.dataflow.server.local.TestUtils;
 import org.springframework.data.authentication.UserCredentials;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -111,7 +111,7 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/apps/task/taskname", createOnlyUser, null },
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps/task/taskname", createOnlyUser,
-						ImmutableMap.of("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
+						TestUtils.toImmutableMap("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
@@ -125,64 +125,64 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", manageOnlyUser,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", viewOnlyUser,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
 								"app=is_ignored", "force", "false") },
 				// Should be 400 -
 				// See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
 								"false") },
 				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/apps", createOnlyUser,
-						ImmutableMap.of("apps",
+						TestUtils.toImmutableMap("apps",
 								"appTypeMissing=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") }, // Should be 400 - See https://github
 				// .com/spring-cloud/spring-cloud-dataflow/issues/1071
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("apps",
+						TestUtils.toImmutableMap("apps",
 								"task" + ".myCoolApp=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps", null,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 
 				/* CompletionController */
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", viewOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", viewOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", viewOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", viewOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				/* ToolsController */
 
@@ -195,18 +195,18 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", manageOnlyUser,
-						ImmutableMap.of("definition", "fooApp") },
+						TestUtils.toImmutableMap("definition", "fooApp") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", viewOnlyUser,
-						ImmutableMap.of("definition", "fooApp") },
+						TestUtils.toImmutableMap("definition", "fooApp") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null,
-						ImmutableMap.of("definition", "fooApp") },
+						TestUtils.toImmutableMap("definition", "fooApp") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", manageOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", viewOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				/* FeaturesController */
 
@@ -223,31 +223,31 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.OK, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123", viewOnlyUser, null },
@@ -255,42 +255,42 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null, null },
 
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 
 				/* JobInstanceController */
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/instances", viewOnlyUser, null },
@@ -315,13 +315,13 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/abc/steps", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", manageOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1", viewOnlyUser, null },
@@ -365,40 +365,40 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", manageOnlyUser, null },
 				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", viewOnlyUser, null },
@@ -413,13 +413,13 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", manageOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/streams/definitions/my-stream/related", viewOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream", viewOnlyUser, null },
@@ -451,20 +451,20 @@ public class LocalServerSecurityWithUsersFileTests {
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", createOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tasks/definitions", createOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") }, // Should
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") }, // Should
 																					// be
 																					// a
 																					// `400`
@@ -473,7 +473,7 @@ public class LocalServerSecurityWithUsersFileTests {
 																					// See
 				// also: https://github.com/spring-cloud/spring-cloud-dataflow/issues/1075
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 
 				/* TaskExecutionController */
 
@@ -483,22 +483,22 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.OK, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions/123", viewOnlyUser, null },
@@ -516,13 +516,13 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				/* UiController */
 

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTestsWithoutTasks.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTestsWithoutTasks.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -32,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.server.local.LocalDataflowResource;
+import org.springframework.cloud.dataflow.server.local.TestUtils;
 import org.springframework.data.authentication.UserCredentials;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -113,7 +113,7 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/apps/task/taskname", createOnlyUser, null },
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps/task/taskname", createOnlyUser,
-						ImmutableMap.of("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
+						TestUtils.toImmutableMap("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
@@ -127,64 +127,64 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", adminOnlyUser,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", viewOnlyUser,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "apps",
 								"app=is_ignored", "force", "false") },
 				// Should be 400 -
 				// See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
+						TestUtils.toImmutableMap("uri", "http://bit" + ".ly/1-0-2-GA-stream-applications-rabbit-maven", "force",
 								"false") },
 				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/apps", createOnlyUser,
-						ImmutableMap.of("apps",
+						TestUtils.toImmutableMap("apps",
 								"appTypeMissing=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") }, // Should be 400 - See https://github
 				// .com/spring-cloud/spring-cloud-dataflow/issues/1071
 				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
-						ImmutableMap.of("apps",
+						TestUtils.toImmutableMap("apps",
 								"task" + ".myCoolApp=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
 								"force", "false") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps", null,
-						ImmutableMap.of("uri", "???", "apps", "??", "force", "true") },
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
 
 				/* CompletionController */
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", viewOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", viewOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser, ImmutableMap.of("start", "2") },
+				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser, TestUtils.toImmutableMap("start", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", adminOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", viewOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", adminOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", viewOnlyUser,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "2") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", createOnlyUser,
-						ImmutableMap.of("start", "2", "detailLevel", "-123") },
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null,
-						ImmutableMap.of("detailLevel", "2") },
+						TestUtils.toImmutableMap("detailLevel", "2") },
 
 				/* FeaturesController */
 
@@ -201,31 +201,31 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", adminOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", adminOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", adminOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						ImmutableMap.of("name", "myname", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123", viewOnlyUser, null },
@@ -233,42 +233,42 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null, null },
 
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", adminOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("stop", "true") },
+						TestUtils.toImmutableMap("stop", "true") },
 
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", adminOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						ImmutableMap.of("restart", "true") },
+						TestUtils.toImmutableMap("restart", "true") },
 
 				/* JobInstanceController */
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", adminOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name") },
+						TestUtils.toImmutableMap("name", "my-job-name") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", adminOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser, null },
@@ -293,13 +293,13 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/abc/steps", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", adminOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null,
-						ImmutableMap.of("name", "my-job-name", "page", "0", "size", "10") },
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1", viewOnlyUser, null },
@@ -343,40 +343,40 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", adminOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", adminOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("search", "mysearch") },
+						TestUtils.toImmutableMap("search", "mysearch") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", adminOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname", "definition", "fooo | baaar") },
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", adminOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						ImmutableMap.of("name", "myname") },
+						TestUtils.toImmutableMap("name", "myname") },
 
 				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", adminOnlyUser, null },
 				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", viewOnlyUser, null },
@@ -390,13 +390,13 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", adminOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/streams/definitions/my-stream/related", viewOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null,
-						ImmutableMap.of("nested", "wrong-param") },
+						TestUtils.toImmutableMap("nested", "wrong-param") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream", viewOnlyUser, null },
@@ -428,20 +428,20 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", adminOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", createOnlyUser,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name") },
+						TestUtils.toImmutableMap("name", "my-name") },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", adminOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", createOnlyUser,
-						ImmutableMap.of("name", "my-name", "definition", "foo") }, // Should
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") }, // Should
 																					// be
 																					// a
 																					// `400`
@@ -452,7 +452,7 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 																					// https://github
 				// .com/spring-cloud/spring-cloud-dataflow/issues/1075
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						ImmutableMap.of("name", "my-name", "definition", "foo") },
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 
 				/* TaskExecutionController */
 
@@ -462,22 +462,22 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", adminOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("page", "0", "size", "10") },
+						TestUtils.toImmutableMap("page", "0", "size", "10") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", adminOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", adminOnlyUser, null },
 				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions/123", viewOnlyUser, null },
@@ -495,13 +495,13 @@ public class LocalServerSecurityWithUsersFileTestsWithoutTasks {
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", adminOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions", createOnlyUser,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						ImmutableMap.of("name", "my-task-name") },
+						TestUtils.toImmutableMap("name", "my-task-name") },
 
 				/* UiController */
 


### PR DESCRIPTION
* Fix checkstyle errors
* Remove guava dependency in spring-cloud-starter-dataflow-server-local
* Add new test utility method n spring-cloud-starter-dataflow-server-local
  to create immutable map from <String, String> pairs
* Fix tests in spring-cloud-starter-dataflow-server-local because of guava removal
* Remove redundant groupId in root pom.xml

Fixes #1663