### PR TITLE
Metadata resource for Docker apps

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AbstractAppRegistryCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AbstractAppRegistryCommon.java
@@ -73,7 +73,7 @@ public abstract class AbstractAppRegistryCommon implements AppRegistryCommon {
 
 	@Override
 	public Resource getAppResource(AppRegistration appRegistration) {
-		return getResourceFromCache(appRegistration);
+		return ResourceUtils.getResource(appRegistration.getUri().toString(), this.mavenProperties);
 	}
 
 	@Override
@@ -82,17 +82,11 @@ public abstract class AbstractAppRegistryCommon implements AppRegistryCommon {
 			return this.resourceLoader.getResource(appRegistration.getMetadataUri().toString());
 		}
 		else {
-			Resource appResource = getResourceFromCache(appRegistration);
+			this.appRegistrationResourceCache.putIfAbsent(appRegistration.getUri(), getAppResource(appRegistration));
+			Resource appResource = this.appRegistrationResourceCache.get(appRegistration.getUri());
+			// If the metadata URI is not set, only the archive type app resource can serve as the metadata resource
 			return (appResource instanceof DockerResource) ? null : appResource;
 		}
-	}
-
-	private Resource getResourceFromCache(AppRegistration appRegistration) {
-		if (this.appRegistrationResourceCache.get(appRegistration.getUri()) == null) {
-			Resource appResource = ResourceUtils.getResource(appRegistration.getUri().toString(), this.mavenProperties);
-			this.appRegistrationResourceCache.put(appRegistration.getUri(), appResource);
-		}
-		return this.appRegistrationResourceCache.get(appRegistration.getUri());
 	}
 
 	protected Properties loadProperties(Resource resource) {

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
@@ -199,4 +199,20 @@ public class AppRegistryTests {
 			assertThat(expected.getMessage(), is("The 'source:foo' application could not be found."));
 		}
 	}
+
+	@Test
+	public void testGetAppResource() {
+		AppRegistration appRegistration1 = new AppRegistration("foo", ApplicationType.source, URI.create("docker:/foo-source"));
+		appRegistry.save(appRegistration1);
+		assertThat(appRegistry.getAppMetadataResource(appRegistration1), nullValue());
+		assertThat(appRegistry.getAppResource(appRegistration1), notNullValue());
+		AppRegistration appRegistration2 = new AppRegistration("bar", ApplicationType.source, URI.create("classpath:/foo-source"));
+		appRegistry.save(appRegistration2);
+		assertThat(appRegistry.getAppResource(appRegistration2), notNullValue());
+		assertThat(appRegistry.getAppMetadataResource(appRegistration2), notNullValue());
+		AppRegistration appRegistration3 = new AppRegistration("bar", ApplicationType.source, URI.create("maven:/org.springframework.cloud:foo-source:1.0.0"));
+		appRegistry.save(appRegistration3);
+		assertThat(appRegistry.getAppResource(appRegistration3), notNullValue());
+		assertThat(appRegistry.getAppMetadataResource(appRegistration3), notNullValue());
+	}
 }


### PR DESCRIPTION
 - When deploying `docker` based applications, if the metadata resource URI is not set, then don't use the app resource as the metadata resource.
 - For all the other resources, if the metadata resource URI is not set, then use the app resource as the metadata resource.
 - Add tests

Resolves #2377