### PR TITLE
Map CT parser endpoints with CREATE-only role

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -121,4 +121,4 @@ spring:
             # Tools
 
             - POST   /tools/**                       => hasRole('ROLE_CREATE')
-            - POST   /tools/**                       => hasRole('ROLE_CREATE')
+

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -117,3 +117,8 @@ spring:
             - GET    /tasks/executions/*             => hasRole('ROLE_VIEW')
             - POST   /tasks/executions               => hasRole('ROLE_CREATE')
             - DELETE /tasks/executions/*             => hasRole('ROLE_CREATE')
+
+            # Tools
+
+            - POST   /tools/**                       => hasRole('ROLE_CREATE')
+            - POST   /tools/**                       => hasRole('ROLE_CREATE')

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
@@ -29,7 +29,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.cloud.dataflow.server.local.LocalDataflowResource;
 import org.springframework.cloud.dataflow.server.local.TestUtils;
 import org.springframework.data.authentication.UserCredentials;
@@ -163,6 +162,21 @@ public class LocalServerSecurityWithSingleUserTests {
 						TestUtils.toImmutableMap("detailLevel", "2") },
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null,
 						TestUtils.toImmutableMap("detailLevel", "2") },
+
+				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", singleUser, null },
+				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", singleUser,
+						TestUtils.toImmutableMap("name", "foo", "dsl", "t1 || t2") },
+
+				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", singleUser, null },
+				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", singleUser,
+						TestUtils.toImmutableMap("detailLevel", "2") },
+
+				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tools/parseTaskTextToGraph", singleUser,
+						TestUtils.toImmutableMap("name", "foo", "dsl", "t1 && t2")},
+				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null, null },
+
+				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/tools/convertTaskGraphToText", singleUser, null},
+				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null, null },
 
 				/* FeaturesController */
 
@@ -392,6 +406,7 @@ public class LocalServerSecurityWithSingleUserTests {
 
 				{ HttpMethod.GET, HttpStatus.OK, "/security/info", singleUser, null },
 				{ HttpMethod.GET, HttpStatus.OK, "/security/info", null, null } });
+
 	}
 
 	@Test


### PR DESCRIPTION
To reproduce the problem, start the server with following security configuration.

```
security.basic.enabled=true
security.user.name=test
security.user.password=pass
security.user.role=VIEW,CREATE
```

Once after you login to the dashboard, go to CT's Flo designer and start typing the DSL; you will see 403 errors in the browser console. 

This PR addresses this by adding the role-mapping for CT parser endpoints. No changes to the UI is necessary.

Resolves spring-cloud/spring-cloud-dataflow#1850