### PR TITLE
Deployer properties for CTR child tasks

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -423,6 +423,14 @@ To have mytaskapp display 'HELLO' and set the mytimestamp timestamp format to 'Y
 task launch my-composed-task --properties "app.my-composed-task.mytaskapp.displayMessage=HELLO,app.my-composed-task.mytimestamp.timestamp.format=YYYY"
 ----
 
+Similar to application properties, the `deployer` properties can also be set for child tasks using the format format of `deployer.<composed task definition name>.<child task app name>.<deployer-property>`.
+
+[source,bash]
+----
+task launch my-composed-task --properties "deployer.my-composed-task.mytaskapp.memory=2048m,app.my-composed-task.mytimestamp.timestamp.format=HH:mm:ss"
+Launched task 'a1'
+----
+
 ===== Passing arguments to the composed task runner
 
 Command line arguments for the composed task runner can be passed using `--arguments` option.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -150,6 +150,7 @@ public class DefaultTaskServiceTests {
 		Map<String, String> properties = new HashMap<>();
 		properties.put("app.foo", "bar");
 		properties.put("app.seqTask.AAA.timestamp.format", "YYYY");
+		properties.put("deployer.seqTask.AAA.memory", "1240m");
 		properties.put("app.composed-task-runner.interval-time-between-checks", "1000");
 		assertEquals(1L, this.taskService.executeTask("seqTask", properties, new LinkedList<>()));
 		ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
@@ -158,7 +159,8 @@ public class DefaultTaskServiceTests {
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 		assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
-		assertEquals("app.seqTask-AAA.app.AAA.timestamp.format=YYYY", request.getDefinition().getProperties().get("composed-task-properties"));
+		assertEquals("app.seqTask-AAA.app.AAA.timestamp.format=YYYY, deployer.seqTask-AAA.deployer.AAA.memory=1240m",
+				request.getDefinition().getProperties().get("composed-task-properties"));
 		assertTrue(request.getDefinition().getProperties().containsKey("interval-time-between-checks"));
 		assertEquals("1000", request.getDefinition().getProperties().get("interval-time-between-checks"));
 		assertFalse(request.getDefinition().getProperties().containsKey("app.foo"));


### PR DESCRIPTION
 - Add support for passing `deployer` properties into the child tasks of CTR
 - Update `DefaultTaskService` to pass both `app` as well as `deployer` properties
 - Update test
 - Add doc with the `task launch` example for CTR

Resolves #2078