### PR TITLE
gh-1818 Root URL using a browser shall redirect to the main dashboard entry-point

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -30,6 +30,7 @@ spring:
       security:
         authorization:
           enabled: true
+          loginUrl: "/"
           permit-all-paths: "/authenticate,/security/info,/features,/assets/**,/dashboard/logout-success-oauth.html"
           rules:
             # Metrics


### PR DESCRIPTION
- Accessing the ROOT URL `/` of Data Flow shall redirect to the dashboard's entry-point not the dashboard's login module

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1818