### PR TITLE
Documentation on server modes

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -219,7 +219,7 @@ To use features such as Stream update and rollback, the Data Flow Server delegat
 +
 [source,bash,subs=attributes]
 ----
-$ java -jar -jar spring-cloud-dataflow-server-local-{project-version}.jar --spring.cloud.config.skipper.client.uri=http://192.51.100.1:7577/api
+$ java -jar spring-cloud-dataflow-server-local-{project-version}.jar --spring.cloud.skipper.client.serverUri=http://192.51.100.1:7577/api --spring.cloud.dataflow.features.skipper-enabled=true
 ----
 
 [[configuration-security]]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started.adoc
@@ -23,6 +23,11 @@ For the deployed streams and tasks to communicate, either link:http://www.rabbit
 
 [[getting-started-deploying-spring-cloud-dataflow]]
 == Installation
+
+Starting 1.3.x, the Data Flow Server can run in either `skipper` or `classic` (non-skipper) modes.
+The modes can be specified when starting the Data Flow server using the property `spring.cloud.dataflow.features.skipper-enabled`.
+By default, the `classic` mode is enabled.
+
 . Download the Spring Cloud Data Flow Server and Shell apps:
 +
 [source,bash,subs=attributes]
@@ -40,7 +45,7 @@ wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework
 wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{skipper-version}/spring-cloud-skipper-shell-{skipper-version}.jar
 ----
 +
-. Launch Skipper
+. Launch Skipper (Required only if you want to run Spring Cloud Data Flow server in `skipper` mode)
 +
 In the directory where you downloaded skipper, run the server using `java -jar`
 +
@@ -53,17 +58,45 @@ $ java -jar spring-cloud-skipper-server-{skipper-version}.jar
 +
 In the directory where you downloaded Data Flow, run the server using `java -jar`
 +
+To run the Data Flow server in `classic` mode:
 [source,bash,subs=attributes]
 ----
 $ java -jar spring-cloud-dataflow-server-local-{project-version}.jar
 ----
+
+To run the Data Flow server in `skipper` mode:
+[source,bash,subs=attributes]
+----
+$ java -jar spring-cloud-dataflow-server-local-{project-version}.jar --spring.cloud.dataflow.features.skipper-enabled=true
+----
+
++
+If Skipper and the Data Flow server are not running on the same host, set the configuration property `spring.cloud.skipper.client.serverUri` to the location of Skipper, e.g.
++
+[source,bash,subs=attributes]
+----
+$ java -jar spring-cloud-dataflow-server-local-{project-version}.jar --spring.cloud.skipper.client.serverUri=http://192.51.100.1:7577/api
+----
+
 +
 . Launch the Data Flow Shell:
 +
+Launching the Data Flow shell requires the appropriate data flow server mode to be specified.
+To start the Data Flow Shell for the Data Flow server running in `classic` mode:
+
 [source,bash,subs=attributes]
 ----
 $ java -jar spring-cloud-dataflow-shell-{project-version}.jar
 ----
+
+To start the Data Flow Shell for the Data Flow server running in `skipper` mode:
+[source,bash,subs=attributes]
+----
+$ java -jar spring-cloud-dataflow-shell-{project-version}.jar --dataflow.mode=skipper
+----
+
+NOTE: Both the Data Flow Server and the Shell must be on the same mode.
+
 +
 If the Data Flow Server and shell are not running on the same host, point the shell to the Data Flow server URL:
 +
@@ -72,13 +105,6 @@ If the Data Flow Server and shell are not running on the same host, point the sh
 server-unknown:>dataflow config server http://198.51.100.0
 Successfully targeted http://198.51.100.0
 dataflow:>
-----
-+
-If Skipper and the Data Flow server are not running on the same host, set the configuration property `spring.cloud.skipper.client.uri` to the location of Skipper, e.g.
-+
-[source,bash,subs=attributes]
-----
-$ java -jar -jar spring-cloud-dataflow-server-local-{project-version}.jar --spring.cloud.config.skipper.client.uri=http://192.51.100.1:7577/api
 ----
 
 [[getting-started-deploying-streams-spring-cloud-dataflow]]
@@ -132,7 +158,7 @@ You can now use the shell commands to list available applications (source/proces
 [source,bash]
 ----
 dataflow:> stream create --name httptest --definition "http --server.port=9000 | log"
-dataflow:> stream skipper deploy --name httptest
+dataflow:> stream deploy --name httptest
 ----
 +
 NOTE: You will need to wait a little while until the apps are actually deployed successfully

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams-skipper.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams-skipper.adoc
@@ -33,7 +33,7 @@ app:
 Now update the Stream
 [source,bash]
 ----
-dataflow:> stream skipper update --name httptest --propertiesFile /home/mpollack/local-log-update.yml
+dataflow:> stream update --name httptest --propertiesFile /home/mpollack/local-log-update.yml
 Update request has been sent for the stream 'httptest'
 ----
 
@@ -81,11 +81,11 @@ $ curl http://localhost:9002/info
 
 === Stream History
 
-The history of the Stream can be viewed by executing the `stream skipper history` command
+The history of the Stream can be viewed by executing the `stream history` command
 
 [source,bash]
 ----
-dataflow:>stream skipper history --name httptest
+dataflow:>stream history --name httptest
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -97,12 +97,12 @@ dataflow:>stream skipper history --name httptest
 === Stream Manifest
 
 The manifest is a YAML document that represents the final state of what was deployed to the platform.
-You can view the manifest for any Stream version using the command `stream skipper manifest --name <name-of-stream> --releaseVersion <optional-version>`
+You can view the manifest for any Stream version using the command `stream manifest --name <name-of-stream> --releaseVersion <optional-version>`
 If the `--releaseVersion` is not specified, the manifest for the last version is returned.
 
 [source,bash]
 ----
-dataflow:>stream skipper manifest --name httptest
+dataflow:>stream manifest --name httptest
 
 ---
 # Source: log.yml
@@ -156,11 +156,11 @@ If you compare this YAML document to the one for `--releaseVersion=1` you will s
 
 == Rolling back
 
-To go back to the previous version of the stream, use the `stream skipper rollback` command.
+To go back to the previous version of the stream, use the `stream rollback` command.
 
 [source,bash]
 ----
-dataflow:>stream skipper rollback --name httptest
+dataflow:>stream rollback --name httptest
 Rollback request has been sent for the stream 'httptest'
 ----
 
@@ -203,7 +203,7 @@ The history command now shows the third version of the stream hsa been deployed.
 
 [source,bash]
 ----
-dataflow:>stream skipper history --name httptest
+dataflow:>stream history --name httptest
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -872,42 +872,48 @@ Subsequent commands to upgrade and rollback applications within the Stream are p
 
 [[spring-cloud-dataflow-stream-lifecycle-skipper-create]]
 === Creating and Deploying a Stream
-You create and deploy a stream using skipper in two steps, creating the stream definition and then deploying the stream.
+You create and deploy a stream as follows:
+[source,bash]
+----
+dataflow:> stream create --name httptest --definition "http --server.port=9000 | log" --deploy
+----
+
+If you want to pass deployment properties, you can create and deploy a stream in two steps:
 [source,bash]
 ----
 dataflow:> stream create --name httptest --definition "http --server.port=9000 | log"
-dataflow:> stream skipper deploy --name httptest
+dataflow:> stream deploy --name httptest
 ----
 
-There is an important optional command argument to the `stream skipper deploy` command, which is `--platformName`.
+There is an important optional command argument to the `stream deploy` command, which is `--platformName`.
 Skipper can be configured to deploy to multiple platforms.
 Skipper is pre-configured with a platform named `default` which will deploys applications to the local machine where Skipper is running.
 The default value of the command line argument `--platformName` is `default`.
 If you are commonly deploying to one platform, when installing Skipper you can override the configuration of the `default` platform.
-Otherwise, specify the platformName to one of the values returned by the command `stream skipper platform-list`
+Otherwise, specify the platformName to one of the values returned by the command `stream platform-list`
 
 NOTE: In future releases, only the local Data Flow server will be configured with the `default` platform.
 
 
 [[spring-cloud-dataflow-stream-lifecycle-skipper-update]]
 === Updating a Stream
-To update the stream, use the command `stream skipper update` which takes as a command argument either `--properties` or `--propertiesFile`.
+To update the stream, use the command `stream update` which takes as a command argument either `--properties` or `--propertiesFile`.
 You can pass in values to these command arguments in the same format as when deploy the stream with or without Skipper.
 There is an important new top level prefix available when using Skipper, which is `version`.
 If the Stream `http | log` was deployed, and the version of `log` which registered at the time of deployment was `1.1.0.RELEASE`, the following command will update the Stream to use the `1.2.0.RELEASE` of the log application.
 [source,bash]
 ----
-dataflow:>stream skipper update --name httptest --properties version.log=1.2.0.RELEASE
+dataflow:>stream update --name httptest --properties version.log=1.2.0.RELEASE
 ----
 
 === Stream versions
 Skipper keeps a history of the Streams that were deployed.
 After updating a Stream, there will be a second version of the stream.
-You can query for the history of the versions using the command `stream skipper history --name <name-of-stream>`.
+You can query for the history of the versions using the command `stream history --name <name-of-stream>`.
 
 [source,bash]
 ----
-dataflow:>stream skipper history --name httptest
+dataflow:>stream history --name httptest
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -919,12 +925,12 @@ dataflow:>stream skipper history --name httptest
 === Stream Manifests
 Skipper keeps an "manifest" of the all the applications, their application properties and deployment properties after all values have been substituted.
 This represents the final state of what was deployed to the platform.
-You can view the manifest for any of the versions of a Stream using the command `stream skipper manifest --name <name-of-stream> --releaseVersion <optional-version>`
+You can view the manifest for any of the versions of a Stream using the command `stream manifest --name <name-of-stream> --releaseVersion <optional-version>`
 If the `--releaseVersion` is not specified, the manifest for the last version is returned.
 
 [source,bash]
 ----
-dataflow:>stream skipper manifest --name httptest
+dataflow:>stream manifest --name httptest
 
 ---
 # Source: log.yml
@@ -976,10 +982,10 @@ The majority of the deployment and application properties were set by Data Flow 
 
 [[spring-cloud-dataflow-stream-lifecycle-skipper-rollback]]
 === Rollback a Stream
-You can rollback to a previous version of the Stream using the command `stream skipper rollback`.
+You can rollback to a previous version of the Stream using the command `stream rollback`.
 [source,bash]
 ----
-dataflow:>stream skipper rollback --name httptest
+dataflow:>stream rollback --name httptest
 ----
 
 There is an optional `--releaseVersion` command argument which is the version of the Stream.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -867,7 +867,7 @@ Spring Cloud Data Flow is integrated with Skipper by generating a Skipper packag
 The generated package name is the same name as the Stream.
 The generated package is uploaded to Skipper's package repository and Data Flow then instructs
 Skipper to install the package that corresponds to the Stream.
-Subsequent commands to upgrade and rollback applications within the Stream are passed through to Skipper after some validation checks are performed by Data Flow.
+Subsequent commands to upgrade and rollback the applications within the Stream are passed through to Skipper after some validation checks are performed by Data Flow.
 
 
 [[spring-cloud-dataflow-stream-lifecycle-skipper-create]]
@@ -885,6 +885,31 @@ dataflow:> stream create --name httptest --definition "http --server.port=9000 |
 dataflow:> stream deploy --name httptest
 ----
 
+The command `stream info` shows useful information about the stream including the deployment properties.
+[source,bash]
+----
+dataflow:>stream info httptest
+╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
+║             Name             │             DSL              │            Status            ║
+╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣
+║httptest                      │http --server.port=9000 | log │deploying                     ║
+╚══════════════════════════════╧══════════════════════════════╧══════════════════════════════╝
+
+Stream Deployment properties: {
+  "log" : {
+    "spring.cloud.deployer.indexed" : "true",
+    "spring.cloud.deployer.group" : "httptest",
+    "maven://org.springframework.cloud.stream.app:log-sink-rabbit" : "1.1.0.RELEASE"
+  },
+  "http" : {
+    "spring.cloud.deployer.group" : "httptest",
+    "maven://org.springframework.cloud.stream.app:http-source-rabbit" : "1.1.0.RELEASE"
+  }
+}
+
+----
+
+
 There is an important optional command argument to the `stream deploy` command, which is `--platformName`.
 Skipper can be configured to deploy to multiple platforms.
 Skipper is pre-configured with a platform named `default` which will deploys applications to the local machine where Skipper is running.
@@ -901,11 +926,43 @@ To update the stream, use the command `stream update` which takes as a command a
 You can pass in values to these command arguments in the same format as when deploy the stream with or without Skipper.
 There is an important new top level prefix available when using Skipper, which is `version`.
 If the Stream `http | log` was deployed, and the version of `log` which registered at the time of deployment was `1.1.0.RELEASE`, the following command will update the Stream to use the `1.2.0.RELEASE` of the log application.
+Before updating the stream with the specific version of the app, we need to make sure that the app is registered with that version.
+[source,bash]
+----
+dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE
+Successfully registered application 'sink:log'
+----
+
 [source,bash]
 ----
 dataflow:>stream update --name httptest --properties version.log=1.2.0.RELEASE
 ----
 
+To verify the deployment properties and the updated version, we can use `stream info`
+
+[source,bash]
+----
+dataflow:>stream info httptest
+╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
+║             Name             │             DSL              │            Status            ║
+╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣
+║httptest                      │http --server.port=9000 | log │deploying                     ║
+╚══════════════════════════════╧══════════════════════════════╧══════════════════════════════╝
+
+Stream Deployment properties: {
+  "log" : {
+    "spring.cloud.deployer.indexed" : "true",
+    "spring.cloud.deployer.count" : "1",
+    "spring.cloud.deployer.group" : "httptest",
+    "maven://org.springframework.cloud.stream.app:log-sink-rabbit" : "1.2.0.RELEASE"
+  },
+  "http" : {
+    "spring.cloud.deployer.group" : "httptest",
+    "maven://org.springframework.cloud.stream.app:http-source-rabbit" : "1.1.0.RELEASE"
+  }
+}
+
+----
 === Stream versions
 Skipper keeps a history of the Streams that were deployed.
 After updating a Stream, there will be a second version of the stream.


### PR DESCRIPTION
 - Add doc for using Data Flow server/shell in classic vs skipper mode
  - Update getting started doc
 - Fix stream commands to remove the `skipper` prefix

Resolves #1932