### PR TITLE
Retrieve app version without downloading

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AbstractAppRegistryCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AbstractAppRegistryCommon.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
@@ -27,6 +28,7 @@ import org.springframework.util.StringUtils;
  * {@link AppRegistryCommon} implementation common for the Classic and the Skipper modes.
  * 
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 public abstract class AbstractAppRegistryCommon implements AppRegistryCommon {
 
@@ -34,19 +36,22 @@ public abstract class AbstractAppRegistryCommon implements AppRegistryCommon {
 
 	public static final String METADATA_KEY_SUFFIX = "metadata";
 
-	private ResourceLoader resourceLoader;
+	protected ResourceLoader resourceLoader;
+
+	protected MavenProperties mavenProperties;
 
 	public AbstractAppRegistryCommon(ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
 	}
 
-	public ResourceLoader getResourceLoader() {
-		return this.resourceLoader;
+	public AbstractAppRegistryCommon(ResourceLoader resourceLoader, MavenProperties mavenProperties) {
+		this.resourceLoader = resourceLoader;
+		this.mavenProperties = mavenProperties;
 	}
 
 	@Override
 	public Resource getAppResource(AppRegistration appRegistration) {
-		return this.resourceLoader.getResource(appRegistration.getUri().toString());
+		return ResourceUtils.getResource(appRegistration.getUri().toString(), this.mavenProperties);
 	}
 
 	@Override
@@ -121,9 +126,7 @@ public abstract class AbstractAppRegistryCommon implements AppRegistryCommon {
 
 	private String getVersionOrBroken(String uri) {
 		try {
-			Resource appResource = resourceLoader.getResource(uri);
-
-			return ResourceUtils.getResourceVersion(appResource);
+			return ResourceUtils.getResourceVersion(uri, this.mavenProperties);
 		}
 		catch (IllegalStateException ise) {
 			logger.warn("", ise);

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -66,8 +67,6 @@ public class AppRegistry extends AbstractAppRegistryCommon implements AppRegistr
 
 	private final UriRegistry uriRegistry;
 
-	private final ResourceLoader resourceLoader;
-
 	private static final Function<Map.Entry<Object, Object>, AbstractMap.SimpleImmutableEntry<String, URI>> toStringAndUriFUNC = kv -> {
 		try {
 			return new AbstractMap.SimpleImmutableEntry<>((String) kv.getKey(), new URI((String) kv.getValue()));
@@ -80,9 +79,14 @@ public class AppRegistry extends AbstractAppRegistryCommon implements AppRegistr
 	public AppRegistry(UriRegistry uriRegistry, ResourceLoader resourceLoader) {
 		super(resourceLoader);
 		Assert.notNull(uriRegistry, "'uriRegistry' must not be null");
+		this.uriRegistry = uriRegistry;
+	}
+
+	public AppRegistry(UriRegistry uriRegistry, ResourceLoader resourceLoader, MavenProperties mavenProperties) {
+		super(resourceLoader, mavenProperties);
+		Assert.notNull(uriRegistry, "'uriRegistry' must not be null");
 		Assert.notNull(resourceLoader, "'resourceLoader' must not be null");
 		this.uriRegistry = uriRegistry;
-		this.resourceLoader = resourceLoader;
 	}
 
 	public AppRegistration find(String name, ApplicationType type) {

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
-import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -36,8 +35,6 @@ public interface AppRegistryService extends AppRegistryCommon {
 	AppRegistration save(String name, ApplicationType type, String version, URI uri, URI metadataUri);
 
 	void delete(String name, ApplicationType type, String version);
-
-	Resource getResource(String uri);
 
 	boolean appExist(String name, ApplicationType type, String version);
 

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.dataflow.registry.AbstractAppRegistryCommon;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
@@ -64,16 +65,11 @@ public class DefaultAppRegistryService extends AbstractAppRegistryCommon impleme
 	private final AppRegistrationRepository appRegistrationRepository;
 
 	public DefaultAppRegistryService(AppRegistrationRepository appRegistrationRepository,
-			ResourceLoader resourceLoader) {
-		super(resourceLoader);
+			ResourceLoader resourceLoader, MavenProperties mavenProperties) {
+		super(resourceLoader, mavenProperties);
 		Assert.notNull(appRegistrationRepository, "'appRegistrationRepository' must not be null");
 		Assert.notNull(resourceLoader, "'resourceLoader' must not be null");
 		this.appRegistrationRepository = appRegistrationRepository;
-	}
-
-	@Override
-	public Resource getResource(String uri) {
-		return (uri == null) ? null : this.getResourceLoader().getResource(uri);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
@@ -15,13 +15,17 @@
  */
 package org.springframework.cloud.dataflow.registry.support;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import java.net.MalformedURLException;
 
 import org.junit.Test;
+
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
+import org.springframework.cloud.deployer.resource.maven.MavenResource;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Mark Pollack
@@ -115,6 +119,19 @@ public class ResourceUtilsTests {
 		assertThat(version).isEqualTo("1.2.0-SNAPSHOT");
 		theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
+	}
 
+	@Test
+	public void testGetResource() {
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
+		Resource resource = ResourceUtils.getResource(mavenUri, new MavenProperties());
+		assertThat(resource).isInstanceOf(MavenResource.class);
+	}
+
+	@Test
+	public void testGetResourceVersion() {
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
+		String version = ResourceUtils.getResourceVersion(ResourceUtils.getResource(mavenUri, new MavenProperties()));
+		assertThat(version).isEqualTo("1.3.0.RELEASE");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -147,8 +147,9 @@ public class DataFlowControllerAutoConfiguration {
 	@Bean
 	@ConditionalOnExpression("#{'${" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED
 			+ ":false}'.equalsIgnoreCase('false')}")
-	public AppRegistry appRegistry(UriRegistry uriRegistry, DelegatingResourceLoader resourceLoader) {
-		return new AppRegistry(uriRegistry, resourceLoader);
+	public AppRegistry appRegistry(UriRegistry uriRegistry, DelegatingResourceLoader resourceLoader,
+			MavenProperties mavenProperties) {
+		return new AppRegistry(uriRegistry, resourceLoader, mavenProperties);
 	}
 
 	@Bean
@@ -156,7 +157,7 @@ public class DataFlowControllerAutoConfiguration {
 			+ ":false}'.equalsIgnoreCase('true')}")
 	public AppRegistryService appRegistryService(AppRegistrationRepository appRegistrationRepository,
 			DelegatingResourceLoader resourceLoader) {
-		return new DefaultAppRegistryService(appRegistrationRepository, resourceLoader);
+		return new DefaultAppRegistryService(appRegistrationRepository, resourceLoader, mavenProperties());
 	}
 
 	@Bean
@@ -164,7 +165,7 @@ public class DataFlowControllerAutoConfiguration {
 			+ ":false}'.equalsIgnoreCase('true')}")
 	public VersionedAppRegistryController appRegistryController2(AppRegistryService appRegistry,
 			ApplicationConfigurationMetadataResolver metadataResolver) {
-		return new VersionedAppRegistryController(appRegistry, metadataResolver, appRegistryFJPFB().getObject());
+		return new VersionedAppRegistryController(appRegistry, metadataResolver, appRegistryFJPFB().getObject(), mavenProperties());
 	}
 
 	@Bean


### PR DESCRIPTION
 - Instead of invoking `getResource` via the underlying LRUCleaningResourceLoader, construct the resource based on the schemes used in the URI
  - For maven resource, parse the co-ordinates and construct MavenResource with the appropriate MavenProperties (configured in the server)
   - Make sure to inject the maven properties

 - Remove `getResource` from AppRegistryService as we no longer need to download the resource at the registry
 - Use DefaultResourceLoader in AppRegistry for the use case where the `--uri` option is used to download the http resource when `registerAll`
 - The delegating resource loader is now used only when downloading the metadata resource at the AppRegistry

 - Add tests for resource version retrieval

Resolves #1843