### PR TITLE
Stream DSL - sanitize sensitive properties

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
@@ -28,12 +28,12 @@ import org.springframework.util.StringUtils;
  * @author Glenn Renfro
  */
 public class ArgumentSanitizer {
-	private static final String[] REGEX_PARTS = {"*", "$", "^", "+"};
+	private static final String[] REGEX_PARTS = { "*", "$", "^", "+" };
 
 	private static final String REDACTION_STRING = "******";
 
-	private static final String[] KEYS_TO_SANITIZE = {"password", "secret", "key", "token", ".*credentials.*",
-			"vcap_services"};
+	private static final String[] KEYS_TO_SANITIZE = { "password", "secret", "key", "token", ".*credentials.*",
+			"vcap_services" };
 	//used to find the passwords embedded in a stream definition
 	private static Pattern passwordParameterPatternForStreams = Pattern.compile(
 			//Search for the -- characters then look for unicode letters
@@ -83,13 +83,27 @@ public class ArgumentSanitizer {
 		}
 		String key = argument.substring(0, indexOfFirstEqual);
 		String value = argument.substring(indexOfFirstEqual + 1);
+
+		value = sanitize(key, value);
+
+		return String.format("%s=%s", key, value);
+	}
+
+	/**
+	 * Replaces a potential secure value with "******".
+	 *
+	 * @param key to check for sensitive words.
+	 * @param value the argument to cleanse.
+	 * @return the argument with a potentially sanitized value
+	 */
+	public String sanitize(String key, String value) {
 		for (Pattern pattern : this.keysToSanitize) {
 			if (pattern.matcher(key).matches()) {
 				value = REDACTION_STRING;
 				break;
 			}
 		}
-		return String.format("%s=%s", key, value);
+		return value;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.support;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.server.controller.support.ArgumentSanitizer;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ArgumentSanitizerTest {
+
+	private ArgumentSanitizer sanitizer;
+
+	private static final String[] keys = { "password", "secret", "key", "token", ".*credentials.*",
+			"vcap_services" };
+
+	@Before
+	public void before() {
+		sanitizer = new ArgumentSanitizer();
+	}
+
+	@Test
+	public void testSanitizeProperties() {
+		for (String key : keys) {
+			Assert.assertEquals("--" + key + "=******", sanitizer.sanitize("--" + key + "=foo"));
+			Assert.assertEquals("******", sanitizer.sanitize(key, "bar"));
+		}
+	}
+
+
+	@Test
+	public void testMultipartProperty() {
+		Assert.assertEquals("--password=******", sanitizer.sanitize("--password=boza"));
+		Assert.assertEquals("--one.two.password=******", sanitizer.sanitize("--one.two.password=boza"));
+		Assert.assertEquals("--one_two_password=******", sanitizer.sanitize("--one_two_password=boza"));
+	}
+
+	@Test
+	public void testHierarchicalPropertyNames() {
+		Assert.assertEquals("time --password=****** | log", ArgumentSanitizer.sanitizeStream("time --password=bar | log"));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-upgradeWithSensitivePropertiesManifest.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-upgradeWithSensitivePropertiesManifest.yml
@@ -1,0 +1,48 @@
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
+    trigger.fixed-delay: 200
+    one.two.password: password
+    one_two_three.secret : secret
+    one.key: key
+    two.token: token
+    spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.output.destination: ticktock.time
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: ticktock
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    log.level: INFO
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: ticktock.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: ticktock


### PR DESCRIPTION
Resolves #1985

- Extend ArgumentSanitizer to handle key,value properties
- Add tests for the ArgumentSanitizer and for the DefaultSkipperStreamService
- Resolution is applied to Skipper mode only.