### PR TITLE
Skip error deprecated properties

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -67,6 +67,16 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		assertThat(properties.size(), is(full.size()));
 	}
 
+	@Test
+	public void deprecatedErrorPropertiesShouldNotBeVisible() {
+		List<ConfigurationMetadataProperty> properties = resolver
+				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()));
+		List<ConfigurationMetadataProperty> full = resolver
+				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()), true);
+		assertThat(properties.size(), is(2));
+		assertThat(full.size(), is(2));
+	}
+
 	private Matcher<ConfigurationMetadataProperty> configPropertyIdentifiedAs(String name) {
 		return hasProperty("id", is(name));
 	}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/resources/org/springframework/cloud/dataflow/configuration/metadata/apps/deprecated-error/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/resources/org/springframework/cloud/dataflow/configuration/metadata/apps/deprecated-error/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,34 @@
+{
+  "groups": [
+    {
+      "name": "filter",
+      "type": "foo.bar.FilterProperties",
+      "sourceType": "foo.bar.FilterProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "filter.expression",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.FilterProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "some.other.property.whitelisted.prefix.expresso2",
+      "type": "org.springframework.cloud.dataflow.completion.Expresso",
+      "description": "A property of type enum and whose name starts like 'expression'",
+      "sourceType": "com.acme.SomeDifferentProperties"
+    },
+    {
+      "name": "some.prefix.hidden.by.default.secret",
+      "type": "java.lang.String",
+      "description": "Some hidden option",
+      "sourceType": "com.acme.OtherProperties",
+      "deprecation": {
+        "level": "error"
+      }
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
- In case property is manually set to error level in
  deprecation field, simply skip returning it, effectively
  not showing it anywhere.
- Fixes #2357