### PR TITLE
Work around warnings about missing attributes in path parameters snippets

### DIFF
--- a/spring-cloud-dataflow-docs/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/spring-cloud-dataflow-docs/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,10 @@
+.+{{path}}+
+|===
+|Parameter|Description
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===


### PR DESCRIPTION
The docs build currently generates warnings like the following:

```
WARNING: skipping reference to missing attribute: task-definition-name
```

They are caused by the title of the table in the REST Docs-generated path parameters snippet having content that Asciidoctor interprets as an attribute reference. This will be fixed by https://github.com/spring-projects/spring-restdocs/issues/527. In the meantime, it can be worked around with a custom path parameters snippet template as proposed here.