### PR TITLE
Fix status msg description

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/DeploymentStateResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/DeploymentStateResource.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 public enum DeploymentStateResource {
 
 	DEPLOYING("deploying", "Deploying", "The app or group is being deployed."),
-	DEPLOYED("deployed", "Deployed", "All apps have been successfully deployed"),
+	DEPLOYED("deployed", "Deployed", "The stream has been successfully deployed"),
 	UNDEPLOYED("undeployed", "Undeployed", "The app or group is known to the system, but is not currently deployed"),
 	PARTIAL("partial", "Partial",
 			"In the case of multiple apps, some have successfully deployed, while others have " + "not"),


### PR DESCRIPTION
 - Given the DeploymentStateResource is only used by the Streams, changed the description to reflect the `Stream` instead of `all the apps`

Resolves #1754