### PR TITLE
gh-1898 Propagate OAuth2 Access Token to Skipper

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -189,6 +189,7 @@ public class DataFlowControllerAutoConfiguration {
 			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 			RestTemplate restTemplate = restTemplateBuilder
 					.errorHandler(new SkipperClientResponseErrorHandler(objectMapper))
+					.interceptors(new OAuth2AccessTokenProvidingClientHttpRequestInterceptor())
 					.messageConverters(Arrays.asList(new StringHttpMessageConverter(),
 							new MappingJackson2HttpMessageConverter(objectMapper)))
 					.build();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/OAuth2AccessTokenProvidingClientHttpRequestInterceptor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/OAuth2AccessTokenProvidingClientHttpRequestInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.config;
+
+import java.io.IOException;
+
+import org.springframework.cloud.common.security.ManualOAuthAuthenticationDetails;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
+
+/**
+ * This implementation of a {@link ClientHttpRequestInterceptor} will retrieve, if available, the OAuth2 Access Token
+ * and add it to the {@code Authorization} HTTP header.
+ *
+ * @author Gunnar Hillert
+ */
+public class OAuth2AccessTokenProvidingClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+			throws IOException {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null && authentication instanceof OAuth2Authentication) {
+			final OAuth2Authentication auth2Authentication = (OAuth2Authentication) authentication;
+
+			final String token;
+			if (auth2Authentication.getDetails() instanceof OAuth2AuthenticationDetails) {
+				final OAuth2AuthenticationDetails auth2AuthenticationDetails =
+					(OAuth2AuthenticationDetails) auth2Authentication.getDetails();
+				token = auth2AuthenticationDetails.getTokenValue();
+			}
+			else if (auth2Authentication.getDetails() instanceof ManualOAuthAuthenticationDetails) {
+				ManualOAuthAuthenticationDetails manualOAuthAuthenticationDetails =
+					(ManualOAuthAuthenticationDetails) auth2Authentication.getDetails();
+				token = manualOAuthAuthenticationDetails.getAccessToken().getValue();
+			}
+			else {
+				token = null;
+			}
+
+			if (token != null) {
+				request.getHeaders().add(HttpHeaders.AUTHORIZATION, OAuth2AccessToken.BEARER_TYPE + " " + token);
+			}
+		}
+		return execution.execute(request, body);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,46 +148,47 @@ public class AboutController {
 
 		final RuntimeEnvironment runtimeEnvironment = new RuntimeEnvironment();
 
-		if (this.streamDeployer != null) {
-			final RuntimeEnvironmentInfo deployerEnvironmentInfo = this.streamDeployer.environmentInfo();
-			final RuntimeEnvironmentDetails deployerInfo = new RuntimeEnvironmentDetails();
+		if (!authenticationEnabled || (authenticationEnabled && SecurityContextHolder.getContext().getAuthentication() != null)) {
+			if (this.streamDeployer != null) {
+				final RuntimeEnvironmentInfo deployerEnvironmentInfo = this.streamDeployer.environmentInfo();
+				final RuntimeEnvironmentDetails deployerInfo = new RuntimeEnvironmentDetails();
 
-			deployerInfo.setDeployerImplementationVersion(deployerEnvironmentInfo.getImplementationVersion());
-			deployerInfo.setDeployerName(deployerEnvironmentInfo.getImplementationName());
-			deployerInfo.setDeployerSpiVersion(deployerEnvironmentInfo.getSpiVersion());
-			deployerInfo.setJavaVersion(deployerEnvironmentInfo.getJavaVersion());
-			deployerInfo.setPlatformApiVersion(deployerEnvironmentInfo.getPlatformApiVersion());
-			deployerInfo.setPlatformClientVersion(deployerEnvironmentInfo.getPlatformClientVersion());
-			deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
-			deployerInfo.setPlatformSpecificInfo(deployerEnvironmentInfo.getPlatformSpecificInfo());
-			deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
-			deployerInfo.setPlatformType(deployerEnvironmentInfo.getPlatformType());
-			deployerInfo.setSpringBootVersion(deployerEnvironmentInfo.getSpringBootVersion());
-			deployerInfo.setSpringVersion(deployerEnvironmentInfo.getSpringVersion());
+				deployerInfo.setDeployerImplementationVersion(deployerEnvironmentInfo.getImplementationVersion());
+				deployerInfo.setDeployerName(deployerEnvironmentInfo.getImplementationName());
+				deployerInfo.setDeployerSpiVersion(deployerEnvironmentInfo.getSpiVersion());
+				deployerInfo.setJavaVersion(deployerEnvironmentInfo.getJavaVersion());
+				deployerInfo.setPlatformApiVersion(deployerEnvironmentInfo.getPlatformApiVersion());
+				deployerInfo.setPlatformClientVersion(deployerEnvironmentInfo.getPlatformClientVersion());
+				deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
+				deployerInfo.setPlatformSpecificInfo(deployerEnvironmentInfo.getPlatformSpecificInfo());
+				deployerInfo.setPlatformHostVersion(deployerEnvironmentInfo.getPlatformHostVersion());
+				deployerInfo.setPlatformType(deployerEnvironmentInfo.getPlatformType());
+				deployerInfo.setSpringBootVersion(deployerEnvironmentInfo.getSpringBootVersion());
+				deployerInfo.setSpringVersion(deployerEnvironmentInfo.getSpringVersion());
 
-			runtimeEnvironment.setAppDeployer(deployerInfo);
+				runtimeEnvironment.setAppDeployer(deployerInfo);
+			}
+
+			if (this.taskLauncher != null) {
+				final RuntimeEnvironmentInfo taskLauncherEnvironmentInfo = this.taskLauncher.environmentInfo();
+				final RuntimeEnvironmentDetails taskLauncherInfo = new RuntimeEnvironmentDetails();
+
+				taskLauncherInfo.setDeployerImplementationVersion(taskLauncherEnvironmentInfo.getImplementationVersion());
+				taskLauncherInfo.setDeployerName(taskLauncherEnvironmentInfo.getImplementationName());
+				taskLauncherInfo.setDeployerSpiVersion(taskLauncherEnvironmentInfo.getSpiVersion());
+				taskLauncherInfo.setJavaVersion(taskLauncherEnvironmentInfo.getJavaVersion());
+				taskLauncherInfo.setPlatformApiVersion(taskLauncherEnvironmentInfo.getPlatformApiVersion());
+				taskLauncherInfo.setPlatformClientVersion(taskLauncherEnvironmentInfo.getPlatformClientVersion());
+				taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
+				taskLauncherInfo.setPlatformSpecificInfo(taskLauncherEnvironmentInfo.getPlatformSpecificInfo());
+				taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
+				taskLauncherInfo.setPlatformType(taskLauncherEnvironmentInfo.getPlatformType());
+				taskLauncherInfo.setSpringBootVersion(taskLauncherEnvironmentInfo.getSpringBootVersion());
+				taskLauncherInfo.setSpringVersion(taskLauncherEnvironmentInfo.getSpringVersion());
+
+				runtimeEnvironment.setTaskLauncher(taskLauncherInfo);
+			}
 		}
-
-		if (this.taskLauncher != null) {
-			final RuntimeEnvironmentInfo taskLauncherEnvironmentInfo = this.taskLauncher.environmentInfo();
-			final RuntimeEnvironmentDetails taskLauncherInfo = new RuntimeEnvironmentDetails();
-
-			taskLauncherInfo.setDeployerImplementationVersion(taskLauncherEnvironmentInfo.getImplementationVersion());
-			taskLauncherInfo.setDeployerName(taskLauncherEnvironmentInfo.getImplementationName());
-			taskLauncherInfo.setDeployerSpiVersion(taskLauncherEnvironmentInfo.getSpiVersion());
-			taskLauncherInfo.setJavaVersion(taskLauncherEnvironmentInfo.getJavaVersion());
-			taskLauncherInfo.setPlatformApiVersion(taskLauncherEnvironmentInfo.getPlatformApiVersion());
-			taskLauncherInfo.setPlatformClientVersion(taskLauncherEnvironmentInfo.getPlatformClientVersion());
-			taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
-			taskLauncherInfo.setPlatformSpecificInfo(taskLauncherEnvironmentInfo.getPlatformSpecificInfo());
-			taskLauncherInfo.setPlatformHostVersion(taskLauncherEnvironmentInfo.getPlatformHostVersion());
-			taskLauncherInfo.setPlatformType(taskLauncherEnvironmentInfo.getPlatformType());
-			taskLauncherInfo.setSpringBootVersion(taskLauncherEnvironmentInfo.getSpringBootVersion());
-			taskLauncherInfo.setSpringVersion(taskLauncherEnvironmentInfo.getSpringVersion());
-
-			runtimeEnvironment.setTaskLauncher(taskLauncherInfo);
-		}
-
 		aboutResource.setRuntimeEnvironment(runtimeEnvironment);
 		aboutResource.add(ControllerLinkBuilder.linkTo(AboutController.class).withSelfRel());
 


### PR DESCRIPTION
- Add `OAuth2AccessTokenProvidingClientHttpRequestInterceptor` to SkipperClient's `RestTemplate`

`OAuth2AccessTokenProvidingClientHttpRequestInterceptor` will retrieve the OAuth2 Access Token (If available) and add it to subsequent Skipper-related REST calls

This is supported for the following 3 use-cases:

- User provides username and password via shell
- User provides Access Token directly to SCDF using the `Authorization` HTTP header (e.g. via shell `--dataflow.credentials-provider-command`)
- User wants to use the UI and at first gets redirected the OAuth Server for authentication and then back to the dashboard UI

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1898

depends on https://github.com/spring-cloud/spring-cloud-common-security-config/issues/4