### PR TITLE
gh-2292 Fix: Don't query for latest task executions when no task definitions are present

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -142,9 +142,18 @@ public class TaskDefinitionController {
 		for (TaskDefinition taskDefinition : taskDefinitions) {
 			taskDefinitionMap.put(taskDefinition.getName(), taskDefinition);
 		}
-		List<TaskExecution> taskExecutions = explorer.getLatestTaskExecutionsByTaskNames(taskDefinitionMap.keySet().toArray(new String[taskDefinitionMap.size()]));
 
-		Page<TaskExecutionAwareTaskDefinition> taskExecutionAwareTaskDefinitions = taskDefinitions.map(new TaskDefinitionConverter(taskExecutions));
+		final List<TaskExecution> taskExecutions;
+
+		if (!taskDefinitionMap.isEmpty()) {
+			taskExecutions =
+					explorer.getLatestTaskExecutionsByTaskNames(taskDefinitionMap.keySet().toArray(new String[taskDefinitionMap.size()]));
+		}
+		else {
+			taskExecutions = null;
+		}
+
+		final Page<TaskExecutionAwareTaskDefinition> taskExecutionAwareTaskDefinitions = taskDefinitions.map(new TaskDefinitionConverter(taskExecutions));
 
 		return assembler.toResource(taskExecutionAwareTaskDefinitions, taskAssembler);
 	}


### PR DESCRIPTION
resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2292