### PR TITLE
Remove skipper enabled REST domain property

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/DeploymentPropertiesBuilder.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/DeploymentPropertiesBuilder.java
@@ -87,7 +87,6 @@ public class DeploymentPropertiesBuilder {
 	class SkipperDeploymentPropertiesBuilder extends DeploymentPropertiesBuilder {
 
 		SkipperDeploymentPropertiesBuilder(Map<String, String> map) {
-			map.put(SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY, "true");
 			this.deploymentProperties.putAll(map);
 		}
 

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -112,7 +112,6 @@ public class StreamDslTests {
 				mapArgumentCaptor.capture());
 		assertThat(mapArgumentCaptor.getValue()).containsKeys("deployer.tick.count",
 				"deployer.tick.memory", SkipperStream.SKIPPER_PLATFORM_NAME,
-				SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY,
 				SkipperStream.SKIPPER_PACKAGE_VERSION, SkipperStream.SKIPPER_REPO_NAME);
 	}
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/SkipperStream.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/SkipperStream.java
@@ -31,8 +31,6 @@ public abstract class SkipperStream {
 
 	public static final String SKIPPER_PLATFORM_NAME = SKIPPER_KEY_PREFIX + ".platformName";
 
-	public static final String SKIPPER_ENABLED_PROPERTY_KEY = SKIPPER_KEY_PREFIX + ".enabled";
-
 	public static final String SKIPPER_DEFAULT_API_VERSION = "skipper.spring.io/v1";
 
 	public static final String SKIPPER_DEFAULT_KIND = "SpringCloudDeployerApplication";

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -46,7 +46,6 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY;
 
 /**
  * Unit tests for StreamDeploymentController.
@@ -80,16 +79,11 @@ public class StreamDeploymentControllerTests {
 
 	@Test
 	public void testDeployViaStreamService() {
-		Map<String, String> deploymentProperties = new HashMap<>();
-		deploymentProperties.put(SKIPPER_ENABLED_PROPERTY_KEY, "true");
-		this.controller.deploy("test", deploymentProperties);
+		this.controller.deploy("test", new HashMap<>());
 		ArgumentCaptor<String> argumentCaptor1 = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<Map> argumentCaptor2 = ArgumentCaptor.forClass(Map.class);
 		verify(defaultStreamService).deployStream(argumentCaptor1.capture(), argumentCaptor2.capture());
 		Assert.assertEquals(argumentCaptor1.getValue(), "test");
-		Assert.assertTrue("Skipper enabled property is missing", argumentCaptor2.getValue().containsKey(SKIPPER_ENABLED_PROPERTY_KEY));
-		Assert.assertFalse("useSkipper key shouldn't exist", argumentCaptor2.getValue().containsKey("useSkipper"));
-		Assert.assertEquals(argumentCaptor2.getValue().get(SKIPPER_ENABLED_PROPERTY_KEY), "true");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
@@ -67,7 +67,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY;
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_NAME;
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_VERSION;
 
@@ -251,7 +250,6 @@ public class SkipperStreamServiceIntegrationTests {
 
 	private Map<String, String> createSkipperDeploymentProperties() {
 		Map<String, String> deploymentProperties = new HashMap<>();
-		deploymentProperties.put(SKIPPER_ENABLED_PROPERTY_KEY, "true");
 		deploymentProperties.put(SKIPPER_PACKAGE_NAME, "ticktock");
 		deploymentProperties.put(SKIPPER_PACKAGE_VERSION, "1.0.0");
 		return deploymentProperties;

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
@@ -50,7 +50,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_ENABLED_PROPERTY_KEY;
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_NAME;
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PACKAGE_VERSION;
 import static org.springframework.cloud.dataflow.rest.SkipperStream.SKIPPER_PLATFORM_NAME;
@@ -116,7 +115,6 @@ public class SkipperStreamCommands extends AbstractStreamCommands implements Com
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, deploymentProperties, PROPERTIES_FILE_OPTION,
 				propertiesFile);
 		Map<String, String> propertiesToUse = getDeploymentProperties(deploymentProperties, propertiesFile, which);
-		propertiesToUse.put(SKIPPER_ENABLED_PROPERTY_KEY, "true");
 		propertiesToUse.put(SKIPPER_PACKAGE_NAME, name);
 		Assert.isTrue(StringUtils.hasText(packageVersion), "Package version must be set when using Skipper.");
 		propertiesToUse.put(SKIPPER_PACKAGE_VERSION, packageVersion);


### PR DESCRIPTION
 - The property `spring.cloud.dataflow.skipper.enabled` is no longer needed and it could be confusing as well.

  - Remove all the usages of it

Resolves #1936