### PR TITLE
Add '--deploy' option for 'stream create' when in Skipper mode

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
@@ -74,12 +74,12 @@ public abstract class AbstractStreamService implements StreamService {
 			throw new NoSuchStreamDefinitionException(name);
 		}
 
-		String status = this.doCalculateStreamState(name);
+		DeploymentState status = this.doCalculateStreamState(name);
 
-		if (DeploymentState.deployed.equals(DeploymentState.valueOf(status))) {
+		if (DeploymentState.deployed == status) {
 			throw new StreamAlreadyDeployedException(name);
 		}
-		else if (DeploymentState.deploying.equals(DeploymentState.valueOf(status))) {
+		else if (DeploymentState.deploying  == status) {
 			throw new StreamAlreadyDeployingException(name);
 		}
 		doDeployStream(streamDefinition, deploymentProperties);
@@ -87,5 +87,5 @@ public abstract class AbstractStreamService implements StreamService {
 
 	protected abstract void doDeployStream(StreamDefinition streamDefinition, Map<String, String> deploymentProperties);
 
-	protected abstract String doCalculateStreamState(String name);
+	protected abstract DeploymentState doCalculateStreamState(String name);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
@@ -70,7 +70,7 @@ public class AppDeployerStreamService extends AbstractStreamService {
 	}
 
 	@Override
-	public String doCalculateStreamState(String name) {
+	public DeploymentState doCalculateStreamState(String name) {
 		return this.appDeployerStreamDeployer.calculateStreamState(name);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamService.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_KEY_PREFIX;
+import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_VERSION;
 
 /**
  * {@link SkipperStreamDeployer} specific {@link AbstractStreamService}.
@@ -63,6 +64,9 @@ public class SkipperStreamService extends AbstractStreamService {
 	private static Log logger = LogFactory.getLog(SkipperStreamService.class);
 
 	public static final String SPRING_CLOUD_DATAFLOW_STREAM_APP_LABEL = "spring.cloud.dataflow.stream.app.label";
+
+	public static final String DEFAULT_SKIPPER_PACKAGE_VERSION = "1.0.0";
+
 
 	/**
 	 * The repository this controller will use for stream CRUD operations.
@@ -93,6 +97,11 @@ public class SkipperStreamService extends AbstractStreamService {
 	public void doDeployStream(StreamDefinition streamDefinition, Map<String, String> deploymentProperties) {
 		// Extract skipper properties
 		Map<String, String> skipperDeploymentProperties = getSkipperProperties(deploymentProperties);
+
+		if (!skipperDeploymentProperties.containsKey(SKIPPER_PACKAGE_VERSION)) {
+			skipperDeploymentProperties.put(SKIPPER_PACKAGE_VERSION, DEFAULT_SKIPPER_PACKAGE_VERSION);
+		}
+
 		// Create map without any skipper properties
 		Map<String, String> deploymentPropertiesToUse = deploymentProperties.entrySet().stream()
 				.filter(mapEntry -> !mapEntry.getKey().startsWith(SKIPPER_KEY_PREFIX))
@@ -117,7 +126,7 @@ public class SkipperStreamService extends AbstractStreamService {
 	}
 
 	@Override
-	public String doCalculateStreamState(String name) {
+	public DeploymentState doCalculateStreamState(String name) {
 		return this.skipperStreamDeployer.calculateStreamState(name);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
@@ -162,7 +162,7 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 	}
 
 	@Override
-	public String calculateStreamState(String streamName) {
+	public DeploymentState calculateStreamState(String streamName) {
 		Set<DeploymentState> appStates = EnumSet.noneOf(DeploymentState.class);
 		StreamDefinition stream = this.streamDefinitionRepository.findOne(streamName);
 		for (StreamAppDefinition appDefinition : stream.getAppDefinitions()) {
@@ -176,7 +176,7 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 				appStates.add(DeploymentState.undeployed);
 			}
 		}
-		return StreamDefinitionController.aggregateState(appStates).toString();
+		return StreamDefinitionController.aggregateState(appStates);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -145,9 +145,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	@Override
-	public String calculateStreamState(String streamName) {
-		// TODO call out to skipper for stream state.
-		return DeploymentState.unknown.toString();
+	public DeploymentState calculateStreamState(String streamName) {
+		return getStreamDeploymentState(streamName);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -34,7 +34,7 @@ import org.springframework.data.domain.Pageable;
  */
 public interface StreamDeployer {
 
-	String calculateStreamState(String streamName);
+	DeploymentState calculateStreamState(String streamName);
 
 	Map<StreamDefinition, DeploymentState> state(List<StreamDefinition> content);
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
@@ -197,6 +197,8 @@ public class SkipperStreamServiceIntegrationTests {
 		this.streamDefinitionRepository.delete(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
+		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));
+
 		streamService.deployStream("ticktock", createSkipperDeploymentProperties());
 
 		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findOne("ticktock");
@@ -208,7 +210,6 @@ public class SkipperStreamServiceIntegrationTests {
 				Charset.defaultCharset());
 		Release release = new Release();
 		release.setManifest(expectedReleaseManifest);
-		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));
 		when(skipperClient.upgrade(isA(UpgradeRequest.class))).thenReturn(release);
 
 		Map<String, String> deploymentProperties = createSkipperDeploymentProperties();
@@ -230,6 +231,8 @@ public class SkipperStreamServiceIntegrationTests {
 		this.streamDefinitionRepository.delete(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
+		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));
+
 		Map<String, String> deploymentProperties = createSkipperDeploymentProperties();
 		this.streamService.deployStream("ticktock", deploymentProperties);
 		String releaseManifest = StreamUtils.copyToString(
@@ -240,7 +243,6 @@ public class SkipperStreamServiceIntegrationTests {
 										+ "\"maven:\\/\\/org.springframework.cloud.stream.app:log-sink-rabbit\":\"1.2.0.RELEASE\"}"
 										+ ",\"time\":{\"maven:\\/\\/org.springframework.cloud.stream.app:time-source-rabbit\":\"1.2.0.RELEASE\","
 										+ "\"spring.cloud.deployer.group\":\"ticktock\"}}";
-		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));
 		when(skipperClient.manifest(streamDefinition.getName())).thenReturn(releaseManifest);
 		StreamDeployment streamDeployment = this.streamService.info(streamDefinition.getName());
 		assertThat(streamDeployment.getStreamName()).isEqualTo(streamDefinition.getName());

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
@@ -46,8 +46,6 @@ import org.springframework.stereotype.Component;
 // todo: reenable optionContext attributes
 public class ClassicStreamCommands extends AbstractStreamCommands implements CommandMarker {
 
-	private static final String CREATE_STREAM = "stream create";
-
 	private static final String DEPLOY_STREAM = "stream deploy";
 
 	@Autowired
@@ -60,23 +58,9 @@ public class ClassicStreamCommands extends AbstractStreamCommands implements Com
 		this.userInput = userInput;
 	}
 
-	@CliAvailabilityIndicator({ CREATE_STREAM, DEPLOY_STREAM })
+	@CliAvailabilityIndicator({ DEPLOY_STREAM })
 	public boolean availableWithCreateRole() {
 		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
-	}
-
-	@CliCommand(value = CREATE_STREAM, help = "Create a new stream definition")
-	public String createStream(
-			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
-			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
-					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
-			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
-		streamOperations().createStream(name, dsl, deploy);
-		String message = String.format("Created new stream '%s'", name);
-		if (deploy) {
-			message += "\nDeployment request has been sent";
-		}
-		return message;
 	}
 
 	@CliCommand(value = DEPLOY_STREAM, help = "Deploy a previously created stream")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
@@ -62,6 +62,8 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractStreamCommands implements CommandMarker {
 
+	private static final String CREATE_STREAM = "stream create";
+
 	private static final String INFO_STREAM = "stream info";
 
 	private static final String LIST_STREAM = "stream list";
@@ -87,10 +89,24 @@ public abstract class AbstractStreamCommands implements CommandMarker {
 		return dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM);
 	}
 
-	@CliAvailabilityIndicator({ UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL, DESTROY_STREAM,
+	@CliAvailabilityIndicator({ CREATE_STREAM, UNDEPLOY_STREAM, UNDEPLOY_STREAM_ALL, DESTROY_STREAM,
 			DESTROY_STREAM_ALL })
 	public boolean availableWithCreateRole() {
 		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
+	}
+
+	@CliCommand(value = CREATE_STREAM, help = "Create a new stream definition")
+	public String createStream(
+			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
+			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
+					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
+			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
+		streamOperations().createStream(name, dsl, deploy);
+		String message = String.format("Created new stream '%s'", name);
+		if (deploy) {
+			message += "\nDeployment request has been sent";
+		}
+		return message;
 	}
 
 	@CliCommand(value = LIST_STREAM, help = "List created streams")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
@@ -68,8 +68,6 @@ import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_REPO
 // todo: reenable optionContext attributes
 public class SkipperStreamCommands extends AbstractStreamCommands implements CommandMarker {
 
-	private static final String CREATE_STREAM = "stream create";
-
 	private static final String STREAM_SKIPPER_DEPLOY = "stream deploy";
 
 	private static final String STREAM_SKIPPER_UPDATE = "stream update";
@@ -96,18 +94,9 @@ public class SkipperStreamCommands extends AbstractStreamCommands implements Com
 		this.userInput = userInput;
 	}
 
-	@CliAvailabilityIndicator({ CREATE_STREAM, STREAM_SKIPPER_DEPLOY, STREAM_SKIPPER_UPDATE })
+	@CliAvailabilityIndicator({ STREAM_SKIPPER_DEPLOY, STREAM_SKIPPER_UPDATE })
 	public boolean availableWithCreateRole() {
 		return dataFlowShell.hasAccess(RoleType.CREATE, OpsType.STREAM);
-	}
-
-	@CliCommand(value = CREATE_STREAM, help = "Create a new stream definition")
-	public String createStream(
-			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
-			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
-					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl) {
-		streamOperations().createStream(name, dsl, false);
-		return String.format("Created new stream '%s'", name);
 	}
 
 	@CliCommand(value = STREAM_SKIPPER_DEPLOY, help = "Deploy a previously created stream using Skipper")


### PR DESCRIPTION
Resolves #1907

 - When the SKIPPER_PACKAGE_VERSION deployment property is not provided the SkipperStreamService#doDeployStream will use the default DEFAULT_SKIPPER_PACKAGE_VERSION = "1.0.0"
 - In AbstractStreamCommmands (e.g. all modes) create a stream-create command implementation that supports an optional '--deploy' argument.
 - Remove the mode specific stream-create command implementations.
 - Use of the DeploymentState enum instead of string state values. Change StreamDeployer#calculateStreamState return type
 - Implement the SkipperStreamDeployer##calculateStreamState(stream)
 - Add tests for deploying streams with pre-defined and default package versions