### PR TITLE
Fix stale app import links

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-howto.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-howto.adoc
@@ -330,7 +330,7 @@ destinations. Since we are publishing and subscribing from two different messagi
 to build the `bridge-processor` with both RabbitMQ and Apache Kafka binders in the classpath. To do that,
 head over to http://start-scs.cfapps.io/ and select `Bridge Processor`, `Kafka binder starter`, and
 `Rabbit binder starter` as the dependencies and follow the patching procedure described in the
-link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Bacon.RELEASE/reference/html/_introduction.html#customizing-binder[reference guide].
+link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Celsius.SR1/reference/html/_introduction.html#customizing-binder[reference guide].
 Specifically, for the `bridge-processor`, you'd have to import the `BridgeProcessorConfiguration`
 provided by the starter.
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -27,17 +27,17 @@ For the deployed streams and tasks to communicate, either link:http://www.rabbit
 +
 [source,bash,subs=attributes]
 ----
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-local/{project-version}/spring-cloud-dataflow-server-local-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-local/{project-version}/spring-cloud-dataflow-server-local-{project-version}.jar
 
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{project-version}/spring-cloud-dataflow-shell-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{project-version}/spring-cloud-dataflow-shell-{project-version}.jar
 ----
 +
 . Download http://cloud.spring.io/spring-cloud-skipper/[Skipper] if you would like the added features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
 +
 [source,yaml,options=nowrap,subs=attributes]
 ----
-wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
-wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{skipper-version}/spring-cloud-skipper-shell-{skipper-version}.jar
+wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
+wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{skipper-version}/spring-cloud-skipper-shell-{skipper-version}.jar
 ----
 +
 . Launch Skipper

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/shell.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/shell.adoc
@@ -195,7 +195,7 @@ Many applications accept options that are to be interpreted as SpEL expressions,
 * literals can be enclosed in either single or double quotes
 * quotes need to be doubled to embed a literal quote. Single quotes inside double quotes need no special treatment, and _vice versa_
 
-As a last example, assume you want to use the link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Bacon.RELEASE/reference/html/spring-cloud-stream-modules-processors.html#spring-clound-stream-modules-transform-processor[transform processor].
+As a last example, assume you want to use the link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Celsius.SR1/reference/html/spring-cloud-stream-modules-processors.html#spring-clound-stream-modules-transform-processor[transform processor].
 This processor accepts an `expression` option which is a SpEL expression. It is to be evaluated against the incoming message, with a default of `payload` (which forwards the message payload untouched).
 
 It is important to understand that the following are equivalent:

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams-developer-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams-developer-guide.adoc
@@ -46,9 +46,9 @@ First, download each application
 
 [source,bash]
 ----
-wget http://repo.spring.io/snapshot/org/springframework/cloud/stream/app/http-source-rabbit/1.2.0.BUILD-SNAPSHOT/http-source-rabbit-1.2.0.BUILD-SNAPSHOT.jar
+wget https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/http-source-rabbit/1.3.1.RELEASE//http-source-rabbit-1.3.1.RELEASE.jar
 
-wget http://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.1.1.RELEASE/log-sink-rabbit-1.1.1.RELEASE.jar
+wget https://repo.spring.io/release/org/springframework/cloud/stream/app/log-sink-rabbit/1.3.1.RELEASE/log-sink-rabbit-1.3.1.RELEASE.jar
 ----
 These are Spring Boot applications that include the
 link:http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready.html[Spring Boot Actuator]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -162,28 +162,20 @@ List of available Stream Application Starters:
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |RabbitMQ + Maven
-|http://bit.ly/Bacon-RELEASE-stream-applications-rabbit-maven
-|http://bit.ly/Bacon-BUILD-SNAPSHOT-stream-applications-rabbit-maven
+|http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
+|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-rabbit-maven
 
 |RabbitMQ + Docker
-|http://bit.ly/Bacon-RELEASE-stream-applications-rabbit-docker
-|N/A
-
-|Kafka 0.9 + Maven
-|http://bit.ly/Bacon-RELEASE-stream-applications-kafka-09-maven
-|http://bit.ly/Bacon-BUILD-SNAPSHOT-stream-applications-kafka-09-maven
-
-|Kafka 0.9 + Docker
-|http://bit.ly/Bacon-RELEASE-stream-applications-kafka-09-docker
-|N/A
+|http://bit.ly/Celsius-SR1-stream-applications-rabbit-docker
+|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-rabbit-docker
 
 |Kafka 0.10 + Maven
-|http://bit.ly/Bacon-RELEASE-stream-applications-kafka-10-maven
-|http://bit.ly/Bacon-BUILD-SNAPSHOT-stream-applications-kafka-10-maven
+|http://bit.ly/Celsius-SR1-stream-applications-kafka-10-maven
+|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-kafka-10-maven
 
 |Kafka 0.10 + Docker
-|http://bit.ly/Bacon-RELEASE-stream-applications-kafka-10-docker
-|N/A
+|http://bit.ly/Celsius-SR1-stream-applications-kafka-10-docker
+|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-kafka-10-docker
 |======================
 
 List of available Task Application Starters:
@@ -193,12 +185,12 @@ List of available Task Application Starters:
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |Maven
-|http://bit.ly/Belmont-GA-task-applications-maven
-|http://bit.ly/Belmont-BUILD-SNAPSHOT-task-applications-maven
+|http://bit.ly/Clark-GA-task-applications-maven
+|http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-maven
 
 |Docker
-|http://bit.ly/Belmont-GA-task-applications-docker
-|N/A
+|http://bit.ly/Clark-GA-task-applications-docker
+|http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
 You can find more information about the available task starters in the http://cloud.spring.io/spring-cloud-task-app-starters/[Task App Starters Project Page] and
@@ -209,13 +201,13 @@ As an example, ff you would like to register all out-of-the-box stream applicati
 
 [source,bash,subs=attributes]
 ----
-$ dataflow:>app import --uri http://bit.ly/Bacon-RELEASE-stream-applications-kafka-10-maven
+$ dataflow:>app import --uri http://bit.ly/Celsius-SR1-stream-applications-kafka-10-maven
 ----
 Alternatively you can register all the stream applications with the Rabbit binder
 
 [source,bash,subs=attributes]
 ----
-$ dataflow:>app import --uri http://bit.ly/Bacon-RELEASE-stream-applications-rabbit-maven
+$ dataflow:>app import --uri http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
 ----
 
 You can also pass the `--local` option (which is `true` by default) to indicate whether the
@@ -1094,7 +1086,7 @@ Would direct the data payloads from the Amazon S3, FTP, and HTTP sources to the 
 would have all the data from those three sources sent to the file sink.
 
 The Fan-out use case is when you determine the destination of a stream based on some information that is only known at runtime.
-In this case, the link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Bacon.RELEASE/reference/html/spring-cloud-stream-modules-sinks.html#spring-cloud-stream-modules-router-sink[Router Application] can be used to specify how to direct the incoming message to one of N named destinations.
+In this case, the link:http://docs.spring.io/spring-cloud-stream-app-starters/docs/Celsius.SR1/reference/html/spring-cloud-stream-modules-sinks.html#spring-cloud-stream-modules-router-sink[Router Application] can be used to specify how to direct the incoming message to one of N named destinations.
 
 [[spring-cloud-dataflow-stream-java-dsl]]
 == Stream Java DSL

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -115,15 +115,15 @@ List of available static property files:
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Stable Release |SNAPSHOT Release
-|Maven   |link:http://bit.ly/Belmont-GA-task-applications-maven[http://bit.ly/Belmont-GA-task-applications-maven] |link:http://bit.ly/Belmont-BUILD-SNAPSHOT-task-applications-maven[http://bit.ly/Belmont-BUILD-SNAPSHOT-task-applications-maven]
-|Docker  |link:http://bit.ly/Belmont-GA-task-applications-docker[http://bit.ly/Belmont-GA-task-applications-docker] | link:http://bit.ly/Belmont-BUILD-SNAPSHOT-task-applications-docker[http://bit.ly/Belmont-BUILD-SNAPSHOT-task-applications-docker]
+|Maven   | http://bit.ly/Clark-GA-task-applications-maven | http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-maven
+|Docker  | http://bit.ly/Clark-GA-task-applications-docker | http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
 For example, if you would like to register all out-of-the-box task applications in bulk, you can with
 the following command.
 
 ```
-dataflow:>app import --uri http://bit.ly/Belmont-GA-task-applications-maven
+dataflow:>app import --uri http://bit.ly/Clark-GA-task-applications-maven
 ```
 
 You can also pass the `--local` option (which is TRUE by default) to indicate whether the


### PR DESCRIPTION
Following changes are included in this proposal.

1) Fix the stale bit.ly links; they point to the latest `Celsius.SR1` and `Clark.GA` releases [Resolves spring-cloud/spring-cloud-dataflow#1886]
1.1) Remove Kafka 09 links
1.2) Add 1.3 BS links 
1.3) Remove unnecessary hyperlink formatting
2) Update wget commands to include https:// links [Resolves spring-cloud/spring-cloud-dataflow#1824]
3) Fix stale app versions in the sample
  