### PR TITLE
gh-1896 Shell: Add Proxy Support

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/shell.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/shell.adoc
@@ -14,9 +14,9 @@ The shell is built upon the link:https://projects.spring.io/spring-shell/[Spring
 There are command line options generic to Spring Shell and some specific to Data Flow.
 The shell takes the following command line options
 
-[source,bash,options="nowrap"]
+[source,bash,options="nowrap",subs=attributes]
 ----
-unix:>java -jar spring-cloud-dataflow-shell-1.2.1.RELEASE.jar --help
+unix:>java -jar spring-cloud-dataflow-shell-{project-version}.jar --help
 Data Flow Options:
   --dataflow.uri=<uri>                              Address of the Data Flow Server [default: http://localhost:9393].
   --dataflow.username=<USER>                        Username of the Data Flow Server [no default].
@@ -25,6 +25,9 @@ Data Flow Options:
                                                     OAuth Bearer Token (Access Token prefixed with 'Bearer '),
                                                     e.g. 'Bearer 12345'), [no default].
   --dataflow.skip-ssl-validation=<true|false>       Accept any SSL certificate (even self-signed) [default: no].
+  --dataflow.proxy.uri=<PROXY-URI>                  Address of an optional proxy server to use [no default].
+  --dataflow.proxy.username=<PROXY-USERNAME>        Username of the proxy server (if required by proxy server) [no default].
+  --dataflow.proxy.password=<PROXY-PASSWORD>        Password of the proxy server (if required by proxy server) [no default].
   --spring.shell.historySize=<SIZE>                 Default size of the shell log file [default: 3000].
   --spring.shell.commandFile=<FILE>                 Data Flow Shell executes commands read from the file(s) and then exits.
   --help                                            This message.

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.util;
+
+import java.net.URI;
+
+import org.apache.http.client.HttpClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Gunnar Hillert
+ * @since 1.4
+ */
+public class HttpClientConfigurerTests {
+
+	/**
+	 * Basic test ensuring that the {@link HttpClient} is built successfully.
+	 */
+	@Test
+	public void testThatHttpClientWithProxyIsCreated() {
+		final HttpClientConfigurer builder = HttpClientConfigurer.create();
+		builder.withProxyCredentials(URI.create("https://spring.io"), "spring", "cloud");
+		builder.buildHttpClient();
+	}
+
+	/**
+	 * Basic test ensuring that the {@link HttpClient} is built successfully with
+	 * null username and password.
+	 */
+	@Test
+	public void testThatHttpClientWithProxyIsCreatedWithNullUsernameAndPassword() {
+		final HttpClientConfigurer builder = HttpClientConfigurer.create();
+		builder.withProxyCredentials(URI.create("https://spring.io"), null, null);
+		builder.buildHttpClient();
+	}
+
+	/**
+	 * Basic test ensuring that an exception is thrown if the scheme of the proxy
+	 * Uri is not set.
+	 */
+	@Test
+	public void testHttpClientWithProxyCreationWithMissingScheme() {
+		final HttpClientConfigurer builder = HttpClientConfigurer.create();
+		try {
+			builder.withProxyCredentials(URI.create("spring"), "spring", "cloud");
+		}
+		catch (IllegalArgumentException e) {
+			Assert.assertEquals("The scheme component of the proxyUri must not be empty.", e.getMessage());
+			return;
+		}
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	/**
+	 * Basic test ensuring that an exception is thrown if the proxy
+	 * Uri is null.
+	 */
+	@Test
+	public void testHttpClientWithNullProxyUri() {
+		final HttpClientConfigurer builder = HttpClientConfigurer.create();
+		try {
+			builder.withProxyCredentials(null, null, null);
+		}
+		catch (IllegalArgumentException e) {
+			Assert.assertEquals("The proxyUri must not be null.", e.getMessage());
+			return;
+		}
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+}

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -86,5 +86,11 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.littleshoot</groupId>
+			<artifactId>littleproxy</artifactId>
+			<version>1.1.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,14 @@ public class Target {
 	public static final String DEFAULT_CREDENTIALS_PROVIDER_COMMAND = "";
 
 	public static final String DEFAULT_TARGET = DEFAULT_SCHEME + "://" + DEFAULT_HOST + ":" + DEFAULT_PORT + "/";
+
+	public static final String DEFAULT_PROXY_USERNAME = "";
+
+	public static final String DEFAULT_PROXY_SPECIFIED_PASSWORD = "";
+
+	public static final String DEFAULT_PROXY_UNSPECIFIED_PASSWORD = "__NULL__";
+
+	public static final String DEFAULT_PROXY_URI = "";
 
 	private final URI targetUri;
 

--- a/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
+++ b/spring-cloud-dataflow-shell-core/src/main/resources/usage.txt
@@ -6,6 +6,9 @@ Data Flow Options:
                                                     OAuth Bearer Token (Access Token prefixed with 'Bearer '),
                                                     e.g. 'Bearer 12345'), [no default].
   --dataflow.skip-ssl-validation=<true|false>       Accept any SSL certificate (even self-signed) [default: no].
+  --dataflow.proxy.uri=<PROXY-URI>                  Address of an optional proxy server to use [no default].
+  --dataflow.proxy.username=<PROXY-USERNAME>        Username of the proxy server (if required by proxy server) [no default].
+  --dataflow.proxy.password=<PROXY-PASSWORD>        Password of the proxy server (if required by proxy server) [no default].
   --dataflow.mode=<MODE>                            Server DataFlow mode: 'classic' or 'skipper' modes. [default: classic].
   --spring.shell.historySize=<SIZE>                 Default size of the shell log file [default: 3000].
   --spring.shell.commandFile=<FILE>                 Data Flow Shell executes commands read from the file(s) and then exits.

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class ConfigCommandTests {
 
 		configCommands.onApplicationEvent(null);
 
-		final String targetResult = configCommands.target("http://localhost:9393", null, null, null, false);
+		final String targetResult = configCommands.target("http://localhost:9393", null, null, null, false, null, null, null);
 		assertThat(targetResult, containsString("Incompatible version of Data Flow server detected"));
 	}
 
@@ -171,8 +171,15 @@ public class ConfigCommandTests {
 		securityInfoResource.setAuthenticationEnabled(false);
 		when(restTemplate.getForObject(Mockito.any(String.class), Mockito.eq(SecurityInfoResource.class))).thenReturn(securityInfoResource);
 
-		final String targetResult = configCommands.target(Target.DEFAULT_TARGET, Target.DEFAULT_USERNAME,
-				Target.DEFAULT_SPECIFIED_PASSWORD, Target.DEFAULT_CREDENTIALS_PROVIDER_COMMAND, true);
+		final String targetResult = configCommands.target(
+				Target.DEFAULT_TARGET,
+				Target.DEFAULT_USERNAME,
+				Target.DEFAULT_SPECIFIED_PASSWORD,
+				Target.DEFAULT_CREDENTIALS_PROVIDER_COMMAND,
+				true,
+				Target.DEFAULT_PROXY_URI,
+				Target.DEFAULT_PROXY_USERNAME,
+				Target.DEFAULT_PROXY_SPECIFIED_PASSWORD);
 
 		System.out.println(targetResult);
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/proxy/ProxyTestServer.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/proxy/ProxyTestServer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.shell.command.proxy;
+
+import java.io.IOException;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.ProxyAuthenticator;
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+/**
+ * Embedded Proxy Server for testing purposes.
+ *
+ * @author Gunnar Hillert
+ */
+public class ProxyTestServer {
+	public static void main(String[] args) throws IOException {
+		final int port = 8077;
+		final boolean withSecurity = true;
+		final boolean withSsl = true;
+		final String proxyServerUsername = "spring";
+		final String proxyServerPassword = "cloud";
+
+		HttpProxyServerBootstrap builder = DefaultHttpProxyServer.bootstrap()
+			.withFiltersSource(
+				new HttpFiltersSourceAdapter() {
+					public HttpFilters filterRequest(HttpRequest originalRequest, ChannelHandlerContext ctx) {
+						System.out.println("Request comining in " + originalRequest.getUri());
+						return new HttpFiltersAdapter(originalRequest) {
+							@Override
+							public HttpResponse clientToProxyRequest(HttpObject httpObject) {
+								return null;
+							}
+
+							@Override
+							public HttpObject serverToProxyResponse(HttpObject httpObject) {
+								return httpObject;
+							}
+						};
+					}
+				}
+			)
+			.withPort(port);
+
+		if (withSecurity) {
+			builder.withProxyAuthenticator(new ProxyAuthenticator() {
+				@Override
+				public String getRealm() {
+					return "dataflow";
+				}
+
+				@Override
+				public boolean authenticate(String userName, String password) {
+					if (proxyServerUsername.equals(userName) && proxyServerPassword.equals(password)) {
+						return true;
+					}
+					else {
+						return false;
+					}
+				}
+			});
+		}
+
+		if (withSsl) {
+			builder.withSslEngineSource(new SelfSignedSslEngineSource())
+				.withAuthenticateSslClients(false);
+		}
+
+		builder.start();
+		System.out.println(String.format("Started proxy server on port %s. With security? %s. Ssl enabled? %s", port, withSecurity, withSsl));
+		if (withSecurity) {
+			System.out.println(String.format("Proxy server username '%s' and password '%s'.", proxyServerUsername, proxyServerPassword));
+		}
+	}
+}


### PR DESCRIPTION
* Add support for specifying an optional proxy server for the Shell
  - Allow to provide credentials (username/password)
  - Support SSL connectivity
* Update documentation
* Add basic tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/1896