### PR TITLE
Adjust graph-to-dsl code to cope with differing input graph JSON

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
@@ -437,6 +437,10 @@ public class Graph {
 		}
 		return result;
 	}
+	
+	private boolean hasNoProperties(Link link) {
+		return link.properties == null || link.properties.size() == 0;
+	}
 
 	private List<Link> findLinksFrom(Node n, boolean includeThoseLeadingToEnd) {
 		List<Link> result = new ArrayList<>();
@@ -444,7 +448,7 @@ public class Graph {
 			if (link.from.equals(n.id)) {
 				// Only include links to 'END' if there are properties on it
 				if (includeThoseLeadingToEnd
-						|| !(findNodeById(link.to).name.equals("END") && link.properties == null)) {
+						|| !(findNodeById(link.to).name.equals("END") && hasNoProperties(link))) {
 					result.add(link);
 				}
 			}

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -896,6 +896,22 @@ public class TaskParserTests {
 		checkForParseError("App1 ->xx", DSLMessage.TASK_ARROW_SHOULD_BE_PRECEDED_BY_CODE, 5);
 		checkForParseError("App1 xx->", DSLMessage.OOD, 9);
 	}
+	
+	@Test
+	public void graphToText_1712() {
+		assertGraph("[0:START][1:timestamp][2:END][0-1][1-2]","timestamp");
+		// In issue 1712 the addition of an empty properties map to the link damages the
+		// generation of the DSL. It was expecting null if there are no properties.
+		TaskNode ctn = parse("timestamp");
+		Graph graph = ctn.toGraph();
+		// Setting these to empty maps mirrors what the UI is doing in SCDF 1.3.0.M3
+		graph.nodes.get(0).metadata = new HashMap<>();
+		graph.nodes.get(1).metadata = new HashMap<>();
+		graph.nodes.get(2).metadata = new HashMap<>();
+		graph.links.get(0).properties = new HashMap<>();
+		graph.links.get(1).properties = new HashMap<>();
+		assertEquals("timestamp", graph.toDSLText());
+	}
 
 	@Test
 	public void graphToText() {


### PR DESCRIPTION
With this change the graph-to-dsl code will now treat an empty map the
same as null for link properties when choosing whether to include
an END reference in the DSL text.

Fixes #1712