### PR TITLE
Respond Not-Found error on missing Task Scheduler

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefiniti
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskBatchException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskExecutionException;
+import org.springframework.cloud.dataflow.server.repository.NoSuchTaskSchedulerException;
 import org.springframework.cloud.dataflow.server.support.ApplicationDoesNotExistException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
@@ -56,6 +57,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
  */
 @ControllerAdvice
 public class RestControllerAdvice {
@@ -143,7 +145,7 @@ public class RestControllerAdvice {
 			NoSuchTaskDefinitionException.class, NoSuchTaskExecutionException.class, NoSuchJobExecutionException.class,
 			NoSuchJobInstanceException.class, NoSuchJobException.class, NoSuchStepExecutionException.class,
 			NoSuchTaskBatchException.class, MetricsMvcEndpoint.NoSuchMetricException.class, NoSuchAppException.class,
-			NoSuchAppInstanceException.class, ApplicationDoesNotExistException.class })
+			NoSuchAppInstanceException.class, ApplicationDoesNotExistException.class, NoSuchTaskSchedulerException.class })
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	@ResponseBody
 	public VndErrors onNotFoundException(Exception e) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.springframework.cloud.dataflow.rest.resource.ScheduleInfoResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.repository.NoSuchTaskSchedulerException;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.cloud.scheduler.spi.core.ScheduleInfo;
 import org.springframework.data.domain.Page;
@@ -44,6 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Controller for operations on {@link ScheduleInfo}. This includes CRUD operations.
  *
  * @author Glenn Renfro
+ * @author Christian Tzolov
  */
 @RestController
 @RequestMapping("/tasks/schedules")
@@ -95,9 +97,12 @@ public class TaskSchedulerController {
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public ScheduleInfoResource getSchedule(
-			@PathVariable("name") String scheduleName) {
-		return taskAssembler.toResource(this.schedulerService.getSchedule(scheduleName));
+	public ScheduleInfoResource getSchedule(@PathVariable("name") String scheduleName) {
+		ScheduleInfo scheduler = this.schedulerService.getSchedule(scheduleName);
+		if (scheduler == null) {
+			throw new NoSuchTaskSchedulerException(String.format("Task scheduler [%s] doesn't exist!" , scheduleName));
+		}
+		return taskAssembler.toResource(scheduler);
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskSchedulerException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskSchedulerException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository;
+
+/**
+ * Exception is thrown if there is no mapping between a batch job execution and
+ * a task execution.
+ *
+ * @author Christian Tzolov
+ */
+public class NoSuchTaskSchedulerException extends RuntimeException {
+
+	public NoSuchTaskSchedulerException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -56,6 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Tests for the {@link TaskSchedulerController}.
  *
  * @author Glenn Renfro
+ * @author Christian Tzolov
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
@@ -118,6 +119,10 @@ public class TaskSchedulerControllerTests {
 				.andDo(print()).andExpect(status().isOk())
 				.andExpect(content().json("{scheduleName: \"schedule2\"}"))
 				.andExpect(content().json("{taskDefinitionName: \"testDefinition\"}"));
+		mockMvc.perform(get("/tasks/schedules/scheduleNotExisting").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isNotFound())
+				.andExpect(content().json("[{\"logref\":\"NoSuchTaskSchedulerException\"," +
+						"\"message\":\"Task scheduler [scheduleNotExisting] doesn't exist!\",\"links\":[]}]"));
 	}
 
 	@Test


### PR DESCRIPTION
  Resolves #2310
  - Add NoSuchTaskSchedulerException thrown when scheduler resources with requested name doesn't exist.
  - Register the NoSuchTaskSchedulerException to the RestControllerAdvice#NotFound handler to transform it into hTTP 404 Error
  - Add test