### PR TITLE
Use HATEOAS objectMapper in converter

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/web/WebConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/web/WebConfiguration.java
@@ -124,9 +124,7 @@ public class WebConfiguration implements ServletContextInitializer, ApplicationL
 	}
 
 	@Bean
-	public HttpMessageConverters messageConverters() {
-		final ObjectMapper objectMapper = new ObjectMapper();
-		setupObjectMapper(objectMapper);
+	public HttpMessageConverters messageConverters(ObjectMapper objectMapper) {
 		return new HttpMessageConverters(
 				// Prevent default converters
 				false,


### PR DESCRIPTION
 - The explicit MappingJackson2HttpMessageConverter should use the Spring HATEOAS object mapper instead of a custom one.
  - Given the registration of HAL module into Spring HATEOAS object mapper happening during via HyperMediaSupportBeanDefinitionRegistrar, it is expected that the object mapper we use has the HAL module registered.

Resolves #1908