### PR TITLE
Fix package deletion upon stream undeploy

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -367,9 +367,15 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	public void undeployStream(String streamName) {
-		DeploymentState streamDeploymentState = getStreamDeploymentState(streamName);
-		if (streamDeploymentState != null && streamDeploymentState != DeploymentState.undeployed) {
-			this.skipperClient.delete(streamName, true);
+		Resources<PackageMetadata> packageMetadataResources = this.skipperClient.search(streamName, false);
+		if (!packageMetadataResources.getContent().isEmpty()) {
+			try {
+				this.skipperClient.delete(streamName, true);
+			}
+			catch (ReleaseNotFoundException e) {
+				logger.info(String.format("Release not found for %s. Deleting the package %s", streamName, streamName));
+				this.skipperClient.packageDelete(streamName);
+			}
 		}
 	}
 


### PR DESCRIPTION
 - When the stream is undeployed in skipper mode, the corresponding package gets deleted (if it was uploaded for this stream) irrespective of whether the release for the stream exists or not

Resolves #2225