### PR TITLE
Fix partial aggregate deployment state

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,6 +145,10 @@ public class StreamDefinitionController {
 		if (states.isEmpty() || states.contains(DeploymentState.error)) {
 			logger.debug("aggregateState: Returning " + DeploymentState.error);
 			return DeploymentState.error;
+		}
+		if (states.contains(DeploymentState.deployed) && states.contains(DeploymentState.failed)) {
+			logger.debug("aggregateState: Returning " + DeploymentState.partial);
+			return DeploymentState.partial;
 		}
 		if (states.contains(DeploymentState.failed)) {
 			logger.debug("aggregateState: Returning " + DeploymentState.failed);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -889,7 +889,7 @@ public class StreamControllerTests {
 
 	@Test
 	public void testAggregateState() {
-		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(deployed, failed)), is(failed));
+		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(deployed, failed)), is(partial));
 		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(unknown, failed)), is(failed));
 		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(deployed, failed, error)), is(error));
 		assertThat(StreamDefinitionController.aggregateState(EnumSet.of(deployed, undeployed)), is(partial));


### PR DESCRIPTION
 - If the stream has at least one of the apps successfully deployed but at least one of the apps has failed, then the aggregate state needs to be set to `partital` instead of `failed`
  - This state will show the appropriate status description as:
`In the case of multiple apps, some have successfully deployed, while others have not`

Resolves #1974