### PR TITLE
Use registry name for the app when deploying in skipper mode

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
@@ -242,7 +242,7 @@ public class DefaultSkipperStreamService extends AbstractStreamService implement
 			if (appDeploymentRequest.getCommandlineArguments().size() == 1) {
 				hasProps = true;
 				String version = appDeploymentRequest.getCommandlineArguments().get(0);
-				this.skipperStreamDeployer.validateAppVersionIsRegistered(appDeploymentRequest, version);
+				this.skipperStreamDeployer.validateAppVersionIsRegistered(streamDefinition, appDeploymentRequest, version);
 				specMap.put("version", version);
 			}
 			if (hasProps) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -43,6 +43,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
@@ -263,20 +264,40 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	private void validateAllAppsRegistered(StreamDeploymentRequest streamDeploymentRequest) {
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(streamDeploymentRequest.getStreamName());
 		for (AppDeploymentRequest adr : streamDeploymentRequest.getAppDeploymentRequests()) {
 			String version = ResourceUtils.getResourceVersion(adr.getResource());
-			validateAppVersionIsRegistered(adr, version);
+			validateAppVersionIsRegistered(getRegisteredName(streamDefinition, adr.getDefinition().getName()), adr, version);
 		}
 	}
 
-	public void validateAppVersionIsRegistered(AppDeploymentRequest appDeploymentRequest, String appVersion) {
-		String name = appDeploymentRequest.getDefinition().getName();
+	private String getRegisteredName(StreamDefinition streamDefinition, String adrAppName) {
+		for (StreamAppDefinition appDefinition: streamDefinition.getAppDefinitions()) {
+			if (appDefinition.getName().equals(adrAppName)) {
+				return appDefinition.getRegisteredAppName();
+			}
+		}
+		return adrAppName;
+	}
+
+	public void validateAppVersionIsRegistered(StreamDefinition streamDefinition, AppDeploymentRequest appDeploymentRequest, String appVersion) {
+		String registeredAppName = getRegisteredName(streamDefinition, appDeploymentRequest.getDefinition().getName());
 		String appTypeString = appDeploymentRequest.getDefinition().getProperties()
 				.get(DataFlowPropertyKeys.STREAM_APP_TYPE);
 		ApplicationType applicationType = ApplicationType.valueOf(appTypeString);
-		if (!this.appRegistryService.appExist(name, applicationType, appVersion)) {
+		if (!this.appRegistryService.appExist(registeredAppName, applicationType, appVersion)) {
 			throw new IllegalStateException(String.format("The %s:%s:%s app is not registered!",
-					name, appTypeString, appVersion));
+					registeredAppName, appTypeString, appVersion));
+		}
+	}
+
+	public void validateAppVersionIsRegistered(String registeredAppName, AppDeploymentRequest appDeploymentRequest, String appVersion) {
+		String appTypeString = appDeploymentRequest.getDefinition().getProperties()
+				.get(DataFlowPropertyKeys.STREAM_APP_TYPE);
+		ApplicationType applicationType = ApplicationType.valueOf(appTypeString);
+		if (!this.appRegistryService.appExist(registeredAppName, applicationType, appVersion)) {
+			throw new IllegalStateException(String.format("The %s:%s:%s app is not registered!",
+					registeredAppName, appTypeString, appVersion));
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -102,15 +102,17 @@ public class SkipperStreamDeployerTests {
 		skipperDeployerProperties.put(SkipperStream.SKIPPER_PACKAGE_VERSION, "1.0.1");
 
 		StreamDeploymentRequest streamDeploymentRequest = new StreamDeploymentRequest("test1",
-				"time | log",
+				"t1: time | log",
 				appDeploymentRequests,
 				skipperDeployerProperties);
 
 		SkipperClient skipperClient = MockUtils.createSkipperClientMock();
 
+		StreamDefinitionRepository streamDefinitionRepository = mock(StreamDefinitionRepository.class);
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
-				mock(StreamDefinitionRepository.class), appRegistryService, mock(ForkJoinPool.class));
+				streamDefinitionRepository, appRegistryService, mock(ForkJoinPool.class));
 
+		when(streamDefinitionRepository.findOne("test1")).thenReturn(new StreamDefinition("test1", "t1: time | log"));
 		skipperStreamDeployer.deployStream(streamDeploymentRequest);
 
 		ArgumentCaptor<UploadRequest> uploadRequestCaptor = ArgumentCaptor.forClass(UploadRequest.class);
@@ -267,9 +269,11 @@ public class SkipperStreamDeployerTests {
 
 		SkipperClient skipperClient = MockUtils.createSkipperClientMock();
 
+		StreamDefinitionRepository streamDefinitionRepository = mock(StreamDefinitionRepository.class);
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
-				mock(StreamDefinitionRepository.class),
-				appRegistryService, mock(ForkJoinPool.class));
+				streamDefinitionRepository, appRegistryService, mock(ForkJoinPool.class));
+
+		when(streamDefinitionRepository.findOne("test1")).thenReturn(new StreamDefinition("test1", "t1: time | log"));
 
 		skipperStreamDeployer.deployStream(streamDeploymentRequest);
 	}


### PR DESCRIPTION
 - When the stream definition uses `label` for the app definitions, then when deploying the stream always use the `registry` name so that the app registry has the correct app info.
 - Update tests

Resolves #2350