### PR TITLE
gh-2254 Fix Task Definition status returns `unknown`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	</organization>
 	<parent>
 		<!-- Note: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
-         are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective
-         release versions -->
+		     are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective
+		     release versions -->
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
 		<version>1.3.8.RELEASE</version>
@@ -37,12 +37,12 @@
 		<spring-boot.version>1.5.13.RELEASE</spring-boot.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud-task.version -->
-		<spring-cloud-task.version>1.2.2.RELEASE</spring-cloud-task.version>
+		<spring-cloud-task.version>1.2.3.BUILD-SNAPSHOT</spring-cloud-task.version>
 
 		<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match the spring-cloud.version -->
-        <!-- Note: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
-         are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective
-         release versions -->
+		<!-- Note: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
+		     are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective
+		     release versions -->
 		<spring-cloud.version>Edgware.SR3</spring-cloud.version>
 
 		<spring-cloud-common-security-config.version>1.0.2.RELEASE</spring-cloud-common-security-config.version>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskDefinitionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskDefinitionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.rest.resource;
 
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceSupport;
 
@@ -24,6 +25,7 @@ import org.springframework.hateoas.ResourceSupport;
  *
  * @author Michael Minella
  * @author Glenn Renfro
+ * @author Gunnar Hillert
  */
 public class TaskDefinitionResource extends ResourceSupport {
 
@@ -37,9 +39,9 @@ public class TaskDefinitionResource extends ResourceSupport {
 	private boolean composed;
 
 	/**
-	 * Stream status (i.e. running, complete, etc).
+	 * The last execution of this task execution.
 	 */
-	private String status;
+	private TaskExecutionResource lastTaskExecution;
 
 	/**
 	 * Default constructor to be used by Jackson.
@@ -80,21 +82,31 @@ public class TaskDefinitionResource extends ResourceSupport {
 	}
 
 	/**
-	 * Return the status of this task (i.e. running, complete, etc)
+	 * Return the status of this task. Returns the value of {@link TaskExecutionStatus#toString()}.
 	 *
 	 * @return task status
 	 */
 	public String getStatus() {
-		return status;
+		if (this.getLastTaskExecution() == null) {
+			return TaskExecutionStatus.UNKNOWN.toString();
+		} else {
+			return this.getLastTaskExecution().getTaskExecutionStatus().toString();
+		}
 	}
 
 	/**
-	 * Set the status of this task (i.e. running, complete, etc)
-	 *
-	 * @param status task status
+	 * @return Last {@link TaskExecution} if available, null otherwise
 	 */
-	public void setStatus(String status) {
-		this.status = status;
+	public TaskExecutionResource getLastTaskExecution() {
+		return lastTaskExecution;
+	}
+
+	/**
+	 *
+	 * @param lastTaskExecution
+	 */
+	public void setLastTaskExecution(TaskExecutionResource lastTaskExecution) {
+		this.lastTaskExecution = lastTaskExecution;
 	}
 
 	public static class Page extends PagedResources<TaskDefinitionResource> {

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,25 @@ public class TaskExecutionResource extends ResourceSupport {
 		}
 	}
 
+	/**
+	 * Constructor to initialize the TaskExecutionResource using a
+	 * {@link TaskExecution}.
+	 *
+	 * @param taskExecution contains the {@link TaskExecution}
+	 */
+	public TaskExecutionResource(TaskExecution taskExecution) {
+		Assert.notNull(taskExecution, "taskExecution must not be null");
+		this.executionId = taskExecution.getExecutionId();
+		this.exitCode = taskExecution.getExitCode();
+		this.taskName = taskExecution.getTaskName();
+		this.exitMessage = taskExecution.getExitMessage();
+		this.arguments = Collections.unmodifiableList(taskExecution.getArguments());
+		this.startTime = taskExecution.getStartTime();
+		this.endTime = taskExecution.getEndTime();
+		this.errorMessage = taskExecution.getErrorMessage();
+		this.externalExecutionId = taskExecution.getExternalExecutionId();
+	}
+
 	public long getExecutionId() {
 		return executionId;
 	}
@@ -160,6 +179,37 @@ public class TaskExecutionResource extends ResourceSupport {
 
 	public String getExternalExecutionId() {
 		return externalExecutionId;
+	}
+
+	/**
+	 * Returns the calculated status of this {@link TaskExecution}.
+	 *
+	 * If {@link #startTime} is
+	 * null, the {@link TaskExecution} is considered to be not running (never executed).
+	 *
+	 * If {@link #endTime} is
+	 * null, the {@link TaskExecution} is considered to be still running:
+	 * {@link TaskExecutionStatus#RUNNING}. If the {@link #endTime} is defined and the
+	 * {@link #exitCode} is non-zero, an status of {@link TaskExecutionStatus#ERROR} is assumed,
+	 * if {@link #exitCode} is zero, {@link TaskExecutionStatus#SUCCESS} is returned.
+	 *
+	 * @return TaskExecutionStatus, never null
+	 */
+	public TaskExecutionStatus getTaskExecutionStatus() {
+		if (this.startTime == null) {
+			return TaskExecutionStatus.UNKNOWN;
+		}
+		if (this.endTime == null) {
+			return TaskExecutionStatus.RUNNING;
+		}
+		else {
+			if (this.exitCode == 0) {
+				return TaskExecutionStatus.COMPLETE;
+			}
+			else {
+				return TaskExecutionStatus.ERROR;
+			}
+		}
 	}
 
 	public static class Page extends PagedResources<TaskExecutionResource> {

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionStatus.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionStatus.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.resource;
+
+/**
+ * Represents the status of an {@link TaskExecution}.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public enum TaskExecutionStatus {
+
+	/**
+	 * The task execution did not complete successfully.
+	 */
+	ERROR,
+
+	/**
+	 * The task execution is still executing.
+	 */
+	RUNNING,
+
+	/**
+	 * The task execution completed successfully.
+	 */
+	COMPLETE,
+
+	/**
+	 * The task execution was never executed.
+	 */
+	UNKNOWN,
+
+}

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.resource;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+import org.springframework.cloud.task.repository.TaskExecution;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Provides tests for the {@link TaskExecutionResourceTests} class.
+ *
+ * @author Gunnar Hillert
+ */
+public class TaskExecutionResourceTests {
+
+	@Test
+	public void testTaskExecutionStatusWithNoTaskExecutionSet()  {
+		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource();
+		assertEquals(TaskExecutionStatus.UNKNOWN, taskExecutionResource.getTaskExecutionStatus());
+	}
+
+	@Test
+	public void testTaskExecutionStatusWithNoStartTime()  {
+		final TaskExecution taskExecution = new TaskExecution();
+		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
+		assertEquals(TaskExecutionStatus.UNKNOWN, taskExecutionResource.getTaskExecutionStatus());
+	}
+
+	@Test
+	public void testTaskExecutionStatusWithRunningTaskExecution()  {
+		final TaskExecution taskExecution = new TaskExecution();
+		taskExecution.setStartTime(new Date());
+		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
+		assertEquals(TaskExecutionStatus.RUNNING, taskExecutionResource.getTaskExecutionStatus());
+	}
+
+	@Test
+	public void testTaskExecutionStatusWithSuccessfulTaskExecution()  {
+		final TaskExecution taskExecution = new TaskExecution();
+		taskExecution.setStartTime(new Date());
+		taskExecution.setEndTime(new Date());
+		taskExecution.setExitCode(0);
+		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
+		assertEquals(TaskExecutionStatus.COMPLETE, taskExecutionResource.getTaskExecutionStatus());
+	}
+
+	@Test
+	public void testTaskExecutionStatusWithFailedTaskExecution()  {
+		final TaskExecution taskExecution = new TaskExecution();
+		taskExecution.setStartTime(new Date());
+		taskExecution.setEndTime(new Date());
+		taskExecution.setExitCode(123);
+		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
+		assertEquals(TaskExecutionStatus.ERROR, taskExecutionResource.getTaskExecutionStatus());
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -226,11 +226,9 @@ public class DataFlowControllerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(TaskDefinitionRepository.class)
-	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
-			DeploymentIdRepository deploymentIdRepository, TaskLauncher taskLauncher, AppRegistryCommon appRegistry,
+	public TaskDefinitionController taskDefinitionController(TaskExplorer taskExplorer, TaskDefinitionRepository repository,
 			TaskService taskService) {
-		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher, appRegistry,
-				taskService);
+		return new TaskDefinitionController(taskExplorer, repository, taskService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionAwareTaskDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionAwareTaskDefinition.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller.support;
+
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.util.Assert;
+
+/**
+ * {@link TaskDefinition} with the associated latest {@link TaskExecution}.
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class TaskExecutionAwareTaskDefinition {
+
+	final TaskDefinition taskDefinition;
+	final TaskExecution latestTaskExecution;
+
+	/**
+	 * Initialized the {@link TaskExecutionAwareTaskDefinition} with the provided
+	 * {@link TaskDefinition} and {@link TaskExecution}.
+	 *
+	 * @param taskDefinition Must not be null
+	 * @param latestTaskExecution Must not be null
+	 */
+	public TaskExecutionAwareTaskDefinition(TaskDefinition taskDefinition, TaskExecution latestTaskExecution) {
+		super();
+
+		Assert.notNull(taskDefinition, "The provided taskDefinition must not be null.");
+		Assert.notNull(latestTaskExecution, "The provided latestTaskExecution must not be null.");
+
+		this.taskDefinition = taskDefinition;
+		this.latestTaskExecution = latestTaskExecution;
+	}
+
+	/**
+	 * Initialized the {@link TaskExecutionAwareTaskDefinition} with the provided
+	 * {@link TaskDefinition}. The underlying {@link TaskExecution} will be set to null.
+	 *
+	 * @param taskDefinition Must not be null
+	 */
+	public TaskExecutionAwareTaskDefinition(TaskDefinition taskDefinition) {
+		super();
+
+		Assert.notNull(taskDefinition, "The provided taskDefinition must not be null.");
+
+		this.taskDefinition = taskDefinition;
+		this.latestTaskExecution = null;
+
+	}
+
+	/**
+	 * Returns the {@link TaskDefinition}.
+	 *
+	 * @return Never null.
+	 */
+	public TaskDefinition getTaskDefinition() {
+		return taskDefinition;
+	}
+
+	/**
+	 * Returns the associated {@link TaskExecution} if available. May return null.
+	 *
+	 * @return May return null
+	 */
+	public TaskExecution getLatestTaskExecution() {
+		return latestTaskExecution;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -144,9 +143,6 @@ import static org.mockito.Mockito.when;
 @EnableJpaRepositories(basePackages = "org.springframework.cloud.dataflow.registry.repository")
 @EnableTransactionManagement
 public class TestDependencies extends WebMvcConfigurationSupport {
-
-	@Autowired
-	private AppRegistrationRepository appRegistrationRepository;
 
 	@Bean
 	public RestControllerAdvice restControllerAdvice() {
@@ -349,11 +345,11 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public TaskDefinitionController taskDefinitionController(TaskDefinitionRepository repository,
+	public TaskDefinitionController taskDefinitionController(TaskExplorer explorer, TaskDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, ApplicationConfigurationMetadataResolver metadataResolver,
 			AppRegistryCommon appRegistry, DelegatingResourceLoader delegatingResourceLoader,
 			CommonApplicationProperties commonApplicationProperties) {
-		return new TaskDefinitionController(repository, deploymentIdRepository, taskLauncher(), appRegistry,
+		return new TaskDefinitionController(explorer, repository,
 				taskService(metadataResolver, taskRepository(), deploymentIdRepository, appRegistry, delegatingResourceLoader, commonApplicationProperties));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.cloud.dataflow.server.service.TaskService;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -93,6 +94,9 @@ public class TaskControllerTests {
 	private TaskLauncher taskLauncher;
 
 	@Autowired
+	private TaskExplorer taskExplorer;
+
+	@Autowired
 	private AppRegistry appRegistry;
 
 	@Before
@@ -104,12 +108,12 @@ public class TaskControllerTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTaskDefinitionControllerConstructorMissingRepository() {
-		new TaskDefinitionController(null, null, taskLauncher, appRegistry, taskService);
+		new TaskDefinitionController(taskExplorer, null, taskService);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testTaskDefinitionControllerConstructorMissingDeployer() {
-		new TaskDefinitionController(new InMemoryTaskDefinitionRepository(), null, null, appRegistry, taskService);
+	public void testTaskDefinitionControllerConstructorMissingTaskExplorer() {
+		new TaskDefinitionController(null, new InMemoryTaskDefinitionRepository(), taskService);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-local/pom.xml
+++ b/spring-cloud-dataflow-server-local/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud-task.version>1.2.2.RELEASE</spring-cloud-task.version>
+		<spring-cloud-task.version>1.2.3.BUILD-SNAPSHOT</spring-cloud-task.version>
 		<spring-cloud.version>Edgware.SR3</spring-cloud.version>
 		<checkstyle.config.location>../src/checkstyle/checkstyle.xml</checkstyle.config.location>
 	</properties>


### PR DESCRIPTION
- Retrieve the latest `TaskExecution` (if available) associated with the `TaskDefinition`
- Add the concept of a TaskExecution status
- Use this status to populate the status property of the `TaskDefinitionResource`
- As an enhancement also return the latest `TaskExecution` (if available) with the `TaskDefinitionResource`
- Add Tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2254

requires https://github.com/spring-cloud/spring-cloud-task/pull/425