### PR TITLE
Resolve #1868 :  Shell commands compatible to the DataFlow mode

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataFlowMode.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataFlowMode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell;
+
+/**
+ * @author Christian Tzolov
+ */
+public enum DataFlowMode {
+	classic,
+	skipper
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/IncompatibleDataFlowMode.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/IncompatibleDataFlowMode.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell;
+
+/**
+ * @author Christian Tzolov
+ */
+public class IncompatibleDataFlowMode extends IllegalStateException {
+
+	public IncompatibleDataFlowMode(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public IncompatibleDataFlowMode(String s) {
+		super(s);
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetHolder.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/TargetHolder.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.shell;
 
-import org.springframework.cloud.dataflow.shell.command.ConfigCommands;
+import org.springframework.cloud.dataflow.shell.command.common.ConfigCommands;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.dataflow.shell.ShellCommandLineParser;
 import org.springframework.cloud.dataflow.shell.ShellProperties;
 import org.springframework.cloud.dataflow.shell.TargetHolder;
@@ -91,14 +92,33 @@ public class BaseShellAutoConfiguration {
 	}
 
 	@Configuration
-	@ComponentScan({ "org.springframework.shell.commands", "org.springframework.cloud.dataflow.shell.command",
+	@ComponentScan({ "org.springframework.shell.commands", "org.springframework.cloud.dataflow.shell.command.common",
+			"org.springframework.cloud.dataflow.shell.command.classic",
 			"org.springframework.cloud.dataflow.shell.converter", "org.springframework.cloud.dataflow.shell.config" })
-	public static class RegisterInternalCommands {
+	@ConditionalOnProperty(name = "dataflow.mode", havingValue = "classic", matchIfMissing = true)
+	public static class ClassicRegisterInternalCommands {
 
 		@PostConstruct
 		public void log() {
+			logger.debug("Classic Mode");
 			logger.debug("(o.s.shell.commands) Spring Shell" + " packages are being scanned");
 			logger.debug("(o.s.c.dataflow.shell.command) Spring Cloud Data Flow Shell" + " packages are being scanned");
 		}
 	}
+
+	@Configuration
+	@ComponentScan({ "org.springframework.shell.commands", "org.springframework.cloud.dataflow.shell.command.common",
+			"org.springframework.cloud.dataflow.shell.command.skipper",
+			"org.springframework.cloud.dataflow.shell.converter", "org.springframework.cloud.dataflow.shell.config" })
+	@ConditionalOnProperty(name = "dataflow.mode", havingValue = "skipper")
+	public static class SkipperRegisterInternalCommands {
+
+		@PostConstruct
+		public void log() {
+			logger.debug("Skipper Mode");
+			logger.debug("(o.s.shell.commands) Spring Shell" + " packages are being scanned");
+			logger.debug("(o.s.c.dataflow.shell.command) Spring Cloud Data Flow Shell" + " packages are being scanned");
+		}
+	}
+
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell.command.classic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationResource;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractAppRegistryCommands;
+import org.springframework.cloud.dataflow.shell.command.common.DataFlowTables;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.table.AbsoluteWidthSizeConstraints;
+import org.springframework.shell.table.CellMatchers;
+import org.springframework.shell.table.TableBuilder;
+import org.springframework.shell.table.TableModelBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Commands for working with the application registry. Allows retrieval of information
+ * about available applications, as well as creating and removing application
+ * registrations.
+ *
+ * @author Glenn Renfro
+ * @author Eric Bottard
+ * @author Florent Biville
+ * @author David Turanski
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author Thomas Risberg
+ * @author Gunnar Hillert
+ * @author Christian Tzolov
+ */
+@Component
+public class ClassicAppRegistryCommands extends AbstractAppRegistryCommands implements CommandMarker, ResourceLoaderAware {
+
+	private final static String APPLICATION_INFO = "app info";
+
+	private final static String UNREGISTER_APPLICATION = "app unregister";
+
+	@Autowired
+	public void setDataFlowShell(DataFlowShell dataFlowShell) {
+		super.setDataFlowShell(dataFlowShell);
+	}
+
+	@Override
+	public void setResourceLoader(ResourceLoader resourceLoader) {
+		super.setResourceLoader(resourceLoader);
+	}
+
+	@CliAvailabilityIndicator({ APPLICATION_INFO })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.APP_REGISTRY);
+	}
+
+	@CliAvailabilityIndicator({ UNREGISTER_APPLICATION })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.APP_REGISTRY);
+	}
+
+	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
+	public List<Object> info(
+			@CliOption(mandatory = true, key = { "", "id" },
+					help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application) {
+		List<Object> result = new ArrayList<>();
+		try {
+			DetailedAppRegistrationResource info =
+					appRegistryOperations().info(application.name, application.type);
+			if (info != null) {
+				List<ConfigurationMetadataProperty> options = info.getOptions();
+				result.add(String.format("Information about %s application '%s':", application.type, application.name));
+				if (info.getVersion() != null) {
+					result.add(String.format("Version: '%s':", info.getVersion()));
+				}
+				result.add(String.format("Resource URI: %s", info.getUri()));
+				if (info.getShortDescription() != null) {
+					result.add(info.getShortDescription());
+				}
+				if (options == null) {
+					result.add("Application options metadata is not available");
+				}
+				else {
+					TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
+					modelBuilder.addRow().addValue("Option Name").addValue("Description").addValue("Default")
+							.addValue("Type");
+					for (ConfigurationMetadataProperty option : options) {
+						modelBuilder.addRow().addValue(option.getId())
+								.addValue(option.getDescription() == null ? "<unknown>" : option.getDescription())
+								.addValue(prettyPrintDefaultValue(option))
+								.addValue(option.getType() == null ? "<unknown>" : option.getType());
+					}
+					TableBuilder builder = DataFlowTables.applyStyle(new TableBuilder(modelBuilder.build()))
+							.on(CellMatchers.table()).addSizer(new AbsoluteWidthSizeConstraints(30)).and();
+					result.add(builder.build());
+				}
+			}
+			else {
+				result.add(String.format("Application info is not available for %s:%s", application.type,
+						application.name));
+			}
+		}
+		catch (Exception e) {
+			result.add(
+					String.format("Application info is not available for %s:%s", application.type, application.name));
+		}
+		return result;
+	}
+
+	@CliCommand(value = UNREGISTER_APPLICATION, help = "Unregister an application")
+	public String unregister(
+			@CliOption(mandatory = true, key = { "",
+					"name" }, help = "name of the application to unregister") String name,
+			@CliOption(mandatory = true, key = {
+					"type" }, help = "type of the application to unregister") ApplicationType type) {
+
+		appRegistryOperations().unregister(name, type, null);
+		return String.format(("Successfully unregistered application '%s' with type %s"), name, type);
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell.command.classic;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.dataflow.shell.command.common.Assertions;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractStreamCommands;
+import org.springframework.cloud.dataflow.shell.command.common.UserInput;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+
+/**
+ * Stream commands.
+ *
+ * @author Ilayaperumal Gopinathan
+ * @author Mark Fisher
+ * @author Gunnar Hillert
+ * @author Glenn Renfro
+ * @author Christian Tzolov
+ */
+@Component
+// todo: reenable optionContext attributes
+public class ClassicStreamCommands extends AbstractStreamCommands implements CommandMarker {
+
+	private static final String CREATE_STREAM = "stream create";
+
+	private static final String DEPLOY_STREAM = "stream deploy";
+
+	@Autowired
+	public void setDataFlowShell(DataFlowShell dataFlowShell) {
+		this.dataFlowShell = dataFlowShell;
+	}
+
+	@Autowired
+	public void setUserInput(UserInput userInput) {
+		this.userInput = userInput;
+	}
+
+	@CliAvailabilityIndicator({ CREATE_STREAM, DEPLOY_STREAM })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
+	}
+
+	@CliCommand(value = CREATE_STREAM, help = "Create a new stream definition")
+	public String createStream(
+			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
+			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
+					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
+			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
+		streamOperations().createStream(name, dsl, deploy);
+		String message = String.format("Created new stream '%s'", name);
+		if (deploy) {
+			message += "\nDeployment request has been sent";
+		}
+		return message;
+	}
+
+	@CliCommand(value = DEPLOY_STREAM, help = "Deploy a previously created stream")
+	public String deployStream(
+			@CliOption(key = { "",
+					"name" }, help = "the name of the stream to deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name,
+			@CliOption(key = {
+					PROPERTIES_OPTION }, help = "the properties for this deployment") String deploymentProperties,
+			@CliOption(key = {
+					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile)
+			throws IOException {
+		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, deploymentProperties, PROPERTIES_FILE_OPTION,
+				propertiesFile);
+		Map<String, String> propertiesToUse = getDeploymentProperties(deploymentProperties, propertiesFile, which);
+		streamOperations().deploy(name, propertiesToUse);
+		return String.format("Deployment request has been sent for stream '%s'\n", name);
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/package-info.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Command classes for the Spring Cloud Data Flow Shell.
+ */
+package org.springframework.cloud.dataflow.shell.command.classic;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractMetricsCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractMetricsCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.util.LinkedHashMap;
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell.command.common;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.io.FilenameUtils;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.cloud.dataflow.rest.client.StreamOperations;
+import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
+import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+import org.springframework.cloud.dataflow.shell.command.support.ShellUtils;
+import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.table.AbsoluteWidthSizeConstraints;
+import org.springframework.shell.table.BeanListTableModel;
+import org.springframework.shell.table.CellMatchers;
+import org.springframework.shell.table.Table;
+import org.springframework.shell.table.TableBuilder;
+import org.springframework.shell.table.TableModelBuilder;
+import org.springframework.util.StringUtils;
+
+/**
+ * Stream commands.
+ *
+ * @author Ilayaperumal Gopinathan
+ * @author Mark Fisher
+ * @author Gunnar Hillert
+ * @author Glenn Renfro
+ * @author Christian Tzolov
+ */
+public abstract class AbstractStreamCommands implements CommandMarker {
+
+	private static final String INFO_STREAM = "stream info";
+
+	private static final String LIST_STREAM = "stream list";
+
+	private static final String UNDEPLOY_STREAM = "stream undeploy";
+
+	private static final String UNDEPLOY_STREAM_ALL = "stream all undeploy";
+
+	private static final String DESTROY_STREAM = "stream destroy";
+
+	private static final String DESTROY_STREAM_ALL = "stream all destroy";
+
+	protected static final String PROPERTIES_OPTION = "properties";
+
+	protected static final String PROPERTIES_FILE_OPTION = "propertiesFile";
+
+	protected DataFlowShell dataFlowShell;
+
+	protected UserInput userInput;
+
+	@CliAvailabilityIndicator({ LIST_STREAM, INFO_STREAM })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM);
+	}
+
+	@CliAvailabilityIndicator({ UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL, DESTROY_STREAM,
+			DESTROY_STREAM_ALL })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
+	}
+
+	@CliCommand(value = LIST_STREAM, help = "List created streams")
+	public Table listStreams() {
+		final PagedResources<StreamDefinitionResource> streams = streamOperations().list();
+		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
+		headers.put("name", "Stream Name");
+		headers.put("dslText", "Stream Definition");
+		headers.put("statusDescription", "Status");
+		BeanListTableModel<StreamDefinitionResource> model = new BeanListTableModel<>(streams, headers);
+		return DataFlowTables.applyStyle(new TableBuilder(model)).build();
+	}
+
+	@CliCommand(value = INFO_STREAM, help = "Show information about a specific stream")
+	public List<Object> streamInfo(@CliOption(key = { "",
+			"name" }, help = "the name of the stream to show", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
+		List<Object> result = new ArrayList<>();
+		final StreamDeploymentResource stream = streamOperations().info(name);
+		TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
+		modelBuilder.addRow().addValue("Name").addValue("DSL").addValue("Status");
+		modelBuilder.addRow().addValue(stream.getStreamName())
+				.addValue(stream.getDslText())
+				.addValue(stream.getStatus());
+		TableBuilder builder = DataFlowTables.applyStyle(new TableBuilder(modelBuilder.build()))
+				.on(CellMatchers.table()).addSizer(new AbsoluteWidthSizeConstraints(30)).and();
+		result.add(builder.build());
+		if (StringUtils.hasText(stream.getDeploymentProperties())) {
+			//TODO: rename Deployment properties for Skipper as it includes apps' info (app:version) as well
+			result.add(String.format("Stream Deployment properties: %s", ShellUtils.prettyPrintIfJson(stream.getDeploymentProperties())));
+		}
+		return result;
+	}
+
+	protected Map<String, String> getDeploymentProperties(@CliOption(key = {
+			PROPERTIES_OPTION }, help = "the properties for this deployment") String deploymentProperties,
+			@CliOption(key = {
+					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile,
+			int which) throws IOException {
+		Map<String, String> propertiesToUse;
+		switch (which) {
+		case 0:
+			propertiesToUse = DeploymentPropertiesUtils.parse(deploymentProperties);
+			break;
+		case 1:
+			String extension = FilenameUtils.getExtension(propertiesFile.getName());
+			Properties props = null;
+			if (extension.equals("yaml") || extension.equals("yml")) {
+				YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
+				yamlPropertiesFactoryBean.setResources(new FileSystemResource(propertiesFile));
+				yamlPropertiesFactoryBean.afterPropertiesSet();
+				props = yamlPropertiesFactoryBean.getObject();
+			}
+			else {
+				props = new Properties();
+				try (FileInputStream fis = new FileInputStream(propertiesFile)) {
+					props.load(fis);
+				}
+			}
+			propertiesToUse = DeploymentPropertiesUtils.convert(props);
+			break;
+		case -1: // Neither option specified
+			propertiesToUse = new HashMap<>(1);
+			break;
+		default:
+			throw new AssertionError();
+		}
+		return propertiesToUse;
+	}
+
+	@CliCommand(value = UNDEPLOY_STREAM, help = "Un-deploy a previously deployed stream")
+	public String undeployStream(@CliOption(key = { "",
+			"name" }, help = "the name of the stream to un-deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
+		streamOperations().undeploy(name);
+		return String.format("Un-deployed stream '%s'", name);
+	}
+
+	@CliCommand(value = UNDEPLOY_STREAM_ALL, help = "Un-deploy all previously deployed stream")
+	public String undeployAllStreams(
+			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really undeploy all streams?", "n", "y", "n"))) {
+			streamOperations().undeployAll();
+			return String.format("Un-deployed all the streams");
+		}
+		else {
+			return "";
+		}
+	}
+
+	@CliCommand(value = DESTROY_STREAM, help = "Destroy an existing stream")
+	public String destroyStream(@CliOption(key = { "",
+			"name" }, help = "the name of the stream to destroy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
+		streamOperations().destroy(name);
+		return String.format("Destroyed stream '%s'", name);
+	}
+
+	@CliCommand(value = DESTROY_STREAM_ALL, help = "Destroy all existing streams")
+	public String destroyAllStreams(
+			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really destroy all streams?", "n", "y", "n"))) {
+			streamOperations().destroyAll();
+			return "Destroyed all streams";
+		}
+		else {
+			return "";
+		}
+	}
+
+	protected StreamOperations streamOperations() {
+		return dataFlowShell.getDataFlowOperations().streamOperations();
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AggregateCounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AggregateCounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.text.NumberFormat;
 import java.text.ParseException;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/Assertions.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.util.Arrays;
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/ConsoleUserInput.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/ConsoleUserInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/CounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/CounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.text.NumberFormat;
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/DataFlowTables.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/DataFlowTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.beans.PropertyDescriptor;
 import java.util.Arrays;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/FieldValueCounterCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/FieldValueCounterCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.text.NumberFormat;
 import java.util.Arrays;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/HttpCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/HttpCommands.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/JobCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/JobCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.util.Map;
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/RuntimeCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/RuntimeCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/TaskCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/UserInput.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/UserInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;
 
 /**
  * Abstraction for a mechanism used to get user interactive user input.
@@ -33,7 +33,7 @@ public interface UserInput {
 	 * @param options valid input option set
 	 * @return the prompt text to display to the user
 	 */
-	public String promptWithOptions(String prompt, String defaultValue, String... options);
+	String promptWithOptions(String prompt, String defaultValue, String... options);
 
 	/**
 	 * Display a prompt text to the user and expect them to enter a free-form value.
@@ -46,6 +46,6 @@ public interface UserInput {
 	 * passwords)
 	 * @return the prompt text to display to the user
 	 */
-	public String prompt(String prompt, String defaultValue, boolean echo);
+	String prompt(String prompt, String defaultValue, boolean echo);
 
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/package-info.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 /**
  * Command classes for the Spring Cloud Data Flow Shell.
  */
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.common;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell.command.skipper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationResource;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractAppRegistryCommands;
+import org.springframework.cloud.dataflow.shell.command.common.DataFlowTables;
+import org.springframework.cloud.dataflow.shell.command.support.OpsType;
+import org.springframework.cloud.dataflow.shell.command.support.RoleType;
+import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.table.AbsoluteWidthSizeConstraints;
+import org.springframework.shell.table.CellMatchers;
+import org.springframework.shell.table.TableBuilder;
+import org.springframework.shell.table.TableModelBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Commands for working with the application registry. Allows retrieval of information
+ * about available applications, as well as creating and removing application
+ * registrations.
+ *
+ * @author Glenn Renfro
+ * @author Eric Bottard
+ * @author Florent Biville
+ * @author David Turanski
+ * @author Patrick Peralta
+ * @author Mark Fisher
+ * @author Thomas Risberg
+ * @author Gunnar Hillert
+ * @author Christian Tzolov
+ */
+@Component
+public class SkipperAppRegistryCommands extends AbstractAppRegistryCommands implements CommandMarker, ResourceLoaderAware {
+
+	private final static String APPLICATION_INFO = "app info";
+
+	private final static String UNREGISTER_APPLICATION = "app unregister";
+
+	private static final String DEFAULT_APPLICATION = "app default";
+
+	@Autowired
+	public void setDataFlowShell(DataFlowShell dataFlowShell) {
+		this.dataFlowShell = dataFlowShell;
+	}
+
+	@Override
+	public void setResourceLoader(ResourceLoader resourceLoader) {
+		Assert.notNull(resourceLoader, "resourceLoader must not be null");
+		this.resourceLoader = resourceLoader;
+	}
+
+	@CliAvailabilityIndicator({ APPLICATION_INFO })
+	public boolean availableWithViewRole() {
+		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.APP_REGISTRY);
+	}
+
+	@CliAvailabilityIndicator({ UNREGISTER_APPLICATION, DEFAULT_APPLICATION })
+	public boolean availableWithCreateRole() {
+		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.APP_REGISTRY);
+	}
+
+	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
+	public List<Object> info(
+			@CliOption(mandatory = true, key = { "", "id" },
+					help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application,
+			@CliOption(key = { "version" }, help = "the version for the registered application") String version) {
+		List<Object> result = new ArrayList<>();
+		try {
+			DetailedAppRegistrationResource info = StringUtils.hasText(version) ?
+					appRegistryOperations().info(application.name, application.type, version) :
+					appRegistryOperations().info(application.name, application.type);
+			if (info != null) {
+				List<ConfigurationMetadataProperty> options = info.getOptions();
+				result.add(String.format("Information about %s application '%s':", application.type, application.name));
+				if (info.getVersion() != null) {
+					result.add(String.format("Version: '%s':", info.getVersion()));
+				}
+				if (info.getDefaultVersion()) {
+					result.add(String.format("Default application version: '%s':", info.getDefaultVersion()));
+				}
+				result.add(String.format("Resource URI: %s", info.getUri()));
+				if (info.getShortDescription() != null) {
+					result.add(info.getShortDescription());
+				}
+				if (options == null) {
+					result.add("Application options metadata is not available");
+				}
+				else {
+					TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
+					modelBuilder.addRow().addValue("Option Name").addValue("Description").addValue("Default")
+							.addValue("Type");
+					for (ConfigurationMetadataProperty option : options) {
+						modelBuilder.addRow().addValue(option.getId())
+								.addValue(option.getDescription() == null ? "<unknown>" : option.getDescription())
+								.addValue(prettyPrintDefaultValue(option))
+								.addValue(option.getType() == null ? "<unknown>" : option.getType());
+					}
+					TableBuilder builder = DataFlowTables.applyStyle(new TableBuilder(modelBuilder.build()))
+							.on(CellMatchers.table()).addSizer(new AbsoluteWidthSizeConstraints(30)).and();
+					result.add(builder.build());
+				}
+			}
+			else {
+				result.add(String.format("Application info is not available for %s:%s", application.type,
+						application.name));
+			}
+		}
+		catch (Exception e) {
+			result.add(
+					String.format("Application info is not available for %s:%s", application.type, application.name));
+		}
+		return result;
+	}
+
+	@CliCommand(value = UNREGISTER_APPLICATION, help = "Unregister an application")
+	public String unregister(
+			@CliOption(mandatory = true, key = { "",
+					"name" }, help = "name of the application to unregister") String name,
+			@CliOption(mandatory = true, key = {
+					"type" }, help = "type of the application to unregister") ApplicationType type,
+			@CliOption(key = { "version" }, help = "the version application to unregister") String version) {
+
+		appRegistryOperations().unregister(name, type, version);
+		return String.format(("Successfully unregistered application '%s' with type %s"), name, type);
+	}
+
+	@CliCommand(value = DEFAULT_APPLICATION, help = "Change the default application version")
+	public String defaultApplicaiton(
+			@CliOption(mandatory = true, key = { "",
+					"id" }, help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application,
+			@CliOption(mandatory = true, key = {
+					"version" }, help = "the new default application version") String version) {
+
+		appRegistryOperations().makeDefault(application.name, application.type, version);
+
+		return String.format("New default Application %s:%s:%s", application.type, application.name, version);
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
@@ -14,49 +14,38 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.shell.command;
+package org.springframework.cloud.dataflow.shell.command.skipper;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.commons.io.FilenameUtils;
 import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.cloud.dataflow.rest.client.StreamOperations;
-import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
-import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
-import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractStreamCommands;
+import org.springframework.cloud.dataflow.shell.command.common.Assertions;
+import org.springframework.cloud.dataflow.shell.command.common.DataFlowTables;
+import org.springframework.cloud.dataflow.shell.command.common.UserInput;
 import org.springframework.cloud.dataflow.shell.command.support.OpsType;
 import org.springframework.cloud.dataflow.shell.command.support.RoleType;
-import org.springframework.cloud.dataflow.shell.command.support.ShellUtils;
 import org.springframework.cloud.dataflow.shell.command.support.YmlUtils;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
-import org.springframework.shell.table.AbsoluteWidthSizeConstraints;
 import org.springframework.shell.table.BeanListTableModel;
-import org.springframework.shell.table.CellMatchers;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableBuilder;
 import org.springframework.shell.table.TableModel;
-import org.springframework.shell.table.TableModelBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -77,108 +66,50 @@ import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_REPO
  */
 @Component
 // todo: reenable optionContext attributes
-public class StreamCommands implements CommandMarker {
-
-	private static final String LIST_STREAM = "stream list";
-
-	private static final String INFO_STREAM = "stream info";
+public class SkipperStreamCommands extends AbstractStreamCommands implements CommandMarker {
 
 	private static final String CREATE_STREAM = "stream create";
 
-	private static final String DEPLOY_STREAM = "stream deploy";
+	private static final String STREAM_SKIPPER_DEPLOY = "stream deploy";
 
-	private static final String STREAM_SKIPPER_DEPLOY = "stream skipper deploy";
+	private static final String STREAM_SKIPPER_UPDATE = "stream update";
 
-	private static final String STREAM_SKIPPER_UPDATE = "stream skipper update";
+	private static final String STREAM_SKIPPER_ROLLBACK = "stream rollback";
 
-	private static final String STREAM_SKIPPER_ROLLBACK = "stream skipper rollback";
+	private static final String STREAM_SKIPPER_MANIFEST_GET = "stream manifest";
 
-	private static final String STREAM_SKIPPER_MANIFEST_GET = "stream skipper manifest";
+	private static final String STREAM_SKIPPER_HISTORY = "stream history";
 
-	private static final String STREAM_SKIPPER_HISTORY = "stream skipper history";
-
-	private static final String STREAM_SKIPPER_PLATFORM_LIST = "stream skipper platform-list";
-
-	private static final String UNDEPLOY_STREAM = "stream undeploy";
-
-	private static final String UNDEPLOY_STREAM_ALL = "stream all undeploy";
-
-	private static final String DESTROY_STREAM = "stream destroy";
-
-	private static final String DESTROY_STREAM_ALL = "stream all destroy";
-
-	private static final String PROPERTIES_OPTION = "properties";
-
-	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
+	private static final String STREAM_SKIPPER_PLATFORM_LIST = "stream platform-list";
 
 	private static final String YAML_OPTION = "yaml";
 
 	private static final String YAML_FILE_OPTION = "yamlFile";
 
 	@Autowired
-	private DataFlowShell dataFlowShell;
+	public void setDataFlowShell(DataFlowShell dataFlowShell) {
+		this.dataFlowShell = dataFlowShell;
+	}
 
 	@Autowired
 	private UserInput userInput;
 
-	@CliAvailabilityIndicator({ LIST_STREAM, INFO_STREAM })
-	public boolean availableWithViewRole() {
-		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM);
-	}
-
-	@CliAvailabilityIndicator({ CREATE_STREAM, DEPLOY_STREAM, STREAM_SKIPPER_DEPLOY, STREAM_SKIPPER_UPDATE,
-			UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL, DESTROY_STREAM, DESTROY_STREAM_ALL })
+	@CliAvailabilityIndicator({ CREATE_STREAM, STREAM_SKIPPER_DEPLOY, STREAM_SKIPPER_UPDATE })
 	public boolean availableWithCreateRole() {
 		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
-	}
-
-	@CliCommand(value = LIST_STREAM, help = "List created streams")
-	public Table listStreams() {
-		final PagedResources<StreamDefinitionResource> streams = streamOperations().list();
-		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
-		headers.put("name", "Stream Name");
-		headers.put("dslText", "Stream Definition");
-		headers.put("statusDescription", "Status");
-		BeanListTableModel<StreamDefinitionResource> model = new BeanListTableModel<>(streams, headers);
-		return DataFlowTables.applyStyle(new TableBuilder(model)).build();
-	}
-
-	@CliCommand(value = INFO_STREAM, help = "Show information about a specific stream")
-	public List<Object> streamInfo(@CliOption(key = { "",
-			"name" }, help = "the name of the stream to show", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
-		List<Object> result = new ArrayList<>();
-		final StreamDeploymentResource stream = streamOperations().info(name);
-		TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
-		modelBuilder.addRow().addValue("Name").addValue("DSL").addValue("Status");
-		modelBuilder.addRow().addValue(stream.getStreamName())
-					.addValue(stream.getDslText())
-					.addValue(stream.getStatus());
-		TableBuilder builder = DataFlowTables.applyStyle(new TableBuilder(modelBuilder.build()))
-									.on(CellMatchers.table()).addSizer(new AbsoluteWidthSizeConstraints(30)).and();
-		result.add(builder.build());
-		if (StringUtils.hasText(stream.getDeploymentProperties())) {
-			//TODO: rename Deployment properties for Skipper as it includes apps' info (app:version) as well
-			result.add(String.format("Stream Deployment properties: %s", ShellUtils.prettyPrintIfJson(stream.getDeploymentProperties())));
-		}
-		return result;
 	}
 
 	@CliCommand(value = CREATE_STREAM, help = "Create a new stream definition")
 	public String createStream(
 			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
 			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
-					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
-			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
-		streamOperations().createStream(name, dsl, deploy);
-		String message = String.format("Created new stream '%s'", name);
-		if (deploy) {
-			message += "\nDeployment request has been sent";
-		}
-		return message;
+					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl) {
+		streamOperations().createStream(name, dsl, false);
+		return String.format("Created new stream '%s'", name);
 	}
 
 	@CliCommand(value = STREAM_SKIPPER_DEPLOY, help = "Deploy a previously created stream using Skipper")
-	public String deployStreamUsingSkipper(
+	public String deployStream(
 			@CliOption(key = { "",
 					"name" }, help = "the name of the stream to deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name,
 			@CliOption(key = {
@@ -206,58 +137,6 @@ public class StreamCommands implements CommandMarker {
 		}
 		streamOperations().deploy(name, propertiesToUse);
 		return String.format("Deployment request has been sent for stream '%s'", name);
-	}
-
-	private Map<String, String> getDeploymentProperties(@CliOption(key = {
-			PROPERTIES_OPTION }, help = "the properties for this deployment") String deploymentProperties,
-			@CliOption(key = {
-					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile,
-			int which) throws IOException {
-		Map<String, String> propertiesToUse;
-		switch (which) {
-		case 0:
-			propertiesToUse = DeploymentPropertiesUtils.parse(deploymentProperties);
-			break;
-		case 1:
-			String extension = FilenameUtils.getExtension(propertiesFile.getName());
-			Properties props = null;
-			if (extension.equals("yaml") || extension.equals("yml")) {
-				YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
-				yamlPropertiesFactoryBean.setResources(new FileSystemResource(propertiesFile));
-				yamlPropertiesFactoryBean.afterPropertiesSet();
-				props = yamlPropertiesFactoryBean.getObject();
-			}
-			else {
-				props = new Properties();
-				try (FileInputStream fis = new FileInputStream(propertiesFile)) {
-					props.load(fis);
-				}
-			}
-			propertiesToUse = DeploymentPropertiesUtils.convert(props);
-			break;
-		case -1: // Neither option specified
-			propertiesToUse = new HashMap<>(1);
-			break;
-		default:
-			throw new AssertionError();
-		}
-		return propertiesToUse;
-	}
-
-	@CliCommand(value = DEPLOY_STREAM, help = "Deploy a previously created stream")
-	public String deployStream(
-			@CliOption(key = { "",
-					"name" }, help = "the name of the stream to deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name,
-			@CliOption(key = {
-					PROPERTIES_OPTION }, help = "the properties for this deployment") String deploymentProperties,
-			@CliOption(key = {
-					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile)
-			throws IOException {
-		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, deploymentProperties, PROPERTIES_FILE_OPTION,
-				propertiesFile);
-		Map<String, String> propertiesToUse = getDeploymentProperties(deploymentProperties, propertiesFile, which);
-		streamOperations().deploy(name, propertiesToUse);
-		return String.format("Deployment request has been sent for stream '%s'\n", name);
 	}
 
 	@CliCommand(value = STREAM_SKIPPER_MANIFEST_GET, help = "Get manifest for the stream deployed using Skipper")
@@ -365,49 +244,5 @@ public class StreamCommands implements CommandMarker {
 					unspecifiedDefaultValue = "0") int releaseVersion) {
 		this.streamOperations().rollbackStream(name, releaseVersion);
 		return String.format("Rollback request has been sent for the stream '%s'", name);
-	}
-
-
-
-	@CliCommand(value = UNDEPLOY_STREAM, help = "Un-deploy a previously deployed stream")
-	public String undeployStream(@CliOption(key = { "",
-			"name" }, help = "the name of the stream to un-deploy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
-		streamOperations().undeploy(name);
-		return String.format("Un-deployed stream '%s'", name);
-	}
-
-	@CliCommand(value = UNDEPLOY_STREAM_ALL, help = "Un-deploy all previously deployed stream")
-	public String undeployAllStreams(
-			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
-		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really undeploy all streams?", "n", "y", "n"))) {
-			streamOperations().undeployAll();
-			return String.format("Un-deployed all the streams");
-		}
-		else {
-			return "";
-		}
-	}
-
-	@CliCommand(value = DESTROY_STREAM, help = "Destroy an existing stream")
-	public String destroyStream(@CliOption(key = { "",
-			"name" }, help = "the name of the stream to destroy", mandatory = true, optionContext = "existing-stream disable-string-converter") String name) {
-		streamOperations().destroy(name);
-		return String.format("Destroyed stream '%s'", name);
-	}
-
-	@CliCommand(value = DESTROY_STREAM_ALL, help = "Destroy all existing streams")
-	public String destroyAllStreams(
-			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
-		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really destroy all streams?", "n", "y", "n"))) {
-			streamOperations().destroyAll();
-			return "Destroyed all streams";
-		}
-		else {
-			return "";
-		}
-	}
-
-	StreamOperations streamOperations() {
-		return dataFlowShell.getDataFlowOperations().streamOperations();
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
@@ -92,7 +92,9 @@ public class SkipperStreamCommands extends AbstractStreamCommands implements Com
 	}
 
 	@Autowired
-	private UserInput userInput;
+	public void setUserInput(UserInput userInput) {
+		this.userInput = userInput;
+	}
 
 	@CliAvailabilityIndicator({ CREATE_STREAM, STREAM_SKIPPER_DEPLOY, STREAM_SKIPPER_UPDATE })
 	public boolean availableWithCreateRole() {

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/package-info.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Command classes for the Spring Cloud Data Flow Shell.
+ */
+package org.springframework.cloud.dataflow.shell.command.skipper;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/converter/QualifiedApplicationNameConverter.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/converter/QualifiedApplicationNameConverter.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
-import org.springframework.cloud.dataflow.shell.command.AppRegistryCommands;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractAppRegistryCommands;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.shell.ShellException;
 import org.springframework.shell.core.Completion;
@@ -32,7 +32,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Knows how to build and query
- * {@link org.springframework.cloud.dataflow.shell.command.AppRegistryCommands.QualifiedApplicationName}s.
+ * {@link AbstractAppRegistryCommands.QualifiedApplicationName}s.
  *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
@@ -40,25 +40,25 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  */
 @Component
-public class QualifiedApplicationNameConverter implements Converter<AppRegistryCommands.QualifiedApplicationName> {
+public class QualifiedApplicationNameConverter implements Converter<AbstractAppRegistryCommands.QualifiedApplicationName> {
 
 	@Autowired
 	private DataFlowShell dataFlowShell;
 
 	@Override
 	public boolean supports(Class<?> type, String optionContext) {
-		return AppRegistryCommands.QualifiedApplicationName.class.isAssignableFrom(type);
+		return AbstractAppRegistryCommands.QualifiedApplicationName.class.isAssignableFrom(type);
 	}
 
 	@Override
-	public AppRegistryCommands.QualifiedApplicationName convertFromText(String value, Class<?> targetType,
+	public AbstractAppRegistryCommands.QualifiedApplicationName convertFromText(String value, Class<?> targetType,
 			String optionContext) {
 		int colonIndex = value.indexOf(':');
 		if (colonIndex == -1) {
 			throw new ShellException("Incorrect syntax. Valid syntax is '<ApplicationType>:<ApplicationName>'.");
 		}
 		ApplicationType applicationType = ApplicationType.valueOf(value.substring(0, colonIndex));
-		return new AppRegistryCommands.QualifiedApplicationName(value.substring(colonIndex + 1), applicationType);
+		return new AbstractAppRegistryCommands.QualifiedApplicationName(value.substring(colonIndex + 1), applicationType);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
+++ b/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
@@ -4,6 +4,7 @@ Data Flow Options:
   --dataflow.password=<PASSWORD>                    Password of the Data Flow Server [no default].
   --dataflow.credentials-provider-command=<COMMAND> Executes an external command which must return an OAuth Access Token [no default].
   --dataflow.skip-ssl-validation=<true|false>       Accept any SSL certificate (even self-signed) [default: no].
+  --dataflow.mode=<MODE>                            Server DataFlow mode: 'classic' or 'skipper' modes. [default: classic].
   --spring.shell.historySize=<SIZE>                 Default size of the shell log file [default: 3000].
   --spring.shell.commandFile=<FILE>                 Data Flow Shell executes commands read from the file(s) and then exits.
   --help                                            This message.

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AggregateCounterCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AggregateCounterCommandsTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.springframework.analytics.metrics.AggregateCounterRepository;
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
+import org.springframework.cloud.dataflow.shell.command.common.AggregateCounterCommands;
 import org.springframework.shell.table.Table;
 
 import static org.hamcrest.Matchers.is;

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AssertionsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AssertionsTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.shell.command;
 
 import org.junit.Test;
 
+import org.springframework.cloud.dataflow.shell.command.common.Assertions;
+
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.springframework.cloud.dataflow.shell.command;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -31,24 +27,31 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.rest.client.AppRegistryOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
+import org.springframework.cloud.dataflow.shell.command.classic.ClassicAppRegistryCommands;
+import org.springframework.cloud.dataflow.shell.command.common.AbstractAppRegistryCommands;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableModel;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
 /**
- * Unit tests for {@link AppRegistryCommands}.
+ * Unit tests for {@link org.springframework.cloud.dataflow.shell.command.classic.ClassicStreamCommands}.
  *
  * @author Eric Bottard
  * @author Mark Fisher
  */
-public class AppRegistryCommandsTests {
+public class ClassicAppRegistryCommandsTests {
 
-	AppRegistryCommands appRegistryCommands = new AppRegistryCommands();
+	ClassicAppRegistryCommands appRegistryCommands = new ClassicAppRegistryCommands();
 
 	@Mock
 	private DataFlowOperations dataFlowOperations;
@@ -108,8 +111,8 @@ public class AppRegistryCommandsTests {
 	@Test
 	public void testUnknownModule() {
 		List<Object> result = appRegistryCommands
-				.info(new AppRegistryCommands.QualifiedApplicationName("unknown", ApplicationType.processor),
-						null);
+				.info(new AbstractAppRegistryCommands.QualifiedApplicationName("unknown", ApplicationType.processor));
+
 		assertEquals((String) result.get(0), "Application info is not available for processor:unknown");
 	}
 
@@ -121,21 +124,7 @@ public class AppRegistryCommandsTests {
 		boolean force = false;
 		AppRegistrationResource resource = new AppRegistrationResource(name, type.name(), uri);
 		when(appRegistryOperations.register(name, type, uri, null, force)).thenReturn(resource);
-		String result = appRegistryCommands.register(name, type, null, uri, null, force);
-		assertEquals("Successfully registered application 'sink:foo'", result);
-	}
-
-	@Test
-	public void versionedRegister() {
-		String name = "foo";
-		ApplicationType type = ApplicationType.sink;
-		String version = "1.0.0";
-		boolean isDefault = true;
-		String uri = "file:///foo";
-		boolean force = false;
-		AppRegistrationResource resource = new AppRegistrationResource(name, type.name(), version, uri, isDefault);
-		when(appRegistryOperations.register(name, type, uri, null, force)).thenReturn(resource);
-		String result = appRegistryCommands.register(name, type, uri, version, null, force);
+		String result = appRegistryCommands.register(name, type, uri, null, force);
 		assertEquals("Successfully registered application 'sink:foo'", result);
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/CounterCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/CounterCommandsTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
+import org.springframework.cloud.dataflow.shell.command.common.CounterCommands;
 import org.springframework.shell.table.Table;
 
 import static org.hamcrest.Matchers.is;

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/FieldValueCounterCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/FieldValueCounterCommandsTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import org.springframework.analytics.metrics.FieldValueCounterRepository;
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
+import org.springframework.cloud.dataflow.shell.command.common.FieldValueCounterCommands;
 import org.springframework.shell.table.Table;
 
 import static org.hamcrest.Matchers.is;

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/MetricsCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/MetricsCommandTemplate.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.dataflow.shell.command;
 
 import java.util.List;
 
+import org.springframework.cloud.dataflow.shell.command.common.AggregateCounterCommands;
+import org.springframework.cloud.dataflow.shell.command.common.CounterCommands;
+import org.springframework.cloud.dataflow.shell.command.common.FieldValueCounterCommands;
 import org.springframework.shell.core.JLineShellComponent;
 import org.springframework.shell.table.Table;
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommandsTests.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.RuntimeOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppInstanceStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
+import org.springframework.cloud.dataflow.shell.command.common.RuntimeCommands;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.table.TableModel;

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/spring/spring-shell-plugin.xml
@@ -5,6 +5,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-    <context:component-scan base-package="org.springframework.cloud.dataflow.shell"/>
+    <context:component-scan base-package="org.springframework.cloud.dataflow.shell.custom"/>
 
 </beans>


### PR DESCRIPTION
* SCDF shell loads only shell commands (and beans) applicable for the DataFlow mode of the server it connects to. Supported modes are: `classic` [*default*] or `skipper`.
* No need off mode specific, command prefixes (e.g. stream skipper xxx) in the commands' signatures.
* Shell is started with a `--dataflow.mode=` to set the shell's mode to correspond to the server mode. Missing argument starts the shell in classic mode.
* If shell's mode is different from the server such (verified during dataflow config serverinitialization) and error message is printed with instructions to use the correct mode.
* Retain backward compatibility (when possible) for the entry points backing the commands from all modes. (API evolution)

Changes:
- Add DataFlowMode enum and IncompatibleDataFlowMode exception.
- ConfigCommands#target is extended to verify that the shell is started in the same mode as the server.
- Use the AboutResource#FeaturesInfo#Skipper-Enabled to determine the server mode.
- Move the common for all modes shell commands from the o.s.c.d.shell.command into o.s.c.d.shell.command.common package.
- Create o.s.c.d.shell.command.skipper package to hold the skipper specific commands.
- Create o.s.c.d.shell.command.classic package to hold the classic specific commands.
- Refactor o.s.c.d.s.c.common.AppRegistryCommands into o.s.c.d.shell.command.common.AbstractAppRegistryCommands, o.s.c.d.s.c.classic.ClassicAppRegistryCommands and o.s.c.d.s.c.skipper.SkipperAppRegistryCommands to split the common and mode-specific app commands.
- For backward compatibility all XXXAppRegistryCommands use the same AppCommandsOperations.
- Refactor o.s.c.d.s.c.StreamCommands into o.s.c.d.s.c.common.AbstractStreamCommands, o.s.c.d.s.c.classic.ClassicStreamCommands and o.s.c.d.s.c.skipper.SkipperStreamCommands to split the common and mode-specific stream commands.
- Remove the `skipper` prefixes for the stream commands in skipper mode.
- For backward compatibility all XXXStreamCommands use the same StreamOperations.
- Refactor the o.s.c.d.s.a.BaseShellAutoConfiguration#RegisterInteranlCommands bean into conditional ClassicRegisterInternalCommands (scans the common + classic command pkgs) and SkipperRegisterInternalCommands ( scans the common + skipper command pkgs).
- Use the @ConditionalOnProperty(name = "dataflow.mode"...) condition
- Add dataflow.mode to the usage.txt