### PR TITLE
Remove explicit mgmt of spring-session

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
 		<spring-analytics.version>1.1.3.RELEASE</spring-analytics.version>
 		<spring-batch-admin-manager.version>1.3.1.RELEASE</spring-batch-admin-manager.version>
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
-		<spring-session.version>1.2.2.RELEASE</spring-session.version>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-lang.version>2.4</commons-lang.version>
 		<jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
@@ -133,11 +132,6 @@
 				<groupId>org.springframework.shell</groupId>
 				<artifactId>spring-shell</artifactId>
 				<version>${spring-shell.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.session</groupId>
-				<artifactId>spring-session</artifactId>
-				<version>${spring-session.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
**PORT ONTO MASTER BRANCH AS WELL**
We were managing the dependency to 1.2.2 when it should be whatever spring cloud common security config requires.

Note, the version of spring-session pulled in for the local server is managed by spring-boot-parent. The 1.2.2 dep was getting pulled into the final jar on the PCF/k8s servers.