### PR TITLE
Split the Skipper and Non-Skipper configurations and functionality

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/ConditionalOnSkipperDisabled.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/ConditionalOnSkipperDisabled.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.dataflow.server.config.features.FeaturesPropert
 /**
  * @author Christian Tzolov
  */
-@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @ConditionalOnExpression("#{'${" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED
 		+ ":false}'.equalsIgnoreCase('false')}")

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/ConditionalOnSkipperEnabled.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/ConditionalOnSkipperEnabled.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.dataflow.server.config.features.FeaturesPropert
 /**
  * @author Christian Tzolov
  */
-@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @ConditionalOnExpression("#{'${" + FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED
 		+ ":false}'.equalsIgnoreCase('true')}")

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -32,7 +32,7 @@ import org.springframework.cloud.dataflow.rest.resource.about.SecurityInfo;
 import org.springframework.cloud.dataflow.rest.resource.about.VersionInfo;
 import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
-import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.dataflow.server.stream.StreamDeployer;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -67,6 +67,8 @@ public class AboutController {
 
 	private static final Logger logger = LoggerFactory.getLogger(AboutController.class);
 
+	private final StreamDeployer streamDeployer;
+
 	private final FeaturesProperties featuresProperties;
 
 	private final VersionInfoProperties versionInfoProperties;
@@ -82,13 +84,11 @@ public class AboutController {
 	@Value("${info.app.version:#{null}}")
 	private String implementationVersion;
 
-	private AppDeployer appDeployer;
-
 	private TaskLauncher taskLauncher;
 
-	public AboutController(AppDeployer appDeployer, TaskLauncher taskLauncher, FeaturesProperties featuresProperties,
+	public AboutController(StreamDeployer streamDeployer, TaskLauncher taskLauncher, FeaturesProperties featuresProperties,
 			VersionInfoProperties versionInfoProperties, SecurityStateBean securityStateBean) {
-		this.appDeployer = appDeployer;
+		this.streamDeployer = streamDeployer;
 		this.taskLauncher = taskLauncher;
 		this.featuresProperties = featuresProperties;
 		this.versionInfoProperties = versionInfoProperties;
@@ -148,8 +148,8 @@ public class AboutController {
 
 		final RuntimeEnvironment runtimeEnvironment = new RuntimeEnvironment();
 
-		if (this.appDeployer != null) {
-			final RuntimeEnvironmentInfo deployerEnvironmentInfo = this.appDeployer.environmentInfo();
+		if (this.streamDeployer != null) {
+			final RuntimeEnvironmentInfo deployerEnvironmentInfo = this.streamDeployer.environmentInfo();
 			final RuntimeEnvironmentDetails deployerInfo = new RuntimeEnvironmentDetails();
 
 			deployerInfo.setDeployerImplementationVersion(deployerEnvironmentInfo.getImplementationVersion());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -29,7 +29,6 @@ import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefiniti
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
-import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -61,8 +60,6 @@ public class StreamDeploymentController {
 
 	private final StreamService streamService;
 
-	private final SkipperClient skipperClient;
-
 	/**
 	 * The repository this controller will use for stream CRUD operations.
 	 */
@@ -78,16 +75,12 @@ public class StreamDeploymentController {
 	 *
 	 * @param repository the repository this controller will use for stream CRUD operations
 	 * @param streamService the underlying StreamService to deploy the stream
-	 * @param skipperClient the Skipper client to use for Skipper related services
 	 */
-	public StreamDeploymentController(StreamDefinitionRepository repository, StreamService streamService,
-			SkipperClient skipperClient) {
+	public StreamDeploymentController(StreamDefinitionRepository repository, StreamService streamService) {
 		Assert.notNull(repository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(streamService, "StreamService must not be null");
-		Assert.notNull(skipperClient, "SkipperClient must not be null");
 		this.repository = repository;
 		this.streamService = streamService;
-		this.skipperClient = skipperClient;
 	}
 
 	/**
@@ -144,29 +137,19 @@ public class StreamDeploymentController {
 	@RequestMapping(value = "/manifest/{name}/{version}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public String manifest(@PathVariable("name") String name, @PathVariable("version") int version) {
-		if (version > 0) {
-			return this.skipperClient.manifest(name, version);
-		}
-		else {
-			return this.skipperClient.manifest(name);
-		}
+		return this.streamService.manifest(name, version);
 	}
 
 	@RequestMapping(path = "/history/{name}/{max}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public Collection<Release> history(@PathVariable("name") String releaseName,
 			@PathVariable("max") int maxRevisions) {
-		if (maxRevisions > 0) {
-			return this.skipperClient.history(releaseName, String.valueOf(maxRevisions));
-		}
-		else {
-			return this.skipperClient.history(releaseName).getContent();
-		}
+		return this.streamService.history(releaseName, maxRevisions);
 	}
 
 	@RequestMapping(path = "/platform/list", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public Collection<Deployer> platformList() {
-		return this.skipperClient.listDeployers().getContent();
+		return this.streamService.platformList();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -15,18 +15,24 @@
  */
 package org.springframework.cloud.dataflow.server.service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
+import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
+import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.skipper.domain.Release;
 
 /**
  * Specify the supported operations on the stream.
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
  */
 public interface StreamService {
 	/**
@@ -36,6 +42,14 @@ public interface StreamService {
 	 * @param deploymentProperties deployment properties to use as passed in from the client.
 	 */
 	void deployStream(String name, Map<String, String> deploymentProperties);
+
+
+	/**
+	 * Un-deploys the stream identified by the given stream name.
+	 *
+	 * @param name the name of the stream to un-deploy
+	 */
+	void undeployStream(String name);
 
 	/**
 	 * Retrieve the deployment state for the given stream definitions.
@@ -51,7 +65,9 @@ public interface StreamService {
 	 * @param streamName the name of the stream to update
 	 * @param updateStreamRequest the UpdateStreamRequest to use during the update
 	 */
-	void updateStream(String streamName, UpdateStreamRequest updateStreamRequest);
+	default void updateStream(String streamName, UpdateStreamRequest updateStreamRequest) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
 
 	/**
 	 * Rollback the stream to the previous or a specific version of the stream.
@@ -60,14 +76,36 @@ public interface StreamService {
 	 * @param releaseVersion the version to rollback to (if not specified, rollback to the previous deleted/deployed
 	 * release version of the stream.
 	 */
-	void rollbackStream(String streamName, int releaseVersion);
-
+	default void rollbackStream(String streamName, int releaseVersion) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
 
 	/**
-	 * Un-deploys the stream identified by the given stream name.
+	 * Return a manifest info of a release version. For packages with dependencies, the
+	 * manifest includes the contents of those dependencies.
 	 *
-	 * @param name the name of the stream to un-deploy
+	 * @param releaseName the release name
+	 * @param releaseVersion the release version
+	 * @return the manifest info of a release
 	 */
-	void undeployStream(String name);
+	default String manifest(String releaseName, int releaseVersion) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
 
+	/**
+	 * Get stream's deployment history
+	 * @param releaseName Stream release name
+	 * @param maxRevisions If positive, the max release revision to filter by. Negative value will return all releases.
+	 * @return List or Releases for this release name
+	 */
+	default Collection<Release> history(String releaseName, int maxRevisions) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
+
+	/**
+	 * @return list of supported deployment platforms
+	 */
+	default Collection<Deployer> platformList() {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -21,8 +21,6 @@ import java.util.Map;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
-import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
-import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Release;
@@ -65,9 +63,7 @@ public interface StreamService {
 	 * @param streamName the name of the stream to update
 	 * @param updateStreamRequest the UpdateStreamRequest to use during the update
 	 */
-	default void updateStream(String streamName, UpdateStreamRequest updateStreamRequest) {
-		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
-	}
+	void updateStream(String streamName, UpdateStreamRequest updateStreamRequest);
 
 	/**
 	 * Rollback the stream to the previous or a specific version of the stream.
@@ -76,9 +72,7 @@ public interface StreamService {
 	 * @param releaseVersion the version to rollback to (if not specified, rollback to the previous deleted/deployed
 	 * release version of the stream.
 	 */
-	default void rollbackStream(String streamName, int releaseVersion) {
-		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
-	}
+	void rollbackStream(String streamName, int releaseVersion);
 
 	/**
 	 * Return a manifest info of a release version. For packages with dependencies, the
@@ -88,9 +82,7 @@ public interface StreamService {
 	 * @param releaseVersion the release version
 	 * @return the manifest info of a release
 	 */
-	default String manifest(String releaseName, int releaseVersion) {
-		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
-	}
+	String manifest(String releaseName, int releaseVersion);
 
 	/**
 	 * Get stream's deployment history
@@ -98,14 +90,10 @@ public interface StreamService {
 	 * @param maxRevisions If positive, the max release revision to filter by. Negative value will return all releases.
 	 * @return List or Releases for this release name
 	 */
-	default Collection<Release> history(String releaseName, int maxRevisions) {
-		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
-	}
+	Collection<Release> history(String releaseName, int maxRevisions);
 
 	/**
 	 * @return list of supported deployment platforms
 	 */
-	default Collection<Deployer> platformList() {
-		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
-	}
+	Collection<Deployer> platformList();
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
@@ -25,21 +25,17 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
-import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployedException;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployingException;
 import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
-import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDeploymentException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Performs manipulation on application and deployment properties, expanding shorthand
@@ -102,42 +98,6 @@ public abstract class AbstractStreamService implements StreamService {
 
 	protected abstract void doUndeployStream(String streamName);
 
-	@Override
-	public void updateStream(String streamName, UpdateStreamRequest updateStreamRequest) {
-		updateStream(streamName, updateStreamRequest.getReleaseName(),
-				updateStreamRequest.getPackageIdentifier(), updateStreamRequest.getUpdateProperties());
-	}
-
-	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdenfier,
-			Map<String, String> updateProperties) {
-		StreamDeployment streamDeployment = this.streamDeploymentRepository.findOne(streamName);
-		if (streamDeployment == null) {
-			throw new NoSuchStreamDeploymentException(streamName);
-		}
-		if (this.streamDeployer != StreamDeployers.valueOf(streamDeployment.getDeployerName())) {
-			throw new IncompatibleStreamDeployerException(streamDeployer.name());
-		}
-
-		doUpdateStream(streamName, releaseName, packageIdenfier, updateProperties);
-	}
-
-	protected abstract void doUpdateStream(String streamName, String releaseName, PackageIdentifier packageIdenfier,
-			Map<String, String> updateProperties);
-
-	@Override
-	public void rollbackStream(String streamName, int releaseVersion) {
-		Assert.isTrue(StringUtils.hasText(streamName), "Stream name must not be null");
-		StreamDeployment streamDeployment = this.streamDeploymentRepository.findOne(streamName);
-		if (streamDeployment == null) {
-			throw new NoSuchStreamDeploymentException(streamName);
-		}
-		if (this.streamDeployer != StreamDeployers.valueOf(streamDeployment.getDeployerName())) {
-			throw new IncompatibleStreamDeployerException(streamDeployer.name());
-		}
-		doRollbackStream(streamName, releaseVersion);
-	}
-
-	protected abstract void doRollbackStream(String streamName, int releaseVersion);
 
 	protected StreamDefinition createStreamDefinitionForDeploy(String name) {
 		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(name);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.service.impl;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeployer;
@@ -32,6 +35,8 @@ import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.util.Assert;
 
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_KEY_PREFIX;
@@ -96,5 +101,30 @@ public class AppDeployerStreamService extends AbstractStreamService {
 	@Override
 	public Map<StreamDefinition, DeploymentState> doState(List<StreamDefinition> streamDefinitions) {
 		return this.appDeployerStreamDeployer.state(streamDefinitions);
+	}
+
+	@Override
+	public void updateStream(String streamName, UpdateStreamRequest updateStreamRequest) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
+
+	@Override
+	public void rollbackStream(String streamName, int releaseVersion) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
+
+	@Override
+	public String manifest(String releaseName, int releaseVersion) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
+
+	@Override
+	public Collection<Release> history(String releaseName, int maxRevisions) {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
+	}
+
+	@Override
+	public Collection<Deployer> platformList() {
+		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
@@ -32,7 +32,6 @@ import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.util.Assert;
 
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_KEY_PREFIX;
@@ -91,17 +90,6 @@ public class AppDeployerStreamService extends AbstractStreamService {
 	@Override
 	public void doUndeployStream(String streamName) {
 		this.appDeployerStreamDeployer.undeployStream(streamName);
-	}
-
-	@Override
-	public void doUpdateStream(String streamName, String releaseName, PackageIdentifier packageIdenfier,
-			Map<String, String> updateProperties) {
-		throw new IllegalStateException("Can only update stream when using the Skipper stream deployer.");
-	}
-
-	@Override
-	public void doRollbackStream(String streamName, int releaseVersion) {
-		throw new IllegalStateException("Can only rollback stream when using the Skipper stream deployer.");
 	}
 
 	// State

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
@@ -15,9 +15,20 @@
  */
 package org.springframework.cloud.dataflow.server.stream;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,13 +46,18 @@ import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.app.MultiStateAppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.data.domain.Pageable;
 import org.springframework.util.Assert;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Uses an AppDeployer instance to deploy the stream.
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
  */
 public class AppDeployerStreamDeployer implements StreamDeployer {
 
@@ -70,17 +86,24 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 	 */
 	private final StreamDeploymentRepository streamDeploymentRepository;
 
+	/**
+	 *
+	 */
+	private final ForkJoinPool forkJoinPool;
+
 	public AppDeployerStreamDeployer(AppDeployer appDeployer, DeploymentIdRepository deploymentIdRepository,
 			StreamDefinitionRepository streamDefinitionRepository,
-			StreamDeploymentRepository streamDeploymentRepository) {
+			StreamDeploymentRepository streamDeploymentRepository, ForkJoinPool forkJoinPool) {
 		Assert.notNull(appDeployer, "AppDeployer must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(streamDefinitionRepository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(streamDeploymentRepository, "StreamDeploymentRepository must not be null");
+		Assert.notNull(forkJoinPool, "ForkJoinPool must not be null");
 		this.appDeployer = appDeployer;
 		this.deploymentIdRepository = deploymentIdRepository;
 		this.streamDefinitionRepository = streamDefinitionRepository;
 		this.streamDeploymentRepository = streamDeploymentRepository;
+		this.forkJoinPool = forkJoinPool;
 	}
 
 	public void deployStream(StreamDeploymentRequest streamDeploymentRequest) {
@@ -175,5 +198,51 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 			return Arrays.stream(ids)
 					.collect(Collectors.toMap(Function.identity(), id -> appDeployer.status(id).getState()));
 		}
+	}
+
+	@Override
+	public List<AppStatus> getAppStatuses(Pageable pageable) throws ExecutionException, InterruptedException {
+
+		Iterable<StreamDefinition> streamDefinitions = this.streamDefinitionRepository.findAll();
+		Iterable<StreamDeployment> streamDeployments = this.streamDeploymentRepository.findAll();
+
+		List<String> appDeployerStreams = new ArrayList<>();
+		for (StreamDeployment streamDeployment : streamDeployments) {
+			appDeployerStreams.add(streamDeployment.getStreamName());
+
+		}
+
+		List<StreamDefinition> appDeployerStreamDefinitions = new ArrayList<>();
+		for (StreamDefinition streamDefinition : streamDefinitions) {
+			if (appDeployerStreams.contains(streamDefinition.getName())) {
+				appDeployerStreamDefinitions.add(streamDefinition);
+			}
+		}
+
+		// First build a sorted list of deployment id's so that we have a predictable paging order.
+		List<String> deploymentIds = appDeployerStreamDefinitions.stream()
+				.flatMap(sd -> sd.getAppDefinitions().stream()).flatMap(sad -> {
+					String key = DeploymentKey.forStreamAppDefinition(sad);
+					String id = this.deploymentIdRepository.findOne(key);
+					return id != null ? Stream.of(id) : Stream.empty();
+				}).sorted(String::compareTo).collect(toList());
+
+		// Running this this inside the FJP will make sure it is used by the parallel stream
+		// Skip first items depending on page size, then take page and discard rest.
+		// todo: Use correct pageable values based on the number of apps deployed via all supported StreamDeployers
+		return this.forkJoinPool.submit(() -> deploymentIds.stream()
+				.skip(pageable.getPageNumber() * pageable.getPageSize())
+				.limit(pageable.getPageSize()).parallel().map(appDeployer::status).collect(toList()))
+				.get();
+	}
+
+	@Override
+	public AppStatus getAppStatus(String id) {
+		return appDeployer.status(id);
+	}
+
+	@Override
+	public RuntimeEnvironmentInfo environmentInfo() {
+		return appDeployer.environmentInfo();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -45,12 +45,14 @@ import org.springframework.cloud.dataflow.core.StreamDeployment;
 import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
 import org.springframework.cloud.dataflow.server.controller.NoSuchAppException;
 import org.springframework.cloud.dataflow.server.controller.StreamDefinitionController;
+import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Deployer;
@@ -345,6 +347,12 @@ public class SkipperStreamDeployer implements StreamDeployer {
 			}
 		}
 		throw new NoSuchAppException(id);
+	}
+
+	@Override
+	public RuntimeEnvironmentInfo environmentInfo() {
+		// TODO To fix when https://github.com/spring-cloud/spring-cloud-skipper/issues/392
+		throw new IncompatibleStreamDeployerException("AppDeployer");
 	}
 
 	private List<List<AppStatus>> getSkipperStatuses(Pageable pageable, List<String> skipperStreamNames)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -17,9 +17,14 @@ package org.springframework.cloud.dataflow.server.stream;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.data.domain.Pageable;
 
 /**
  * SPI for handling deployment related operations on the apps in a stream.
@@ -40,4 +45,11 @@ public interface StreamDeployer {
 	 */
 	void undeployStream(String name);
 
+	List<AppStatus> getAppStatuses(Pageable pageable) throws ExecutionException, InterruptedException;
+
+	AppStatus getAppStatus(String id);
+
+	default RuntimeEnvironmentInfo environmentInfo() {
+		throw new IncompatibleStreamDeployerException("AppDeployer");
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
-import org.springframework.cloud.dataflow.server.repository.IncompatibleStreamDeployerException;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
@@ -49,7 +48,5 @@ public interface StreamDeployer {
 
 	AppStatus getAppStatus(String id);
 
-	default RuntimeEnvironmentInfo environmentInfo() {
-		throw new IncompatibleStreamDeployerException("AppDeployer");
-	}
+	RuntimeEnvironmentInfo environmentInfo();
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerSkipperTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerSkipperTests.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.StreamDeployment;
+import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
+import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
+import org.springframework.cloud.skipper.client.SkipperClient;
+import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class, properties = { "spring.cloud.dataflow.features.skipper-enabled=true",
+		"spring.datasource.url=jdbc:h2:tcp://localhost:19092/mem:dataflow" })
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class RuntimeAppsControllerSkipperTests {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@Autowired
+	private AppRegistrationRepository appRegistrationRepository;
+
+	@Autowired
+	private StreamDeploymentRepository streamDeploymentRepository;
+
+	@Autowired
+	private StreamDefinitionRepository streamDefinitionRepository;
+
+	@Autowired
+	private SkipperClient skipperClient;
+
+	@Before
+	public void setupMocks() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		for (AppRegistration appRegistration : this.appRegistrationRepository.findAll()) {
+			this.appRegistrationRepository.deleteAll();
+		}
+
+		StreamDefinition streamDefinition3 = new StreamDefinition("ticktock3", "time|log");
+		StreamDefinition streamDefinition4 = new StreamDefinition("ticktock4", "time|log");
+		streamDefinitionRepository.save(streamDefinition3);
+		streamDefinitionRepository.save(streamDefinition4);
+
+		StreamDeployment streamDeployment3 = new StreamDeployment(streamDefinition3.getName(), StreamDeployers
+				.skipper.name());
+		StreamDeployment streamDeployment4 = new StreamDeployment(streamDefinition4.getName(), StreamDeployers
+				.skipper.name());
+		this.streamDeploymentRepository.save(streamDeployment3);
+		this.streamDeploymentRepository.save(streamDeployment4);
+
+		Info ticktock3Info = new Info();
+		Status ticktock3Status = new Status();
+		ticktock3Status.setStatusCode(StatusCode.DEPLOYED);
+		ticktock3Status.setPlatformStatus("[{\"deploymentId\":\"ticktock3.log-v1\","
+				+ "\"instances\":{\"ticktock3.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock3.log-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"},"
+				+ "{\"deploymentId\":\"ticktock3.time-v1\",\"instances\":{\"ticktock3.time-v1-0\":{\"instanceNumber\":0,\"baseUrl\":\"http://192.168.1.100:32451\","
+				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
+				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
+				+ "\"id\":\"ticktock3.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
+		ticktock3Info.setStatus(ticktock3Status);
+		Info ticktock4Info = new Info();
+		Status ticktock4Status = new Status();
+		ticktock4Status.setStatusCode(StatusCode.DEPLOYED);
+		ticktock4Status.setPlatformStatus("[{\"deploymentId\":\"ticktock4.log-v1\","
+				+ "\"instances\":{\"ticktock4.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock4.log-v1-0\","
+				+ "\"state\":\"deployed\"}},\"state\":\"deployed\"},"
+				+ "{\"deploymentId\":\"ticktock4.time-v1\",\"instances\":{\"ticktock4.time-v1-0\":{\"instanceNumber\":0,"
+				+ "\"baseUrl\":\"http://192.168.1.100:32451\","
+				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
+				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
+				+ "\"id\":\"ticktock4.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
+		ticktock4Info.setStatus(ticktock4Status);
+		when(this.skipperClient.status("ticktock3")).thenReturn(ticktock3Info);
+		when(this.skipperClient.status("ticktock4")).thenReturn(ticktock4Info);
+	}
+
+	@Test
+	public void testFindNonExistentApp() throws Exception {
+		MockHttpServletResponse responseString = mockMvc
+				.perform(get("/runtime/apps/foo").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+		Assert.assertTrue(responseString.getContentAsString().contains("NoSuchAppException"));
+	}
+
+	// TODO
+	@Test
+	@Ignore
+	public void testFindNonExistentAppInstance() throws Exception {
+		MockHttpServletResponse responseString = mockMvc
+				.perform(get("/runtime/apps/valid/instances/valid-0").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+		Assert.assertTrue(responseString.getContentAsString().contains("NoSuchAppInstanceException"));
+	}
+
+	@Test
+	public void testListRuntimeApps() throws Exception {
+		MockHttpServletResponse responseString = mockMvc
+				.perform(get("/runtime/apps").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse();
+		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(true));
+	}
+
+	@Test
+	public void testListRuntimeAppsPageSizes() throws Exception {
+		MockHttpServletResponse responseString = mockMvc
+				.perform(get("/runtime/apps?page=0&size=1").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk()).andReturn().getResponse();
+		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(false));
+		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(false));
+
+		responseString = mockMvc.perform(get("/runtime/apps?page=0&size=2").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isOk()).andReturn().getResponse();
+		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(true));
+		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(true));
+
+		responseString = mockMvc.perform(get("/runtime/apps?page=1&size=2").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isOk()).andReturn().getResponse();
+		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(false));
+		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(false));
+		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(false));
+		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(false));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
-import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
@@ -35,10 +35,6 @@ import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.skipper.client.SkipperClient;
-import org.springframework.cloud.skipper.domain.Info;
-import org.springframework.cloud.skipper.domain.Status;
-import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
@@ -83,11 +79,8 @@ public class RuntimeAppsControllerTests {
 	@Autowired
 	private DeploymentIdRepository deploymentIdRepository;
 
-	@Autowired
-	private SkipperClient skipperClient;
-
 	@Before
-	public void setupMocks() throws Exception {
+	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
 		for (AppRegistration appRegistration : this.appRegistry.findAll()) {
@@ -96,25 +89,15 @@ public class RuntimeAppsControllerTests {
 
 		StreamDefinition streamDefinition1 = new StreamDefinition("ticktock1", "time|log");
 		StreamDefinition streamDefinition2 = new StreamDefinition("ticktock2", "time|log");
-		StreamDefinition streamDefinition3 = new StreamDefinition("ticktock3", "time|log");
-		StreamDefinition streamDefinition4 = new StreamDefinition("ticktock4", "time|log");
 		streamDefinitionRepository.save(streamDefinition1);
 		streamDefinitionRepository.save(streamDefinition2);
-		streamDefinitionRepository.save(streamDefinition3);
-		streamDefinitionRepository.save(streamDefinition4);
 
 		StreamDeployment streamDeployment1 = new StreamDeployment(streamDefinition1.getName(), StreamDeployers
 				.appdeployer.name());
 		StreamDeployment streamDeployment2 = new StreamDeployment(streamDefinition2.getName(), StreamDeployers
 				.appdeployer.name());
-		StreamDeployment streamDeployment3 = new StreamDeployment(streamDefinition3.getName(), StreamDeployers
-				.skipper.name());
-		StreamDeployment streamDeployment4 = new StreamDeployment(streamDefinition4.getName(), StreamDeployers
-				.skipper.name());
 		this.streamDeploymentRepository.save(streamDeployment1);
 		this.streamDeploymentRepository.save(streamDeployment2);
-		this.streamDeploymentRepository.save(streamDeployment3);
-		this.streamDeploymentRepository.save(streamDeployment4);
 
 		deploymentIdRepository.save("ticktock1.time", "ticktock1.time");
 		deploymentIdRepository.save("ticktock1.log", "ticktock1.log");
@@ -129,30 +112,6 @@ public class RuntimeAppsControllerTests {
 				.thenReturn(AppStatus.of("ticktock2.time").generalState(DeploymentState.deployed).build());
 		when(appDeployer.status("ticktock2.log"))
 				.thenReturn(AppStatus.of("ticktock2.log").generalState(DeploymentState.deployed).build());
-		Info ticktock3Info = new Info();
-		Status ticktock3Status = new Status();
-		ticktock3Status.setStatusCode(StatusCode.DEPLOYED);
-		ticktock3Status.setPlatformStatus("[{\"deploymentId\":\"ticktock3.log-v1\","
-				+ "\"instances\":{\"ticktock3.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock3.log-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"},"
-				+ "{\"deploymentId\":\"ticktock3.time-v1\",\"instances\":{\"ticktock3.time-v1-0\":{\"instanceNumber\":0,\"baseUrl\":\"http://192.168.1.100:32451\","
-				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
-				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
-				+ "\"id\":\"ticktock3.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
-		ticktock3Info.setStatus(ticktock3Status);
-		Info ticktock4Info = new Info();
-		Status ticktock4Status = new Status();
-		ticktock4Status.setStatusCode(StatusCode.DEPLOYED);
-		ticktock4Status.setPlatformStatus("[{\"deploymentId\":\"ticktock4.log-v1\","
-				+ "\"instances\":{\"ticktock4.log-v1-0\":{\"instanceNumber\":0,\"id\":\"ticktock4.log-v1-0\","
-				+ "\"state\":\"deployed\"}},\"state\":\"deployed\"},"
-				+ "{\"deploymentId\":\"ticktock4.time-v1\",\"instances\":{\"ticktock4.time-v1-0\":{\"instanceNumber\":0,"
-				+ "\"baseUrl\":\"http://192.168.1.100:32451\","
-				+ "\"process\":{\"alive\":true,\"inputStream\":{},\"outputStream\":{},\"errorStream\":{}},"
-				+ "\"attributes\":{\"guid\":\"32451\",\"pid\":\"53492\",\"port\":\"32451\"},"
-				+ "\"id\":\"ticktock4.time-v1-0\",\"state\":\"deployed\"}},\"state\":\"deployed\"}]");
-		ticktock4Info.setStatus(ticktock4Status);
-		when(this.skipperClient.status("ticktock3")).thenReturn(ticktock3Info);
-		when(this.skipperClient.status("ticktock4")).thenReturn(ticktock4Info);
 
 		when(appDeployer.status("foo")).thenReturn(AppStatus.of("foo").generalState(DeploymentState.unknown).build());
 		AppStatus validAppStatus = AppStatus.of("a1.valid").generalState(DeploymentState.failed).build();
@@ -184,10 +143,6 @@ public class RuntimeAppsControllerTests {
 		assertThat(responseString.getContentAsString().contains("ticktock1.log"), is(true));
 		assertThat(responseString.getContentAsString().contains("ticktock2.time"), is(true));
 		assertThat(responseString.getContentAsString().contains("ticktock2.log"), is(true));
-		assertThat(responseString.getContentAsString().contains("ticktock3.time"), is(true));
-		assertThat(responseString.getContentAsString().contains("ticktock3.log"), is(true));
-		assertThat(responseString.getContentAsString().contains("ticktock4.time"), is(true));
-		assertThat(responseString.getContentAsString().contains("ticktock4.log"), is(true));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -52,7 +52,6 @@ import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -126,9 +125,6 @@ public class StreamControllerTests {
 	@Autowired
 	private StreamService defaultStreamService;
 
-	@Autowired
-	private SkipperClient skipperClient;
-
 	@Before
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
@@ -145,7 +141,7 @@ public class StreamControllerTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructorMissingRepository() {
 		StreamDeploymentController deploymentController = new StreamDeploymentController(
-				new InMemoryStreamDefinitionRepository(), defaultStreamService, skipperClient);
+				new InMemoryStreamDefinitionRepository(), defaultStreamService);
 		new StreamDefinitionController(null, appRegistry, defaultStreamService);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,8 +32,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.StreamService;
-import org.springframework.cloud.skipper.client.SkipperClient;
-import org.springframework.hateoas.Resources;
+import org.springframework.cloud.skipper.domain.Deployer;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,11 +60,11 @@ public class StreamDeploymentControllerTests {
 	private StreamService defaultStreamService;
 
 	@Mock
-	private SkipperClient skipperClient;
+	private Deployer deployer;
 
 	@Before
 	public void setup() {
-		this.controller = new StreamDeploymentController(streamDefinitionRepository, defaultStreamService, skipperClient);
+		this.controller = new StreamDeploymentController(streamDefinitionRepository, defaultStreamService);
 	}
 
 	@Test
@@ -94,9 +93,9 @@ public class StreamDeploymentControllerTests {
 
 	@Test
 	public void tesPlatformsListViaSkipperClient() {
-		when(skipperClient.listDeployers()).thenReturn(new Resources<>(new ArrayList<>(), new ArrayList<>()));
+		when(defaultStreamService.platformList()).thenReturn(Arrays.asList(deployer));
 		this.controller.platformList();
-		verify(skipperClient, times(1)).listDeployers();
+		verify(defaultStreamService, times(1)).platformList();
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceUpgradeStreamTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceUpgradeStreamTests.java
@@ -23,18 +23,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
+import org.springframework.cloud.dataflow.server.ConditionalOnSkipperEnabled;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
-import org.springframework.cloud.dataflow.server.stream.AppDeployerStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.StreamDeployers;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -55,13 +53,11 @@ public class SkipperStreamServiceUpgradeStreamTests {
 	private SkipperStreamService streamService;
 
 	@MockBean
+	@ConditionalOnSkipperEnabled
 	private SkipperStreamDeployer skipperStreamDeployer;
 
 	@MockBean
 	private StreamDeploymentRepository streamDeploymentRepository;
-
-	@MockBean
-	private AppDeployerStreamDeployer appDeployerStreamDeployer;
 
 	private StreamDefinition streamDefinition2 = new StreamDefinition("test2", "time | log");
 
@@ -79,7 +75,6 @@ public class SkipperStreamServiceUpgradeStreamTests {
 				.upgradeStream(this.streamDeployment2.getReleaseName(),
 						null, "");
 		verifyNoMoreInteractions(this.skipperStreamDeployer);
-		verify(this.appDeployerStreamDeployer, never()).deployStream(any());
 	}
 
 }

--- a/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
+++ b/spring-cloud-starter-dataflow-server-local/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithSingleUserTests.java
@@ -60,7 +60,7 @@ public class LocalServerSecurityWithSingleUserTests {
 	private final static Logger logger = LoggerFactory.getLogger(LocalServerSecurityWithSingleUserTests.class);
 
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(
-			"classpath:org/springframework/cloud/dataflow/server/local/security" + "/singleUser.yml");
+			"classpath:org/springframework/cloud/dataflow/server/local/security/singleUser.yml");
 
 	@ClassRule
 	public static TestRule springDataflowAndLdapServer = RuleChain.outerRule(localDataflowResource);


### PR DESCRIPTION
Resolves #1869 
Resolves #1872

 - Use StreamDeployer interface to abstract Skipper and AppDeployer functionality from top-level Controllers.
 - Move SkipperClient from RuntimeAppsController to SkipperStreamDeployer
 - Move SkipperClient from StreamDeploymentController to SkipperStreamDeployer
 - Refactor DataFlowControllerAutoConfiguration to have clear wiring for Skipper and Non-Skipper beans
 - Move AppDeployer from AboutController to StreamDeployer
 - Move AppDeployer from RuntimeController to StreamDeployer
 - Resolve missing support for App state and instance state in  RuntimeController