### PR TITLE
gh-2168 Use JpaTransactionManager

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
+import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
@@ -31,7 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * Configuration for the Data Flow Server application context. This includes support for
@@ -56,8 +58,8 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 public class DataFlowServerConfiguration {
 
 	@Bean
-	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-		return new DataSourceTransactionManager(dataSource);
+	public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+		return new JpaTransactionManager(entityManagerFactory);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -55,7 +55,7 @@ import org.springframework.cloud.task.repository.support.TaskRepositoryInitializ
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -64,6 +64,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author Glenn Renfro
  * @author Michael Minella
  * @author Ilayaperumal Gopinathan
+ * @author Gunnar Hillert
  */
 @Configuration
 @ConditionalOnProperty(prefix = FeaturesProperties.FEATURES_PREFIX, name = FeaturesProperties.TASKS_ENABLED, matchIfMissing = true)
@@ -132,7 +133,7 @@ public class TaskConfiguration {
 
 		@Bean
 		public JobRepositoryFactoryBean jobRepositoryFactoryBeanForServer(DataSource dataSource,
-				DataSourceTransactionManager dataSourceTransactionManager) {
+				PlatformTransactionManager dataSourceTransactionManager) {
 			JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 			repositoryFactoryBean.setDataSource(dataSource);
 			repositoryFactoryBean.setTransactionManager(dataSourceTransactionManager);
@@ -167,10 +168,10 @@ public class TaskConfiguration {
 
 		@Bean
 		public JobRepositoryFactoryBean jobRepositoryFactoryBean(DataSource dataSource,
-				DataSourceTransactionManager dataSourceTransactionManager) {
+				PlatformTransactionManager platformTransactionManager) {
 			JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
 			repositoryFactoryBean.setDataSource(dataSource);
-			repositoryFactoryBean.setTransactionManager(dataSourceTransactionManager);
+			repositoryFactoryBean.setTransactionManager(platformTransactionManager);
 			return repositoryFactoryBean;
 		}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/DataflowRdbmsInitializer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/DataflowRdbmsInitializer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.repository.support;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
@@ -132,11 +133,25 @@ public final class DataflowRdbmsInitializer implements InitializingBean {
 	}
 
 	private String getDatabaseType(DataSource dataSource) {
+		Connection connection = null;
+
 		try {
-			return DatabaseDriver.fromJdbcUrl(dataSource.getConnection().getMetaData().getURL()).getId();
+			connection = dataSource.getConnection();
+			return DatabaseDriver.fromJdbcUrl(connection.getMetaData().getURL()).getId();
 		}
 		catch (SQLException ex) {
 			throw new IllegalStateException("Unable to detect database type", ex);
+		}
+		finally {
+			if (connection != null) {
+				try {
+					connection.close();
+				}
+				catch (SQLException e)
+				{
+					throw new IllegalStateException("Unable to detect database type", e);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Fixes an issue were with a small connection pool size, methods hang or time out (Connection pool exhaustion) due to JPA calls occurring outside TX
- Also fixes an unclosed DB connection issue occurring in the `DataflowRdbmsInitializer`

Resolves spring-cloud/spring-cloud-dataflow#2168
Resolves spring-cloud/spring-cloud-dataflow#2169