### PR TITLE
Add package name/version/platformName/repoName for stream deploy

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -66,8 +66,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpStatusCodeException;
 
-import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPERTY_KEY;
-
 /**
  * Delegates to Skipper to deploy the stream.
  *
@@ -77,6 +75,14 @@ import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPE
 public class SkipperStreamDeployer implements StreamDeployer {
 
 	public static final String SKIPPER_KEY_PREFIX = "spring.cloud.dataflow.skipper";
+
+	public static final String SKIPPER_PACKAGE_NAME = SKIPPER_KEY_PREFIX + ".packageName";
+
+	public static final String SKIPPER_PACKAGE_VERSION = SKIPPER_KEY_PREFIX + ".packageVersion";
+
+	public static final String SKIPPER_PACKAGE_REPO_NAME = SKIPPER_KEY_PREFIX + ".repoName";
+
+	public static final String SKIPPER_PLATFORM_NAME = SKIPPER_KEY_PREFIX + ".platformName";
 
 	public static final String SKIPPER_ENABLED_PROPERTY_KEY = SKIPPER_KEY_PREFIX + ".enabled";
 
@@ -172,15 +178,23 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	@Override
 	public void deployStream(StreamDeploymentRequest streamDeploymentRequest) {
 		logger.info("Deploying Stream " + streamDeploymentRequest.getStreamName() + " using skipper.");
+		Map<String, String> streamDeployerProperties = streamDeploymentRequest.getStreamDeployerProperties();
+		String repoName = streamDeployerProperties.get(SKIPPER_PACKAGE_REPO_NAME);
+		repoName = (StringUtils.hasText(repoName)) ? (repoName) : "local";
+		String platformName = streamDeployerProperties.get(SKIPPER_PLATFORM_NAME);
+		platformName = (StringUtils.hasText(platformName)) ? platformName : "default";
+		String packageName = streamDeployerProperties.get(SKIPPER_PACKAGE_NAME);
+		packageName = (StringUtils.hasText(packageName)) ? packageName : streamDeploymentRequest.getStreamName();
+		String packageVersion = streamDeployerProperties.get(SKIPPER_PACKAGE_VERSION);
+		packageVersion = (StringUtils.hasText(packageVersion)) ? packageVersion : "1.0.0";
 		// Create the package .zip file to upload
-		File packageFile = createPackageForStream(streamDeploymentRequest);
-
+		File packageFile = createPackageForStream(packageName, packageVersion, streamDeploymentRequest);
 		// Upload the package
 		UploadRequest uploadRequest = new UploadRequest();
-		uploadRequest.setName(streamDeploymentRequest.getStreamName());
-		uploadRequest.setVersion("1.0.0"); // TODO use from skipperDeploymentProperties if set.
+		uploadRequest.setName(streamDeployerProperties.get(SKIPPER_PACKAGE_NAME));
+		uploadRequest.setVersion(packageVersion);
 		uploadRequest.setExtension("zip");
-		uploadRequest.setRepoName("local"); // TODO use from skipperDeploymentProperties if set.
+		uploadRequest.setRepoName(repoName); // TODO use from skipperDeploymentProperties if set.
 		try {
 			uploadRequest.setPackageFileAsBytes(Files.readAllBytes(packageFile.toPath()));
 		}
@@ -188,18 +202,16 @@ public class SkipperStreamDeployer implements StreamDeployer {
 			throw new IllegalArgumentException("Can't read packageFile " + packageFile, e);
 		}
 		skipperClient.upload(uploadRequest);
-
 		// Install the package
+		String streamName = streamDeploymentRequest.getStreamName();
 		InstallRequest installRequest = new InstallRequest();
 		PackageIdentifier packageIdentifier = new PackageIdentifier();
-		String streamName = streamDeploymentRequest.getStreamName();
-		packageIdentifier.setPackageName(streamName);
-		packageIdentifier.setPackageVersion("1.0.0");
-		String repoName = "local";
+		packageIdentifier.setPackageName(packageName);
+		packageIdentifier.setPackageVersion(packageVersion);
 		packageIdentifier.setRepositoryName(repoName);
 		installRequest.setPackageIdentifier(packageIdentifier);
 		InstallProperties installProperties = new InstallProperties();
-		installProperties.setPlatformName("default");
+		installProperties.setPlatformName(platformName);
 		//todo: Better naming for the release name
 		String releaseName = "my" + streamName;
 		installProperties.setReleaseName(releaseName);
@@ -215,9 +227,10 @@ public class SkipperStreamDeployer implements StreamDeployer {
 
 	}
 
-	private File createPackageForStream(StreamDeploymentRequest streamDeploymentRequest) {
+	private File createPackageForStream(String packageName, String packageVersion, StreamDeploymentRequest
+			streamDeploymentRequest) {
 		PackageWriter packageWriter = new DefaultPackageWriter();
-		Package pkgtoWrite = createPackage(streamDeploymentRequest);
+		Package pkgtoWrite = createPackage(packageName, packageVersion, streamDeploymentRequest);
 		Path tempPath;
 		try {
 			tempPath = Files.createTempDirectory("streampackages");
@@ -231,34 +244,36 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		return zipFile;
 	}
 
-	private Package createPackage(StreamDeploymentRequest streamDeploymentRequest) {
+	private Package createPackage(String packageName, String packageVersion, StreamDeploymentRequest
+			streamDeploymentRequest) {
 		Package pkg = new Package();
 		PackageMetadata packageMetadata = new PackageMetadata();
-		packageMetadata.setName(streamDeploymentRequest.getStreamName());
-		packageMetadata.setVersion("1.0.0");
+		packageMetadata.setName(packageName);
+		packageMetadata.setVersion(packageVersion);
 		packageMetadata.setMaintainer("dataflow");
 		packageMetadata.setDescription(streamDeploymentRequest.getDslText());
 		pkg.setMetadata(packageMetadata);
-
-		pkg.setDependencies(createDependentPackages(streamDeploymentRequest));
-
+		pkg.setDependencies(createDependentPackages(packageVersion, streamDeploymentRequest));
 		return pkg;
 	}
 
-	private List<Package> createDependentPackages(StreamDeploymentRequest streamDeploymentRequest) {
+	private List<Package> createDependentPackages(String packageVersion, StreamDeploymentRequest
+			streamDeploymentRequest) {
 		List<Package> packageList = new ArrayList<>();
 		for (AppDeploymentRequest appDeploymentRequest : streamDeploymentRequest.getAppDeploymentRequests()) {
-			packageList.add(createDependentPackage(streamDeploymentRequest.getStreamName(), appDeploymentRequest));
+			packageList.add(createDependentPackage(packageVersion, appDeploymentRequest));
 		}
 		return packageList;
 	}
 
-	private Package createDependentPackage(String streamName, AppDeploymentRequest appDeploymentRequest) {
+	private Package createDependentPackage(String packageVersion, AppDeploymentRequest
+			appDeploymentRequest) {
 		Package pkg = new Package();
+		String packageName = appDeploymentRequest.getDefinition().getName();
 
 		PackageMetadata packageMetadata = new PackageMetadata();
-		packageMetadata.setName(appDeploymentRequest.getDefinition().getName());
-		packageMetadata.setVersion("1.0.0");
+		packageMetadata.setName(packageName);
+		packageMetadata.setVersion(packageVersion);
 		packageMetadata.setMaintainer("dataflow");
 
 		pkg.setMetadata(packageMetadata);
@@ -273,10 +288,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		configValueMap.put("version", version);
 
 		// Add metadata
-		String countProperty = appDeploymentRequest.getDeploymentProperties().get(COUNT_PROPERTY_KEY);
-		int count = (StringUtils.hasText(countProperty)) ? Integer.parseInt(countProperty) : 1;
-		metadataMap.put("count", Integer.toString(count));
-		metadataMap.put("name", appDeploymentRequest.getDefinition().getName());
+		metadataMap.put("name", packageName);
 
 		// Add spec
 		String resourceWithoutVersion = getResourceWithoutVersion(appDeploymentRequest.getResource());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeploymentRequest.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeploymentRequest.java
@@ -22,7 +22,10 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.util.Assert;
 
 /**
+ * Deployment request for {@link StreamDeployer} implementations.
+ *
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public class StreamDeploymentRequest {
 
@@ -82,5 +85,14 @@ public class StreamDeploymentRequest {
 	 */
 	public List<AppDeploymentRequest> getAppDeploymentRequests() {
 		return appDeploymentRequests;
+	}
+
+	/**
+	 * Return the Stream Deployer properties.
+	 *
+	 * @return the map of stream deployer properties specific to StreamDeployer implementations.
+	 */
+	public Map<String, String> getStreamDeployerProperties() {
+		return streamDeployerProperties;
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -87,6 +87,8 @@ public class StreamCommands implements CommandMarker {
 
 	private static final String YAML_FILE_OPTION = "yamlFile";
 
+	public static final String SKIPPER_KEY_PREFIX = "spring.cloud.dataflow.skipper";
+
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
@@ -136,10 +138,18 @@ public class StreamCommands implements CommandMarker {
 			@CliOption(key = { "",
 					"name" }, help = "the name of the stream to deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name,
 			@CliOption(key = {
-					PROPERTIES_OPTION }, help = "the properties for this deployment", mandatory = false) String properties,
+					PROPERTIES_OPTION }, help = "the properties for this deployment") String properties,
 			@CliOption(key = {
-					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)", mandatory = false) File propertiesFile,
-			@CliOption(key = "useSkipper", help = "whether to deploy the stream using skipper", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean useSkipper)
+					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile,
+			@CliOption(key = "useSkipper", help = "whether to deploy the stream using skipper",
+					unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean useSkipper,
+			@CliOption(key = "packageName", help = "the name of the package to deploy when using Skipper") String packageName,
+			@CliOption(key = "packageVersion", help = "the package version of the package to deploy when using "
+					+ "Skipper") String packageVersion,
+			@CliOption(key = "platformName", help = "the name of the target platform to deploy when using Skipper")
+					String platformName,
+			@CliOption(key = "repoName", help = "the name of the local repository to upload the package when using "
+					+ "Skipper") String repoName)
 			throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION, propertiesFile);
 		Map<String, String> propertiesToUse;
@@ -172,6 +182,27 @@ public class StreamCommands implements CommandMarker {
 		}
 		if (useSkipper) {
 			propertiesToUse.put("useSkipper", "true");
+			propertiesToUse.put(SKIPPER_KEY_PREFIX + "." + "packageName" ,
+					StringUtils.hasText(packageName) ? packageName : name);
+			Assert.isTrue(StringUtils.hasText(packageVersion), "Package version is required when deploying the stream"
+					+ " using Skipper.");
+			propertiesToUse.put(SKIPPER_KEY_PREFIX + "." + "packageVersion", packageVersion);
+			if (StringUtils.hasText(platformName)) {
+				propertiesToUse.put(SKIPPER_KEY_PREFIX + "." + "platformName", platformName);
+			}
+			if (StringUtils.hasText(repoName)) {
+				propertiesToUse.put(SKIPPER_KEY_PREFIX + "." + "repoName", repoName);
+			}
+		}
+		else {
+			Assert.isTrue(platformName == null, "Platform name can only be specified when deploying the stream using "
+							+ "Skipper");
+			Assert.isTrue(repoName == null, "Repository name can only be specified when deploying the stream using "
+					+ "Skipper");
+			Assert.isTrue(packageName == null, "Package name can only be specified when deploying the stream using "
+					+ "Skipper");
+			Assert.isTrue(packageVersion == null, "Package version can only be specified when deploying the stream "
+					+ "using Skipper");
 		}
 		streamOperations().deploy(name, propertiesToUse);
 		return String.format("Deployment request has been sent for stream '%s'", name);
@@ -184,15 +215,23 @@ public class StreamCommands implements CommandMarker {
 			@CliOption(key = { "properties" }, help = "Flattened YAML style properties to update the stream",
 					mandatory = false) String properties,
 			@CliOption(key = { YAML_FILE_OPTION }, help = "the YAML file with values to update the stream",
-					mandatory = false) File yamlFile)
+					mandatory = false) File yamlFile,
+			@CliOption(key = "packageVersion", help = "the package version of the package to update when using "
+					+ "Skipper") String packageVersion,
+			@CliOption(key = "repoName", help = "the name of the local repository to upload the package when using "
+					+ "Skipper") String repoName)
 			throws IOException {
 		assertMutuallyExclusiveFileAndProperties(yamlFile, properties);
 		String yamlConfigValues = getYamlConfigValues(yamlFile, properties);
 		String releaseName = "my" + name;
 		PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("local");
 		packageIdentifier.setPackageName(name);
+		if (StringUtils.hasText(packageVersion)) {
+			packageIdentifier.setPackageVersion(packageVersion);
+		}
+		if (StringUtils.hasText(repoName)) {
+			packageIdentifier.setRepositoryName(repoName);
+		}
 		streamOperations().updateStream(name, releaseName, packageIdentifier, yamlConfigValues);
 		return String.format("Update request has been sent for stream '%s'", name);
 	}


### PR DESCRIPTION
 - When deploying stream via Skipper, specify package name, version, platformName and repoName
    - By default, package name will be the stream name
    - package version is a mandatory property when using Skipper
 - Set package name and version as skipper deployer properties
    - Use the skipper deployer properties to set Upload/InstallRequest's package name/version,
platform name and repo name
    - For platform name use `default` as the default if no value is specified
    - For repo name use `local` as the default
    - Make sure these properties are updated when creating the package
 - Update packageVersion and repoName options for `stream update` command

- Add tests

Resolves #1686
Resolves #1698