### PR TITLE
Support downloading http based resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<spring-cloud-dataflow-ui.version>1.3.0.M3</spring-cloud-dataflow-ui.version>
 
-		<spring-cloud-deployer.version>1.3.0.M1</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>1.3.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-deployer-local.version>1.3.0.M1</spring-cloud-deployer-local.version>
 
 		<spring-cloud-skipper.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-skipper.version>

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ProposalsCollectorSupportUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ProposalsCollectorSupportUtils.java
@@ -76,28 +76,31 @@ class ProposalsCollectorSupportUtils {
 
 	void addValueHintsProposals(final String dsl, AppRegistration appRegistration, final List<CompletionProposal> collector, final String propertyName, final ValueHintProvider[] valueHintProviders){
 		final Resource metadataResource = appRegistration.getMetadataResource();
-
-		final URLClassLoader classLoader = metadataResolver.createAppClassLoader(metadataResource);
-		this.doWithClassLoader(classLoader, () -> {
-			CompletionProposal.Factory proposals = expanding(dsl);
-			List<ConfigurationMetadataProperty> whiteList = metadataResolver.listProperties(metadataResource);
-			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource, true)) {
-				if (CompletionUtils.isMatchingProperty(propertyName, property, whiteList)) {
-					for (ValueHintProvider valueHintProvider : valueHintProviders) {
-						for (ValueHint valueHint : valueHintProvider.generateValueHints(property, classLoader)) {
-							collector.add(proposals.withSuffix(String.valueOf(valueHint.getValue()),
-									valueHint.getShortDescription()));
+		if (metadataResource != null) {
+			final URLClassLoader classLoader = metadataResolver.createAppClassLoader(metadataResource);
+			this.doWithClassLoader(classLoader, () -> {
+				CompletionProposal.Factory proposals = expanding(dsl);
+				List<ConfigurationMetadataProperty> whiteList = metadataResolver.listProperties(metadataResource);
+				for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource, true)) {
+					if (CompletionUtils.isMatchingProperty(propertyName, property, whiteList)) {
+						for (ValueHintProvider valueHintProvider : valueHintProviders) {
+							for (ValueHint valueHint : valueHintProvider.generateValueHints(property, classLoader)) {
+								collector.add(proposals.withSuffix(String.valueOf(valueHint.getValue()),
+										valueHint.getShortDescription()));
+							}
 						}
 					}
 				}
-			}
-			return null;
-		});
+				return null;
+			});
+		}
 	}
 
 	boolean addAlreadyTypedValueHintsProposals(final String text, AppRegistration appRegistration, final List<CompletionProposal> collector, final String propertyName, final ValueHintProvider[] valueHintProviders, final String alreadyTyped){
 		final Resource metadataResource = appRegistration.getMetadataResource();
-
+		if (metadataResource == null) {
+			return false;
+		}
 		final URLClassLoader classLoader = metadataResolver.createAppClassLoader(metadataResource);
 		return this.doWithClassLoader(classLoader, () -> {
 			CompletionProposal.Factory proposals = expanding(text);

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ProposalsCollectorSupportUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ProposalsCollectorSupportUtils.java
@@ -54,21 +54,24 @@ class ProposalsCollectorSupportUtils {
 
 	void addPropertiesProposals(String text, String startsWith, AppRegistration appRegistration, Set<String> alreadyPresentOptions, List<CompletionProposal> collector, int detailLevel){
 		Resource metadataResource = appRegistration.getMetadataResource();
-		CompletionProposal.Factory proposals = expanding(text);
-
 		// For whitelisted properties, use their simple name
-		for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource)) {
-			String name = property.getName();
-			if (!alreadyPresentOptions.contains(name) && name.startsWith(startsWith)) {
-				collector.add(proposals.withSeparateTokens("--" + property.getName() + "=", property.getShortDescription()));
+		if (metadataResource != null) {
+			CompletionProposal.Factory proposals = expanding(text);
+			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource)) {
+				String name = property.getName();
+				if (!alreadyPresentOptions.contains(name) && name.startsWith(startsWith)) {
+					collector.add(proposals
+							.withSeparateTokens("--" + property.getName() + "=", property.getShortDescription()));
+				}
 			}
-		}
-		// For other properties (including WL'ed in full form), use their id
-		if (detailLevel > 1) {
-			for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource, true)) {
-				String id = property.getId();
-				if (!alreadyPresentOptions.contains(id) && id.startsWith(startsWith)) {
-					collector.add(proposals.withSeparateTokens("--" + property.getId() + "=", property.getShortDescription()));
+			// For other properties (including WL'ed in full form), use their id
+			if (detailLevel > 1) {
+				for (ConfigurationMetadataProperty property : metadataResolver.listProperties(metadataResource, true)) {
+					String id = property.getId();
+					if (!alreadyPresentOptions.contains(id) && id.startsWith(startsWith)) {
+						collector.add(proposals
+								.withSeparateTokens("--" + property.getId() + "=", property.getShortDescription()));
+					}
 				}
 			}
 		}

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -113,7 +113,7 @@ public class BootVersionsCompletionProviderTests {
 					String filename = name + "-1.0.0.BUILD-SNAPSHOT.jar";
 					File file = new File(ROOT, filename);
 					if (file.exists()) {
-						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+						return new AppRegistration(name, type, file.toURI(), file.toURI(), resourceLoader);
 					}
 					else {
 						return null;

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -231,7 +231,7 @@ public class StreamCompletionProviderTests {
 					String filename = name + "-" + type;
 					File file = new File(ROOT, filename);
 					if (file.exists()) {
-						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+						return new AppRegistration(name, type, file.toURI(), file.toURI(), resourceLoader);
 					}
 					else {
 						return null;

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
@@ -185,7 +185,7 @@ public class TaskCompletionProviderTests {
 					String filename = name + "-" + type;
 					File file = new File(ROOT, filename);
 					if (file.exists()) {
-						return new AppRegistration(name, type, file.toURI(), resourceLoader);
+						return new AppRegistration(name, type, file.toURI(), file.toURI(), resourceLoader);
 					}
 					else {
 						return null;
@@ -207,7 +207,7 @@ public class TaskCompletionProviderTests {
 					Assert.isTrue(matcher.matches(), fileName + " does not match expected pattern.");
 					String name = matcher.group("name");
 					ApplicationType type = ApplicationType.valueOf(matcher.group("type"));
-					return new AppRegistration(name, type, file.toURI(), resourceLoader);
+					return new AppRegistration(name, type, file.toURI(), file.toURI(), resourceLoader);
 				}
 			};
 		}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -92,12 +92,14 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 	 */
 	public List<ConfigurationMetadataProperty> listProperties(Resource app, boolean exhaustive) {
 		try {
-			Archive archive = resolveAsArchive(app);
-			return listProperties(archive, exhaustive);
+			if (app != null) {
+				Archive archive = resolveAsArchive(app);
+				return listProperties(archive, exhaustive);
+			}
 		}
 		catch (IOException e) {
-			return Collections.emptyList();
 		}
+		return Collections.emptyList();
 	}
 
 	public List<ConfigurationMetadataProperty> listProperties(Archive archive, boolean exhaustive) {

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistration.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistration.java
@@ -124,7 +124,7 @@ public class AppRegistration implements Comparable<AppRegistration> {
 	}
 
 	public Resource getMetadataResource() {
-		return metadataUri != null ? this.loader.getResource(this.metadataUri.toString()) : getResource();
+		return metadataUri != null ? this.loader.getResource(this.metadataUri.toString()) : null;
 	}
 
 	public Resource getResource() {

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistrationTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistrationTests.java
@@ -43,7 +43,7 @@ public class AppRegistrationTests {
 	@Test
 	public void testMetadata() throws IOException {
 		AppRegistration registration = new AppRegistration("foo", task, URI.create("file:///foobar"),
-				new DefaultResourceLoader());
+				URI.create("file:///foobar"), new DefaultResourceLoader());
 		assertThat(registration.getMetadataResource().getFile()).hasName("foobar");
 
 		registration = new AppRegistration("foo", task, URI.create("file:///foobar"),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreator.java
@@ -196,7 +196,6 @@ public class AppDeploymentRequestCreator {
 			nextAppCount = getInstanceCount(deployerDeploymentProperties);
 			isDownStreamAppPartitioned = isPartitionedConsumer(appDeployTimeProperties, upstreamAppSupportsPartition);
 
-			logger.info(String.format("Downloading resource URI [%s]", appRegistration.getUri()));
 			Resource appResource = appRegistration.getResource();
 			Resource metadataResource = appRegistration.getMetadataResource();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -162,6 +162,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 
 	private static String extractGenericResourceWithoutVersion(Resource resource) {
 		try {
+			// For generic resources we return the complete URI which could contain the version as well
 			return resource.getURI().toString();
 		}
 		catch (IOException ioe) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -162,9 +162,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 
 	private static String extractGenericResourceWithoutVersion(Resource resource) {
 		try {
-			String uri = resource.getURI().toString();
-			return String.format("%s.%s", uri.substring(0, getVersionIndex(uri)),
-					StringUtils.getFilenameExtension(uri));
+			return resource.getURI().toString();
 		}
 		catch (IOException ioe) {
 			throw new RuntimeException(ioe);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
-import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
@@ -42,9 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 public class DefaultStreamServiceUpdateTests {
-
-	@Autowired
-	private AppRegistry appRegistry;
 
 	@Autowired
 	private DefaultStreamService streamService;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -106,19 +106,19 @@ public class SkipperStreamDeployerTests {
 	@Test
 	public void testFileResourceProcessing() throws MalformedURLException{
 		Resource resource = new UrlResource("file:/springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
-		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10.jar");
+		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
 		assertThat(SkipperStreamDeployer.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
 
 		resource = new UrlResource("file:/springcloudstream/file-source-kafka-10-1.2.0.BUILD-SNAPSHOT.jar");
-		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10.jar");
+		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10-1.2.0.BUILD-SNAPSHOT.jar");
 		assertThat(SkipperStreamDeployer.getResourceVersion(resource)).isEqualTo("1.2.0.BUILD-SNAPSHOT");
 
 		resource = new UrlResource("http://springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
-		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka-10.jar");
+		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
 		assertThat(SkipperStreamDeployer.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
 
 		resource = new UrlResource("http://springcloudstream/file-source-kafka-crap.jar");
-		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka.jar");
+		assertThat(SkipperStreamDeployer.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka-crap.jar");
 		assertThat(SkipperStreamDeployer.getResourceVersion(resource)).isEqualTo("crap");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
@@ -1,4 +1,8 @@
 source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT
 processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT
 sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT
 task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
@@ -1,4 +1,8 @@
 source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT
 processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT
 sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
 task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT


### PR DESCRIPTION
 -In SkipperStreamDeployer, return the URI string when setting the spec.resource
which will make sure the the resource location is appropriately set

Resolves #1762

Return null when metadataUri is not set for AppRegistration

 - This avoids downloading the resource when metadataUri is not found
 - It is also expected that the metadata be set only via metadataUri

Resolves #1773

Update Spring Cloud Deployer to 1.3.0.BUILD-SNAPSHOT