### PR TITLE
Support undeploy/destroy operation via StreamService

### DIFF
--- a/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeAppsDocumentation.java
+++ b/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeAppsDocumentation.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Creates asciidoc snippets for endpoints exposed by {@literal RuntimeAppsController}.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public class RuntimeAppsDocumentation extends BaseDocumentation {
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -22,19 +22,27 @@ import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 
 /**
- * Deploys the specified stream. Implementations are responsible for expanding deployment
- * wildcard expressions.
+ * Specify the supported operations on the stream.
  *
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public interface StreamService {
 	/**
-	 * Deploys the stream with the user provided deployment properites.
+	 * Deploys the stream with the user provided deployment properties.
+	 * Implementations are responsible for expanding deployment wildcard expressions.
 	 * @param name the name of the stream
 	 * @param deploymentProperties deployment properties to use as passed in from the client.
 	 */
 	void deployStream(String name, Map<String, String> deploymentProperties);
 
 	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+
+	/**
+	 * Un-deploys the stream identified by the given stream name.
+	 *
+	 * @param name the name of the stream to un-deploy
+	 */
+	void undeployStream(String name);
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -307,6 +307,12 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		return templateList;
 	}
 
+	@Override
+	public void undeployStream(String streamName) {
+		String releaseName = "my" + streamName;
+		this.skipperClient.delete(releaseName);
+	}
+
 	public void upgradeStream(String name, String releaseName, PackageIdentifier packageIdentifier, String yaml) {
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
 		upgradeRequest.setPackageIdentifier(packageIdentifier);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -22,9 +22,10 @@ import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 
 /**
- * SPI for deploying the apps in a stream and providing information about the status of
- * those deployed apps.
+ * SPI for handling deployment related operations on the apps in a stream.
+ *
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public interface StreamDeployer {
 
@@ -36,5 +37,12 @@ public interface StreamDeployer {
 	String calculateStreamState(String streamName);
 
 	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+
+	/**
+	 * Undeploys the stream identified by the given stream name.
+	 *
+	 * @param name the name of the stream to un-deploy
+	 */
+	void undeployStream(String name);
 
 }


### PR DESCRIPTION
- Have the StreamDeploymentController delegate the undeploy operation via StreamService
 - Add SPI contract `undeployStream` at StreamService and StreamDeployer
 - Implement `undeployStream` in SkipperStreamDeployer to invoke `delete` release REST endpoint after constructing the release name
 - Move AppDeployerStreamDeployer specific code
 - Add tests

Resolves #1682
Resolves #1683