### PR TITLE
Diagnose credentials provider command failure

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/CheckableResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/CheckableResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.util;
+
+import org.springframework.core.io.Resource;
+import java.io.IOException;
+
+/**
+ * A CheckableResource is a {@link org.springframework.core.io.Resource} which can be checked for validity.
+ * If the check method throws an exception, any information obtained from the Resource should be discarded.
+ *
+ * @author Glyn Normington
+ */
+public interface CheckableResource extends Resource {
+
+	// Check the resource for validity and throw an exception unless the resource is valid.
+	void check() throws IOException;
+}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
@@ -35,15 +35,16 @@ import org.springframework.util.StreamUtils;
  */
 public class ResourceBasedAuthorizationInterceptor implements HttpRequestInterceptor {
 
-	private final Resource resource;
+	private final CheckableResource resource;
 
-	public ResourceBasedAuthorizationInterceptor(Resource resource) {
+	public ResourceBasedAuthorizationInterceptor(CheckableResource resource) {
 		this.resource = resource;
 	}
 
 	@Override
 	public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
 		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8).trim();
+		resource.check();
 		httpRequest.addHeader(HttpHeaders.AUTHORIZATION, credentials);
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.dataflow.rest.resource.about.FeatureInfo;
 import org.springframework.cloud.dataflow.rest.resource.about.RuntimeEnvironmentDetails;
 import org.springframework.cloud.dataflow.rest.resource.about.SecurityInfo;
 import org.springframework.cloud.dataflow.rest.resource.security.SecurityInfoResource;
+import org.springframework.cloud.dataflow.rest.util.CheckableResource;
 import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.cloud.dataflow.rest.util.ProcessOutputResource;
 import org.springframework.cloud.dataflow.rest.util.ResourceBasedAuthorizationInterceptor;
@@ -53,7 +54,6 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.Resource;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
 import org.springframework.shell.core.CommandMarker;
@@ -197,7 +197,7 @@ public class ConfigCommands implements CommandMarker, InitializingBean, Applicat
 			}
 			if (StringUtils.hasText(credentialsProviderCommand)) {
 				this.targetHolder.getTarget().setTargetCredentials(new TargetCredentials(true));
-				final Resource credentialsResource = new ProcessOutputResource(credentialsProviderCommand.split("\\s+"));
+				final CheckableResource credentialsResource = new ProcessOutputResource(credentialsProviderCommand.split("\\s+"));
 				httpClientConfigurer.addInterceptor(new ResourceBasedAuthorizationInterceptor(credentialsResource));
 			}
 			this.restTemplate.setRequestFactory(httpClientConfigurer.buildClientHttpRequestFactory());


### PR DESCRIPTION
If a command specified using --dataflow.credentials-provider-command fails and
returns a non-zero exit status code, an exception is thrown to simplify problem diagnosis.

Before this was implemented, any output of the failed command was used as an authentication header, resulting in an obscure HTTP 4xx error.

Resolves spring-cloud/spring-cloud-dataflow#1775.