### PR TITLE
Client Evaluates EXECUTIONS_CURRENT_RELATION if version 1.7 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
 		<checkstyle.config.location>src/checkstyle/checkstyle.xml</checkstyle.config.location>
+		<semver.version>2.2.0</semver.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-configuration-metadata</module>

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -53,5 +53,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-resource</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.vdurmont</groupId>
+			<artifactId>semver4j</artifactId>
+			<version>${semver.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowTemplate.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.dataflow.rest.client.support.StepExecutionHisto
 import org.springframework.cloud.dataflow.rest.client.support.StepExecutionJacksonMixIn;
 import org.springframework.cloud.dataflow.rest.job.StepExecutionHistory;
 import org.springframework.cloud.dataflow.rest.resource.RootResource;
+import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.UriTemplate;
@@ -208,7 +209,7 @@ public class DataFlowTemplate implements DataFlowOperations {
 				this.aggregateCounterOperations = null;
 			}
 			if (resourceSupport.hasLink(TaskTemplate.DEFINITIONS_RELATION)) {
-				this.taskOperations = new TaskTemplate(restTemplate, resourceSupport);
+				this.taskOperations = new TaskTemplate(restTemplate, resourceSupport, getVersion());
 				this.jobOperations = new JobTemplate(restTemplate, resourceSupport);
 				if(resourceSupport.hasLink(SchedulerTemplate.SCHEDULES_RELATION)) {
 					this.schedulerOperations = new SchedulerTemplate(restTemplate, resourceSupport);
@@ -239,6 +240,16 @@ public class DataFlowTemplate implements DataFlowOperations {
 			this.completionOperations = null;
 			this.schedulerOperations = null;
 		}
+	}
+
+	private String getVersion() {
+		String versionPrefix = "";
+
+		AboutResource aboutResource = this.aboutOperations.get();
+		if(aboutResource != null) {
+			versionPrefix = aboutResource.getVersionInfo().getCore().getVersion();
+		}
+		return versionPrefix;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -19,7 +19,8 @@ package org.springframework.cloud.dataflow.rest.client;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.StringTokenizer;
+
+import com.vdurmont.semver4j.Semver;
 
 import org.springframework.cloud.dataflow.rest.resource.CurrentTaskExecutionsResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
@@ -171,24 +172,11 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	private boolean isDataFlowServerVersionViable(String expectedVersion, String serverVersion) {
-		StringTokenizer expectedVersionTokenizer = new StringTokenizer(expectedVersion, ".");
-		StringTokenizer serverVersionTokenizer = new StringTokenizer(serverVersion,  ".");
-		boolean result = true;
-		while(expectedVersionTokenizer.hasMoreTokens()) {
-			if(serverVersionTokenizer.hasMoreTokens()) {
-				int expectedCurrentNum = Integer.valueOf(expectedVersionTokenizer.nextToken());
-				int serverCurrentNum = Integer.valueOf(serverVersionTokenizer.nextToken());
-				if (serverCurrentNum < expectedCurrentNum ) { //serverVersion is below the minimum expected
-					result = false;
-					break;
-				}
-				else if(serverCurrentNum > expectedCurrentNum) { //serverVersion is greater than minimum expected
-					break;
-				}
-			}
-			else {  //reached the end of the server tokens.
-				break;
-			}
+		boolean result =  false;
+		if(!StringUtils.isEmpty(serverVersion)) {
+			Semver minRequiredVersion = new Semver(expectedVersion);
+			Semver currentVersion = new Semver(serverVersion);
+			result = currentVersion.isGreaterThanOrEqualTo(minRequiredVersion);
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.web.client.RestTemplate;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the {@link TaskTemplate} implementation of {@link TaskOperations}.
+ *
+ * @author Glenn Renfro
+ */
+public class TaskTemplateTests {
+
+	private static final String CURRENT_TASK_EXECUTION_LINK = "tasks/executions/current";
+
+	private RestTemplate restTemplate;
+
+	@Before
+	public void setup() {
+		restTemplate = mock(RestTemplate.class);
+
+	}
+
+	@Test
+	public void testOldDataFlow() {
+		validateExecutionLinkNotPresent("1.6.0");
+	}
+
+	@Test
+	public void testMinDataFlow() {
+		validateExecutionLinkPresent("1.7.0");
+	}
+
+	@Test
+	public void testFutureDataFlow() {
+		validateExecutionLinkPresent("1.8.0");
+		validateExecutionLinkPresent("1.9.0");
+		validateExecutionLinkPresent("2.0.0");
+	}
+
+	@Test
+	public void testLongerDataFlowVersion() {
+		validateExecutionLinkPresent("1.7.0.5");
+	}
+
+	@Test
+	public void testShorterDataFlowVersion() {
+		validateExecutionLinkNotPresent("1.6");
+		validateExecutionLinkPresent("1.7");
+	}
+
+	private void validateExecutionLinkPresent(String version) {
+		TestResource testResource = new TestResource();
+		new TaskTemplate(this.restTemplate, testResource, version);
+		Assert.assertTrue(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
+	}
+
+	private void validateExecutionLinkNotPresent(String version) {
+		TestResource testResource = new TestResource();
+		new TaskTemplate(this.restTemplate, testResource, version);
+		Assert.assertFalse(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
+	}
+
+	public static class TestResource extends ResourceSupport {
+
+		private Map<String, Long> linksRequested = new HashMap<>();
+
+		public Link getLink(String rel) {
+			if (this.linksRequested.containsKey(rel)) {
+				Long count = this.linksRequested.get(rel);
+				this.linksRequested.put(rel, count + 1L);
+			}
+			else {
+				this.linksRequested.put(rel, 1L);
+			}
+			return new Link("foo", "bar");
+		}
+
+		public boolean isLinkRequested(String linkName) {
+			boolean result = false;
+
+			if (this.linksRequested.containsKey(linkName) &&
+					this.linksRequested.get(linkName) > 1L) {
+				result = true;
+			}
+			return result;
+		}
+
+	}
+}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -63,16 +63,6 @@ public class TaskTemplateTests {
 		validateExecutionLinkPresent("2.0.0");
 	}
 
-	@Test
-	public void testLongerDataFlowVersion() {
-		validateExecutionLinkPresent("1.7.0.5");
-	}
-
-	@Test
-	public void testShorterDataFlowVersion() {
-		validateExecutionLinkNotPresent("1.6");
-		validateExecutionLinkPresent("1.7");
-	}
 
 	private void validateExecutionLinkPresent(String version) {
 		TestResource testResource = new TestResource();


### PR DESCRIPTION
TaskTemplate (client) extracts the numeric portion of the version number as reported by the AboutOperation
if the version is 1.7 or above then the EXECUTIONS_CURRENT_RELATION will be tested, else it will be skipped.

resolves SCDF-2401