### PR TITLE
Changed the task-definition type to LONGVARCHAR

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepository.java
@@ -53,7 +53,7 @@ public class RdbmsTaskDefinitionRepository extends AbstractRdbmsKeyValueReposito
 					definition.getName()));
 		}
 		Object[] insertParameters = new Object[] { definition.getName(), definition.getDslText() };
-		jdbcTemplate.update(saveRow, insertParameters, new int[] { Types.VARCHAR, Types.CLOB });
+		jdbcTemplate.update(saveRow, insertParameters, new int[] { Types.VARCHAR, Types.LONGVARCHAR });
 		return definition;
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepositoryTests.java
@@ -157,6 +157,19 @@ public class RdbmsTaskDefinitionRepositoryTests extends AbstractTaskDefinitionTe
 		findAllPageable(pageable, names);
 	}
 
+	@Test
+	public void initializeRepositoryLargeDefinition() {
+		String name = "task2";
+		String definition = new String(new char[4500]).replace("\0", "t");
+		TaskDefinition defOne = new TaskDefinition(name, definition);
+		this.repository.save(defOne);
+		Iterable<TaskDefinition> items = this.repository.findAll();
+		items.forEach(item -> {
+			assertEquals(definition, item.getDslText());
+			assertEquals(name, item.getName());
+		});
+	}
+
 	private void findAllPageable(Pageable pageable, String[] expectedOrder) {
 
 		assertFalse(repository.findAll().iterator().hasNext());


### PR DESCRIPTION
Originally the type was a CLOB but when saving over 4000 char Postgres would fail via exception because it does not support clob.
It supports only LONGVARCHAR.   I regression tested this change against:
Oracle, SQLServer, DB2, H2, MYSql  for cases of under 4000 and over 4000.
They all work with the exception of Oracle which is a VARCHAR(4000) when testing over 4000 char.   I'm trying to remember why we used VARCHAR(4000) instead of a CLOB, but there was a reason. So this is expected behavior in this case.

resolves #2349