### PR TITLE
Handle backslash characters in Skipper mode

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
@@ -112,9 +112,16 @@ public class StreamDefinitionToDslConverter {
 	}
 
 	private String autoQuotes(String propertyValue) {
-		if (!propertyValue.contains("'")) {
-			if (propertyValue.contains(" ") || propertyValue.contains(";")  || propertyValue.contains("*")) {
-				return "'" + propertyValue + "'";
+		if (!propertyValue.startsWith("\"") || !propertyValue.endsWith("\"")) {
+			if (!propertyValue.contains("'")) {
+				if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
+					return "'" + propertyValue + "'";
+				}
+			}
+			else {
+				if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
+					return "\"" + propertyValue + "\"";
+				}
 			}
 		}
 		return propertyValue;

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverterTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverterTests.java
@@ -42,7 +42,7 @@ public class StreamDefinitionToDslConverterTests {
 
 	@Test
 	public void quotesInParams2() {
-		reverseDslTest("http --port=9700 | filter --expression=payload.matches('hello world') | file", 3);
+		reverseDslTest("http --port=9700 | filter --expression=\"payload.matches('hello world')\" | file", 3);
 	}
 
 	@Test
@@ -167,7 +167,6 @@ public class StreamDefinitionToDslConverterTests {
 
 		StreamDefinition streamDefinition = new StreamDefinition("streamName", "foo | bar");
 
-
 		StreamAppDefinition foo = streamDefinition.getAppDefinitions().get(0);
 		StreamAppDefinition bar = streamDefinition.getAppDefinitions().get(1);
 
@@ -175,6 +174,8 @@ public class StreamDefinitionToDslConverterTests {
 				.setProperty("p1", "a b")
 				.setProperty("p2", "'c d'")
 				.setProperty("p3", "ef")
+				.setProperty("p4", "'i' 'j'")
+				.setProperty("p5", "\"k l\"")
 				.build("stream2");
 
 		StreamAppDefinition bar2 = StreamAppDefinition.Builder.from(bar)
@@ -183,7 +184,7 @@ public class StreamDefinitionToDslConverterTests {
 				.setProperty("p3", "ef")
 				.build("stream2");
 
-		assertEquals("foo --p1='a b' --p2='c d' --p3=ef | bar --p1='a b' --p2='c d' --p3=ef",
+		assertEquals("foo --p1='a b' --p2=\"'c d'\" --p3=ef --p4=\"'i' 'j'\" --p5=\"k l\" | bar --p1='a b' --p2=\"'c d'\" --p3=ef",
 				new StreamDefinitionToDslConverter().toDsl(Arrays.asList(foo2, bar2)));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -105,6 +105,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 
 	private final ForkJoinPool forkJoinPool;
 
+	private final YamlEscapeUtility yamlEscapeUtility;
+
 	public SkipperStreamDeployer(SkipperClient skipperClient, StreamDefinitionRepository streamDefinitionRepository,
 			AppRegistryService appRegistryService, ForkJoinPool forkJoinPool) {
 		Assert.notNull(skipperClient, "SkipperClient can not be null");
@@ -115,6 +117,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		this.streamDefinitionRepository = streamDefinitionRepository;
 		this.appRegistryService = appRegistryService;
 		this.forkJoinPool = forkJoinPool;
+		this.yamlEscapeUtility = new YamlEscapeUtility();
 	}
 
 	public static List<AppStatus> deserializeAppStatus(String platformStatus) {
@@ -331,8 +334,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		// Add spec
 		String resourceWithoutVersion = ResourceUtils.getResourceWithoutVersion(appDeploymentRequest.getResource());
 		specMap.put("resource", resourceWithoutVersion);
-		specMap.put("applicationProperties", appDeploymentRequest.getDefinition().getProperties());
-		specMap.put("deploymentProperties", appDeploymentRequest.getDeploymentProperties());
+		specMap.put("applicationProperties", yamlEscapeUtility.escapeSingleBackslashInProperties(appDeploymentRequest.getDefinition().getProperties()));
+		specMap.put("deploymentProperties", yamlEscapeUtility.escapeSingleBackslashInProperties(appDeploymentRequest.getDeploymentProperties()));
 		String version = ResourceUtils.getResourceVersion(appDeploymentRequest.getResource());
 		// Add version, including possible override via deploymentProperties - hack to store version in cmdline args
 		if (appDeploymentRequest.getCommandlineArguments().size() == 1) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/YamlEscapeUtility.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/YamlEscapeUtility.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.stream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.MapUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class YamlEscapeUtility {
+
+	private List<String> filterKeywords;
+
+	public YamlEscapeUtility() {
+		this.filterKeywords = new ArrayList<>();
+		this.filterKeywords.add("expression");
+	}
+
+	public YamlEscapeUtility(List<String> filterKeywords) {
+		this.filterKeywords = filterKeywords;
+	}
+
+	/**
+	 * In Java '\\\\' sands for escaped backslash. E.g. it corresponds to '\\' in regular expression.
+	 *
+	 * (?<!\\) - (negative lookbehind) - the previous character is not a backslash.
+	 * (\\)    - (non-capturing group) - current character is a backslash
+	 * (?![\\0abtnvfreN_LP\s"]) - (negative lookforward) - next character is neither of \, 0, a, b, t, n, v, f, r, e, N, _, L, P, ,\s, "
+	 */
+	private static final Pattern SINGLE_BACKSLASH = Pattern.compile("(?<!\\\\)(\\\\)(?![\\\\0abtnvfreN_LP\\s\"])");
+
+	public Map escapeSingleBackslashInProperties(Map<String, String> properties) {
+		return MapUtils.unmodifiableMap(properties.entrySet().stream()
+				.collect(Collectors.toMap(
+						e -> e.getKey(),
+						e -> this.isEscapeCandidate(e.getKey()) ? backslashEscape(e.getValue()) : e.getValue())));
+	}
+
+	private boolean isEscapeCandidate(String text) {
+		return this.filterKeywords.stream().filter(v -> text.contains(v)).findFirst().isPresent();
+	}
+
+	public String backslashEscape(String text) {
+		return SINGLE_BACKSLASH.matcher(text).replaceAll("\\\\\\\\");
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
@@ -15,13 +15,10 @@
  */
 package org.springframework.cloud.dataflow.server.service.impl;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.yaml.snakeyaml.DumperOptions;
-import org.zeroturnaround.zip.ZipUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,6 +44,7 @@ import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepo
 import org.springframework.cloud.dataflow.server.service.SkipperStreamService;
 import org.springframework.cloud.dataflow.server.support.MockUtils;
 import org.springframework.cloud.dataflow.server.support.PlatformUtils;
+import org.springframework.cloud.dataflow.server.support.SkipperPackageUtils;
 import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.client.SkipperClient;
@@ -58,9 +55,6 @@ import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.cloud.skipper.io.DefaultPackageReader;
-import org.springframework.cloud.skipper.io.PackageReader;
-import org.springframework.cloud.skipper.io.TempFileUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -145,7 +139,7 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		ArgumentCaptor<UploadRequest> uploadRequestCaptor = ArgumentCaptor.forClass(UploadRequest.class);
 		verify(skipperClient).upload(uploadRequestCaptor.capture());
 
-		Package pkg = loadPackageFromBytes(uploadRequestCaptor);
+		Package pkg = SkipperPackageUtils.loadPackageFromBytes(uploadRequestCaptor);
 
 		// ExpectedYaml will have version: 1.2.0.RELEASE and not 1.1.1.RELEASE
 		String expectedYaml = StreamUtils.copyToString(
@@ -312,18 +306,4 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		StreamDefinition streamDefinition = new StreamDefinition("ticktock", "time | log");
 		this.streamDefinitionRepository.save(streamDefinition);
 	}
-
-	private Package loadPackageFromBytes(ArgumentCaptor<UploadRequest> uploadRequestCaptor) throws IOException {
-		PackageReader packageReader = new DefaultPackageReader();
-		String packageName = uploadRequestCaptor.getValue().getName();
-		String packageVersion = uploadRequestCaptor.getValue().getVersion();
-		byte[] packageBytes = uploadRequestCaptor.getValue().getPackageFileAsBytes();
-		Path targetPath = TempFileUtils.createTempDirectory("service" + packageName);
-		File targetFile = new File(targetPath.toFile(), packageName + "-" + packageVersion + ".zip");
-		StreamUtils.copy(packageBytes, new FileOutputStream(targetFile));
-		ZipUtil.unpack(targetFile, targetPath.toFile());
-		return packageReader
-				.read(new File(targetPath.toFile(), packageName + "-" + packageVersion));
-	}
-
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/YamlEscapeUtilTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/YamlEscapeUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.stream;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+public class YamlEscapeUtilTest {
+
+	private YamlEscapeUtility yamlEscapeUtility;
+
+	@Before
+	public void before() {
+		yamlEscapeUtility = new YamlEscapeUtility();
+	}
+
+	@Test
+	public void testSkipEscapeForYamlSpecialCharacters() {
+		assertThat(yamlEscapeUtility.backslashEscape("\\d \\\\ \\0 \\a \\b \t \\t \\n \\v \\f \\r \\e \\N \\_ \\L \\\" \\P \\ "),
+				is("\\\\d \\\\ \\0 \\a \\b \t \\t \\n \\v \\f \\r \\e \\N \\_ \\L \\\" \\P \\ "));
+	}
+
+	@Test
+	public void testDefaultFilterKeywords() {
+		Map<String, String> map = new HashMap<>();
+		map.put("foo.expression", "\\d");
+		map.put("foo.simple", "\\d");
+
+		Map escapedMap = yamlEscapeUtility.escapeSingleBackslashInProperties(map);
+		assertThat(escapedMap.size(), is(2));
+		assertThat(escapedMap.get("foo.expression"), is("\\\\d"));
+		assertThat(escapedMap.get("foo.simple"), is("\\d"));
+	}
+
+	@Test
+	public void testAlternativeFilterKeywords() {
+
+		Map<String, String> map = new HashMap<>();
+		map.put("expression", "\\d");
+		map.put("foo.blue", "\\d");
+		map.put("green.bar", "\\d");
+
+		Map escapedMap = new YamlEscapeUtility(Arrays.asList("foo", "bar")).escapeSingleBackslashInProperties(map);
+		assertThat(escapedMap.size(), is(3));
+		assertThat(escapedMap.get("expression"), is("\\d"));
+		assertThat(escapedMap.get("foo.blue"), is("\\\\d"));
+		assertThat(escapedMap.get("green.bar"), is("\\\\d"));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/SkipperPackageUtils.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/SkipperPackageUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.support;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.mockito.ArgumentCaptor;
+import org.zeroturnaround.zip.ZipUtil;
+
+import org.springframework.cloud.skipper.domain.Package;
+import org.springframework.cloud.skipper.domain.UploadRequest;
+import org.springframework.cloud.skipper.io.DefaultPackageReader;
+import org.springframework.cloud.skipper.io.PackageReader;
+import org.springframework.cloud.skipper.io.TempFileUtils;
+import org.springframework.util.StreamUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class SkipperPackageUtils {
+
+	public static Package loadPackageFromBytes(ArgumentCaptor<UploadRequest> uploadRequestCaptor) throws IOException {
+		PackageReader packageReader = new DefaultPackageReader();
+		String packageName = uploadRequestCaptor.getValue().getName();
+		String packageVersion = uploadRequestCaptor.getValue().getVersion();
+		byte[] packageBytes = uploadRequestCaptor.getValue().getPackageFileAsBytes();
+		Path targetPath = TempFileUtils.createTempDirectory("service" + packageName);
+		File targetFile = new File(targetPath.toFile(), packageName + "-" + packageVersion + ".zip");
+		StreamUtils.copy(packageBytes, new FileOutputStream(targetFile));
+		ZipUtil.unpack(targetFile, targetPath.toFile());
+		return packageReader
+				.read(new File(targetPath.toFile(), packageName + "-" + packageVersion));
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-install.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-install.yml
@@ -4,8 +4,8 @@ spec:
   resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
   applicationProperties:
     spring.metrics.export.triggers.application.includes: integration**
-    spring.cloud.dataflow.stream.app.label: log
     spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.dataflow.stream.app.label: log
     spring.cloud.stream.bindings.input.group: ticktock
     spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
     spring.cloud.dataflow.stream.name: ticktock


### PR DESCRIPTION
Resolves #2142

 - In Skipper mode, escape the single backslash characters in deployed properties (SkipperStreamDeployer.escapeSingleBackslashProperties)
 - DSL reverse engineering will wrap with double quotes all property values that contain an empty spaces and contain single-quote already (StreamDefinitionToDslConverter.autoQuotes)