### PR TITLE
gh-1671 Fix: When creating a task that does not exist don't return 500 Http Status

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.server.repository.DuplicateTaskExcepti
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskExecutionException;
+import org.springframework.cloud.dataflow.server.support.ApplicationDoesNotExistException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -139,7 +140,7 @@ public class RestControllerAdvice {
 			NoSuchTaskDefinitionException.class, NoSuchTaskExecutionException.class, NoSuchJobExecutionException.class,
 			NoSuchJobInstanceException.class, NoSuchJobException.class, NoSuchStepExecutionException.class,
 			MetricsMvcEndpoint.NoSuchMetricException.class, NoSuchAppException.class,
-			NoSuchAppInstanceException.class })
+			NoSuchAppInstanceException.class, ApplicationDoesNotExistException.class })
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	@ResponseBody
 	public VndErrors onNotFoundException(Exception e) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.TaskService;
+import org.springframework.cloud.dataflow.server.support.ApplicationDoesNotExistException;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -296,7 +297,7 @@ public class DefaultTaskService implements TaskService {
 	private void saveStandardTaskDefinition(TaskDefinition taskDefinition) {
 		String appName = taskDefinition.getRegisteredAppName();
 		if (registry.find(appName, ApplicationType.task) == null) {
-			throw new IllegalArgumentException(
+			throw new ApplicationDoesNotExistException(
 					String.format("Application name '%s' with type '%s' does not exist in the app registry.", appName,
 							ApplicationType.task));
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/ApplicationDoesNotExistException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/ApplicationDoesNotExistException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.support;
+
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.server.service.TaskService;
+
+/**
+ * Exception is thrown by {@link TaskService} to indicate that the
+ * {@link AppRegistration} does not exist in the registry.
+ *
+ * @author Gunnar Hillert
+ */
+public class ApplicationDoesNotExistException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public ApplicationDoesNotExistException(String message) {
+		super(message);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -128,7 +128,7 @@ public class TaskControllerTests {
 		assertEquals(0, repository.count());
 
 		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
-				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().is5xxServerError());
+				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isNotFound());
 
 		assertEquals(0, repository.count());
 	}

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
@@ -315,15 +315,9 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
 						TestUtils.toImmutableMap("name", "my-name") },
 
-				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tasks/definitions", singleUser,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") }, // Should
-																					// be
-																					// a
-																					// `400`
-																					// error
-																					// -
-																					// See
-				// also: https://github.com/spring-cloud/spring-cloud-dataflow/issues/1075
+				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", singleUser,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
+				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", singleUser, null },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
 						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
@@ -463,15 +463,8 @@ public class LocalServerSecurityWithUsersFileTests {
 						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
 						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
-				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tasks/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") }, // Should
-																					// be
-																					// a
-																					// `400`
-																					// error
-																					// -
-																					// See
-				// also: https://github.com/spring-cloud/spring-cloud-dataflow/issues/1075
+				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
 						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
 


### PR DESCRIPTION

* Return `404` status for non-existing app registrations
* Add dedicated class `ApplicationDoesNotExistException`
* Add `ApplicationDoesNotExistException` to `RestControllerAdvice`
* Add tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1671