### PR TITLE
Add stream skipper rollback operation

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -90,6 +90,14 @@ public interface StreamOperations {
 			Map<String, String> updateProperties);
 
 	/**
+	 * Rollback the stream to the previous or a specific release version.
+	 *
+	 * @param releaseName the name of the release to rollback
+	 * @param version the version to rollback to (if not specified, rollback to the previous version)
+	 */
+	void rollbackStream(String releaseName, int version);
+
+	/**
 	 * Queries the server for the stream definition
 	 * @param streamName the name of the stream to get status
 	 * @return The current stream definition with updated status

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -126,6 +126,13 @@ public class StreamTemplate implements StreamOperations {
 	}
 
 	@Override
+	public void rollbackStream(String releaseName, int version) {
+		Assert.hasText(releaseName, "Release name cannot be null or empty");
+		String url = deploymentsLink.getHref() + "/rollback/" + releaseName + "/" + version;
+		restTemplate.postForObject(url, null, Object.class);
+	}
+
+	@Override
 	public StreamDefinitionResource getStreamDefinition(String streamName) {
 		String uriTemplate = this.definitionLink.expand(streamName).getHref();
 		return restTemplate.getForObject(uriTemplate, StreamDefinitionResource.class);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -116,9 +116,14 @@ public class StreamDeploymentController {
 
 	@RequestMapping(value = "/update/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public void update(@PathVariable("name") String name,
-			@RequestBody UpdateStreamRequest updateStreamRequest) {
+	public void update(@PathVariable("name") String name, @RequestBody UpdateStreamRequest updateStreamRequest) {
 		this.streamService.updateStream(name, updateStreamRequest);
+	}
+
+	@RequestMapping(value = "/rollback/{name}/{version}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public void rollback(@PathVariable("name") String name, @PathVariable("version") int version) {
+		this.streamService.rollbackStream(name, version);
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -53,6 +53,15 @@ public interface StreamService {
 	 */
 	void updateStream(String streamName, UpdateStreamRequest updateStreamRequest);
 
+	/**
+	 * Rollback the stream to the previous or a specific version of the stream.
+	 *
+	 * @param streamName the name of the stream to rollback
+	 * @param releaseVersion the version to rollback to (if not specified, rollback to the previous deleted/deployed
+	 * release version of the stream.
+	 */
+	void rollbackStream(String streamName, int releaseVersion);
+
 
 	/**
 	 * Un-deploys the stream identified by the given stream name.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.util.StringUtils;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -139,7 +140,22 @@ public class DefaultStreamService implements StreamService {
 			this.skipperStreamDeployer.upgradeStream(releaseName, packageIdenfier, yaml);
 		}
 		else {
-			throw new IllegalStateException("Can only update stream when using the Skipper deployer.");
+			throw new IllegalStateException("Can only update stream when using the Skipper stream deployer.");
+		}
+	}
+
+	@Override
+	public void rollbackStream(String streamName, int releaseVersion) {
+		Assert.isTrue(StringUtils.hasText(streamName), "Stream name must not be null");
+		StreamDeployment streamDeployment = this.streamDeploymentRepository.findOne(streamName);
+		if (streamDeployment == null) {
+			throw new NoSuchStreamDeploymentException(streamName);
+		}
+		if (streamDeployment.getDeployerName().equals(StreamDeployers.skipper.name())) {
+			this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
+		}
+		else {
+			throw new IllegalStateException("Can only rollback stream when using the Skipper stream deployer.");
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -395,4 +395,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		upgradeRequest.setUpgradeProperties(upgradeProperties);
 		this.skipperClient.upgrade(upgradeRequest);
 	}
+
+	public void rollbackStream(String streamName, int releaseVersion) {
+		this.skipperClient.rollback(streamName, releaseVersion);
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -74,4 +74,14 @@ public class StreamDeploymentControllerTests {
 		Assert.assertEquals(argumentCaptor2.getValue().get(SKIPPER_ENABLED_PROPERTY_KEY), "true");
 	}
 
+	@Test
+	public void testRollbackViaStreamService() {
+		this.controller.rollback("test1", 2);
+		ArgumentCaptor<String> argumentCaptor1 = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<Integer> argumentCaptor2 = ArgumentCaptor.forClass(Integer.class);
+		verify(defaultStreamService).rollbackStream(argumentCaptor1.capture(), argumentCaptor2.capture());
+		Assert.assertEquals(argumentCaptor1.getValue(), "test1");
+		Assert.assertTrue("Rollback version is incorrect", argumentCaptor2.getValue() == 2);
+	}
+
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -78,6 +78,8 @@ public class StreamCommands implements CommandMarker {
 
 	private static final String STREAM_SKIPPER_UPDATE = "stream skipper update";
 
+	private static final String STREAM_SKIPPER_ROLLBACK = "stream skipper rollback";
+
 	private static final String UNDEPLOY_STREAM = "stream undeploy";
 
 	private static final String UNDEPLOY_STREAM_ALL = "stream all undeploy";
@@ -248,7 +250,7 @@ public class StreamCommands implements CommandMarker {
 			packageIdentifier.setRepositoryName(repoName);
 		}
 		streamOperations().updateStream(name, name, packageIdentifier, propertiesToUse);
-		return String.format("Update request has been sent for stream '%s'", name);
+		return String.format("Update request has been sent for the stream '%s'", name);
 	}
 
 	private void assertMutuallyExclusiveFileAndProperties(File yamlFile, String propertyString) {
@@ -273,6 +275,18 @@ public class StreamCommands implements CommandMarker {
 		}
 		return configValuesYML;
 	}
+
+	@CliCommand(value = STREAM_SKIPPER_ROLLBACK, help = "Rollback a stream using Skipper")
+	public String rollbackStreamUsingSkipper(
+			@CliOption(key = { "", "name" }, help = "the name of the stream to rollback", mandatory = true,
+					optionContext = "existing-stream disable-string-converter") String name,
+			@CliOption(key = { "releaseVersion" }, help = "the Skipper release version to rollback to",
+					unspecifiedDefaultValue = "0") int releaseVersion) {
+		this.streamOperations().rollbackStream(name, releaseVersion);
+		return String.format("Rollback request has been sent for the stream '%s'", name);
+	}
+
+
 
 	@CliCommand(value = UNDEPLOY_STREAM, help = "Un-deploy a previously deployed stream")
 	public String undeployStream(@CliOption(key = { "",


### PR DESCRIPTION
 - Add both server/client side support for rollback operation using Skipper

 - Add `rollback` REST endpoint in StreamDeploymentController that delegates the request to the StreamService's `rollbackStream`
   - In DefaultStreamService check for Skipper Deployer usage from StreamDeployment and use SkipperStreamDeployer's `rollbackStream` method to perform rollback
 - Add unit tests to check the rollback request handover

 - Add `rollback` stream operation to the REST client stream operations
 - Implement this for StreamTemplate
 - Add `stream skipper rollback` command in StreamCommands

Resolves #1747
Resolves #1771