### PR TITLE
Authenticate Skipper GET endpoints

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -86,6 +86,7 @@ spring:
             - DELETE /streams/deployments/*          => hasRole('ROLE_CREATE')
             - DELETE /streams/deployments            => hasRole('ROLE_CREATE')
             - POST   /streams/deployments/**         => hasRole('ROLE_CREATE')
+            - GET    /streams/deployments/**         => hasRole('ROLE_VIEW')
 
             # Task Definitions
 

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
@@ -308,6 +308,12 @@ public class LocalServerSecurityWithSingleUserTests {
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", singleUser, null },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null },
 
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/history/my-stream/2", null, null },
+
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/manifest/my-stream/2", null, null },
+
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/platform/list", null, null },
+
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", singleUser,

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithUsersFileTests.java
@@ -448,6 +448,12 @@ public class LocalServerSecurityWithUsersFileTests {
 				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", createOnlyUser, null },
 				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null },
 
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/history/my-stream/2", null, null },
+
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/manifest/my-stream/2", null, null },
+
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/platform/list", null, null },
+
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,


### PR DESCRIPTION
 - Assign VIEW role for the Skipper GET REST endpoints under `/streams/deployments`
 - Update tests

Resolves #1814