### PR TITLE
stream skipper update to use same prop format as stream skipper deploy

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -84,9 +84,10 @@ public interface StreamOperations {
 	 * @param streamName the name of the stream to update
 	 * @param releaseName the corresponding release name of the stream in skipper
 	 * @param packageIdentifier the package that corresponds to this stream
-	 * @param yaml the values to change in the update
+	 * @param updateProperties a map of properties to use for updating the stream
 	 */
-	void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier, String yaml);
+	void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier,
+			Map<String, String> updateProperties);
 
 	/**
 	 * Queries the server for the stream definition

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -86,7 +86,6 @@ public class StreamTemplate implements StreamOperations {
 		return stream;
 	}
 
-
 	@Override
 	public void deploy(String name, Map<String, String> properties) {
 		restTemplate.postForObject(deploymentLink.expand(name).getHref(), properties, Object.class);
@@ -113,12 +112,15 @@ public class StreamTemplate implements StreamOperations {
 	}
 
 	@Override
-	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier, String yaml) {
+	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier,
+			Map<String, String> updateProperties) {
 		Assert.hasText(streamName, "Stream name cannot be null or empty");
 		Assert.notNull(packageIdentifier, "PackageIdentifier cannot be null");
 		Assert.hasText(packageIdentifier.getPackageName(), "Package Name cannot be null or empty");
 		Assert.hasText(releaseName, "Release name cannot be null or empty");
-		UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest(releaseName, packageIdentifier, yaml);
+		Assert.notNull(updateProperties, "UpdateProperties cannot be null");
+		UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest(releaseName, packageIdentifier,
+				updateProperties);
 		String url = deploymentsLink.getHref() + "/update/" + streamName;
 		restTemplate.postForObject(url, updateStreamRequest, Object.class);
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/UpdateStreamRequest.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/UpdateStreamRequest.java
@@ -17,8 +17,10 @@ package org.springframework.cloud.dataflow.rest;
 
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 
+import java.util.Map;
+
 /**
- * Caputures the required data for updating a stream using Skipper.
+ * Captures the required data for updating a stream using Skipper.
  * @author Mark Pollack
  */
 public class UpdateStreamRequest {
@@ -27,15 +29,17 @@ public class UpdateStreamRequest {
 
 	private PackageIdentifier packageIdentifier;
 
-	private String yaml;
+	private Map<String, String> updateProperties;
 
 	public UpdateStreamRequest() {
 	}
+	
 
-	public UpdateStreamRequest(String releaseName, PackageIdentifier packageIdentifier, String yaml) {
+	public UpdateStreamRequest(String releaseName, PackageIdentifier packageIdentifier,
+			Map<String, String> updateProperties) {
 		this.releaseName = releaseName;
 		this.packageIdentifier = packageIdentifier;
-		this.yaml = yaml;
+		this.updateProperties = updateProperties;
 	}
 
 	public String getReleaseName() {
@@ -54,12 +58,12 @@ public class UpdateStreamRequest {
 		this.packageIdentifier = packageIdentifier;
 	}
 
-	public String getYaml() {
-		return yaml;
+	public Map<String, String> getUpdateProperties() {
+		return updateProperties;
 	}
 
-	public void setYaml(String yaml) {
-		this.yaml = yaml;
+	public void setUpdateProperties(Map<String, String> updateProperties) {
+		this.updateProperties = updateProperties;
 	}
 
 	@Override
@@ -67,7 +71,7 @@ public class UpdateStreamRequest {
 		return "UpdateStreamRequest{" +
 				"releaseName='" + releaseName + '\'' +
 				", packageIdentifier=" + packageIdentifier +
-				", yaml='" + yaml + '\'' +
+				", updateProperties=" + updateProperties +
 				'}';
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StreamUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Mark Pollack
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class)
+public class DefaultStreamServiceUpdateTests {
+
+	@Autowired
+	private AppRegistry appRegistry;
+
+	@Autowired
+	private DefaultStreamService streamService;
+
+	@Autowired
+	private StreamDefinitionRepository streamDefinitionRepository;
+
+	@Test
+	public void testCreateUpdateRequests() throws IOException {
+		StreamDefinition streamDefinition = new StreamDefinition("test", "time | log");
+		this.streamDefinitionRepository.save(streamDefinition);
+		Map<String, String> updateProperties = new HashMap<>();
+		updateProperties.put("app.log.server.port", "9999");
+		updateProperties.put("app.log.endpoints.sensitive", "false");
+		updateProperties.put("app.log.level", "ERROR"); //this should be expanded
+		updateProperties.put("deployer.log.memory", "4096m");
+		updateProperties.put("version.log", "1.1.1.RELEASE");
+		String yml = streamService.convertPropertiesToSkipperYaml("test", updateProperties);
+		String expectedYaml = StreamUtils.copyToString(
+				TestResourceUtils.qualifiedResource(getClass(), "update.yml").getInputStream(),
+				Charset.defaultCharset());
+		assertThat(yml).isEqualTo(expectedYaml);
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TestResourceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TestResourceUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.support;
+
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Convenience utilities for common operations with test resources.
+ *
+ * @author Chris Beams
+ */
+public abstract class TestResourceUtils {
+
+	/**
+	 * Load a {@link ClassPathResource} qualified by the simple name of clazz, and relative to
+	 * the package for clazz.
+	 * <p>
+	 * Example: given a clazz 'com.foo.BarTests' and a resourceSuffix of 'context.xml', this
+	 * method will return a ClassPathResource representing com/foo/BarTests-context.xml
+	 * <p>
+	 * Intended for use loading context configuration XML files within JUnit tests.
+	 */
+	public static ClassPathResource qualifiedResource(Class<?> clazz, String resourceSuffix) {
+		return new ClassPathResource(String.format("%s-%s", clazz.getSimpleName(), resourceSuffix), clazz);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests-update.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests-update.yml
@@ -1,0 +1,9 @@
+log:
+  version: 1.1.1.RELEASE
+  spec:
+    applicationProperties:
+      server.port: '9999'
+      log.level: ERROR
+      endpoints.sensitive: 'false'
+    deploymentProperties:
+      spring.cloud.deployer.memory: 4096m

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -226,14 +226,19 @@ public class StreamCommands implements CommandMarker {
 			@CliOption(key = {
 					"properties" }, help = "Flattened YAML style properties to update the stream", mandatory = false) String properties,
 			@CliOption(key = {
-					YAML_FILE_OPTION }, help = "the YAML file with values to update the stream", mandatory = false) File yamlFile,
+					PROPERTIES_FILE_OPTION }, help = "the properties for the stream update (as a File)", mandatory = false) File propertiesFile,
 			@CliOption(key = "packageVersion", help = "the package version of the package to update when using "
 					+ "Skipper") String packageVersion,
 			@CliOption(key = "repoName", help = "the name of the local repository to upload the package when using "
 					+ "Skipper") String repoName)
 			throws IOException {
-		assertMutuallyExclusiveFileAndProperties(yamlFile, properties);
-		String yamlConfigValues = getYamlConfigValues(yamlFile, properties);
+		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION,
+				propertiesFile);
+		Map<String, String> propertiesToUse = getDeploymentProperties(properties, propertiesFile, which);
+
+
+		//assertMutuallyExclusiveFileAndProperties(propertiesFile, properties);
+		//String yamlConfigValues = getYamlConfigValues(propertiesFile, properties);
 		PackageIdentifier packageIdentifier = new PackageIdentifier();
 		packageIdentifier.setPackageName(name);
 		if (StringUtils.hasText(packageVersion)) {
@@ -242,7 +247,7 @@ public class StreamCommands implements CommandMarker {
 		if (StringUtils.hasText(repoName)) {
 			packageIdentifier.setRepositoryName(repoName);
 		}
-		streamOperations().updateStream(name, name, packageIdentifier, yamlConfigValues);
+		streamOperations().updateStream(name, name, packageIdentifier, propertiesToUse);
 		return String.format("Update request has been sent for stream '%s'", name);
 	}
 


### PR DESCRIPTION
Minor integration testing using
```
app import --uri http://bit.ly/Bacon-RELEASE-stream-applications-rabbit-maven
stream create --name ticktock --definition "time | log"
stream skipper update --name ticktock --properties "version.log=1.1.0.RELEASE"
```

See added test for more involved update changes.

Fixes #1750