### PR TITLE
App bulk registration controller

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/BulkAppRegisterRequest.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/BulkAppRegisterRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Vinicius Carvalho
+ *
+ * Suport class for bulk registration operations @see {@link org.springframework.cloud.dataflow.server.controller.BulkAppRegistryController}
+ *
+ */
+public class BulkAppRegisterRequest {
+
+	private List<RegisteredApp> registeredApps = new LinkedList<>();
+
+	public List<RegisteredApp> getRegisteredApps() {
+		return registeredApps;
+	}
+
+	public void setRegisteredApps(List<RegisteredApp> registeredApps) {
+		this.registeredApps = registeredApps;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/BulkAppRegisterResponse.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/BulkAppRegisterResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Vinicius Carvalho
+ *
+ * Suport class for bulk registration operations @see {@link org.springframework.cloud.dataflow.server.controller.BulkAppRegistryController}
+ */
+public class BulkAppRegisterResponse {
+
+	private List<UnregisterAppResponse> unregisterAppResponses = new LinkedList<>();
+
+	public List<UnregisterAppResponse> getUnregisterAppResponses() {
+		return unregisterAppResponses;
+	}
+
+	public void setUnregisterAppResponses(List<UnregisterAppResponse> unregisterAppResponses) {
+		this.unregisterAppResponses = unregisterAppResponses;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/RegisteredApp.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/RegisteredApp.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+
+/**
+ * @author Vinicius Carvalho
+ *
+ */
+public class RegisteredApp {
+
+	public RegisteredApp(String name, ApplicationType type, String version) {
+		this.name = name;
+		this.type = type;
+		this.version = version;
+	}
+
+	public RegisteredApp(){}
+
+	private String name;
+
+	private ApplicationType type;
+
+	private String version;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public ApplicationType getType() {
+		return type;
+	}
+
+	public void setType(ApplicationType type) {
+		this.type = type;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/UnregisterAppResponse.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/UnregisterAppResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * @author Vinicius Carvalho
+ *
+ */
+public class UnregisterAppResponse {
+
+	public UnregisterAppResponse(RegisteredApp app, String status, String message) {
+		this.app = app;
+		this.status = status;
+		this.message = message;
+	}
+
+	public UnregisterAppResponse(){}
+
+	@JsonUnwrapped
+	private RegisteredApp app;
+
+	private String status;
+
+	private String message;
+
+	public RegisteredApp getApp() {
+		return app;
+	}
+
+	public void setApp(RegisteredApp app) {
+		this.app = app;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +29,8 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.cloud.dataflow.server.controller.support.BulkAppRegisterRequest;
+import org.springframework.cloud.dataflow.server.controller.support.RegisteredApp;
 import org.springframework.cloud.dataflow.server.registry.DataFlowAppRegistryPopulator;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -278,6 +283,23 @@ public class AppRegistryControllerTests {
 				.andExpect(jsonPath("page.totalElements", is(3)))
 				.andExpect(jsonPath("page.totalPages", is(2)))
 				.andExpect(jsonPath("page.number", is(0)));
+	}
+
+	@Test
+	public void testBulkUnregister() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		appRegistry.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
+		List<AppRegistration> apps = appRegistry.findAll();
+		BulkAppRegisterRequest request = new BulkAppRegisterRequest();
+		apps.forEach(app -> {
+			request.getRegisteredApps().add(new RegisteredApp(app.getName(), app.getType(), app.getVersion()));
+		});
+		mockMvc.perform(post("/apps/bulk/unregister").content(mapper.writeValueAsString(request))
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("unregisterAppResponses", hasSize(4)));
+		assertThat(appRegistry.findAll(), hasSize(0));
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/VersionedAppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/VersionedAppRegistryControllerTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +32,8 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.cloud.dataflow.server.controller.support.BulkAppRegisterRequest;
+import org.springframework.cloud.dataflow.server.controller.support.RegisteredApp;
 import org.springframework.cloud.dataflow.server.registry.DataFlowAppRegistryPopulator;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -310,6 +315,23 @@ public class VersionedAppRegistryControllerTests {
 				.andExpect(jsonPath("page.totalElements", is(3)))
 				.andExpect(jsonPath("page.totalPages", is(2)))
 				.andExpect(jsonPath("page.number", is(5)));
+	}
+
+	@Test
+	public void testBulkUnregister() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		appRegistryService.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
+		List<AppRegistration> apps = appRegistryService.findAll();
+		BulkAppRegisterRequest request = new BulkAppRegisterRequest();
+		apps.forEach(app -> {
+			request.getRegisteredApps().add(new RegisteredApp(app.getName(), app.getType(), app.getVersion()));
+		});
+		mockMvc.perform(post("/apps/bulk/unregister").content(mapper.writeValueAsString(request))
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("unregisterAppResponses", hasSize(4)));
+		assertThat(appRegistryService.findAll(), hasSize(0));
 	}
 
 }


### PR DESCRIPTION
Fixes #2031 
This PR intends to reduce the number of calls from the client to the server when doing bulk unregister. Internally we will still (for now) make several calls to the Resource Loaders and Repositories.

There's a pending PR to validate that if an app is being used by a Stream we should throw an exception. The code here relies on `unregister(...)` to throw such exception if we are to return a list of failed deletions to the client. For now, all deletes would complete succesfully