### PR TITLE
Standardizes properties for CTR to be like dataflow.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -210,14 +210,17 @@ public class DefaultTaskService implements TaskService {
 		for (TaskApp subTask : taskNode.getTaskApps()) {
 			String subTaskName = String.format("app.%s-%s.", taskNode.getName(),
 					(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
+			String scdfTaskName = String.format("app.%s.%s.", taskNode.getName(),
+					(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
 			Set<String> propertyKeys = taskDeploymentProperties.keySet().
-					stream().filter(taskProperty -> taskProperty.startsWith(subTaskName))
+					stream().filter(taskProperty -> taskProperty.startsWith(scdfTaskName))
 					.collect(Collectors.toSet());
 			for (String taskProperty : propertyKeys) {
 				if (result.length() != 0) {
 					result += ", ";
 				}
-				result += String.format("%sapp.%s=%s", subTaskName,
+				result += String.format("%sapp.%s.%s=%s", subTaskName,
+						subTask.getName(),
 						taskProperty.substring(subTaskName.length()),
 						taskDeploymentProperties.get(taskProperty));
 				taskDeploymentProperties.remove(taskProperty);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
@@ -44,6 +45,7 @@ import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentId
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.TaskService;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
@@ -62,7 +64,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.cloud.dataflow.core.ApplicationType.task;
 
@@ -126,6 +130,50 @@ public class DefaultTaskServiceTests {
 		when(taskLauncher.launch(anyObject())).thenReturn("0");
 		assertEquals(1L, this.taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>()));
 		assertEquals(2L, this.taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>()));
+	}
+	@Test
+	@DirtiesContext
+	public void executeComposedTask() {
+		String dsl = "AAA && BBB";
+		taskService.saveTaskDefinition("seqTask", dsl);
+		when(taskLauncher.launch(anyObject())).thenReturn("0");
+		Map<String, String> properties = new HashMap<>();
+		properties.put("app.foo", "bar");
+		properties.put("app.seqTask-AAA.timestamp.format", "YYYY");
+		properties.put("app.composed-task-runner.interval-time-between-checks", "1000");
+		assertEquals(1L, this.taskService.executeTask("seqTask", properties, new LinkedList<>()));
+		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
+
+		AppDeploymentRequest request = argumentCaptor.getValue();
+		assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
+		assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
+		assertEquals("app.seqTask-AAA.app.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
+		assertTrue(request.getDefinition().getProperties().containsKey("interval-time-between-checks"));
+		assertEquals("1000", request.getDefinition().getProperties().get("interval-time-between-checks"));
+		assertFalse(request.getDefinition().getProperties().containsKey("app.foo"));
+
+	}
+
+	@Test
+	@DirtiesContext
+	public void executeComposedTaskWithLabels() {
+		String dsl = "t1: AAA && t2: BBB";
+		taskService.saveTaskDefinition("seqTask", dsl);
+		when(taskLauncher.launch(anyObject())).thenReturn("0");
+		Map<String, String> properties = new HashMap<>();
+		properties.put("app.seqTask-t1.timestamp.format", "YYYY");
+		properties.put("app.composed-task-runner.interval-time-between-checks", "1000");
+		assertEquals(1L, this.taskService.executeTask("seqTask", properties, new LinkedList<>()));
+		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
+
+		AppDeploymentRequest request = argumentCaptor.getValue();
+		assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
+		assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
+		assertEquals("app.seqTask-t1.app.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
+		assertTrue(request.getDefinition().getProperties().containsKey("interval-time-between-checks"));
+		assertEquals("1000", request.getDefinition().getProperties().get("interval-time-between-checks"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -135,11 +135,12 @@ public class DefaultTaskServiceTests {
 	@DirtiesContext
 	public void executeComposedTask() {
 		String dsl = "AAA && BBB";
+		initializeSuccessfulRegistry();
 		taskService.saveTaskDefinition("seqTask", dsl);
 		when(taskLauncher.launch(anyObject())).thenReturn("0");
 		Map<String, String> properties = new HashMap<>();
 		properties.put("app.foo", "bar");
-		properties.put("app.seqTask-AAA.timestamp.format", "YYYY");
+		properties.put("app.seqTask.AAA.timestamp.format", "YYYY");
 		properties.put("app.composed-task-runner.interval-time-between-checks", "1000");
 		assertEquals(1L, this.taskService.executeTask("seqTask", properties, new LinkedList<>()));
 		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
@@ -148,7 +149,7 @@ public class DefaultTaskServiceTests {
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 		assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
-		assertEquals("app.seqTask-AAA.app.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
+		assertEquals("app.seqTask-AAA.app.AAA.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
 		assertTrue(request.getDefinition().getProperties().containsKey("interval-time-between-checks"));
 		assertEquals("1000", request.getDefinition().getProperties().get("interval-time-between-checks"));
 		assertFalse(request.getDefinition().getProperties().containsKey("app.foo"));
@@ -159,10 +160,11 @@ public class DefaultTaskServiceTests {
 	@DirtiesContext
 	public void executeComposedTaskWithLabels() {
 		String dsl = "t1: AAA && t2: BBB";
+		initializeSuccessfulRegistry();
 		taskService.saveTaskDefinition("seqTask", dsl);
 		when(taskLauncher.launch(anyObject())).thenReturn("0");
 		Map<String, String> properties = new HashMap<>();
-		properties.put("app.seqTask-t1.timestamp.format", "YYYY");
+		properties.put("app.seqTask.t1.timestamp.format", "YYYY");
 		properties.put("app.composed-task-runner.interval-time-between-checks", "1000");
 		assertEquals(1L, this.taskService.executeTask("seqTask", properties, new LinkedList<>()));
 		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
@@ -171,7 +173,7 @@ public class DefaultTaskServiceTests {
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 		assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
-		assertEquals("app.seqTask-t1.app.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
+		assertEquals("app.seqTask-t1.app.AAA.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
 		assertTrue(request.getDefinition().getProperties().containsKey("interval-time-between-checks"));
 		assertEquals("1000", request.getDefinition().getProperties().get("interval-time-between-checks"));
 	}


### PR DESCRIPTION
A user can now set the properties for the subtasks of a CTR like that those of streams.  For example:
each subtask in the task `task create foo --definition "t1: timestamp && t2: timestamp"` can be configured as follows:
`task launch fooz --properties "app.fooz-t1.timestamp.format=YYYY,  app.fooz-t2.timestamp.format=SS"`

Must merge https://github.com/spring-cloud-task-app-starters/composed-task-runner/pull/14 prior to merging this PR

resolves spring-cloud/spring-cloud-dataflow#1709
resolves spring-cloud/spring-cloud-dataflow#1514