### PR TITLE
Supports a max num of schedules to return in a single query

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/FeatureInfo.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/about/FeatureInfo.java
@@ -32,6 +32,8 @@ public class FeatureInfo {
 
 	private boolean skipperEnabled = false;
 
+	private boolean schedulerEnabled = false;
+
 	/**
 	 * Default constructor for serialization frameworks.
 	 */
@@ -70,4 +72,11 @@ public class FeatureInfo {
 		this.skipperEnabled = skipperEnabled;
 	}
 
+	public boolean isSchedulerEnabled() {
+		return schedulerEnabled;
+	}
+
+	public void setSchedulerEnabled(boolean schedulerEnabled) {
+		this.schedulerEnabled = schedulerEnabled;
+	}
 }

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -164,8 +164,8 @@ public final class DeploymentPropertiesUtils {
 	}
 
 	/**
-	 * Ensure that deployment properties only have keys starting with {@code app.} or
-	 * {@code deployer.}. In case non supported key is found {@link IllegalArgumentException}
+	 * Ensure that deployment properties only have keys starting with {@code app.},
+	 * {@code deployer.} or, {@code spring.cloud.scheduler.}. In case non supported key is found {@link IllegalArgumentException}
 	 * is thrown.
 	 *
 	 * @param properties the properties to check
@@ -176,9 +176,10 @@ public final class DeploymentPropertiesUtils {
 		}
 		for (Entry<String, String> property : properties.entrySet()) {
 			String key = property.getKey();
-			if (!key.startsWith("app.") && !key.startsWith("deployer.")) {
+			if (!key.startsWith("app.") && !key.startsWith("deployer.")
+					&& !key.startsWith("spring.cloud.scheduler.")) {
 				throw new IllegalArgumentException(
-						"Only deployment property keys starting with 'app.', 'deployer.' allowed, got '" + key + "'");
+						"Only deployment property keys starting with 'app.', 'deployer.' or, 'spring.cloud.scheduler.' allowed, got '" + key + "'");
 			}
 		}
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -177,9 +177,9 @@ public final class DeploymentPropertiesUtils {
 		for (Entry<String, String> property : properties.entrySet()) {
 			String key = property.getKey();
 			if (!key.startsWith("app.") && !key.startsWith("deployer.")
-					&& !key.startsWith("spring.cloud.scheduler.")) {
+					&& !key.startsWith("scheduler.")) {
 				throw new IllegalArgumentException(
-						"Only deployment property keys starting with 'app.', 'deployer.' or, 'spring.cloud.scheduler.' allowed, got '" + key + "'");
+						"Only deployment property keys starting with 'app.', 'deployer.' or, 'scheduler.' allowed, got '" + key + "'");
 			}
 		}
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -176,9 +176,9 @@ public final class DeploymentPropertiesUtils {
 		}
 		for (Entry<String, String> property : properties.entrySet()) {
 			String key = property.getKey();
-			if (!key.startsWith("app.") && !key.startsWith("deployer.") && !key.startsWith("scheduler.")) {
+			if (!key.startsWith("app.") && !key.startsWith("deployer.")) {
 				throw new IllegalArgumentException(
-						"Only deployment property keys starting with 'app.', 'deployer.' or 'scheduler.' allowed, got '" + key + "'");
+						"Only deployment property keys starting with 'app.', 'deployer.' allowed, got '" + key + "'");
 			}
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
+import org.springframework.cloud.dataflow.server.service.SchedulerServiceProperties;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.scheduler.spi.core.Scheduler;
@@ -42,7 +43,7 @@ import org.springframework.core.io.ResourceLoader;
 
 @Configuration
 @Conditional({SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class})
-@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class})
+@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class, SchedulerServiceProperties.class})
 public class SchedulerConfiguration {
 
 	@Value("${spring.cloud.dataflow.server.uri:}")
@@ -55,11 +56,12 @@ public class SchedulerConfiguration {
 			AppRegistryCommon registry, ResourceLoader resourceLoader,
 			TaskConfigurationProperties taskConfigurationProperties,
 			DataSourceProperties dataSourceProperties,
-			ApplicationConfigurationMetadataResolver metaDataResolver) {
+			ApplicationConfigurationMetadataResolver metaDataResolver,
+			SchedulerServiceProperties schedulerServiceProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				scheduler, taskDefinitionRepository, registry, resourceLoader,
 				taskConfigurationProperties, dataSourceProperties,
-				this.dataflowServerUri, metaDataResolver);
+				this.dataflowServerUri, metaDataResolver, schedulerServiceProperties);
 	}
 
 	public static class SchedulerConfigurationPropertyChecker extends AllNestedConditions {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -110,6 +110,7 @@ public class AboutController {
 		featureInfo.setStreamsEnabled(featuresProperties.isStreamsEnabled());
 		featureInfo.setTasksEnabled(featuresProperties.isTasksEnabled());
 		featureInfo.setSkipperEnabled(featuresProperties.isSkipperEnabled());
+		featureInfo.setSchedulerEnabled(featuresProperties.isSchedulesEnabled());
 
 
 		final VersionInfo versionInfo = getVersionInfo();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
@@ -78,7 +78,9 @@ public class TaskSchedulerController {
 	public PagedResources<ScheduleInfoResource> list(
 			PagedResourcesAssembler<ScheduleInfo> assembler) {
 		List<ScheduleInfo> result = this.schedulerService.list();
-		Pageable pageable = new PageRequest(0, result.size());
+		int resultSize = result.size();
+		Pageable pageable = new PageRequest(0,
+				(resultSize == 0) ? resultSize = 1 : resultSize); //handle empty result set
 
 		Page<ScheduleInfo> page = new PageImpl<>(result, pageable,
 				result.size());
@@ -97,7 +99,9 @@ public class TaskSchedulerController {
 	public PagedResources<ScheduleInfoResource> filteredList(@PathVariable String taskDefinitionName,
 			PagedResourcesAssembler<ScheduleInfo> assembler) {
 		List<ScheduleInfo> result = this.schedulerService.list(taskDefinitionName);
-		Pageable pageable = new PageRequest(0, result.size());
+		int resultSize = result.size();
+		Pageable pageable = new PageRequest(0,
+				(resultSize == 0) ? resultSize = 1 : resultSize); //handle empty result set
 		Page<ScheduleInfo> page = new PageImpl<>(result, pageable,
 				result.size());
 		return assembler.toResource(page, taskAssembler);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.cloud.scheduler.spi.core.ScheduleInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -69,16 +70,16 @@ public class TaskSchedulerController {
 	/**
 	 * Return a page-able list of {@link ScheduleInfo}s.
 	 *
-	 * @param pageable  page-able collection of {@code ScheduleResource}.
 	 * @param assembler assembler for the {@link ScheduleInfo}
 	 * @return a list of Schedules
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public PagedResources<ScheduleInfoResource> list(Pageable pageable,
+	public PagedResources<ScheduleInfoResource> list(
 			PagedResourcesAssembler<ScheduleInfo> assembler) {
+		List<ScheduleInfo> result = this.schedulerService.list();
+		Pageable pageable = new PageRequest(0, result.size());
 
-		List<ScheduleInfo> result = this.schedulerService.list(pageable);
 		Page<ScheduleInfo> page = new PageImpl<>(result, pageable,
 				result.size());
 		return assembler.toResource(page, taskAssembler);
@@ -88,15 +89,15 @@ public class TaskSchedulerController {
 	 * Return a page-able list of {@link ScheduleInfo}s for a specific
 	 * {@link org.springframework.cloud.dataflow.core.TaskDefinition} name.
 	 *
-	 * @param pageable page-able collection of {@code ScheduleResource}.
 	 * @param taskDefinitionName name of the taskDefinition to search.
 	 * @param assembler assembler for the {@link ScheduleInfo}.
 	 * @return a list of Schedules.
 	 */
 	@RequestMapping("/instances/{taskDefinitionName}")
-	public PagedResources<ScheduleInfoResource> filteredList(Pageable pageable, @PathVariable String taskDefinitionName,
+	public PagedResources<ScheduleInfoResource> filteredList(@PathVariable String taskDefinitionName,
 			PagedResourcesAssembler<ScheduleInfo> assembler) {
-		List<ScheduleInfo> result = this.schedulerService.list(pageable, taskDefinitionName);
+		List<ScheduleInfo> result = this.schedulerService.list(taskDefinitionName);
+		Pageable pageable = new PageRequest(0, result.size());
 		Page<ScheduleInfo> page = new PageImpl<>(result, pageable,
 				result.size());
 		return assembler.toResource(page, taskAssembler);
@@ -119,7 +120,6 @@ public class TaskSchedulerController {
 			@RequestParam String properties,
 			@RequestParam(required = false) List<String> arguments) {
 		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parse(properties);
-		DeploymentPropertiesUtils.validateDeploymentProperties(propertiesToUse);
 		schedulerService.schedule(scheduleName, taskDefinitionName, propertiesToUse, arguments);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerService.java
@@ -73,4 +73,21 @@ public interface SchedulerService {
 	 * @return A List of Schedules for the given system.
 	 */
 	List<ScheduleInfo> list(Pageable pageable);
+
+	/**
+	 * List all of the Schedules associated with the provided TaskDefinition up to the
+	 * established maximum as specified {@link SchedulerServiceProperties#maxSchedulesReturned}.
+	 *
+	 * @param taskDefinitionName to retrieve Schedules for a specified taskDefinitionName.
+	 * @return A List of Schedules configured for the provided taskDefinitionName.
+	 */
+	List<ScheduleInfo> list(String taskDefinitionName) ;
+
+	/**
+	 * List all of the schedules registered with the system up to the
+	 * established maximum as specified {@link SchedulerServiceProperties#maxSchedulesReturned}.
+	 *
+	 * @return A List of Schedules for the given system.
+	 */
+	List<ScheduleInfo> list();
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerServiceProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerServiceProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+
+/**
+ * Specifies the properties required to configure how data flow handles schedules.
+ *
+ * @author Glenn Renfro
+ */
+@ConfigurationProperties(prefix = SchedulerServiceProperties.SCHEDULER_SERVICE_PREFIX)
+public class SchedulerServiceProperties {
+	public static final String SCHEDULER_SERVICE_PREFIX = DataFlowPropertyKeys.PREFIX + "scheduler.service";
+
+	public static final int SCHEDULER_MAX_RETURNED_NUMBER = 10000;
+
+	/**
+	 * Establish the maximum number of schedules to return in a single request.
+	 */
+	private int maxSchedulesReturned = SCHEDULER_MAX_RETURNED_NUMBER;
+
+	public int getMaxSchedulesReturned() {
+		return maxSchedulesReturned;
+	}
+
+	public void setMaxSchedulesReturned(int maxSchedulesReturned) {
+		this.maxSchedulesReturned = maxSchedulesReturned;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -131,8 +131,10 @@ public class DefaultSchedulerService implements SchedulerService {
 		}
 		AppDefinition revisedDefinition = TaskServiceUtils.mergeAndExpandAppProperties(taskDefinition, metadataResource,
 				appDeploymentProperties, whitelistProperties);
+		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
+		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
 		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition,
-				extractAndQualifySchedulerProperties(taskDeploymentProperties),
+				taskDeploymentProperties,
 				deployerDeploymentProperties, scheduleName, getTaskResource(taskDefinitionName));
 		this.scheduler.schedule(scheduleRequest);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -131,8 +131,8 @@ public class DefaultSchedulerService implements SchedulerService {
 		}
 		AppDefinition revisedDefinition = TaskServiceUtils.mergeAndExpandAppProperties(taskDefinition, metadataResource,
 				appDeploymentProperties, whitelistProperties);
-		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
 		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
+		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
 		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition,
 				taskDeploymentProperties,
 				deployerDeploymentProperties, scheduleName, getTaskResource(taskDefinitionName));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -113,18 +113,6 @@ public class TaskServiceUtils {
 	}
 
 	/**
-	 * Extract scheduler properties from the deployment properties by task name.
-	 * @param name the task app name to search for in the deployment properties.
-	 * @param taskDeploymentProperties the properties for the task deployment.
-	 * @return a map containing the scheduler properties for a task schedule.
-	 */
-	public static Map<String, String> extractSchedulerProperties(String name, Map<String, String> taskDeploymentProperties) {
-		Assert.hasText(name, "name must not be empty or null");
-		Assert.notNull(taskDeploymentProperties, "taskDeploymentProoperties must not be null");
-		return extractPropertiesByPrefix("scheduler", name, taskDeploymentProperties);
-	}
-
-	/**
 	 * Return a copy of a given task definition where short form parameters have been expanded
 	 * to their long form (amongst the whitelisted supported properties of the app) if
 	 * applicable.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.dataflow.server.repository.RdbmsTaskDefinitionR
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.support.DataflowRdbmsInitializer;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
+import org.springframework.cloud.dataflow.server.service.SchedulerServiceProperties;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
@@ -131,6 +132,11 @@ public class TaskServiceDependencies {
 	}
 
 	@Bean
+	public SchedulerServiceProperties schedulerServiceProperties() {
+		return new SchedulerServiceProperties();
+	}
+
+	@Bean
 	public DataSourceTransactionManager transactionManager(DataSource dataSource) {
 		return new DataSourceTransactionManager(dataSource);
 	}
@@ -150,13 +156,14 @@ public class TaskServiceDependencies {
 			Scheduler scheduler, TaskDefinitionRepository taskDefinitionRepository,
 			AppRegistry registry, ResourceLoader resourceLoader,
 			DataSourceProperties dataSourceProperties,
-			ApplicationConfigurationMetadataResolver metaDataResolver) {
+			ApplicationConfigurationMetadataResolver metaDataResolver,
+			SchedulerServiceProperties schedulerServiceProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				scheduler, taskDefinitionRepository,
 				registry, resourceLoader,
 				new TaskConfigurationProperties(),
 				dataSourceProperties, null,
-				metaDataResolver);
+				metaDataResolver, schedulerServiceProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -78,6 +78,7 @@ import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepo
 import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
+import org.springframework.cloud.dataflow.server.service.SchedulerServiceProperties;
 import org.springframework.cloud.dataflow.server.service.SkipperStreamService;
 import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.service.TaskService;
@@ -439,7 +440,7 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 				registry, resourceLoader,
 				new TaskConfigurationProperties(),
 				dataSourceProperties, null,
-				metaDataResolver);
+				metaDataResolver, new SchedulerServiceProperties());
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
@@ -78,7 +78,7 @@ public class AboutControllerTests {
 	@Test
 	public void testListApplications() throws Exception {
 		ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
-				result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(true)))
+				result.andDo(print()).andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(true)))
 				.andExpect(jsonPath("$.featureInfo.skipperEnabled", is(false)))
 				.andExpect(jsonPath("$.versionInfo.implementation.name", is("${info.app.name}")))
 				.andExpect(jsonPath("$.versionInfo.implementation.version", is("1.2.3.IMPLEMENTATION.TEST")))
@@ -96,6 +96,10 @@ public class AboutControllerTests {
 				.andExpect(jsonPath("$.securityInfo.formLogin", is(false)))
 				.andExpect(jsonPath("$.securityInfo.authenticated", is(false)))
 				.andExpect(jsonPath("$.securityInfo.username", isEmptyOrNullString()))
+				.andExpect(jsonPath("$.featureInfo.streamsEnabled", is(true)))
+				.andExpect(jsonPath("$.featureInfo.tasksEnabled", is(true)))
+				.andExpect(jsonPath("$.featureInfo.skipperEnabled", is(false)))
+				.andExpect(jsonPath("$.featureInfo.schedulerEnabled", is(false)))
 				.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", not(isEmptyOrNullString())));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -123,7 +123,7 @@ public class TaskSchedulerControllerTests {
 		repository.save(new TaskDefinition("testDefinition", "testApp"));
 		mockMvc.perform(post("/tasks/schedules/").param("taskDefinitionName", "testDefinition").
 				param("scheduleName", "mySchedule").
-				param("properties", "scheduler.testApp.spring.cloud.scheduler.cron.expression=* * * * *")
+				param("properties", "scheduler.cron.expression=* * * * *")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, simpleTestScheduler.list().size());
 		ScheduleInfo scheduleInfo = simpleTestScheduler.list().get(0);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
@@ -121,21 +121,6 @@ public class TaskServiceUtilsTests {
 	}
 
 	@Test
-	public void testExtractSchedulerProperties() {
-		Map<String, String> taskDeploymentProperties = new HashMap<>();
-		taskDeploymentProperties.put("scheduler.test.foo", "bar");
-		taskDeploymentProperties.put("app.test.none", "boo");
-		taskDeploymentProperties.put("scheduler.test.test", "baz");
-		taskDeploymentProperties.put("scheduler.none.test", "boo");
-		Map<String, String> result = TaskServiceUtils.extractSchedulerProperties("test",
-				taskDeploymentProperties);
-
-		assertThat(result.size()).isEqualTo(2);
-		assertThat(result.get("foo")).isEqualTo("bar");
-		assertThat(result.get("test")).isEqualTo("baz");
-	}
-
-	@Test
 	public void testMergeAndExpandAppProperties() {
 		TaskDefinition taskDefinition = new TaskDefinition("testTask", "testApp");
 		Map<String, String> appDeploymentProperties = new HashMap<>();

--- a/spring-cloud-dataflow-shell-core/src/test/resources/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests-testInfo.txt
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests-testInfo.txt
@@ -2,6 +2,7 @@
 ║     Target      │        http://localhost:9393        ║
 ╟─────────────────┼─────────────────────────────────────╢
 ║                 │Analytics Enabled: true              ║
+║                 │Scheduler Enabled: false             ║
 ║    Features     │  Skipper Enabled: false             ║
 ║                 │  Streams Enabled: true              ║
 ║                 │    Tasks Enabled: false             ║


### PR DESCRIPTION
Spring Cloud Data Flow Scheduler Service should return no more than 10,000 per request.
The user can change this by setting the spring.cloud.dataflow.scheduler.service property to the desired max

Updated to standardize scheduler properties
This allows a user to set the expression for specific schedule by using the following key:
scheduler.cron.expression=<whatever>

You will note is this PR that the extraction of scheduler properties  was removed from the deployer utils.
This was because, the original method of defining scheduler properties matched deployment properties.  Now this is no longer the case.

resolves #2299
resolves #2301