### PR TITLE
Avoid stackoverflow when asking server for related streams

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -68,6 +68,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Oleg Zhurakousky
  * @author Glenn Renfro
  * @author Christian Tzolov
+ * @author Andy Clement
  */
 @RestController
 @RequestMapping("/streams/definitions")
@@ -250,8 +251,8 @@ public class StreamDefinitionController {
 			if (sn.getSourceDestinationNode() != null) {
 				String nameComponent = sn.getSourceDestinationNode().getDestinationName();
 				if (nameComponent.equals(currentStreamName) || nameComponent.startsWith(indexedStreamName)) {
-					relatedDefinitions.add(definition);
-					if (nested) {
+					boolean isNewEntry = relatedDefinitions.add(definition);
+					if (nested && isNewEntry) {
 						findRelatedDefinitions(definition, definitions, relatedDefinitions, true);
 					}
 				}


### PR DESCRIPTION
Without this fix the endpoint for finding related streams
will stackoverflow for one or more streams that refer
to each other. Streams like this are bad/incorrect but
they shouldn't cause the server to break. This simple change
simply avoids recursing multiple times into the same stream
def.

Fixes #2150