### PR TITLE
Fix Skipper manifest command

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -412,7 +412,12 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	public String manifest(String name, int version) {
-		return this.skipperClient.manifest(name, version);
+		if (version > 0) {
+			return this.skipperClient.manifest(name, version);
+		}
+		else {
+			return this.skipperClient.manifest(name);
+		}
 	}
 
 	public String manifest(String name) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -137,8 +137,10 @@ public class SkipperStreamDeployerTests {
 				mock(StreamDefinitionRepository.class), mock(ForkJoinPool.class));
 
 		skipperStreamDeployer.manifest("name", 666);
-
 		verify(skipperClient).manifest(eq("name"), eq(666));
+
+		skipperStreamDeployer.manifest("name");
+		verify(skipperClient).manifest(eq("name"));
 	}
 
 	@Test


### PR DESCRIPTION
 - Use Skipper server controller's `/manifest/name/version` only when a valid version int is used. Otherwise, use `/manifest/name` REST endpoint
 - Update test

Resolves #1902