### PR TITLE
AboutController returns correct repo for version RC1

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -271,6 +271,8 @@ public class AboutController {
 		final String REPO_SNAPSHOT_ROOT = "https://repo.spring.io/libs-snapshot";
 		final String REPO_MILESTONE_ROOT = "https://repo.spring.io/libs-milestone";
 		final String MAVEN_ROOT = "https://repo1.maven.org/maven2";
+		final String REPO_RELEASE_ROOT = "https://repo.spring.io/libs-release";
+
 		String result = MAVEN_ROOT;
 		if (version.endsWith(BUILD_SNAPSHOT_CRITERIA)) {
 			result = REPO_SNAPSHOT_ROOT;
@@ -280,6 +282,9 @@ public class AboutController {
 		}
 		else if (version.contains(".RC")) {
 			result = REPO_MILESTONE_ROOT;
+		}
+		else if (version.contains(".RELEASE")) {
+			result = REPO_RELEASE_ROOT;
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -270,7 +270,6 @@ public class AboutController {
 		final String BUILD_SNAPSHOT_CRITERIA = "BUILD-SNAPSHOT";
 		final String REPO_SNAPSHOT_ROOT = "https://repo.spring.io/libs-snapshot";
 		final String REPO_MILESTONE_ROOT = "https://repo.spring.io/libs-milestone";
-		final String REPO_RELEASE_ROOT = "https://repo.spring.io/libs-release";
 		final String MAVEN_ROOT = "https://repo1.maven.org/maven2";
 		String result = MAVEN_ROOT;
 		if (version.endsWith(BUILD_SNAPSHOT_CRITERIA)) {
@@ -280,7 +279,7 @@ public class AboutController {
 			result = REPO_MILESTONE_ROOT;
 		}
 		else if (version.contains(".RC")) {
-			result = REPO_RELEASE_ROOT;
+			result = REPO_MILESTONE_ROOT;
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
@@ -132,6 +132,106 @@ public class AboutControllerTests {
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.M1",
+			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
+	})
+	public static class MilestoneUrlTests {
+
+		private MockMvc mockMvc;
+
+		@Autowired
+		private WebApplicationContext wac;
+
+		@Before
+		public void setupMocks() {
+			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		}
+
+		@Test
+		public void testMilestone() throws Exception {
+			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
+			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(false)))
+					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/libs-milestone/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.M1/spring-cloud-dataflow-shell-1.2.3.M1.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.M1")))
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
+		}
+	}
+
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = TestDependencies.class)
+	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+	@TestPropertySource(properties = {
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.RC1",
+			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
+	})
+	public static class RCUrlTests {
+
+		private MockMvc mockMvc;
+
+		@Autowired
+		private WebApplicationContext wac;
+
+		@Before
+		public void setupMocks() {
+			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		}
+
+		@Test
+		public void testRC() throws Exception {
+			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
+			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(false)))
+					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/libs-milestone/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.RC1/spring-cloud-dataflow-shell-1.2.3.RC1.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.RC1")))
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = TestDependencies.class)
+	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+	@TestPropertySource(properties = {
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.GA1",
+			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
+	})
+	public static class ReleaseUrlTests {
+
+		private MockMvc mockMvc;
+
+		@Autowired
+		private WebApplicationContext wac;
+
+		@Before
+		public void setupMocks() {
+			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		}
+
+		@Test
+		public void testRelease() throws Exception {
+			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
+			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(false)))
+					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.GA1/spring-cloud-dataflow-shell-1.2.3.GA1.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.GA1")))
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = TestDependencies.class)
+	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+	@TestPropertySource(properties = {
 			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.RELEASE",
 			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=true",
 			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.url=https://repo.spring.io/libs-milestone/org/springframework/cloud/spring-cloud-dataflow-shell/1.3.0.BUILD-SNAPSHOT/spring-cloud-dataflow-shell-1.3.0.BUILD-SNAPSHOT.jsdfasdf",

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
@@ -199,7 +199,40 @@ public class AboutControllerTests {
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
-			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.GA1",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.GA",
+			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
+	})
+	public static class GAUrlTests {
+
+		private MockMvc mockMvc;
+
+		@Autowired
+		private WebApplicationContext wac;
+
+		@Before
+		public void setupMocks() {
+			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		}
+
+		@Test
+		public void testGA() throws Exception {
+			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
+			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(false)))
+					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.GA/spring-cloud-dataflow-shell-1.2.3.GA.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.GA")))
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
+					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = TestDependencies.class)
+	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+	@TestPropertySource(properties = {
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.RELEASE",
 			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
 			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
 	})
@@ -221,8 +254,8 @@ public class AboutControllerTests {
 			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
 			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(false)))
 					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
-					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.GA1/spring-cloud-dataflow-shell-1.2.3.GA1.jar")))
-					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.GA1")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/libs-release/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.RELEASE/spring-cloud-dataflow-shell-1.2.3.RELEASE.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.RELEASE")))
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
 		}


### PR DESCRIPTION
Originally the repo was libs-release for RC1 for any About URL that used the {repository} tag.
This has been updated to set the repo to libs-milestone.
resolves #2005