### PR TITLE
Use SkipperClient from skipper

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -88,7 +88,7 @@ import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoa
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.skipper.client.SkipperClient;
-import org.springframework.cloud.skipper.client.SkipperClientProperties;
+import org.springframework.cloud.skipper.client.SkipperClientConfiguration;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -111,13 +111,24 @@ import org.springframework.scheduling.concurrent.ForkJoinPoolFactoryBean;
 @Configuration
 @Import(CompletionConfiguration.class)
 @ConditionalOnBean({ EnableDataFlowServerConfiguration.Marker.class, AppDeployer.class, TaskLauncher.class })
-@EnableConfigurationProperties({ FeaturesProperties.class, VersionInfoProperties.class, MetricsProperties.class,
-		SkipperClientProperties.class })
+@EnableConfigurationProperties({ FeaturesProperties.class, VersionInfoProperties.class, MetricsProperties.class })
 @ConditionalOnProperty(prefix = "dataflow.server", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableCircuitBreaker
 public class DataFlowControllerAutoConfiguration {
 
 	private static Log logger = LogFactory.getLog(DataFlowControllerAutoConfiguration.class);
+
+	@Configuration
+	@Import(SkipperClientConfiguration.class)
+	@ConditionalOnBean({StreamDefinitionRepository.class, StreamDeploymentRepository.class})
+	public static class SkipperConfiguration {
+
+		@Bean
+		public SkipperStreamDeployer skipperStreamDeployer(SkipperClient skipperClient,
+				StreamDeploymentRepository streamDeploymentRepository) {
+			return new SkipperStreamDeployer(skipperClient, streamDeploymentRepository);
+		}
+	}
 
 	@Bean
 	public UriRegistry uriRegistry(DataSource dataSource) {
@@ -165,13 +176,6 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean({StreamDefinitionRepository.class, StreamDeploymentRepository.class})
-	public SkipperClient skipperClient(SkipperClientProperties skipperClientProperties) {
-		logger.info("Skipper URI = [" + skipperClientProperties.getUri() + "]");
-		return SkipperClient.create(skipperClientProperties.getUri());
-	}
-
-	@Bean
-	@ConditionalOnBean({StreamDefinitionRepository.class, StreamDeploymentRepository.class})
 	public DefaultStreamService streamDeploymentService(AppRegistry appRegistry,
 			CommonApplicationProperties commonApplicationProperties,
 			ApplicationConfigurationMetadataResolver applicationConfigurationMetadataResolver,
@@ -196,12 +200,6 @@ public class DataFlowControllerAutoConfiguration {
 			StreamDeploymentRepository streamDeploymentRepository) {
 		return new AppDeployerStreamDeployer(appDeployer, deploymentIdRepository, streamDefinitionRepository,
 				streamDeploymentRepository);
-	}
-
-	@Bean
-	@ConditionalOnBean({StreamDefinitionRepository.class, StreamDeploymentRepository.class})
-	public SkipperStreamDeployer skipperStreamDeployer(SkipperClient skipperClient, StreamDeploymentRepository streamDeploymentRepository) {
-		return new SkipperStreamDeployer(skipperClient, streamDeploymentRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TestUtils.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TestUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.support;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ *
+ * @author Janne Valkealahti
+ * @author Soby Chacko
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			}
+			catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		}
+		while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException(
+					"Cannot find field '" + name + "' in the class hierarchy of " + target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException(
+					"Cannot find method '" + method + "' in the class hierarchy of " + target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			}
+			catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		}
+		while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException(
+					"Cannot find field '" + name + "' in the class hierarchy of " + target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException(
+					"Cannot find method '" + method + "' in the class hierarchy of " + target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+	public static Map<String, String> toImmutableMap(
+			String... entries) {
+		if(entries.length % 2 == 1)
+			throw new IllegalArgumentException("Entries should contain even number of values");
+		return Collections.unmodifiableMap(IntStream.range(0, entries.length / 2).map(i -> i * 2)
+				.collect(HashMap::new,
+						(m, i) -> m.put(entries[i], entries[i + 1]),
+						Map::putAll));
+	}
+
+}


### PR DESCRIPTION
- In favour of letting skipper to create its client
  modify DataFlowControllerAutoConfiguration to import
  SkipperClientConfiguration and move skipperStreamDeployer
  into nested config class.
- With this mod we get same RestTemplate as used in
  skipper shell which works better for exception handling
  related to errors thrown via rest layer.
- Modify some existing tests and add new one to ensure
  SkipperClientProperties are processed into new
  SkipperClient.
- Fixes #1713