### PR TITLE
Removes deprecated spring.cloud.deployer as an app property.

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -160,51 +160,7 @@ public final class DeploymentPropertiesUtils {
 						: "spring.cloud.deployer." + kv.getKey().substring(appLength), kv -> kv.getValue(),
 						(fromWildcard, fromApp) -> fromApp));
 
-		Map<String, String> deprecated = extractDeprecatedDeployerProperties(input, appName);
-		// Also, 'count' used to be treated as a special case. Handle here
-		String deprecatedWildcardCound = input.get("app.*.count");
-		String deprecatedCount = input.getOrDefault("app." + appName + ".count", deprecatedWildcardCound);
-		if (deprecatedCount != null && deprecated.get("spring.cloud.deployer.count") == null) {
-			deprecated.put("spring.cloud.deployer.count", deprecatedCount);
-			logger.warn("Usage of application property 'app.{}.count' to specify number of instances has been "
-					+ "deprecated and will be removed in a future release\n"
-					+ "Instead, please use 'deployer.{}.count = {}'", appName, appName, deprecatedCount);
-		}
-
-		if (deprecated.isEmpty()) {
-			return result;
-		}
-		else {
-			deprecated.entrySet().forEach(kv -> {
-				logger.warn(
-						"Usage of application property prefix 'spring.cloud.deployer' to pass properties to the "
-								+ "deployer has been deprecated and will be removed in a future release\n"
-								+ "Instead of 'app.{}.{} = {}', please use\n" + "           'deployer.{}.{} = {}'",
-						appName, kv.getKey(), kv.getValue(), appName,
-						kv.getKey().substring("spring.cloud.deployer.".length()), kv.getValue());
-			});
-			if (result.isEmpty()) {
-				return deprecated;
-			}
-			else {
-				return result;
-			}
-		}
-
-	}
-
-	private static Map<String, String> extractDeprecatedDeployerProperties(Map<String, String> input, String appName) {
-		final String wildcardPrefix = "app.*.spring.cloud.deployer.";
-		final int wildcardLength = "app.*.".length();
-		final String appPrefix = String.format("app.%s.spring.cloud.deployer.", appName);
-		final int appLength = String.format("app.%s.", appName).length();
-
-		return new TreeMap<>(input).entrySet().stream()
-				.filter(kv -> kv.getKey().startsWith(wildcardPrefix) || kv.getKey().startsWith(appPrefix))
-				.collect(Collectors.toMap(
-						kv -> kv.getKey().startsWith(wildcardPrefix) ? kv.getKey().substring(wildcardLength)
-								: kv.getKey().substring(appLength),
-						kv -> kv.getValue(), (fromWildcard, fromApp) -> fromApp));
+		return result;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -28,7 +28,6 @@ import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -120,56 +119,6 @@ public class DeploymentPropertiesUtilsTests {
 		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
 		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
 		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
-	}
-
-	@Test
-	// TO BE REMOVED once deprecated support is removed
-	public void testDeprecatedDeployerProperties() {
-		Map<String, String> props = new LinkedHashMap<>();
-		props.put("app.myapp.spring.cloud.deployer.count", "2");
-		props.put("app.myapp.spring.cloud.deployer.foo", "bar");
-		props.put("app.otherapp.spring.cloud.deployer.count", "5");
-		props.put("app.*.spring.cloud.deployer.precedence", "wildcard");
-		props.put("app.myapp.spring.cloud.deployer.precedence", "app");
-		props.put("app.myapp.something.else", "not-considered-a-deployer-property");
-		props.put("deployer.myapp.count", "7");
-		props.put("deployer.myapp.foo", "wizz");
-		props.put("deployer.otherapp.count", "6");
-		props.put("deployer.*.precedence", "wildcard");
-		props.put("deployer.myapp.precedence", "the-app");
-
-		Map<String, String> result = DeploymentPropertiesUtils.extractAndQualifyDeployerProperties(props, "myapp");
-		assertThat(result.keySet(), hasSize(3));
-		assertThat(result, hasEntry("spring.cloud.deployer.count", "7"));
-		assertThat(result, hasEntry("spring.cloud.deployer.foo", "wizz"));
-		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "the-app"));
-	}
-
-	@Test
-	// TO BE REMOVED once deprecated support is removed
-	public void testDeprecatedDeployerPropertiesMixed() {
-		Map<String, String> props = new LinkedHashMap<>();
-		props.put("app.myapp.spring.cloud.deployer.count", "2");
-		props.put("app.myapp.spring.cloud.deployer.foo", "bar");
-		props.put("app.otherapp.spring.cloud.deployer.count", "5");
-		props.put("app.*.spring.cloud.deployer.precedence", "wildcard");
-		props.put("app.myapp.spring.cloud.deployer.precedence", "app");
-		props.put("app.myapp.something.else", "not-considered-a-deployer-property");
-
-		Map<String, String> result = DeploymentPropertiesUtils.extractAndQualifyDeployerProperties(props, "myapp");
-		assertThat(result.keySet(), hasSize(3));
-		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
-		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
-		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
-	}
-
-	@Test
-	// TO BE REMOVED once deprecated support is removed
-	public void testDeprecatedDeployerPropertyCount() {
-		Map<String, String> props = new LinkedHashMap<>();
-		props.put("app.myapp.count", "2");
-		Map<String, String> result = DeploymentPropertiesUtils.extractAndQualifyDeployerProperties(props, "myapp");
-		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
 	}
 
 	@Test


### PR DESCRIPTION
Looks like docs have been updated already. As far as app.*.spring.cloud.deployer references.

resolves #1756