### PR TITLE
Auto-quote CTR properties with blank characters

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DefinitionUtils.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/DefinitionUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.core;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class DefinitionUtils {
+
+	public static String autoQuotes(String propertyValue) {
+
+		if (!StringUtils.hasText(propertyValue)) {
+			return propertyValue;
+		}
+
+		if (propertyValue.startsWith("\"") && propertyValue.endsWith("\"")) {
+			return propertyValue;
+		}
+
+		if (!propertyValue.contains("'")) {
+			if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
+				return "'" + propertyValue + "'";
+			}
+		}
+		else {
+			if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
+				return "\"" + propertyValue + "\"";
+			}
+		}
+
+		return propertyValue;
+	}
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
@@ -88,7 +88,8 @@ public class StreamDefinitionToDslConverter {
 			for (String propertyName : props.keySet()) {
 				if (!dataFlowAddedProperties.contains(propertyName)) {
 					String propertyValue = unescape(props.get(propertyName));
-					dslBuilder.append(" --").append(propertyName).append("=").append(autoQuotes(propertyValue));
+					dslBuilder.append(" --").append(propertyName).append("=").append(
+							DefinitionUtils.autoQuotes(propertyValue));
 				}
 			}
 
@@ -111,21 +112,6 @@ public class StreamDefinitionToDslConverter {
 		return dsl;
 	}
 
-	private String autoQuotes(String propertyValue) {
-		if (!propertyValue.startsWith("\"") || !propertyValue.endsWith("\"")) {
-			if (!propertyValue.contains("'")) {
-				if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
-					return "'" + propertyValue + "'";
-				}
-			}
-			else {
-				if (propertyValue.contains(" ") || propertyValue.contains(";") || propertyValue.contains("*")) {
-					return "\"" + propertyValue + "\"";
-				}
-			}
-		}
-		return propertyValue;
-	}
 
 	private String unescape(String text) {
 		return StringEscapeUtils.unescapeHtml(text);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.DefinitionUtils;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.dsl.TaskNode;
 import org.springframework.cloud.dataflow.core.dsl.TaskParser;
@@ -243,7 +244,8 @@ public class DefaultTaskService implements TaskService {
 			taskNode.getTaskApps().stream().forEach(task -> {
 				// Add arguments to child task definitions
 				String generatedTaskDSL = task.getName() + task.getArguments().entrySet().stream()
-						.map(argument -> String.format(" --%s=%s", argument.getKey(), argument.getValue()))
+						.map(argument -> String.format(" --%s=%s", argument.getKey(),
+								DefinitionUtils.autoQuotes(argument.getValue())))
 						.collect(Collectors.joining());
 				TaskDefinition composedTaskDefinition = new TaskDefinition(task.getExecutableDSLName(),
 						generatedTaskDSL);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +34,7 @@ import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.cloud.scheduler.spi.core.ScheduleInfo;
 import org.springframework.cloud.scheduler.spi.core.SchedulerPropertyKeys;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -58,6 +58,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class TaskSchedulerControllerTests {
 
 	@Autowired
@@ -81,13 +82,6 @@ public class TaskSchedulerControllerTests {
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
-	}
-
-	@After
-	public void tearDown() {
-		repository.deleteAll();
-		assertEquals(0, repository.count());
-		simpleTestScheduler.getSchedules().clear();
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
@@ -81,7 +81,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(classes = TestDependencies.class)
 @TestPropertySource(properties = { "spring.main.banner-mode=off",
 		FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED + "=true" })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DefaultSkipperStreamServiceIntegrationTests {
 
 	@Autowired
@@ -96,9 +96,6 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 	@MockBean
 	private SkipperClient skipperClient;
 
-	@Autowired
-	private FeaturesProperties featuresProperties;
-
 	@Before
 	public void before() throws URISyntaxException {
 		createTickTock();
@@ -107,8 +104,6 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 
 	@After
 	public void destroyStream() {
-		appRegistryService.delete("log", ApplicationType.sink, "1.2.0.RELEASE");
-		appRegistryService.delete("time", ApplicationType.source, "1.2.0.RELEASE");
 		when(this.skipperClient.search(anyString(), anyBoolean()))
 				.thenReturn(new Resources<>(Collections.singletonList(new PackageMetadata())));
 		streamService.undeployStream("ticktock");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpdateTests.java
@@ -22,7 +22,6 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.yaml.snakeyaml.DumperOptions;
@@ -39,6 +38,7 @@ import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepo
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.support.PlatformUtils;
 import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.fail;
 @SpringBootTest(classes = TestDependencies.class)
 @TestPropertySource(properties = {
 		FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED + "=true" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DefaultSkipperStreamServiceUpdateTests {
 
 	@Autowired
@@ -72,12 +73,6 @@ public class DefaultSkipperStreamServiceUpdateTests {
 
 	@Autowired
 	private AppRegistryService appRegistryService;
-
-	@After
-	public void after() {
-		this.appRegistryService.delete("log", ApplicationType.sink, "1.1.1.RELEASE");
-		this.streamDefinitionRepository.deleteAll();
-	}
 
 	@Test
 	public void testCreateUpdateRequestsWithRegisteredApp() throws IOException {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpgradeStreamTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpgradeStreamTests.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepo
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.SkipperStreamService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,6 +47,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @TestPropertySource(properties = { FeaturesProperties.FEATURES_PREFIX + "." + FeaturesProperties.SKIPPER_ENABLED + "=true" })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DefaultSkipperStreamServiceUpgradeStreamTests {
 
 	@MockBean


### PR DESCRIPTION
Resolves #2114

- for CTR tasks auto-quote the property values that contain blank or special characters.
- Reuses same auto-quote utility used by StreamDslConverter
- Factor out the `auto-Quotes` function in a common utility DefinitionUtils class
- Ensure that all @SpringBootTest(classes = TestDependencies.class) tests use DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD
- Remove the After test cleaning for DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD annotated tests