### PR TITLE
Updated database section

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -37,6 +37,8 @@ The REST `/about` endpoint provides information on the features that have been e
 
 A relational database is used to store stream and task definitions as well as the state of executed tasks.
 Spring Cloud Data Flow provides schemas for H2, HSQLDB, MySQL, Oracle, Postgresql, DB2, and SqlServer. The schema is automatically created when the server starts.
+
+
 By default, Spring Cloud Data Flow offers an embedded instance of the H2 database.
 The H2 database is good for development purposes but is not recommended for production use.
 
@@ -87,20 +89,21 @@ java -jar spring-cloud-dataflow-server-local/target/spring-cloud-dataflow-server
     --spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver &
 ----
 
-NOTE: There is a schema update to the Spring Cloud Data Flow datastore when
-upgrading from version `1.0.x` to `1.1.x`.  Migration scripts for specific
-database types can be found
-https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-core/src/main/resources/org/springframework/cloud/task/migration[here].
-
-NOTE: There is a schema update to the Spring Cloud Data Flow datastore when upgrading to version `1.3.x` from any of the previous releases.
-Migration scripts for specific database types can be found https://github.com/spring-cloud/spring-cloud-dataflow/spring-cloud-dataflow-server-core/src/main/resources/migration/1.3.x[here].
-
 NOTE: If you wish to use an external H2 database instance instead of the one
 embedded with Spring Cloud Data Flow, set the
 `spring.dataflow.embedded.database.enabled` property to false.  If
 `spring.dataflow.embedded.database.enabled` is set to false or a database
 other than h2 is specified as the datasource, the embedded database does not
 start.
+
+=== Disabling database schema creation and migration strategies
+
+You can control whether or not Data Flow bootstraps your database on startup. On most production environments chances are you will not have enough privileges to do so.
+If that's the case you can disable it by setting the property `spring.cloud.dataflow.rdbms.initialize.enable` to `false`.
+The scripts that the server uses to bootstrap the database can be found under `spring-cloud-dataflow-core/src/main/resources/` folder.
+
+For new installations run the corresponding database script located under `/schemas` and `/migrations.1.x.x`, for upgrades from version `1.2.0` you only need to run the `/migrations.1.x.x` scripts.
+
 
 === Adding a Custom JDBC Driver
 To add a custom driver for the database (for example, Oracle), you should rebuild the Data Flow Server and add the dependency to the Maven `pom.xml` file.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Data Flow Reference Guide
-Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Patrick Peralta; Glenn Renfro; Thomas Risberg; Dave Syer; David Turanski; Janne Valkealahti; Oleg Zhurakousky; Jay Bryant
+Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Patrick Peralta; Glenn Renfro; Thomas Risberg; Dave Syer; David Turanski; Janne Valkealahti; Oleg Zhurakousky; Jay Bryant; Vinicius Carvalho
 :doctype: book
 :toc: left
 :toclevels: 4


### PR DESCRIPTION
Fixes #1958
- Added a specific session for schema management
- Removed old section on migration from 1.1.x
- Explained how to disable auto schema creation for production
  environments where users may not have DDL privileges