### PR TITLE
Fix yaml file handling with tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
 		<spring-batch-admin-manager.version>1.3.1.RELEASE</spring-batch-admin-manager.version>
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
 		<spring-session.version>1.2.2.RELEASE</spring-session.version>
+		<commons-io.version>2.4</commons-io.version>
+		<commons-lang.version>2.4</commons-lang.version>
 		<jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
 		<checkstyle.config.location>src/checkstyle/checkstyle.xml</checkstyle.config.location>
@@ -152,6 +154,16 @@
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-entitymanager</artifactId>
 				<version>5.2.12.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${commons-io.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-lang</groupId>
+				<artifactId>commons-lang</artifactId>
+				<version>${commons-lang.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>

--- a/spring-cloud-dataflow-core/pom.xml
+++ b/spring-cloud-dataflow-core/pom.xml
@@ -24,7 +24,6 @@
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -54,6 +54,10 @@
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.rest.job.support;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -24,6 +27,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.util.FileCopyUtils;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -137,5 +141,19 @@ public class DeploymentPropertiesUtilsTests {
 		assertArrays(new String[] { " --foo1=bar1 ", " --foo2=bar2 " }, new String[] { "--foo1=bar1", "--foo2=bar2" });
 		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'", "--foo1=bar1" },
 				new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS", "--foo1=bar1" });
+	}
+
+	@Test
+	public void testParseDeploymentProperties() throws IOException {
+		File file = Files.createTempFile(null, ".yaml").toFile();
+		FileCopyUtils.copy("foo1:\n  bar1: spam".getBytes(), file);
+
+		Map<String, String> props = DeploymentPropertiesUtils.parseDeploymentProperties("foo2=bar2", file, 0);
+		assertThat(props.size(), is(1));
+		assertThat(props.get("foo2"), is("bar2"));
+
+		props = DeploymentPropertiesUtils.parseDeploymentProperties("foo2=bar2", file, 1);
+		assertThat(props.size(), is(1));
+		assertThat(props.get("foo1.bar1"), is("spam"));
 	}
 }

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -33,7 +33,6 @@
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicStreamCommands.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.shell.command.common.Assertions;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.shell.command.common.AbstractStreamCommands;
 import org.springframework.cloud.dataflow.shell.command.common.UserInput;
 import org.springframework.cloud.dataflow.shell.command.support.OpsType;
@@ -41,6 +42,7 @@ import org.springframework.stereotype.Component;
  * @author Gunnar Hillert
  * @author Glenn Renfro
  * @author Christian Tzolov
+ * @author Janne Valkealahti
  */
 @Component
 // todo: reenable optionContext attributes
@@ -74,7 +76,8 @@ public class ClassicStreamCommands extends AbstractStreamCommands implements Com
 			throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, deploymentProperties, PROPERTIES_FILE_OPTION,
 				propertiesFile);
-		Map<String, String> propertiesToUse = getDeploymentProperties(deploymentProperties, propertiesFile, which);
+		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parseDeploymentProperties(deploymentProperties,
+				propertiesFile, which);
 		streamOperations().deploy(name, propertiesToUse);
 		return String.format("Deployment request has been sent for stream '%s'\n", name);
 	}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/AbstractStreamCommands.java
@@ -16,28 +16,17 @@
 
 package org.springframework.cloud.dataflow.shell.command.common;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 
-import org.apache.commons.io.FilenameUtils;
-
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.cloud.dataflow.rest.client.StreamOperations;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
-import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.shell.command.support.OpsType;
 import org.springframework.cloud.dataflow.shell.command.support.RoleType;
 import org.springframework.cloud.dataflow.shell.command.support.ShellUtils;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
@@ -57,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Gunnar Hillert
  * @author Glenn Renfro
  * @author Christian Tzolov
+ * @author Janne Valkealahti
  */
 public abstract class AbstractStreamCommands implements CommandMarker {
 
@@ -135,42 +125,6 @@ public abstract class AbstractStreamCommands implements CommandMarker {
 			result.add(String.format("Stream Deployment properties: %s", ShellUtils.prettyPrintIfJson(stream.getDeploymentProperties())));
 		}
 		return result;
-	}
-
-	protected Map<String, String> getDeploymentProperties(@CliOption(key = {
-			PROPERTIES_OPTION }, help = "the properties for this deployment") String deploymentProperties,
-			@CliOption(key = {
-					PROPERTIES_FILE_OPTION }, help = "the properties for this deployment (as a File)") File propertiesFile,
-			int which) throws IOException {
-		Map<String, String> propertiesToUse;
-		switch (which) {
-		case 0:
-			propertiesToUse = DeploymentPropertiesUtils.parse(deploymentProperties);
-			break;
-		case 1:
-			String extension = FilenameUtils.getExtension(propertiesFile.getName());
-			Properties props = null;
-			if (extension.equals("yaml") || extension.equals("yml")) {
-				YamlPropertiesFactoryBean yamlPropertiesFactoryBean = new YamlPropertiesFactoryBean();
-				yamlPropertiesFactoryBean.setResources(new FileSystemResource(propertiesFile));
-				yamlPropertiesFactoryBean.afterPropertiesSet();
-				props = yamlPropertiesFactoryBean.getObject();
-			}
-			else {
-				props = new Properties();
-				try (FileInputStream fis = new FileInputStream(propertiesFile)) {
-					props.load(fis);
-				}
-			}
-			propertiesToUse = DeploymentPropertiesUtils.convert(props);
-			break;
-		case -1: // Neither option specified
-			propertiesToUse = new HashMap<>(1);
-			break;
-		default:
-			throw new AssertionError();
-		}
-		return propertiesToUse;
 	}
 
 	@CliCommand(value = UNDEPLOY_STREAM, help = "Un-deploy a previously deployed stream")

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/common/TaskCommands.java
@@ -17,14 +17,11 @@
 package org.springframework.cloud.dataflow.shell.command.common;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
@@ -53,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Michael Minella
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @Component
 public class TaskCommands implements CommandMarker {
@@ -122,24 +120,9 @@ public class TaskCommands implements CommandMarker {
 					ARGUMENTS_OPTION }, help = "the commandline arguments for this launch", mandatory = false) String arguments)
 			throws IOException {
 		int which = Assertions.atMostOneOf(PROPERTIES_OPTION, properties, PROPERTIES_FILE_OPTION, propertiesFile);
-		Map<String, String> propertiesToUse;
-		switch (which) {
-		case 0:
-			propertiesToUse = DeploymentPropertiesUtils.parse(properties);
-			break;
-		case 1:
-			Properties props = new Properties();
-			try (FileInputStream fis = new FileInputStream(propertiesFile)) {
-				props.load(fis);
-			}
-			propertiesToUse = DeploymentPropertiesUtils.convert(props);
-			break;
-		case -1: // Neither option specified
-			propertiesToUse = Collections.emptyMap();
-			break;
-		default:
-			throw new AssertionError();
-		}
+		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parseDeploymentProperties(properties,
+				propertiesFile, which);
+
 		List<String> argumentsToUse = new ArrayList<String>();
 		if (StringUtils.hasText(arguments)) {
 			argumentsToUse.add(arguments);


### PR DESCRIPTION
- Extract common deployment properties handling
  from streams and use it in a same way with tasks.
- Move commons-io and commons-lang dep versions to parent
  as need commons-io in rest-resource.
- Generic polish for files touched with this commit, ie
  remove dead code.
- Now shared code is in
  DeploymentPropertiesUtils.parseDeploymentProperties()
- We now get proper error if yaml is not expected like:
  Command failed java.lang.IllegalArgumentException:
  Only deployment property keys starting with 'app.' or 'deployer.' allowed, got 'appx.footask.AAA.keys'
- Fixes #1878