### PR TITLE
Auto-quote property values on DSL reverse engineering

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
@@ -88,7 +88,7 @@ public class StreamDefinitionToDslConverter {
 			for (String propertyName : props.keySet()) {
 				if (!dataFlowAddedProperties.contains(propertyName)) {
 					String propertyValue = unescape(props.get(propertyName));
-					dslBuilder.append(" --").append(propertyName).append("=").append(propertyValue);
+					dslBuilder.append(" --").append(propertyName).append("=").append(autoQuotes(propertyValue));
 				}
 			}
 
@@ -109,6 +109,13 @@ public class StreamDefinitionToDslConverter {
 		String dsl = dslBuilder.toString().replace("> bridge >", ">");
 
 		return dsl;
+	}
+
+	private String autoQuotes(String propertyValue) {
+		if (propertyValue.contains(" ") && !propertyValue.contains("'")) {
+			return "'" + propertyValue + "'";
+		}
+		return propertyValue;
 	}
 
 	private String unescape(String text) {

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverterTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverterTests.java
@@ -126,7 +126,7 @@ public class StreamDefinitionToDslConverterTests {
 	}
 
 	@Test
-	public void textExclusionOfDataFlowAddedProperties() {
+	public void testExclusionOfDataFlowAddedProperties() {
 
 		List<String> dataFlowAddedProperties = Arrays.asList(
 				DataFlowPropertyKeys.STREAM_APP_TYPE,
@@ -151,7 +151,7 @@ public class StreamDefinitionToDslConverterTests {
 	}
 
 	@Test
-	public void textInputDestinatioProperty() {
+	public void testInputDestinationProperty() {
 
 		String dslText = "foo --" + BindingPropertyKeys.INPUT_DESTINATION + "=boza  | bar";
 
@@ -160,6 +160,31 @@ public class StreamDefinitionToDslConverterTests {
 
 		assertEquals(":boza > foo | bar",
 				new StreamDefinitionToDslConverter().toDsl(streamDefinition.getAppDefinitions()));
+	}
+
+	@Test
+	public void testPropertyAutoQuotes() {
+
+		StreamDefinition streamDefinition = new StreamDefinition("streamName", "foo | bar");
+
+
+		StreamAppDefinition foo = streamDefinition.getAppDefinitions().get(0);
+		StreamAppDefinition bar = streamDefinition.getAppDefinitions().get(1);
+
+		StreamAppDefinition foo2 = StreamAppDefinition.Builder.from(foo)
+				.setProperty("p1", "a b")
+				.setProperty("p2", "'c d'")
+				.setProperty("p3", "ef")
+				.build("stream2");
+
+		StreamAppDefinition bar2 = StreamAppDefinition.Builder.from(bar)
+				.setProperty("p1", "a b")
+				.setProperty("p2", "'c d'")
+				.setProperty("p3", "ef")
+				.build("stream2");
+
+		assertEquals("foo --p1='a b' --p2='c d' --p3=ef | bar --p1='a b' --p2='c d' --p3=ef",
+				new StreamDefinitionToDslConverter().toDsl(Arrays.asList(foo2, bar2)));
 	}
 
 }


### PR DESCRIPTION
 * If property contains space and doesn't contain quotes then add quotes
 * Add tests
Resolves #1984