### PR TITLE
URLResource path can have version

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/ResourceUtils.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/ResourceUtils.java
@@ -58,7 +58,6 @@ public class ResourceUtils {
 		String version = getUrlResourceVersion(urlResource);
 		URI uri = getUri(urlResource);
 		String theRest = uri.toString().substring(0, uri.toString().indexOf("-" + version));
-		Assert.isTrue(!theRest.contains(version), "URL resource with version as part of its path is not supported.");
 		return theRest;
 	}
 

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
@@ -40,11 +40,10 @@ public class ResourceUtilsTests {
 		ResourceUtils.getUrlResourceVersion(urlResource);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidUrlResourceWithoutVersion() throws Exception {
 		UrlResource urlResource = new UrlResource("http://repo.spring"
 				+ ".io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar");
-		ResourceUtils.getUrlResourceWithoutVersion(urlResource);
+		assertThat(ResourceUtils.getUrlResourceWithoutVersion(urlResource)).isEqualTo("1.2.0.RELEASE");
 	}
 
 	@Test


### PR DESCRIPTION
 - Remove assertion on not expecting `version` as part of the URL path
 - Update test

Resolves #2082