### PR TITLE
Sync Skipper client changes

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -127,10 +127,9 @@ public interface StreamOperations {
 	/**
 	 * Get the history of releases for the given stream deployed via Skipper.
 	 * @param streamName the stream(release) name
-	 * @param max the maximum number of revisions to include in the history
 	 * @return the history of releases for the stream
 	 */
-	Collection<Release> history(String streamName, int max);
+	Collection<Release> history(String streamName);
 
 	/**
 	 * @return the list of all Skipper platforms

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -173,13 +173,13 @@ public class StreamTemplate implements StreamOperations {
 	}
 
 	@Override
-	public Collection<Release> history(String streamName, int maxRevisions) {
+	public Collection<Release> history(String streamName) {
 		Assert.hasText(streamName, "Release name cannot be null or empty");
 		ParameterizedTypeReference<Collection<Release>> typeReference = new ParameterizedTypeReference<Collection<Release>>
 				() {
 		};
 		Map<String, Object> parameters = new HashMap<>();
-		String url = String.format("%s/%s/%s/%s", deploymentsLink.getHref(), "history", streamName, maxRevisions);
+		String url = String.format("%s/%s/%s", deploymentsLink.getHref(), "history", streamName);
 		return this.restTemplate.exchange(url, HttpMethod.GET, null, typeReference, parameters).getBody();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
@@ -168,6 +169,12 @@ public class StreamDeploymentController {
 	@ResponseStatus(HttpStatus.OK)
 	public String manifest(@PathVariable("name") String name, @PathVariable("version") int version) {
 		return this.streamService.manifest(name, version);
+	}
+
+	@RequestMapping(path = "/history/{name}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public Collection<Release> history(@PathVariable("name") String releaseName) {
+		return this.streamService.history(releaseName);
 	}
 
 	@RequestMapping(path = "/platform/list", method = RequestMethod.GET)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -36,7 +36,6 @@ import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.Deployer;
-import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
@@ -169,13 +168,6 @@ public class StreamDeploymentController {
 	@ResponseStatus(HttpStatus.OK)
 	public String manifest(@PathVariable("name") String name, @PathVariable("version") int version) {
 		return this.streamService.manifest(name, version);
-	}
-
-	@RequestMapping(path = "/history/{name}/{max}", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	public Collection<Release> history(@PathVariable("name") String releaseName,
-			@PathVariable("max") int maxRevisions) {
-		return this.streamService.history(releaseName, maxRevisions);
 	}
 
 	@RequestMapping(path = "/platform/list", method = RequestMethod.GET)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -88,10 +88,9 @@ public interface StreamService {
 	/**
 	 * Get stream's deployment history
 	 * @param releaseName Stream release name
-	 * @param maxRevisions If positive, the max release revision to filter by. Negative value will return all releases.
 	 * @return List or Releases for this release name
 	 */
-	Collection<Release> history(String releaseName, int maxRevisions);
+	Collection<Release> history(String releaseName);
 
 	/**
 	 * @return list of supported deployment platforms

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
@@ -116,7 +116,7 @@ public class AppDeployerStreamService extends AbstractStreamService {
 	}
 
 	@Override
-	public Collection<Release> history(String releaseName, int maxRevisions) {
+	public Collection<Release> history(String releaseName) {
 		throw new IncompatibleStreamDeployerException(StreamDeployers.appdeployer.toString());
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamService.java
@@ -263,8 +263,8 @@ public class SkipperStreamService extends AbstractStreamService {
 	}
 
 	@Override
-	public Collection<Release> history(String releaseName, int maxRevisions) {
-		return this.skipperStreamDeployer.history(releaseName, maxRevisions);
+	public Collection<Release> history(String releaseName) {
+		return this.skipperStreamDeployer.history(releaseName);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -480,7 +480,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		return this.skipperClient.manifest(name);
 	}
 
-	public Collection<Release> history(String releaseName, int maxRevisions) {
+	public Collection<Release> history(String releaseName) {
 		return this.skipperClient.history(releaseName).getContent();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/SkipperStreamServiceIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -250,6 +250,7 @@ public class SkipperStreamDeployerTests {
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenThrow(new ReleaseNotFoundException(""));
 
 		skipperStreamDeployer.undeployStream(streamDefinition.getName());
+
 		verify(skipperClient, times(0)).delete(eq(streamDefinition.getName()), eq(true));
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperStreamCommands.java
@@ -142,10 +142,8 @@ public class SkipperStreamCommands extends AbstractStreamCommands implements Com
 	public Table history(
 			@CliOption(key = { "",
 					"name" }, help = "the name of the stream", mandatory = true, optionContext = "existing-stream "
-					+ "disable-string-converter") String name,
-			@CliOption(key = { "max" }, help = "the maximum number of revisions to retrieve",
-					unspecifiedDefaultValue = "0") int max) {
-		Collection<Release> releases = streamOperations().history(name, max);
+					+ "disable-string-converter") String name) {
+		Collection<Release> releases = streamOperations().history(name);
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("version", "Version");
 		headers.put("info.lastDeployed", "Last updated");


### PR DESCRIPTION
 - Update release delete request changes
  - Use boolean path variable instead of DeleteProperties
  - Update tests
 - Remove release history --max option
  - Remove the references of max revisions from history command, client and controller side
 - Fix Release.setManifest changes

Resolves #1947