### PR TITLE
Updated asciidocs to remove warnings

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
@@ -333,7 +333,7 @@ image::{dataflow-asciidoc}/images/dataflow-job-executions-list.png[List of Job E
 
 
 [[dashboard-job-executions-details]]
-==== Job Execution Details
+=== Job Execution Details
 
 After having launched a batch job, the Job Execution Details page will show information about the job.
 
@@ -348,7 +348,7 @@ You can further drill into the details of each step's execution by clicking the 
 
 
 [[dashboard-job-executions-steps]]
-==== Step Execution Details
+=== Step Execution Details
 
 The Step Execution Details page provides information about an individual step within a job.
 
@@ -370,7 +370,7 @@ When that happens, refer to the server log files for further details.
 
 
 [[dashboard-job-executions-steps-progress]]
-==== Step Execution Progress
+=== Step Execution Progress
 
 On this screen, you can see a progress bar indicator in regards to the execution
 of the current step. Under the Step Execution History, you can also view various

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/samples.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/samples.adoc
@@ -1,10 +1,17 @@
 [[dataflow-samples]]
 = Samples
 
+[partintro]
+--
+This section shows the available samples.
+--
+
+[[samples-links]]
+== Links
 Several samples have been created to help you get started on implementing higher-level use cases than the basic Streams and Tasks shown in the reference guide.
 The samples are part of a separate https://github.com/spring-cloud/spring-cloud-dataflow-samples[repository] and have their own https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/[reference documentation].
 
-.Streams
+
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#_java_dsl[Java DSL]
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#spring-cloud-data-flow-samples-http-cassandra-overview[HTTP to Cassandra]
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#_http_to_mysql_demo[HTTP to MySQL]
@@ -28,4 +35,3 @@ The samples are part of a separate https://github.com/spring-cloud/spring-cloud-
 
 {sp}+
 {sp}+
-// Keep the {sp}+ otherise the TOC is messed up.

--- a/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
+++ b/spring-cloud-dataflow-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
@@ -59,7 +59,7 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 	public void createSchedule() throws Exception {
 		this.mockMvc.perform(
 				post("/tasks/schedules")
-						.param("scheduleName", "my-schedule")
+						.param("scheduleName", "mySchedule")
 						.param("taskDefinitionName", "taskC")
 						.param("properties", "scheduler.AAA.spring.cloud.scheduler.cron.expression=00%2041%2017%20?%20*%20*")
 						.param("arguments", "--foo=bar"))
@@ -77,11 +77,11 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 	@Test
 	public void deleteSchedule() throws Exception {
 		this.mockMvc.perform(
-				delete("/tasks/schedules/{my-schedule}", "my-schedule"))
+				delete("/tasks/schedules/{scheduleName}", "mytestschedule"))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						pathParameters(parameterWithName("my-schedule")
+						pathParameters(parameterWithName("scheduleName")
 								.description("The name of an existing schedule (required)"))));
 	}
 

--- a/spring-cloud-dataflow-docs/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/spring-cloud-dataflow-docs/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,10 @@
+.+{{path}}+
+|===
+|Parameter|Description
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===


### PR DESCRIPTION
* Updated samples adoc to remove the ERROR reported by api-guide.adoc.  Basically samples.adoc structure was incorrect causing api-guide to be out of the formal structure of the docs.
* Reset the sections in the schedules document
* There is a bug in Spring Restdocs that caused the WARNING: skipping reference to missing attribute: XYZ.  Andy Wilkinson gave us a template to resolve those warnings and has opened an issue in Restdocs to resolve the problem.  https://github.com/spring-projects/spring-restdocs/issues/527
* Using the doc build there are no error or warnings that popup, however there are still 2 that popup when I do the CI Plan build, but no followup information on where they can be sourced to.

resolves #2233

