### PR TITLE
Added DSL package and base classes

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
@@ -122,7 +122,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 	private final AboutOperations aboutOperations;
 
 	/**
-	 * Setup a {@link DataFlowTemplate} using the provided baseURI. Will create a
+	 * Setup a {@link DataFlowTemplate} using the provided baseURI. Will build a
 	 * {@link RestTemplate} implicitly with the required set of Jackson MixIns. For more
 	 * information, please see {@link #prepareRestTemplate(RestTemplate)}.
 	 * <p>

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -104,4 +104,5 @@ public interface StreamOperations {
 	 * @return The current stream definition with updated status
 	 */
 	StreamDefinitionResource getStreamDefinition(String streamName);
+
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
@@ -1,0 +1,323 @@
+package org.springframework.cloud.dataflow.rest.client.dsl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class Stream {
+
+	private String name;
+
+	private List<StreamApplication> applications = new LinkedList<>();
+
+	private String definition;
+
+	private DataFlowOperations client;
+
+	private Stream(String name, List<StreamApplication> applications, String definition,
+			DataFlowOperations client) {
+		this.name = name;
+		this.applications = applications;
+		this.definition = definition;
+		this.client = client;
+	}
+
+	public static Builder builder(DataFlowOperations client) {
+		return new Builder(client);
+	}
+
+	String getDefinition() {
+		return this.definition;
+	}
+
+	public StreamBuilder undeploy() {
+		client.streamOperations().undeploy(this.name);
+		return new StreamBuilder(this.name, this.client, this.definition,
+				this.applications);
+	}
+
+	public void destroy() {
+		client.streamOperations().destroy(this.name);
+	}
+
+	public String getStatus() {
+		StreamDefinitionResource resource = client.streamOperations()
+				.getStreamDefinition(this.name);
+		return resource.getStatus();
+	}
+
+	public static class Builder {
+
+		private DataFlowOperations client;
+
+		private Builder(DataFlowOperations client) {
+			this.client = client;
+		}
+
+		public StreamNameBuilder name(String name) {
+			return new StreamNameBuilder(name, client);
+		}
+
+	}
+
+	public static class StreamNameBuilder {
+
+		private String name;
+
+		private List<StreamApplication> applications = new LinkedList<>();
+
+		private DataFlowOperations client;
+
+		private String definition;
+
+		private StreamNameBuilder(String name, DataFlowOperations client) {
+			this.client = client;
+			Assert.hasLength(name, "Stream name can't be empty");
+			this.name = name;
+		}
+
+		public SourceBuilder source(StreamApplication source) {
+			Assert.notNull(source, "Source application can't be null");
+			return new SourceBuilder(
+					source.type(StreamApplication.ApplicationType.SOURCE), this);
+		}
+
+		public SourceBuilder source(String name) {
+			Assert.isTrue(StringUtils.hasLength(name),
+					"Source application can't be null");
+			StreamApplication source = new StreamApplication(name);
+			return new SourceBuilder(
+					source.type(StreamApplication.ApplicationType.SOURCE), this);
+		}
+
+		/**
+		 * Creates a Stream bypassing the fluent API and just using the provided
+		 * definition
+		 * @param definiton the Stream definition to use
+		 * @return A {@link Stream} object
+		 */
+		public StreamDefinitionBuilder definition(String definiton) {
+			Assert.hasLength(name, "Stream definition can't be empty");
+			this.definition = definiton;
+			return new StreamDefinitionBuilder(this.name, this.client, this.definition);
+		}
+
+		private StreamBuilder create() {
+			return new StreamBuilder(this.name, this.client, this.definition,
+					this.applications);
+		}
+
+		private void addApplication(StreamApplication application) {
+			if (contains(application)) {
+				throw new IllegalStateException(
+						"There's already an application with the same definition in this stream");
+			}
+			this.applications.add(application);
+		}
+
+		private boolean contains(StreamApplication application) {
+			for (StreamApplication app : this.applications) {
+				if (app.getType().equals(application.getType())
+						&& app.getIdentity().equals(application.getIdentity())) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	public static class StreamDefinitionBuilder {
+
+		private String name;
+
+		private DataFlowOperations client;
+
+		private String definition;
+
+		private StreamDefinitionBuilder(String name, DataFlowOperations client,
+				String definition) {
+			this.name = name;
+			this.client = client;
+			this.definition = definition;
+		}
+
+		public StreamBuilder create() {
+			return new StreamBuilder(this.name, this.client, this.definition,
+					Collections.emptyList());
+		}
+	}
+
+	public static class StreamBuilder {
+
+		private String name;
+
+		private DataFlowOperations client;
+
+		private String definition;
+
+		private List<StreamApplication> applications = new LinkedList<>();
+
+		private StreamBuilder(String name, DataFlowOperations client, String definition,
+				List<StreamApplication> applications) {
+			this.name = name;
+			this.client = client;
+			this.definition = definition;
+			this.applications = applications;
+			if (StringUtils.isEmpty(definition)) {
+				createStreamDefinition();
+			}
+			this.client.streamOperations().createStream(this.name, this.definition,
+					false);
+		}
+
+		public void destroy() {
+			this.client.streamOperations().destroy(this.name);
+		}
+
+		public Stream deploy(Map<String, String> deploymentProperties) {
+			Map<String, String> resolvedProperties = resolveDeploymentProperties(
+					deploymentProperties);
+			client.streamOperations().deploy(this.name, resolvedProperties);
+			return new Stream(this.name, this.applications, this.definition, this.client);
+		}
+
+		public Stream deploy() {
+			return deploy(null);
+		}
+
+		private void createStreamDefinition() {
+			StringBuilder buffer = new StringBuilder();
+			this.definition = StringUtils.collectionToDelimitedString(applications,
+					" | ");
+		}
+
+		/**
+		 * Concatenates any deployment properties from the apps with a given map used
+		 * during {@link StreamBuilder#deploy(Map)}
+		 * @return
+		 */
+		private Map<String, String> resolveDeploymentProperties(
+				Map<String, String> deploymentProperties) {
+			Map<String, String> properties = new HashMap<>();
+			if (deploymentProperties != null) {
+				properties.putAll(deploymentProperties);
+			}
+			for (StreamApplication app : this.applications) {
+				for (Map.Entry<String, Object> entry : app.getDeploymentProperties()
+						.entrySet()) {
+					properties.put(entry.getKey(), entry.getValue().toString());
+				}
+			}
+			return properties;
+		}
+	}
+
+	public static class SourceBuilder extends BaseBuilder {
+
+		private SourceBuilder(StreamApplication source, StreamNameBuilder parent) {
+			super(source, parent);
+		}
+
+		public ProcessorBuilder processor(StreamApplication processor) {
+			Assert.notNull(processor, "Processor application can't be null");
+			return new ProcessorBuilder(
+					processor.type(StreamApplication.ApplicationType.PROCESSOR),
+					this.parent);
+		}
+
+		public ProcessorBuilder processor(String name) {
+			Assert.hasLength(name, "Processor name can't be empty");
+			StreamApplication processor = new StreamApplication(name);
+			return new ProcessorBuilder(
+					processor.type(StreamApplication.ApplicationType.PROCESSOR),
+					this.parent);
+		}
+
+		public SinkBuilder sink(StreamApplication sink) {
+			Assert.notNull(sink, "Sink application can't be null");
+			return new SinkBuilder(sink.type(StreamApplication.ApplicationType.SINK),
+					this.parent);
+		}
+
+		public SinkBuilder sink(String name) {
+			Assert.hasLength(name, "Sink name can't be empty");
+			StreamApplication sink = new StreamApplication(name);
+			return new SinkBuilder(sink.type(StreamApplication.ApplicationType.SINK),
+					this.parent);
+		}
+
+	}
+
+	public static class ProcessorBuilder extends BaseBuilder {
+
+		private ProcessorBuilder(StreamApplication application,
+				StreamNameBuilder parent) {
+			super(application, parent);
+		}
+
+		public ProcessorBuilder processor(String name) {
+			Assert.hasLength(name, "Processor name can't be empty");
+			StreamApplication processor = new StreamApplication(name);
+			return new ProcessorBuilder(
+					processor.type(StreamApplication.ApplicationType.PROCESSOR),
+					this.parent);
+		}
+
+		public ProcessorBuilder processor(StreamApplication processor) {
+			Assert.notNull(processor, "Processor application can't be null");
+			return new ProcessorBuilder(
+					processor.type(StreamApplication.ApplicationType.PROCESSOR),
+					this.parent);
+		}
+
+		public SinkBuilder sink(StreamApplication sink) {
+			Assert.notNull(sink, "Sink application can't be null");
+			return new SinkBuilder(sink.type(StreamApplication.ApplicationType.SINK),
+					this.parent);
+		}
+
+		public SinkBuilder sink(String name) {
+			Assert.hasLength(name, "Sink name can't be empty");
+			StreamApplication sink = new StreamApplication(name);
+			return new SinkBuilder(sink.type(StreamApplication.ApplicationType.SINK),
+					this.parent);
+		}
+	}
+
+	public static class SinkBuilder extends BaseBuilder {
+
+		private SinkBuilder(StreamApplication application, StreamNameBuilder parent) {
+			super(application, parent);
+		}
+
+		public StreamBuilder create() {
+			return this.parent.create();
+		}
+
+	}
+
+	static abstract class BaseBuilder {
+
+		protected StreamApplication application;
+
+		protected StreamNameBuilder parent;
+
+		public BaseBuilder(StreamApplication application, StreamNameBuilder parent) {
+			this.application = application;
+			this.parent = parent;
+			this.parent.addApplication(application);
+		}
+
+	}
+
+}

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamApplication.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamApplication.java
@@ -1,0 +1,113 @@
+package org.springframework.cloud.dataflow.rest.client.dsl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class StreamApplication {
+
+	public StreamApplication(String name) {
+		Assert.hasLength(name, "Application name can't be empty");
+		this.name = name;
+	}
+
+	private final String deployerPrefix = "deployer.%s.";
+
+	private final String name;
+
+	private String label;
+
+	private Map<String, Object> properties = new HashMap<>();
+
+	private Map<String, Object> deploymentProperties = new HashMap<>();
+
+	private ApplicationType type;
+
+	public String getName() {
+		return name;
+	}
+
+	public StreamApplication label(String label){
+		Assert.hasLength(label, "Label can't be empty");
+		this.label = label;
+		return this;
+	}
+
+	public StreamApplication addProperty(String key, Object value){
+		this.properties.put(key, value);
+		return this;
+	}
+
+	public StreamApplication addDeploymentProperty(String key, Object value){
+		this.deploymentProperties.put(key, value);
+		return this;
+	}
+
+	public StreamApplication addProperties(Map<String, Object> properties){
+		this.properties.putAll(properties);
+		return this;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public Map<String, Object> getProperties() {
+		return properties;
+	}
+
+	public StreamApplication type(ApplicationType type){
+		this.type = type;
+		return this;
+	}
+
+	public Map<String, Object> getDeploymentProperties(){
+		Map<String, Object> formattedProperties = new HashMap<>();
+		String id = StringUtils.isEmpty(label) ? name : label;
+		for(Map.Entry<String, Object> entry : deploymentProperties.entrySet()){
+			formattedProperties.put(String.format(deployerPrefix, id)+entry.getKey(), entry.getValue());
+		}
+		return formattedProperties;
+	}
+
+	/**
+	 * @return Returns the unique identity of an application in a Stream.
+	 * This could be name or label: name
+	 *
+	 */
+	public String getIdentity() {
+		if(!StringUtils.isEmpty(label)){
+			return label+": "+name;
+		}else{
+			return name;
+		}
+	}
+
+	public String getDefinition(){
+		StringBuilder buffer = new StringBuilder();
+
+		buffer.append(getIdentity());
+		for(Map.Entry<String, Object> entry : properties.entrySet()){
+			buffer.append(" --"+entry.getKey()+"="+entry.getValue());
+		}
+		return buffer.toString();
+	}
+
+	public ApplicationType getType() {
+		return type;
+	}
+
+	@Override
+	public String toString() {
+		return getDefinition();
+	}
+
+	public enum ApplicationType {
+		SOURCE, PROCESSOR, SINK;
+	}
+}

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
@@ -1,0 +1,88 @@
+package org.springframework.cloud.dataflow.rest.client.dsl;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class StreamBuilder {
+
+	private String name;
+
+	private DataFlowOperations client;
+
+	private String definition;
+
+	private List<StreamApplication> applications = new LinkedList<>();
+
+	StreamBuilder(String name, DataFlowOperations client, String definition,
+			List<StreamApplication> applications) {
+		this.name = name;
+		this.client = client;
+		this.definition = definition;
+		this.applications = applications;
+		if (StringUtils.isEmpty(definition)) {
+			createStreamDefinition();
+		}
+		this.client.streamOperations().createStream(this.name, this.definition,
+				false);
+	}
+
+	/**
+	 * Destroy the stream from the server. This method invokes the remote server
+	 */
+	public void destroy() {
+		this.client.streamOperations().destroy(this.name);
+	}
+
+	/**
+	 * Deploy the current stream using the deploymentProperties. This method invokes the remote server
+	 * @param deploymentProperties Map of properties to be used during deployment
+	 * @return A deployed {@link Stream}
+	 */
+	public Stream deploy(Map<String, String> deploymentProperties) {
+		Map<String, String> resolvedProperties = resolveDeploymentProperties(
+				deploymentProperties);
+		client.streamOperations().deploy(this.name, resolvedProperties);
+		return new Stream(this.name, this.applications, this.definition, this.client);
+	}
+	/**
+	 * Deploy the current stream without any extra properties
+	 * @return A deployed {@link Stream}
+	 */
+	public Stream deploy() {
+		return deploy(null);
+	}
+
+	private void createStreamDefinition() {
+		StringBuilder buffer = new StringBuilder();
+		this.definition = StringUtils.collectionToDelimitedString(applications,
+				" | ");
+	}
+
+	/**
+	 * Concatenates any deployment properties from the apps with a given map used
+	 * during {@link StreamBuilder#deploy(Map)}
+	 * @return A concatenated map containing all applications deployment properties
+	 */
+	private Map<String, String> resolveDeploymentProperties(
+			Map<String, String> deploymentProperties) {
+		Map<String, String> properties = new HashMap<>();
+		if (deploymentProperties != null) {
+			properties.putAll(deploymentProperties);
+		}
+		for (StreamApplication app : this.applications) {
+			for (Map.Entry<String, Object> entry : app.getDeploymentProperties()
+					.entrySet()) {
+				properties.put(entry.getKey(), entry.getValue().toString());
+			}
+		}
+		return properties;
+	}
+}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -1,0 +1,213 @@
+package org.springframework.cloud.dataflow.rest.client.dsl;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
+import org.springframework.cloud.dataflow.rest.client.StreamOperations;
+import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class StreamDslTests {
+
+	@Mock
+	private DataFlowOperations client;
+
+	@Mock
+	private StreamOperations streamOperations;
+
+	@Before
+	public void init() {
+		MockitoAnnotations.initMocks(this);
+		Mockito.when(client.streamOperations()).thenReturn(this.streamOperations);
+	}
+
+	@Test
+	public void simpleDefinition() throws Exception {
+		StreamApplication time = new StreamApplication("time");
+		StreamApplication log = new StreamApplication("log");
+		Stream stream = Stream.builder(client).name("foo").source(time).sink(log)
+				.create().deploy();
+		assertThat("time | log").isEqualTo(stream.getDefinition());
+	}
+
+	@Test
+	public void definitionWithLabel() throws Exception {
+		StreamApplication time = new StreamApplication("time").label("tick");
+		StreamApplication log = new StreamApplication("log");
+
+		Stream stream = Stream.builder(client).name("foo").source(time).sink(log)
+				.create().deploy();
+		assertThat("tick: time | log").isEqualTo(stream.getDefinition());
+	}
+
+	@Test
+	public void definitionWithProcessor() throws Exception {
+		StreamApplication time = new StreamApplication("time").label("tick");
+		StreamApplication filter = new StreamApplication("filter");
+		StreamApplication log = new StreamApplication("log");
+		Stream stream = Stream.builder(client).name("foo").source(time).processor(filter)
+				.sink(log).create().deploy();
+		assertThat("tick: time | filter | log").isEqualTo(stream.getDefinition());
+	}
+
+	@Test
+	public void definitionWithProperties() throws Exception {
+		StreamApplication time = new StreamApplication("time").label("tick")
+				.addProperty("fixed-delay", 5000);
+		StreamApplication log = new StreamApplication("log");
+		Stream stream = Stream.builder(client).name("foo").source(time).sink(log)
+				.create().deploy();
+		assertThat("tick: time --fixed-delay=5000 | log")
+				.isEqualTo(stream.getDefinition());
+	}
+
+	@Test
+	public void definitionWithDeploymentProperties() throws Exception {
+		StreamApplication time = new StreamApplication("time").label("tick")
+				.addProperty("fixed-delay", "5000").addDeploymentProperty("count", 2);
+
+		Map<String, Object> deploymentProperties = time.getDeploymentProperties();
+		assertThat(deploymentProperties.get("deployer.tick.count")).isEqualTo(2);
+	}
+
+	@Test
+	public void deployWithCreate() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("deploying");
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+		StreamApplication time = new StreamApplication("time");
+		StreamApplication log = new StreamApplication("log");
+		Stream stream = Stream.builder(client).name("ticktock").source(time).sink(log)
+				.create().deploy();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+		Mockito.verify(streamOperations, Mockito.times(1)).deploy(Mockito.eq("ticktock"),
+				Mockito.anyMap());
+	}
+
+	@Test
+	public void deployWithDefinition() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("deploying");
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+
+		Stream stream = Stream.builder(client).name("ticktock").definition("time | log")
+				.create().deploy(Collections.singletonMap("deployer.log.count", "2"));
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+		Mockito.verify(streamOperations, Mockito.times(1)).deploy(Mockito.eq("ticktock"),
+				Mockito.eq(Collections.singletonMap("deployer.log.count", "2")));
+
+	}
+
+	@Test
+	public void getStatus() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("unknown");
+		Mockito.when(streamOperations.getStreamDefinition(Mockito.eq("ticktock")))
+				.thenReturn(resource);
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+		Mockito.doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				resource.setStatus("deploying");
+				return null;
+			}
+		}).when(streamOperations).deploy(Mockito.eq("ticktock"), Mockito.anyMap());
+
+		Stream.StreamBuilder streamBuilder = Stream.builder(client).name("ticktock").definition("time | log")
+				.create();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+		Stream stream = streamBuilder.deploy();
+		assertThat("deploying").isEqualTo(stream.getStatus());
+	}
+
+	@Test
+	public void createStream() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("deploying");
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+		StreamApplication time = new StreamApplication("time");
+		StreamApplication log = new StreamApplication("log");
+		Stream.builder(client).name("ticktock").source(time).sink(log)
+				.create();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+	}
+
+	@Test
+	public void testDuplicateNameWithLabel() throws Exception {
+		StreamApplication filter2 = new StreamApplication("filter").label("filter2");
+		Stream.builder(client).name("test").source("time").processor("filter").processor(filter2).sink("log").create();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("test"), Mockito.eq("time | filter | filter2: filter | log"), Mockito.eq(false));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testDuplicateNameNoLabel() throws Exception {
+		Stream.builder(client).name("test").source("time").processor("filter").processor("filter").sink("log").create();
+	}
+
+	@Test
+	public void undeploy() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("deploying");
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+		StreamApplication time = new StreamApplication("time");
+		StreamApplication log = new StreamApplication("log");
+
+		Stream stream = Stream.builder(client).name("ticktock").source(time).sink(log)
+				.create().deploy();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+		Mockito.verify(streamOperations, Mockito.times(1)).deploy(Mockito.eq("ticktock"),
+				Mockito.anyMap());
+		stream.undeploy();
+		Mockito.verify(streamOperations, Mockito.times(1))
+				.undeploy(Mockito.eq("ticktock"));
+	}
+
+	@Test
+	public void destroy() throws Exception {
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
+				"time | log");
+		resource.setStatus("deploying");
+		Mockito.when(streamOperations.createStream(Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(resource);
+		StreamApplication time = new StreamApplication("time");
+		StreamApplication log = new StreamApplication("log");
+		Stream stream = Stream.builder(client).name("ticktock").source(time).sink(log)
+				.create().deploy();
+		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
+				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));
+		Mockito.verify(streamOperations, Mockito.times(1)).deploy(Mockito.eq("ticktock"),
+				Mockito.anyMap());
+		stream.destroy();
+		Mockito.verify(streamOperations, Mockito.times(1))
+				.destroy(Mockito.eq("ticktock"));
+	}
+}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -134,7 +134,7 @@ public class StreamDslTests {
 			}
 		}).when(streamOperations).deploy(Mockito.eq("ticktock"), Mockito.anyMap());
 
-		Stream.StreamBuilder streamBuilder = Stream.builder(client).name("ticktock").definition("time | log")
+		StreamBuilder streamBuilder = Stream.builder(client).name("ticktock").definition("time | log")
 				.create();
 		Mockito.verify(streamOperations, Mockito.times(1)).createStream(
 				Mockito.eq("ticktock"), Mockito.eq("time | log"), Mockito.eq(false));


### PR DESCRIPTION
Fixes #1620 

This adds a Fluent DSL around the `DataFlowTemplate`.  

Users can use a fluent style using `from`, `via`, `to` methods to chain a builder, or simply override it using `definition(dslDefinition)`

To build (but not create on the server) a Stream definition:

```java
DataFlowTemplate template = ...;
StreamApplication time = new StreamApplication("time")
    .addProperty("fixed-interval", 5000);

Stream ticktock = Stream.Builder(template)
    .name("ticktock")
    .from(time)
    .to(new StreamApplication("log")
    .build();

//create:

stream.create();
stream.deploy();

//deploying:
String status = stream.getStatus();

...
//invokes server to fetch latest status
stream.refreshStatus();

stream.undeploy();

stream.destroy();

```


