### PR TITLE
Modify app info cmd options

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -97,7 +97,7 @@ One may also specify the longhand version as well, as shown in the following exa
 This shorthand behavior is discussed more in the section on <<spring-cloud-dataflow-stream-app-whitelisting>>.
 If you have <<spring-cloud-dataflow-stream-app-metadata-artifact, registered application property metadata>> you can use tab completion in the shell after typing `--` to get a list of candidate property names.
 
-The shell provides tab completion for application properties. The shell command `app info <appType>:<appName>` provides additional documentation for all the supported properties.
+The shell provides tab completion for application properties. The shell command `app info --name <appName> --type <appType>` provides additional documentation for all the supported properties.
 
 NOTE: Supported Stream `<appType>` possibilities are: source, processor, and sink.
 
@@ -421,14 +421,14 @@ The following stream can have application properties defined at the time of stre
 dataflow:> stream create --definition "time | log" --name ticktock
 ----
 
-The shell command `app info <appType>:<appName>` displays the white-listed application properties for the application.
+The shell command `app info --name <appName> --type <appType>` displays the white-listed application properties for the application.
 For more info on the property white listing, refer to <<spring-cloud-dataflow-stream-app-whitelisting>>
 
 The following listing shows the white_listed properties for the `time` app:
 
 [source,bash,options="nowrap"]
 ----
-dataflow:> app info source:time
+dataflow:> app info --name time --type source
 ╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
 ║         Option Name          │         Description          │           Default            │             Type             ║
 ╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣
@@ -450,7 +450,7 @@ The following listing shows the white-listed properties for the `log` app:
 
 [source,bash,options="nowrap"]
 ----
-dataflow:> app info sink:log
+dataflow:> app info --name log --type sink
 ╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
 ║         Option Name          │         Description          │           Default            │             Type             ║
 ╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -34,7 +34,7 @@ One may also specify the longhand version as well, as shown in the following exa
 This shorthand behavior is discussed more in the section on <<spring-cloud-dataflow-stream-app-whitelisting>>.
 If you have <<spring-cloud-dataflow-stream-app-metadata-artifact, registered application property metadata>> you can use tab completion in the shell after typing `--` to get a list of candidate property names.
 
-The shell provides tab completion for application properties. The shell command `app info <appType>:<appName>` provides additional documentation for all the supported properties.
+The shell provides tab completion for application properties. The shell command `app info --name <appName> --type <appType>` provides additional documentation for all the supported properties.
 
 NOTE: The supported Task `<appType>` is task.
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
@@ -84,15 +84,17 @@ public class ClassicAppRegistryCommands extends AbstractAppRegistryCommands impl
 
 	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
 	public List<Object> info(
-			@CliOption(mandatory = true, key = { "", "id" },
-					help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application) {
+			@CliOption(mandatory = true, key = { "",
+					"name" }, help = "name of the application to unregister") String name,
+			@CliOption(mandatory = true, key = {
+					"type" }, help = "type of the application to unregister") ApplicationType type) {
 		List<Object> result = new ArrayList<>();
 		try {
 			DetailedAppRegistrationResource info =
-					appRegistryOperations().info(application.name, application.type);
+					appRegistryOperations().info(name, type);
 			if (info != null) {
 				List<ConfigurationMetadataProperty> options = info.getOptions();
-				result.add(String.format("Information about %s application '%s':", application.type, application.name));
+				result.add(String.format("Information about %s application '%s':", type, name));
 				if (info.getVersion() != null) {
 					result.add(String.format("Version: '%s':", info.getVersion()));
 				}
@@ -119,13 +121,11 @@ public class ClassicAppRegistryCommands extends AbstractAppRegistryCommands impl
 				}
 			}
 			else {
-				result.add(String.format("Application info is not available for %s:%s", application.type,
-						application.name));
+				result.add(String.format("Application info is not available for %s:%s", type, name));
 			}
 		}
 		catch (Exception e) {
-			result.add(
-					String.format("Application info is not available for %s:%s", application.type, application.name));
+			result.add(String.format("Application info is not available for %s:%s", type, name));
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
@@ -93,17 +93,19 @@ public class SkipperAppRegistryCommands extends AbstractAppRegistryCommands impl
 
 	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
 	public List<Object> info(
-			@CliOption(mandatory = true, key = { "", "id" },
-					help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application,
+			@CliOption(mandatory = true, key = { "",
+					"name" }, help = "name of the application to unregister") String name,
+			@CliOption(mandatory = true, key = {
+					"type" }, help = "type of the application to unregister") ApplicationType type,
 			@CliOption(key = { "version" }, help = "the version for the registered application") String version) {
 		List<Object> result = new ArrayList<>();
 		try {
 			DetailedAppRegistrationResource info = StringUtils.hasText(version) ?
-					appRegistryOperations().info(application.name, application.type, version) :
-					appRegistryOperations().info(application.name, application.type);
+					appRegistryOperations().info(name, type, version) :
+					appRegistryOperations().info(name, type);
 			if (info != null) {
 				List<ConfigurationMetadataProperty> options = info.getOptions();
-				result.add(String.format("Information about %s application '%s':", application.type, application.name));
+				result.add(String.format("Information about %s application '%s':", type, name));
 				if (info.getVersion() != null) {
 					result.add(String.format("Version: '%s':", info.getVersion()));
 				}
@@ -133,13 +135,11 @@ public class SkipperAppRegistryCommands extends AbstractAppRegistryCommands impl
 				}
 			}
 			else {
-				result.add(String.format("Application info is not available for %s:%s", application.type,
-						application.name));
+				result.add(String.format("Application info is not available for %s:%s", type, name));
 			}
 		}
 		catch (Exception e) {
-			result.add(
-					String.format("Application info is not available for %s:%s", application.type, application.name));
+			result.add(String.format("Application info is not available for %s:%s", type, name));
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
@@ -109,7 +109,7 @@ public class ClassicAppRegistryCommandsTests {
 
 	@Test
 	public void testUnknownModule() {
-		List<Object> result = appRegistryCommands.info("unknown", ApplicationType.processor);
+		List<Object> result = appRegistryCommands.info(null,"unknown", ApplicationType.processor);
 		assertEquals((String) result.get(0), "Application info is not available for processor:unknown");
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
@@ -33,7 +33,6 @@ import org.springframework.cloud.dataflow.rest.client.AppRegistryOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
 import org.springframework.cloud.dataflow.shell.command.classic.ClassicAppRegistryCommands;
-import org.springframework.cloud.dataflow.shell.command.common.AbstractAppRegistryCommands;
 import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.table.Table;
@@ -110,9 +109,7 @@ public class ClassicAppRegistryCommandsTests {
 
 	@Test
 	public void testUnknownModule() {
-		List<Object> result = appRegistryCommands
-				.info(new AbstractAppRegistryCommands.QualifiedApplicationName("unknown", ApplicationType.processor));
-
+		List<Object> result = appRegistryCommands.info("unknown", ApplicationType.processor);
 		assertEquals((String) result.get(0), "Application info is not available for processor:unknown");
 	}
 


### PR DESCRIPTION
 - Use `app info --name <> --type <>` to be in sync with other app commands
 - Fix both the skipper/classic `app info` commands
 - Fix test
 - Update documenation references for `app info`

Resolves #1906