### PR TITLE
Skipper integration enhancement/bug fixes

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -53,9 +53,11 @@ public interface StreamOperations {
 	 * @param definition the stream definition DSL
 	 * @param deploy whether to deploy the stream after creating its definition
 	 * @param useSkipper delegate the deployment of the stream to skipper
+	 * @param packageVersion the package version to use for this stream
 	 * @return the new stream definition
 	 */
-	StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper);
+	StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper,
+			String packageVersion);
 
 	/**
 	 * Deploy an already created stream.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -77,16 +77,18 @@ public class StreamTemplate implements StreamOperations {
 
 	@Override
 	public StreamDefinitionResource createStream(String name, String definition, boolean deploy) {
-		return createStream(name, definition, deploy, false);
+		return createStream(name, definition, deploy, false, null);
 	}
 
 	@Override
-	public StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper) {
+	public StreamDefinitionResource createStream(String name, String definition, boolean deploy, boolean useSkipper,
+			String packageVersion) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		values.add("name", name);
 		values.add("definition", definition);
 		values.add("deploy", Boolean.toString(deploy));
 		values.add("useSkipper", Boolean.toString(useSkipper));
+		values.add("packageVersion", packageVersion);
 		StreamDefinitionResource stream = restTemplate.postForObject(definitionsLink.expand().getHref(), values,
 				StreamDefinitionResource.class);
 		return stream;

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/SkipperStream.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/SkipperStream.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest;
+
+/**
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class SkipperStream {
+
+	public static final String SKIPPER_STREAM_PREFIX = "scdf_";
+
+	public static final String USE_SKIPPER = "useSkipper";
+
+	public static final String SKIPPER_KEY_PREFIX = "spring.cloud.dataflow.skipper";
+
+	public static final String SKIPPER_PACKAGE_NAME = SKIPPER_KEY_PREFIX + ".packageName";
+
+	public static final String SKIPPER_PACKAGE_VERSION = SKIPPER_KEY_PREFIX + ".packageVersion";
+
+	public static final String SKIPPER_REPO_NAME = SKIPPER_KEY_PREFIX + ".repoName";
+
+	public static final String SKIPPER_PLATFORM_NAME = SKIPPER_KEY_PREFIX + ".platformName";
+
+	public static final String SKIPPER_ENABLED_PROPERTY_KEY = SKIPPER_KEY_PREFIX + ".enabled";
+
+	public static final String SKIPPER_DEFAULT_API_VERSION = "skipper/v1";
+
+	public static final String SKIPPER_DEFAULT_KIND = "SpringBootApp";
+
+	public static final String SKIPPER_DEFAULT_MAINTAINER = "dataflow";
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -40,14 +40,12 @@ import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
 import org.springframework.cloud.dataflow.server.controller.support.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.server.controller.support.ControllerUtils;
 import org.springframework.cloud.dataflow.server.controller.support.InvalidStreamDefinitionException;
-import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DuplicateStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.support.SearchPageable;
 import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.support.CannotDetermineApplicationTypeException;
-import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -66,7 +64,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer.SKIPPER_ENABLED_PROPERTY_KEY;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_VERSION;
 
 /**
  * Controller for operations on {@link StreamDefinition}. This includes CRUD and optional
@@ -88,24 +87,9 @@ public class StreamDefinitionController {
 	private static final Logger logger = LoggerFactory.getLogger(StreamDefinitionController.class);
 
 	/**
-	 * The service that is responsible for deploying streams.
-	 */
-	private final StreamService streamService;
-
-	/**
 	 * The repository this controller will use for stream CRUD operations.
 	 */
 	private final StreamDefinitionRepository repository;
-
-	/**
-	 * The repository this controller will use for deployment IDs.
-	 */
-	private final DeploymentIdRepository deploymentIdRepository;
-
-	/**
-	 * The deployer this controller will use to compute stream deployment status.
-	 */
-	private final AppDeployer deployer;
 
 	/**
 	 * The app registry this controller will use to lookup apps.
@@ -113,40 +97,27 @@ public class StreamDefinitionController {
 	private final AppRegistry appRegistry;
 
 	/**
-	 * This deployment controller is used as a delegate when stream creation is immediately
-	 * followed by deployment.
+	 * The service that is responsible for deploying streams.
 	 */
-	private final StreamDeploymentController deploymentController;
+	private final StreamService streamService;
 
 	/**
 	 * Create a {@code StreamDefinitionController} that delegates
 	 * <ul>
 	 * <li>CRUD operations to the provided {@link StreamDefinitionRepository}</li>
-	 * <li>deployment ID operations to the provided {@link DeploymentIdRepository}</li>
-	 * <li>deployment operations to the provided {@link StreamDeploymentController}</li>
-	 * <li>deployment status computation to the provided {@link AppDeployer}</li>
+	 * <li>deployment operations and status computation via {@link StreamService}</li>
 	 * </ul>
 	 *
 	 * @param repository the repository this controller will use for stream CRUD operations
-	 * @param deploymentIdRepository the repository this controller will use for deployment
-	 * IDs
-	 * @param deploymentController the deployment controller to delegate deployment operations
-	 * @param deployer the deployer this controller will use to compute deployment status
 	 * @param appRegistry the app registry to look up registered apps
+	 * @param streamService the stream service to use to delegate stream operations such as deploy/status.
 	 */
-	public StreamDefinitionController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController,
-			AppDeployer deployer, AppRegistry appRegistry, StreamService streamService) {
+	public StreamDefinitionController(StreamDefinitionRepository repository, AppRegistry appRegistry,
+			StreamService streamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
-		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
-		Assert.notNull(deploymentController, "StreamDeploymentController must not be null");
-		Assert.notNull(deployer, "AppDeployer must not be null");
 		Assert.notNull(appRegistry, "AppRegistry must not be null");
-		Assert.notNull(streamService, "StreamDeploymentService must not be null");
-		this.deploymentController = deploymentController;
-		this.deploymentIdRepository = deploymentIdRepository;
+		Assert.notNull(streamService, "StreamService must not be null");
 		this.repository = repository;
-		this.deployer = deployer;
 		this.appRegistry = appRegistry;
 		this.streamService = streamService;
 	}
@@ -226,6 +197,7 @@ public class StreamDefinitionController {
 	 * {@code false})
 	 * @param useSkipper if {@code true}, delegate the deployment of the stream to skipper
 	 * (default is false)
+	 * @param packageVersion the version of the package to use when deploying.
 	 * @return the created stream definition
 	 * @throws DuplicateStreamDefinitionException if a stream definition with the same name
 	 * already exists
@@ -236,7 +208,8 @@ public class StreamDefinitionController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public StreamDefinitionResource save(@RequestParam("name") String name, @RequestParam("definition") String dsl,
 			@RequestParam(value = "deploy", defaultValue = "false") boolean deploy,
-			@RequestParam(value = "useSkipper", defaultValue = "false") boolean useSkipper) {
+			@RequestParam(value = "useSkipper", defaultValue = "false") boolean useSkipper,
+			@RequestParam(value = "packageVersion", required = false) String packageVersion) {
 		StreamDefinition stream;
 		try {
 			stream = new StreamDefinition(name, dsl);
@@ -271,6 +244,8 @@ public class StreamDefinitionController {
 			Map<String, String> streamDeploymentProperties = new HashMap<>();
 			if (useSkipper) {
 				streamDeploymentProperties.put(SKIPPER_ENABLED_PROPERTY_KEY, "true");
+				Assert.isTrue(StringUtils.hasText(packageVersion), "Package version must be set");
+				streamDeploymentProperties.put(SKIPPER_PACKAGE_VERSION, packageVersion);
 			}
 			this.streamService.deployStream(name, streamDeploymentProperties);
 		}
@@ -288,7 +263,7 @@ public class StreamDefinitionController {
 		if (this.repository.findOne(name) == null) {
 			throw new NoSuchStreamDefinitionException(name);
 		}
-		this.deploymentController.undeploy(name);
+		this.streamService.undeployStream(name);
 		this.repository.delete(name);
 	}
 
@@ -362,7 +337,9 @@ public class StreamDefinitionController {
 	@RequestMapping(value = "", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	public void deleteAll() {
-		deploymentController.undeployAll();
+		for (StreamDefinition streamDefinition: this.repository.findAll()) {
+			this.streamService.undeployStream(streamDefinition.getName());
+		}
 		this.repository.deleteAll();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.deployer.spi.app.DeploymentState;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  */
-public interface StreamService {
+public interface StreamService extends StreamUpdateService {
 	/**
 	 * Deploys the stream with the user provided deployment properties.
 	 * Implementations are responsible for expanding deployment wildcard expressions.
@@ -36,7 +36,13 @@ public interface StreamService {
 	 */
 	void deployStream(String name, Map<String, String> deploymentProperties);
 
-	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
+	/**
+	 * Retrieve the deployment state for the given stream definitions.
+	 *
+	 * @param streamDefinitions the list of Stream definitions to calculate the deployment states.
+	 * @return the map containing the stream definitions and their deployment states.
+	 */
+	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> streamDefinitions);
 
 	/**
 	 * Un-deploys the stream identified by the given stream name.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamUpdateService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamUpdateService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service;
+
+import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
+
+/**
+ * Interface for the service that does Stream update operation.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public interface StreamUpdateService {
+
+	/**
+	 * Update the stream using the UpdateStreamRequest.
+	 *
+	 * @param streamName the name of the stream to update
+	 * @param updateStreamRequest the UpdateStreamRequest to use during the update
+	 */
+	void updateStream(String streamName, UpdateStreamRequest updateStreamRequest);
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -16,9 +16,7 @@
 package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,22 +24,11 @@ import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.cloud.dataflow.core.ApplicationType;
-import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
-import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
-import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
-import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
-import org.springframework.cloud.dataflow.registry.AppRegistration;
-import org.springframework.cloud.dataflow.registry.AppRegistry;
-import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
-import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
-import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployedException;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployingException;
-import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDeploymentException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
@@ -51,16 +38,14 @@ import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeploye
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
-import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
-import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPERTY_KEY;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_KEY_PREFIX;
 
 /**
  * Performs manipulation on application and deployment properties, expanding shorthand
@@ -76,18 +61,7 @@ import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPE
 @Service
 public class DefaultStreamService implements StreamService {
 
-	/**
-	 * This is the spring boot property key that Spring Cloud Stream uses to filter the
-	 * metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is
-	 * fired for metrics export.
-	 */
-	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
-
-	private static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";
-
 	private static Log logger = LogFactory.getLog(DefaultStreamService.class);
-
-	private final WhitelistProperties whitelistProperties;
 
 	/**
 	 * The repository this controller will use for stream CRUD operations.
@@ -96,41 +70,27 @@ public class DefaultStreamService implements StreamService {
 
 	private final StreamDeploymentRepository streamDeploymentRepository;
 
-	/**
-	 * The app registry this controller will use to lookup apps.
-	 */
-	private final AppRegistry appRegistry;
-
 	private final AppDeployerStreamDeployer appDeployerStreamDeployer;
 
 	private final SkipperStreamDeployer skipperStreamDeployer;
 
-	/**
-	 * General properties to be applied to applications on deployment.
-	 */
-	private final CommonApplicationProperties commonApplicationProperties;
+	private final StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils;
 
-	public DefaultStreamService(AppRegistry appRegistry,
-			CommonApplicationProperties commonApplicationProperties,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			StreamDefinitionRepository streamDefinitionRepository,
+	public DefaultStreamService(StreamDefinitionRepository streamDefinitionRepository,
 			StreamDeploymentRepository streamDeploymentRepository,
 			AppDeployerStreamDeployer appDeployerStreamDeployer,
-			SkipperStreamDeployer skipperStreamDeployer) {
-		Assert.notNull(appRegistry, "AppRegistry must not be null");
-		Assert.notNull(commonApplicationProperties, "CommonApplicationProperties must not be null");
-		Assert.notNull(metadataResolver, "MetadataResolver must not be null");
+			SkipperStreamDeployer skipperStreamDeployer,
+			StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils) {
 		Assert.notNull(streamDefinitionRepository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(streamDeploymentRepository, "StreamDeploymentRepository must not be null");
 		Assert.notNull(appDeployerStreamDeployer, "AppDeployerStreamDeployer must not be null");
 		Assert.notNull(skipperStreamDeployer, "SkipperStreamDeployer must not be null");
-		this.appRegistry = appRegistry;
-		this.commonApplicationProperties = commonApplicationProperties;
-		this.whitelistProperties = new WhitelistProperties(metadataResolver);
+		Assert.notNull(streamDeploymentPropertiesUtils, "StreamDeploymentPropertiesUtils must not be null");
 		this.streamDefinitionRepository = streamDefinitionRepository;
 		this.streamDeploymentRepository = streamDeploymentRepository;
 		this.appDeployerStreamDeployer = appDeployerStreamDeployer;
 		this.skipperStreamDeployer = skipperStreamDeployer;
+		this.streamDeploymentPropertiesUtils = streamDeploymentPropertiesUtils;
 	}
 
 	@Override
@@ -159,6 +119,25 @@ public class DefaultStreamService implements StreamService {
 		}
 	}
 
+	@Override
+	public void updateStream(String streamName, UpdateStreamRequest updateStreamRequest) {
+		updateStream(streamName, updateStreamRequest.getReleaseName(),
+				updateStreamRequest.getPackageIdentifier(), updateStreamRequest.getYaml());
+	}
+
+	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdenfier, String yaml) {
+		StreamDeployment streamDeployment = this.streamDeploymentRepository.findOne(streamName);
+		if (streamDeployment == null) {
+			throw new NoSuchStreamDeploymentException(streamName);
+		}
+		if (streamDeployment.getDeployerName().equals(StreamDeployers.skipper.name())) {
+			this.skipperStreamDeployer.upgradeStream(releaseName, packageIdenfier, yaml);
+		}
+		else {
+			throw new IllegalStateException("Can only update stream when using the Skipper deployer.");
+		}
+	}
+
 	private StreamDefinition createStreamDefinitionForDeploy(String name,
 			Map<String, String> deploymentProperties) {
 		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(name);
@@ -168,7 +147,7 @@ public class DefaultStreamService implements StreamService {
 
 		Map<String, String> skipperDeploymentProperties = getSkipperProperties(deploymentProperties);
 		String status;
-		if (skipperDeploymentProperties.containsKey(SkipperStreamDeployer.SKIPPER_ENABLED_PROPERTY_KEY)) {
+		if (skipperDeploymentProperties.containsKey(SKIPPER_ENABLED_PROPERTY_KEY)) {
 			status = this.skipperStreamDeployer.calculateStreamState(name);
 		}
 		else {
@@ -187,7 +166,7 @@ public class DefaultStreamService implements StreamService {
 	private Map<String, String> getSkipperProperties(Map<String, String> deploymentProperties) {
 		// Extract skipper properties
 		return deploymentProperties.entrySet().stream()
-				.filter(mapEntry -> mapEntry.getKey().startsWith(SkipperStreamDeployer.SKIPPER_KEY_PREFIX))
+				.filter(mapEntry -> mapEntry.getKey().startsWith(SKIPPER_KEY_PREFIX))
 				.collect(Collectors.toMap(mapEntry -> mapEntry.getKey(), mapEntry -> mapEntry.getValue()));
 	}
 
@@ -205,239 +184,20 @@ public class DefaultStreamService implements StreamService {
 		Map<String, String> skipperDeploymentProperties = getSkipperProperties(streamDeploymentProperties);
 		// Create map without any skipper properties
 		Map<String, String> deploymentPropertiesToUse = streamDeploymentProperties.entrySet().stream()
-				.filter(mapEntry -> !mapEntry.getKey().startsWith(SkipperStreamDeployer.SKIPPER_KEY_PREFIX))
+				.filter(mapEntry -> !mapEntry.getKey().startsWith(SKIPPER_KEY_PREFIX))
 				.collect(Collectors.toMap(mapEntry -> mapEntry.getKey(), mapEntry -> mapEntry.getValue()));
 
-		List<AppDeploymentRequest> appDeploymentRequests = createRequests(streamDefinition,
-				deploymentPropertiesToUse);
+		List<AppDeploymentRequest> appDeploymentRequests = this.streamDeploymentPropertiesUtils.createRequests
+				(streamDefinition, deploymentPropertiesToUse);
 
-		if (skipperDeploymentProperties.containsKey(SkipperStreamDeployer.SKIPPER_ENABLED_PROPERTY_KEY)) {
-			skipperStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
+		if (skipperDeploymentProperties.containsKey(SKIPPER_ENABLED_PROPERTY_KEY)) {
+			this.skipperStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
 					streamDefinition.getDslText(), appDeploymentRequests, skipperDeploymentProperties));
 		}
 		else {
-			appDeployerStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
+			this.appDeployerStreamDeployer.deployStream(new StreamDeploymentRequest(streamDefinition.getName(),
 					streamDefinition.getDslText(), appDeploymentRequests, new HashMap<>()));
 		}
-	}
-
-	private List<AppDeploymentRequest> createRequests(StreamDefinition stream,
-			Map<String, String> streamDeploymentProperties) {
-		List<AppDeploymentRequest> appDeploymentRequests = new ArrayList<>();
-		if (streamDeploymentProperties == null) {
-			streamDeploymentProperties = Collections.emptyMap();
-		}
-		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
-		int nextAppCount = 0;
-		boolean isDownStreamAppPartitioned = false;
-		while (iterator.hasNext()) {
-			StreamAppDefinition currentApp = iterator.next();
-			ApplicationType type = DataFlowServerUtil.determineApplicationType(currentApp);
-
-			AppRegistration registration = this.appRegistry.find(currentApp.getRegisteredAppName(), type);
-			Assert.notNull(registration, String.format("no application '%s' of type '%s' exists in the registry",
-					currentApp.getName(), type));
-
-			Map<String, String> appDeployTimeProperties = extractAppProperties(currentApp, streamDeploymentProperties);
-			Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
-					.extractAndQualifyDeployerProperties(streamDeploymentProperties, currentApp.getName());
-			deployerDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
-
-			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp,
-					streamDeploymentProperties);
-			// Set instance count property
-			if (deployerDeploymentProperties.containsKey(COUNT_PROPERTY_KEY)) {
-				appDeployTimeProperties.put(StreamPropertyKeys.INSTANCE_COUNT,
-						deployerDeploymentProperties.get(COUNT_PROPERTY_KEY));
-			}
-			if (!type.equals(ApplicationType.source)) {
-				deployerDeploymentProperties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
-			}
-
-			// consumer app partition properties
-			if (upstreamAppSupportsPartition) {
-				updateConsumerPartitionProperties(appDeployTimeProperties);
-			}
-
-			// producer app partition properties
-			if (isDownStreamAppPartitioned) {
-				updateProducerPartitionProperties(appDeployTimeProperties, nextAppCount);
-			}
-
-			nextAppCount = getInstanceCount(deployerDeploymentProperties);
-			isDownStreamAppPartitioned = isPartitionedConsumer(appDeployTimeProperties, upstreamAppSupportsPartition);
-
-			logger.info(String.format("Downloading resource URI [%s]", registration.getUri()));
-			Resource appResource = registration.getResource();
-			Resource metadataResource = registration.getMetadataResource();
-
-			// add properties needed for metrics system
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_NAME, currentApp.getStreamName());
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_LABEL, currentApp.getName());
-			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_TYPE, type.toString());
-			StringBuilder sb = new StringBuilder().append(currentApp.getStreamName()).append(".")
-					.append(currentApp.getName()).append(".").append("${spring.cloud.application.guid}");
-			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
-
-			// Merge *definition time* app properties with *deployment time* properties
-			// and expand them to their long form if applicable
-			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource,
-					appDeployTimeProperties);
-
-			AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition, appResource,
-					deployerDeploymentProperties);
-
-			appDeploymentRequests.add(request);
-		}
-		DeploymentPropertiesUtils.ensureJustDeploymentProperties(streamDeploymentProperties);
-		return appDeploymentRequests;
-	}
-
-	/**
-	 * Extract and return a map of properties for a specific app within the deployment
-	 * properties of a stream.
-	 *
-	 * @param appDefinition the {@link StreamAppDefinition} for which to return a map of
-	 * properties
-	 * @param streamDeploymentProperties deployment properties for the stream that the app
-	 * is defined in
-	 * @return map of properties for an app
-	 */
-	private Map<String, String> extractAppProperties(StreamAppDefinition appDefinition,
-			Map<String, String> streamDeploymentProperties) {
-		Map<String, String> appDeploymentProperties = new HashMap<>();
-		// add common properties first
-		appDeploymentProperties.putAll(this.commonApplicationProperties.getStream());
-		// add properties with wild card prefix
-		String wildCardProducerPropertyPrefix = "app.*.producer.";
-		String wildCardConsumerPropertyPrefix = "app.*.consumer.";
-		String wildCardPrefix = "app.*.";
-		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, wildCardProducerPropertyPrefix,
-				wildCardConsumerPropertyPrefix, wildCardPrefix);
-		// add application specific properties
-		String producerPropertyPrefix = String.format("app.%s.producer.", appDefinition.getName());
-		String consumerPropertyPrefix = String.format("app.%s.consumer.", appDefinition.getName());
-		String appPrefix = String.format("app.%s.", appDefinition.getName());
-		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, producerPropertyPrefix,
-				consumerPropertyPrefix, appPrefix);
-		return appDeploymentProperties;
-	}
-
-	/**
-	 * Return {@code true} if the upstream app (the app that appears before the provided
-	 * app) contains partition related properties.
-	 *
-	 * @param stream stream for the app
-	 * @param currentApp app for which to determine if the upstream app has partition
-	 * properties
-	 * @param streamDeploymentProperties deployment properties for the stream
-	 * @return true if the upstream app has partition properties
-	 */
-	private boolean upstreamAppHasPartitionInfo(StreamDefinition stream, StreamAppDefinition currentApp,
-			Map<String, String> streamDeploymentProperties) {
-		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
-		while (iterator.hasNext()) {
-			StreamAppDefinition app = iterator.next();
-			if (app.equals(currentApp) && iterator.hasNext()) {
-				StreamAppDefinition prevApp = iterator.next();
-				Map<String, String> appDeploymentProperties = extractAppProperties(prevApp, streamDeploymentProperties);
-				return appDeploymentProperties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)
-						|| appDeploymentProperties
-								.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXTRACTOR_CLASS);
-			}
-		}
-		return false;
-	}
-
-	private void parseAndPopulateProperties(Map<String, String> streamDeploymentProperties,
-			Map<String, String> appDeploymentProperties, String producerPropertyPrefix,
-			String consumerPropertyPrefix,
-			String appPrefix) {
-		for (Map.Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
-			if (entry.getKey().startsWith(appPrefix)) {
-				if (entry.getKey().startsWith(producerPropertyPrefix)) {
-					appDeploymentProperties.put(BindingPropertyKeys.OUTPUT_BINDING_KEY_PREFIX
-							+ entry.getKey().substring(appPrefix.length()), entry.getValue());
-				}
-				else if (entry.getKey().startsWith(consumerPropertyPrefix)) {
-					appDeploymentProperties.put(
-							BindingPropertyKeys.INPUT_BINDING_KEY_PREFIX + entry.getKey().substring(appPrefix.length()),
-							entry.getValue());
-				}
-				else {
-					appDeploymentProperties.put(entry.getKey().substring(appPrefix.length()), entry.getValue());
-				}
-			}
-		}
-	}
-
-	/**
-	 * Return a new app definition where definition-time and deploy-time properties have
-	 * been merged and short form parameters have been expanded to their long form
-	 * (amongst the whitelisted supported properties of the app) if applicable.
-	 */
-	/* default */ AppDefinition mergeAndExpandAppProperties(StreamAppDefinition original, Resource metadataResource,
-			Map<String, String> appDeployTimeProperties) {
-		Map<String, String> merged = new HashMap<>(original.getProperties());
-		merged.putAll(appDeployTimeProperties);
-		merged = whitelistProperties.qualifyProperties(merged, metadataResource);
-
-		merged.putIfAbsent(StreamPropertyKeys.METRICS_PROPERTIES, "spring.application.name,spring.application.index,"
-				+ "spring.cloud.application.*,spring.cloud.dataflow.*");
-		merged.putIfAbsent(METRICS_TRIGGER_INCLUDES, "integration**");
-
-		return new AppDefinition(original.getName(), merged);
-	}
-
-	/**
-	 * Add app properties for producing partitioned data to the provided properties.
-	 *
-	 * @param properties properties to update
-	 * @param nextInstanceCount the number of instances for the next (downstream) app in
-	 * the stream
-	 */
-	private void updateProducerPartitionProperties(Map<String, String> properties, int nextInstanceCount) {
-		properties.put(BindingPropertyKeys.OUTPUT_PARTITION_COUNT, String.valueOf(nextInstanceCount));
-		if (!properties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)) {
-			properties.put(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION, DEFAULT_PARTITION_KEY_EXPRESSION);
-		}
-	}
-
-	/**
-	 * Add app properties for consuming partitioned data to the provided properties.
-	 *
-	 * @param properties properties to update
-	 */
-	private void updateConsumerPartitionProperties(Map<String, String> properties) {
-		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
-	}
-
-	/**
-	 * Return the app instance count indicated in the provided properties.
-	 *
-	 * @param properties deployer properties for the app for which to determine the count
-	 * @return instance count indicated in the provided properties; if the properties do
-	 * not contain a count, a value of {@code 1} is returned
-	 */
-	private int getInstanceCount(Map<String, String> properties) {
-		return Integer.valueOf(properties.getOrDefault(COUNT_PROPERTY_KEY, "1"));
-	}
-
-	/**
-	 * Return {@code true} if an app is a consumer of partitioned data. This is determined
-	 * either by the deployment properties for the app or whether the previous (upstream)
-	 * app is publishing partitioned data.
-	 *
-	 * @param appDeploymentProperties deployment properties for the app
-	 * @param upstreamAppSupportsPartition if true, previous (upstream) app in the stream
-	 * publishes partitioned data
-	 * @return true if the app consumes partitioned data
-	 */
-	private boolean isPartitionedConsumer(Map<String, String> appDeploymentProperties,
-			boolean upstreamAppSupportsPartition) {
-		return upstreamAppSupportsPartition
-				|| (appDeploymentProperties.containsKey(BindingPropertyKeys.INPUT_PARTITIONED)
-						&& appDeploymentProperties.get(BindingPropertyKeys.INPUT_PARTITIONED).equalsIgnoreCase("true"));
 	}
 
 	// State
@@ -472,18 +232,5 @@ public class DefaultStreamService implements StreamService {
 			states.putAll(this.appDeployerStreamDeployer.state(appDeployerStreams));
 		}
 		return states;
-	}
-
-	public void upgradeStream(String streamName, String releaseName, PackageIdentifier packageIdenfier, String yaml) {
-		StreamDeployment streamDeployment = this.streamDeploymentRepository.findOne(streamName);
-		if (streamDeployment == null) {
-			throw new NoSuchStreamDeploymentException(streamName);
-		}
-		if (streamDeployment.getDeployerName().equals(StreamDeployers.skipper.name())) {
-			this.skipperStreamDeployer.upgradeStream(streamName, releaseName, packageIdenfier, yaml);
-		}
-		else {
-			throw new IllegalStateException("Can only update stream when using the Skipper deployer.");
-		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/StreamDeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/StreamDeploymentPropertiesUtils.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.BindingPropertyKeys;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.StreamPropertyKeys;
+import org.springframework.cloud.dataflow.registry.AppRegistration;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.DataFlowServerUtil;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+
+import static org.springframework.cloud.deployer.spi.app.AppDeployer.COUNT_PROPERTY_KEY;
+
+/**
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
+ * @author Janne Valkealahti
+ */
+public class StreamDeploymentPropertiesUtils {
+
+	private static Log logger = LogFactory.getLog(StreamDeploymentPropertiesUtils.class);
+
+	/**
+	 * This is the spring boot property key that Spring Cloud Stream uses to filter the
+	 * metrics to import when the specific Spring Cloud Stream "applicaiton" trigger is
+	 * fired for metrics export.
+	 */
+	private static final String METRICS_TRIGGER_INCLUDES = "spring.metrics.export.triggers.application.includes";
+
+	private static final String DEFAULT_PARTITION_KEY_EXPRESSION = "payload";
+
+	private final AppRegistry appRegistry;
+
+	private final CommonApplicationProperties commonApplicationProperties;
+
+	private final WhitelistProperties whitelistProperties;
+
+	public StreamDeploymentPropertiesUtils(AppRegistry appRegistry,
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		Assert.notNull(appRegistry, "AppRegistry must not be null");
+		Assert.notNull(commonApplicationProperties, "CommonApplicationProperties must not be null");
+		Assert.notNull(metadataResolver, "MetadataResolver must not be null");
+		this.appRegistry = appRegistry;
+		this.commonApplicationProperties = commonApplicationProperties;
+		this.whitelistProperties = new WhitelistProperties(metadataResolver);
+	}
+
+	List<AppDeploymentRequest> createRequests(StreamDefinition stream,
+			Map<String, String> streamDeploymentProperties) {
+		List<AppDeploymentRequest> appDeploymentRequests = new ArrayList<>();
+		if (streamDeploymentProperties == null) {
+			streamDeploymentProperties = Collections.emptyMap();
+		}
+		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
+		int nextAppCount = 0;
+		boolean isDownStreamAppPartitioned = false;
+		while (iterator.hasNext()) {
+			StreamAppDefinition currentApp = iterator.next();
+			ApplicationType type = DataFlowServerUtil.determineApplicationType(currentApp);
+
+			AppRegistration registration = this.appRegistry.find(currentApp.getRegisteredAppName(), type);
+			Assert.notNull(registration, String.format("no application '%s' of type '%s' exists in the registry",
+					currentApp.getName(), type));
+
+			Map<String, String> appDeployTimeProperties = extractAppProperties(currentApp, streamDeploymentProperties);
+			Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
+					.extractAndQualifyDeployerProperties(streamDeploymentProperties, currentApp.getName());
+			deployerDeploymentProperties.put(AppDeployer.GROUP_PROPERTY_KEY, currentApp.getStreamName());
+
+			boolean upstreamAppSupportsPartition = upstreamAppHasPartitionInfo(stream, currentApp,
+					streamDeploymentProperties);
+			// Set instance count property
+			if (deployerDeploymentProperties.containsKey(COUNT_PROPERTY_KEY)) {
+				appDeployTimeProperties.put(StreamPropertyKeys.INSTANCE_COUNT,
+						deployerDeploymentProperties.get(COUNT_PROPERTY_KEY));
+			}
+			if (!type.equals(ApplicationType.source)) {
+				deployerDeploymentProperties.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
+			}
+
+			// consumer app partition properties
+			if (upstreamAppSupportsPartition) {
+				updateConsumerPartitionProperties(appDeployTimeProperties);
+			}
+
+			// producer app partition properties
+			if (isDownStreamAppPartitioned) {
+				updateProducerPartitionProperties(appDeployTimeProperties, nextAppCount);
+			}
+
+			nextAppCount = getInstanceCount(deployerDeploymentProperties);
+			isDownStreamAppPartitioned = isPartitionedConsumer(appDeployTimeProperties, upstreamAppSupportsPartition);
+
+			logger.info(String.format("Downloading resource URI [%s]", registration.getUri()));
+			Resource appResource = registration.getResource();
+			Resource metadataResource = registration.getMetadataResource();
+
+			// add properties needed for metrics system
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_NAME, currentApp.getStreamName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_LABEL, currentApp.getName());
+			appDeployTimeProperties.put(DataFlowPropertyKeys.STREAM_APP_TYPE, type.toString());
+			StringBuilder sb = new StringBuilder().append(currentApp.getStreamName()).append(".")
+					.append(currentApp.getName()).append(".").append("${spring.cloud.application.guid}");
+			appDeployTimeProperties.put(StreamPropertyKeys.METRICS_KEY, sb.toString());
+
+			// Merge *definition time* app properties with *deployment time* properties
+			// and expand them to their long form if applicable
+			AppDefinition revisedDefinition = mergeAndExpandAppProperties(currentApp, metadataResource,
+					appDeployTimeProperties);
+
+			AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition, appResource,
+					deployerDeploymentProperties);
+
+			appDeploymentRequests.add(request);
+		}
+		DeploymentPropertiesUtils.ensureJustDeploymentProperties(streamDeploymentProperties);
+		return appDeploymentRequests;
+	}
+
+	/**
+	 * Extract and return a map of properties for a specific app within the deployment
+	 * properties of a stream.
+	 *
+	 * @param appDefinition the {@link StreamAppDefinition} for which to return a map of
+	 * properties
+	 * @param streamDeploymentProperties deployment properties for the stream that the app
+	 * is defined in
+	 * @return map of properties for an app
+	 */
+	private Map<String, String> extractAppProperties(StreamAppDefinition appDefinition,
+			Map<String, String> streamDeploymentProperties) {
+		Map<String, String> appDeploymentProperties = new HashMap<>();
+		// add common properties first
+		appDeploymentProperties.putAll(this.commonApplicationProperties.getStream());
+		// add properties with wild card prefix
+		String wildCardProducerPropertyPrefix = "app.*.producer.";
+		String wildCardConsumerPropertyPrefix = "app.*.consumer.";
+		String wildCardPrefix = "app.*.";
+		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, wildCardProducerPropertyPrefix,
+				wildCardConsumerPropertyPrefix, wildCardPrefix);
+		// add application specific properties
+		String producerPropertyPrefix = String.format("app.%s.producer.", appDefinition.getName());
+		String consumerPropertyPrefix = String.format("app.%s.consumer.", appDefinition.getName());
+		String appPrefix = String.format("app.%s.", appDefinition.getName());
+		parseAndPopulateProperties(streamDeploymentProperties, appDeploymentProperties, producerPropertyPrefix,
+				consumerPropertyPrefix, appPrefix);
+		return appDeploymentProperties;
+	}
+
+	/**
+	 * Return {@code true} if the upstream app (the app that appears before the provided
+	 * app) contains partition related properties.
+	 *
+	 * @param stream stream for the app
+	 * @param currentApp app for which to determine if the upstream app has partition
+	 * properties
+	 * @param streamDeploymentProperties deployment properties for the stream
+	 * @return true if the upstream app has partition properties
+	 */
+	private boolean upstreamAppHasPartitionInfo(StreamDefinition stream, StreamAppDefinition currentApp,
+			Map<String, String> streamDeploymentProperties) {
+		Iterator<StreamAppDefinition> iterator = stream.getDeploymentOrderIterator();
+		while (iterator.hasNext()) {
+			StreamAppDefinition app = iterator.next();
+			if (app.equals(currentApp) && iterator.hasNext()) {
+				StreamAppDefinition prevApp = iterator.next();
+				Map<String, String> appDeploymentProperties = extractAppProperties(prevApp, streamDeploymentProperties);
+				return appDeploymentProperties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)
+						|| appDeploymentProperties
+						.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXTRACTOR_CLASS);
+			}
+		}
+		return false;
+	}
+
+	private void parseAndPopulateProperties(Map<String, String> streamDeploymentProperties,
+			Map<String, String> appDeploymentProperties, String producerPropertyPrefix,
+			String consumerPropertyPrefix,
+			String appPrefix) {
+		for (Map.Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
+			if (entry.getKey().startsWith(appPrefix)) {
+				if (entry.getKey().startsWith(producerPropertyPrefix)) {
+					appDeploymentProperties.put(BindingPropertyKeys.OUTPUT_BINDING_KEY_PREFIX
+							+ entry.getKey().substring(appPrefix.length()), entry.getValue());
+				}
+				else if (entry.getKey().startsWith(consumerPropertyPrefix)) {
+					appDeploymentProperties.put(
+							BindingPropertyKeys.INPUT_BINDING_KEY_PREFIX + entry.getKey().substring(appPrefix.length()),
+							entry.getValue());
+				}
+				else {
+					appDeploymentProperties.put(entry.getKey().substring(appPrefix.length()), entry.getValue());
+				}
+			}
+		}
+	}
+
+	/**
+	 * Return a new app definition where definition-time and deploy-time properties have
+	 * been merged and short form parameters have been expanded to their long form
+	 * (amongst the whitelisted supported properties of the app) if applicable.
+	 */
+	/* default */ AppDefinition mergeAndExpandAppProperties(StreamAppDefinition original, Resource metadataResource,
+			Map<String, String> appDeployTimeProperties) {
+		Map<String, String> merged = new HashMap<>(original.getProperties());
+		merged.putAll(appDeployTimeProperties);
+		merged = this.whitelistProperties.qualifyProperties(merged, metadataResource);
+
+		merged.putIfAbsent(StreamPropertyKeys.METRICS_PROPERTIES, "spring.application.name,spring.application.index,"
+				+ "spring.cloud.application.*,spring.cloud.dataflow.*");
+		merged.putIfAbsent(METRICS_TRIGGER_INCLUDES, "integration**");
+
+		return new AppDefinition(original.getName(), merged);
+	}
+
+	/**
+	 * Add app properties for producing partitioned data to the provided properties.
+	 *
+	 * @param properties properties to update
+	 * @param nextInstanceCount the number of instances for the next (downstream) app in
+	 * the stream
+	 */
+	private void updateProducerPartitionProperties(Map<String, String> properties, int nextInstanceCount) {
+		properties.put(BindingPropertyKeys.OUTPUT_PARTITION_COUNT, String.valueOf(nextInstanceCount));
+		if (!properties.containsKey(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION)) {
+			properties.put(BindingPropertyKeys.OUTPUT_PARTITION_KEY_EXPRESSION, DEFAULT_PARTITION_KEY_EXPRESSION);
+		}
+	}
+
+	/**
+	 * Add app properties for consuming partitioned data to the provided properties.
+	 *
+	 * @param properties properties to update
+	 */
+	private void updateConsumerPartitionProperties(Map<String, String> properties) {
+		properties.put(BindingPropertyKeys.INPUT_PARTITIONED, "true");
+	}
+
+	/**
+	 * Return the app instance count indicated in the provided properties.
+	 *
+	 * @param properties deployer properties for the app for which to determine the count
+	 * @return instance count indicated in the provided properties; if the properties do
+	 * not contain a count, a value of {@code 1} is returned
+	 */
+	private int getInstanceCount(Map<String, String> properties) {
+		return Integer.valueOf(properties.getOrDefault(COUNT_PROPERTY_KEY, "1"));
+	}
+
+	/**
+	 * Return {@code true} if an app is a consumer of partitioned data. This is determined
+	 * either by the deployment properties for the app or whether the previous (upstream)
+	 * app is publishing partitioned data.
+	 *
+	 * @param appDeploymentProperties deployment properties for the app
+	 * @param upstreamAppSupportsPartition if true, previous (upstream) app in the stream
+	 * publishes partitioned data
+	 * @return true if the app consumes partitioned data
+	 */
+	private boolean isPartitionedConsumer(Map<String, String> appDeploymentProperties,
+			boolean upstreamAppSupportsPartition) {
+		return upstreamAppSupportsPartition
+				|| (appDeploymentProperties.containsKey(BindingPropertyKeys.INPUT_PARTITIONED)
+				&& appDeploymentProperties.get(BindingPropertyKeys.INPUT_PARTITIONED).equalsIgnoreCase("true"));
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -57,9 +57,11 @@ import org.springframework.cloud.dataflow.server.repository.InMemoryTaskDefiniti
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.service.TaskService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
+import org.springframework.cloud.dataflow.server.service.impl.StreamDeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
@@ -123,29 +125,30 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	public StreamDeploymentController streamDeploymentController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, AppRegistry registry,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			CommonApplicationProperties applicationProperties, StreamDeploymentRepository streamDeploymentRepository,
-			DefaultStreamService defaultStreamService) {
-		return new StreamDeploymentController(repository, deploymentIdRepository, registry, appDeployer(),
-				metadataResolver, applicationProperties, streamDeploymentRepository, defaultStreamService);
+			StreamService streamService) {
+		return new StreamDeploymentController(repository, streamService);
 	}
 
 	@Bean
-	public DefaultStreamService streamDeploymentService(AppRegistry appRegistry,
-			CommonApplicationProperties commonApplicationProperties,
-			ApplicationConfigurationMetadataResolver applicationConfigurationMetadataResolver,
-			StreamDefinitionRepository streamDefinitionRepository,
+	public StreamService streamService(StreamDefinitionRepository streamDefinitionRepository,
 			StreamDeploymentRepository streamDeploymentRepository,
 			AppDeployerStreamDeployer appDeployerStreamDeployer,
-			SkipperStreamDeployer skipperStreamDeployer) {
-		return new DefaultStreamService(appRegistry,
-				commonApplicationProperties,
-				applicationConfigurationMetadataResolver,
-				streamDefinitionRepository,
+			SkipperStreamDeployer skipperStreamDeployer,
+			StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils) {
+		return new DefaultStreamService(streamDefinitionRepository,
 				streamDeploymentRepository,
 				appDeployerStreamDeployer,
-				skipperStreamDeployer);
+				skipperStreamDeployer,
+				streamDeploymentPropertiesUtils);
+	}
+
+	@Bean
+	StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils(AppRegistry appRegistry,
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver applicationConfigurationMetadataResolver) {
+		return new StreamDeploymentPropertiesUtils(appRegistry,
+				commonApplicationProperties,
+				applicationConfigurationMetadataResolver);
 	}
 
 	@Bean
@@ -164,15 +167,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	public SkipperClient skipperClient() {
-		return SkipperClient.create("http://localhost:7577");
+		return mock(SkipperClient.class);
 	}
 
 	@Bean
 	public StreamDefinitionController streamDefinitionController(StreamDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, StreamDeploymentController deploymentController,
-			DefaultStreamService defaultStreamService) {
-		return new StreamDefinitionController(repository, deploymentIdRepository, deploymentController, appDeployer(),
-				appRegistry(), defaultStreamService);
+			StreamService streamService) {
+		return new StreamDefinitionController(repository, appRegistry(), streamService);
 	}
 
 	@Bean
@@ -203,9 +204,10 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public RuntimeAppsController runtimeAppsController(MetricStore metricStore) {
-		return new RuntimeAppsController(streamDefinitionRepository(), deploymentIdRepository(), appDeployer(),
-				metricStore, new ForkJoinPool(2));
+	public RuntimeAppsController runtimeAppsController(MetricStore metricStore, StreamService streamService) {
+		return new RuntimeAppsController(streamDefinitionRepository(), streamDeploymentRepository(),
+				deploymentIdRepository(), appDeployer(),
+				metricStore, new ForkJoinPool(2), skipperClient());
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
@@ -24,14 +24,21 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.StreamDeployment;
 import org.springframework.cloud.dataflow.registry.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
+import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.client.SkipperClient;
+import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
@@ -68,10 +75,16 @@ public class RuntimeAppsControllerTests {
 	private AppDeployer appDeployer;
 
 	@Autowired
+	private StreamDeploymentRepository streamDeploymentRepository;
+
+	@Autowired
 	private StreamDefinitionRepository streamDefinitionRepository;
 
 	@Autowired
 	private DeploymentIdRepository deploymentIdRepository;
+
+	@Autowired
+	private SkipperClient skipperClient;
 
 	@Before
 	public void setupMocks() throws Exception {
@@ -83,8 +96,25 @@ public class RuntimeAppsControllerTests {
 
 		StreamDefinition streamDefinition1 = new StreamDefinition("ticktock1", "time|log");
 		StreamDefinition streamDefinition2 = new StreamDefinition("ticktock2", "time|log");
+		StreamDefinition streamDefinition3 = new StreamDefinition("ticktock3", "time|log");
+		StreamDefinition streamDefinition4 = new StreamDefinition("ticktock4", "time|log");
 		streamDefinitionRepository.save(streamDefinition1);
 		streamDefinitionRepository.save(streamDefinition2);
+		streamDefinitionRepository.save(streamDefinition3);
+		streamDefinitionRepository.save(streamDefinition4);
+
+		StreamDeployment streamDeployment1 = new StreamDeployment(streamDefinition1.getName(), StreamDeployers
+				.appdeployer.name());
+		StreamDeployment streamDeployment2 = new StreamDeployment(streamDefinition2.getName(), StreamDeployers
+				.appdeployer.name());
+		StreamDeployment streamDeployment3 = new StreamDeployment(streamDefinition3.getName(), StreamDeployers
+				.skipper.name());
+		StreamDeployment streamDeployment4 = new StreamDeployment(streamDefinition4.getName(), StreamDeployers
+				.skipper.name());
+		this.streamDeploymentRepository.save(streamDeployment1);
+		this.streamDeploymentRepository.save(streamDeployment2);
+		this.streamDeploymentRepository.save(streamDeployment3);
+		this.streamDeploymentRepository.save(streamDeployment4);
 
 		deploymentIdRepository.save("ticktock1.time", "ticktock1.time");
 		deploymentIdRepository.save("ticktock1.log", "ticktock1.log");
@@ -99,6 +129,30 @@ public class RuntimeAppsControllerTests {
 				.thenReturn(AppStatus.of("ticktock2.time").generalState(DeploymentState.deployed).build());
 		when(appDeployer.status("ticktock2.log"))
 				.thenReturn(AppStatus.of("ticktock2.log").generalState(DeploymentState.deployed).build());
+		Info ticktock3Info = new Info();
+		Status ticktock3Status = new Status();
+		ticktock3Status.setStatusCode(StatusCode.DEPLOYED);
+		ticktock3Status.setPlatformStatus("[{\"deploymentId\":\"ticktock3.log-v1\","
+				+ "\"instances\":{\"ticktock3.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock3.log-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"},"
+				+ "{\"deploymentId\":\"ticktock3.time-v1\",\"instances\":{\"ticktock3.time-v1-0\":{\"instanceNumber\":0,\"baseUrl\":\"http://192.168.1.100:32451\","
+				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
+				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
+				+ "\"id\":\"ticktock3.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
+		ticktock3Info.setStatus(ticktock3Status);
+		Info ticktock4Info = new Info();
+		Status ticktock4Status = new Status();
+		ticktock4Status.setStatusCode(StatusCode.DEPLOYED);
+		ticktock4Status.setPlatformStatus("[{\"deploymentId\":\"ticktock4.log-v1\","
+				+ "\"instances\":{\"ticktock4.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock4.log-v1-0\","
+				+ "\"state\":\"deployed\"}},\"state\":\"deployed\"},"
+				+ "{\"deploymentId\":\"ticktock4.time-v1\",\"instances\":{\"ticktock4.time-v1-0\":{\"instanceNumber\":0,"
+				+ "\"baseUrl\":\"http://192.168.1.100:32451\","
+				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
+				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
+				+ "\"id\":\"ticktock4.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
+		ticktock4Info.setStatus(ticktock4Status);
+		when(this.skipperClient.status("scdf_ticktock3")).thenReturn(ticktock3Info);
+		when(this.skipperClient.status("scdf_ticktock4")).thenReturn(ticktock4Info);
 
 		when(appDeployer.status("foo")).thenReturn(AppStatus.of("foo").generalState(DeploymentState.unknown).build());
 		AppStatus validAppStatus = AppStatus.of("a1.valid").generalState(DeploymentState.failed).build();
@@ -130,6 +184,10 @@ public class RuntimeAppsControllerTests {
 		assertThat(responseString.getContentAsString().contains("ticktock1.log"), is(true));
 		assertThat(responseString.getContentAsString().contains("ticktock2.time"), is(true));
 		assertThat(responseString.getContentAsString().contains("ticktock2.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(true));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -40,10 +40,8 @@ import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationPr
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
-import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.InMemoryStreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
-import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResource;
@@ -125,9 +123,6 @@ public class StreamControllerTests {
 	private CommonApplicationProperties appsProperties;
 
 	@Autowired
-	private StreamDeploymentRepository streamDeploymentRepository;
-
-	@Autowired
 	private DefaultStreamService defaultStreamService;
 
 	@Before
@@ -146,26 +141,13 @@ public class StreamControllerTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingRepository() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(
-				new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), appRegistry,
-				appDeployer, metadataResolver, new CommonApplicationProperties(), streamDeploymentRepository,
-				defaultStreamService);
-		new StreamDefinitionController(null, null, deploymentController, appDeployer, appRegistry, defaultStreamService);
+				new InMemoryStreamDefinitionRepository(), defaultStreamService);
+		new StreamDefinitionController(null, appRegistry, defaultStreamService);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testConstructorMissingDeploymentController() {
-		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(),
-				null, appDeployer, appRegistry, defaultStreamService);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testConstructorMissingDeployer() {
-		StreamDeploymentController deploymentController = new StreamDeploymentController(
-				new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(), appRegistry,
-				appDeployer, metadataResolver, new CommonApplicationProperties(), streamDeploymentRepository,
-				defaultStreamService);
-		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), new InMemoryDeploymentIdRepository(),
-				deploymentController, null, appRegistry, defaultStreamService);
+	public void testConstructorMissingStreamService() {
+		new StreamDefinitionController(new InMemoryStreamDefinitionRepository(), appRegistry, null);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionControllerTests.java
@@ -23,7 +23,6 @@ import sun.misc.Unsafe;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
-import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
@@ -46,7 +45,7 @@ public class StreamDefinitionControllerTests {
 		when(uriRegistry.find("sink.bar")).thenReturn(new URI("file://bar"));
 
 		StreamDefinitionController controller = buildStreamDefinitionControllerStub(uriRegistry);
-		controller.save("foo", "foo|bar", false, false);
+		controller.save("foo", "foo|bar", false, false, null);
 	}
 
 	private static StreamDefinitionController buildStreamDefinitionControllerStub(UriRegistry uriRegistry)
@@ -61,8 +60,6 @@ public class StreamDefinitionControllerTests {
 		accessor.setPropertyValue("appRegistry", appRegistry);
 		accessor.setPropertyValue("streamService", mock(StreamService.class));
 		accessor.setPropertyValue("repository", mock(StreamDefinitionRepository.class));
-		accessor.setPropertyValue("deploymentIdRepository", mock(DeploymentIdRepository.class));
-
 		return controller;
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.services.impl;
+package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,17 +22,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
@@ -51,9 +52,13 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Ilayaperumal Gopinathan
+ * @author Eric Bottard
  */
 @RunWith(SpringRunner.class)
 public class DefaultStreamServiceTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	private StreamDefinition streamDefinition1 = new StreamDefinition("test1", "time | log");
 
@@ -82,6 +87,8 @@ public class DefaultStreamServiceTests {
 
 	private SkipperStreamDeployer skipperStreamDeployer;
 
+	private StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils;
+
 	private DefaultStreamService defaultStreamService;
 
 	@Before
@@ -89,11 +96,12 @@ public class DefaultStreamServiceTests {
 		this.streamDeploymentRepository = mock(StreamDeploymentRepository.class);
 		this.appDeployerStreamDeployer = mock(AppDeployerStreamDeployer.class);
 		this.skipperStreamDeployer = mock(SkipperStreamDeployer.class);
-		this.defaultStreamService = new DefaultStreamService(mock(AppRegistry.class),
+		this.streamDeploymentPropertiesUtils = new StreamDeploymentPropertiesUtils(mock(AppRegistry.class),
 				mock(CommonApplicationProperties.class),
-				mock(ApplicationConfigurationMetadataResolver.class),
-				mock(StreamDefinitionRepository.class),
-				this.streamDeploymentRepository, this.appDeployerStreamDeployer, this.skipperStreamDeployer);
+				new BootApplicationConfigurationMetadataResolver());
+		this.defaultStreamService = new DefaultStreamService(mock(StreamDefinitionRepository.class),
+				this.streamDeploymentRepository, this.appDeployerStreamDeployer, this.skipperStreamDeployer,
+				streamDeploymentPropertiesUtils);
 		this.streamDefinitionList.add(streamDefinition1);
 		this.appDeployerStreamDefinitions.add(streamDefinition1);
 		this.streamDefinitionList.add(streamDefinition2);
@@ -107,10 +115,9 @@ public class DefaultStreamServiceTests {
 
 	@Test
 	public void verifyUpgradeStream() {
-		this.defaultStreamService.upgradeStream(streamDeployment2.getStreamName(), streamDeployment2.getReleaseName(),
+		this.defaultStreamService.updateStream(streamDeployment2.getStreamName(), streamDeployment2.getReleaseName(),
 				null, null);
-		verify(this.skipperStreamDeployer, times(1)).upgradeStream(this.streamDeployment2.getStreamName(),
-				this.streamDeployment2.getReleaseName(), null, null);
+		verify(this.skipperStreamDeployer, times(1)).upgradeStream(this.streamDeployment2.getReleaseName(), null, null);
 		verifyNoMoreInteractions(this.skipperStreamDeployer);
 		verify(this.appDeployerStreamDeployer, never()).deployStream(any());
 	}
@@ -138,7 +145,7 @@ public class DefaultStreamServiceTests {
 	@Test
 	public void verifyAppDeployerUpgrade() {
 		try {
-			this.defaultStreamService.upgradeStream(this.streamDeployment1.getStreamName(), this.streamDeployment1.getReleaseName(),
+			this.defaultStreamService.updateStream(this.streamDeployment1.getStreamName(), this.streamDeployment1.getReleaseName(),
 					null, null);
 			fail("IllegalStateException is expected to be thrown.");
 		}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.server.services.impl;
+package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -43,8 +43,6 @@ import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentId
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.TaskService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/StreamDeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/StreamDeploymentPropertiesUtilsTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.util.HashMap;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ * @author Eric Bottard
+ */
+@RunWith(SpringRunner.class)
+public class StreamDeploymentPropertiesUtilsTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private StreamDeploymentPropertiesUtils streamDeploymentPropertiesUtils;
+
+	@Before
+	public void setupMock() {
+		this.streamDeploymentPropertiesUtils = new StreamDeploymentPropertiesUtils(mock(AppRegistry.class),
+				mock(CommonApplicationProperties.class),
+				new BootApplicationConfigurationMetadataResolver());
+	}
+
+	@Test
+	public void testRequalifyShortWhiteListedProperty() {
+		StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
+				.setProperty("timezone", "GMT+2").build("streamname");
+
+		Resource app = new ClassPathResource("/apps/whitelist-source");
+		AppDefinition modified = this.streamDeploymentPropertiesUtils.mergeAndExpandAppProperties(appDefinition, app,
+				new HashMap<>());
+
+		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.timezone", "GMT+2"));
+		org.junit.Assert.assertThat(modified.getProperties(), not(IsMapContaining.hasKey("timezone")));
+	}
+
+	@Test
+	public void testSameNamePropertiesOKAsLongAsNotUsedAsShorthand() {
+		StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
+				.setProperty("time.format", "hh").setProperty("date.format", "yy").build("streamname");
+
+		Resource app = new ClassPathResource("/apps/whitelist-source");
+		AppDefinition modified = this.streamDeploymentPropertiesUtils.mergeAndExpandAppProperties(appDefinition, app,
+				new HashMap<>());
+
+		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.format", "yy"));
+		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("time.format", "hh"));
+	}
+
+	@Test
+	public void testSameNamePropertiesKOWhenShorthand() {
+		StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
+				.setProperty("format", "hh").build("streamname");
+
+		Resource app = new ClassPathResource("/apps/whitelist-source");
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("Ambiguous short form property 'format'");
+		thrown.expectMessage("date.format");
+		thrown.expectMessage("time.format");
+
+		this.streamDeploymentPropertiesUtils.mergeAndExpandAppProperties(appDefinition, app, new HashMap<>());
+	}
+
+	@Test
+	public void testShorthandsAcceptRelaxedVariations() {
+		StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
+				.setProperty("someLongProperty", "yy") // Use camelCase here
+				.build("streamname");
+
+		Resource app = new ClassPathResource("/apps/whitelist-source");
+		AppDefinition modified = this.streamDeploymentPropertiesUtils.mergeAndExpandAppProperties(appDefinition, app,
+				new HashMap<>());
+
+		org.junit.Assert.assertThat(modified.getProperties(),
+				IsMapContaining.hasEntry("date.some-long-property", "yy"));
+
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -35,6 +35,10 @@ import org.springframework.core.io.UrlResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_NAME;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_VERSION;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PLATFORM_NAME;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_REPO_NAME;
 
 /**
  * @author Mark Pollack
@@ -72,10 +76,10 @@ public class SkipperStreamDeployerTests {
 	@Test
 	public void testInstallUploadProperties() {
 		Map<String, String> skipperDeployerProperties = new HashMap<>();
-		skipperDeployerProperties.put(SkipperStreamDeployer.SKIPPER_PACKAGE_NAME, "package1");
-		skipperDeployerProperties.put(SkipperStreamDeployer.SKIPPER_PACKAGE_VERSION, "1.0.1");
-		skipperDeployerProperties.put(SkipperStreamDeployer.SKIPPER_PLATFORM_NAME, "platform1");
-		skipperDeployerProperties.put(SkipperStreamDeployer.SKIPPER_PACKAGE_REPO_NAME, "mylocal-repo1");
+		skipperDeployerProperties.put(SKIPPER_PACKAGE_NAME, "package1");
+		skipperDeployerProperties.put(SKIPPER_PACKAGE_VERSION, "1.0.1");
+		skipperDeployerProperties.put(SKIPPER_PLATFORM_NAME, "platform1");
+		skipperDeployerProperties.put(SKIPPER_REPO_NAME, "mylocal-repo1");
 		StreamDeploymentRequest streamDeploymentRequest = new StreamDeploymentRequest("test1", "time | log",
 				new ArrayList<>(),
 				skipperDeployerProperties);


### PR DESCRIPTION
 - Add release name prefix as `scdf_` for the releases created from stream deploy
   - This prefix is added to the stream name in scope
 - Add a common REST resource class SkipperStream to have all the constants used by both SCDF server/client
   - Move all the skipper related properties in there
Resolves #1688

 - Make package-version a mandator property when using Skipper at the shell
  - Update Shell command and the template methods
Resolves #1733

 - Refactor StreamDefinition/Deployment controllers
   - Remove unused dependencies
 - Move all the stream deployment properties handler methods into `StreamDeploymentPropertiesUtils`
 - Add StreamUpdateService interface
 - Have StreamService extend StreamUpdateService
 - Use interface type `StreamService` in the dependencies instead of strong type
 - Avoid using `useSkipper` as the deployment property and this will just be a shell option
Resolves #1731

 - When using destroyAll() make sure to call the `undeploy` via stream service
Resolves #1730

 - Fix setting UploadRequest package name
Resolves #1734

 - RuntimeApps controller now uses SkipperClient to get the status of streams that are deployed via Skipper
   - Check the StreamDeploymentRepository to retrive the status from appDeployer/Skipper
   - Update test
   Resolves #1707