### PR TITLE
Include "app default" endpoint in security role mapping

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -74,6 +74,7 @@ spring:
             - DELETE /apps/**                        => hasRole('ROLE_CREATE')
             - POST   /apps                           => hasRole('ROLE_CREATE')
             - POST   /apps/**                        => hasRole('ROLE_CREATE')
+            - PUT    /apps/**                        => hasRole('ROLE_CREATE')
 
             # Completions
 


### PR DESCRIPTION
This proposal adds `app default` (PUT) endpoint to the default security role mapping. 

I've verified the change with the following config/example (in skipper mode):

configs:
```
security.basic.enabled=true
security.user.name=test
security.user.password=pass
security.user.role=VIEW,CREATE,MANAGE
```

before this change:
```
dataflow:>app default --id source:http --version 2.0.0.BUILD-SNAPSHOT
Command failed org.springframework.cloud.dataflow.rest.client.DataFlowClientException: Access is denied
```

after this change:
```
dataflow:>app list --id source:http
╔═════════════════════════════╤═════════╤════╤════╗
║           source            │processor│sink│task║
╠═════════════════════════════╪═════════╪════╪════╣
║> http-2.0.0.BUILD-SNAPSHOT <│         │    │    ║
║http-1.3.1.RELEASE           │         │    │    ║
╚═════════════════════════════╧═════════╧════╧════╝

dataflow:>app default --
app default --id         app default --version
dataflow:>app default --id source:http --version 1.3.1.RELEASE
New default Application source:http:1.3.1.RELEASE
dataflow:>app list --id source:http
╔═════════════════════════╤═════════╤════╤════╗
║         source          │processor│sink│task║
╠═════════════════════════╪═════════╪════╪════╣
║http-2.0.0.BUILD-SNAPSHOT│         │    │    ║
║> http-1.3.1.RELEASE <   │         │    │    ║
╚═════════════════════════╧═════════╧════╧════╝
```

resolves spring-cloud/spring-cloud-dataflow#2256

As next steps, we will include RESTDocs and the relevant tests via spring-cloud/spring-cloud-dataflow#2283. 

Also, there's an unrelated problem in the App Default trigger from the UI, which is trakced via spring-cloud/spring-cloud-dataflow-ui#832.