### PR TITLE
Fix typo in architecture.adoc

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
@@ -227,7 +227,7 @@ Rolling back to a previous application version is also supported.
 
 ifndef::omit-tasks-docs[]
 [[arch-task]]
-== Task Programming Mdoel
+== Task Programming Model
 
 The Spring Cloud Task programming model provides:
 


### PR DESCRIPTION
Fixing typo 'Mdoel' to 'Model' at paragraph 13