### PR TITLE
Fix versioned app registry update

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
@@ -143,15 +143,15 @@ public class DefaultAppRegistryService extends AbstractAppRegistryCommon impleme
 	public AppRegistration save(AppRegistration app) {
 		AppRegistration appRegistration = this.appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
 				app.getName(), app.getType(), app.getVersion());
-		if (getDefaultApp(app.getName(), app.getType()) == null) {
-			app.setDefaultVersion(true);
-		}
 		if (appRegistration != null) {
 			appRegistration.setUri(app.getUri());
 			appRegistration.setMetadataUri(app.getMetadataUri());
 			return this.appRegistrationRepository.save(appRegistration);
 		}
 		else {
+			if (getDefaultApp(app.getName(), app.getType()) == null) {
+				app.setDefaultVersion(true);
+			}
 			return this.appRegistrationRepository.save(app);
 		}
 	}

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
@@ -141,10 +141,19 @@ public class DefaultAppRegistryService extends AbstractAppRegistryCommon impleme
 
 	@Override
 	public AppRegistration save(AppRegistration app) {
+		AppRegistration appRegistration = this.appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				app.getName(), app.getType(), app.getVersion());
 		if (getDefaultApp(app.getName(), app.getType()) == null) {
 			app.setDefaultVersion(true);
 		}
-		return this.appRegistrationRepository.save(app);
+		if (appRegistration != null) {
+			appRegistration.setUri(app.getUri());
+			appRegistration.setMetadataUri(app.getMetadataUri());
+			return this.appRegistrationRepository.save(appRegistration);
+		}
+		else {
+			return this.appRegistrationRepository.save(app);
+		}
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -15,6 +15,9 @@ logging:
     # The following INFO is to log the embedded tomcat port
     org.springframework.boot.context.embedded.tomcat: 'INFO'
 spring:
+  jpa:
+    properties:
+      hibernate.id.new_generator_mappings: true
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
   cloud:

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/VersionedAppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/VersionedAppRegistryControllerTests.java
@@ -159,13 +159,13 @@ public class VersionedAppRegistryControllerTests {
 	public void testRegisterAllWithForce() throws Exception {
 		this.appRegistryService.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
 		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT"));
 		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT"));
 		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
-				is("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT"));
 		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT"));
 	}
 
 	@Test

--- a/spring-cloud-starter-dataflow-server-local/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/main/resources/dataflow-server.yml
@@ -22,9 +22,8 @@ spring:
   application:
     name: spring-cloud-dataflow-server-local
   jpa:
-    generate-ddl: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
   cloud:
     config:
       uri: http://localhost:8888

--- a/spring-cloud-starter-dataflow-server-local/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-starter-dataflow-server-local/src/main/resources/dataflow-server.yml
@@ -22,8 +22,9 @@ spring:
   application:
     name: spring-cloud-dataflow-server-local
   jpa:
+    generate-ddl: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
   cloud:
     config:
       uri: http://localhost:8888


### PR DESCRIPTION
 - When re-register the app using `--force` option, the existing app registrations need to be updated instead of creating new app registration entries
   - This will make sure there will be unique entry for the app by the given name, type and version.
   - Update test

Resolves #1955

Fix schema issue in local server

 - Remove `spring.jpa.generate-ddl:false` and set `spring.jpa.hibernate.ddl-auto:create`

Resolves #1959