### PR TITLE
Retrieves only white-listed properties by default

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
@@ -56,13 +56,18 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 	public void getSingleApplication() throws Exception {
 		registerApp(ApplicationType.source, "http");
 
-		this.mockMvc.perform(get("/apps/{type}/{name}", ApplicationType.source, "http").accept(MediaType.APPLICATION_JSON))
+		this.mockMvc.perform(
+			get("/apps/{type}/{name}", ApplicationType.source, "http").accept(MediaType.APPLICATION_JSON)
+				.param("exhaustive", "false"))
 			.andExpect(status().isOk())
 			.andDo(
 				this.documentationHandler.document(
 					pathParameters(
 						parameterWithName("type").description("The type of application to query. One of " + Arrays.asList(ApplicationType.values())),
 						parameterWithName("name").description("The name of the application to query")
+					),
+					requestParameters(
+						parameterWithName("exhaustive").optional().description("Return all application properties, including common Spring Boot properties")
 					)
 				)
 			);

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,15 +112,13 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			Collection<String> whiteListedClasses = new HashSet<>(globalWhiteListedClasses);
 			Collection<String> whiteListedProperties = new HashSet<>(globalWhiteListedProperties);
 			Resource[] whitelistDescriptors = moduleResourceLoader.getResources(WHITELIST_PROPERTIES);
-			boolean include = (whitelistDescriptors.length == 0) || exhaustive;
-			// when no descriptors return everything
 			loadWhiteLists(whitelistDescriptors, whiteListedClasses, whiteListedProperties);
 			ConfigurationMetadataRepositoryJsonBuilder builder = ConfigurationMetadataRepositoryJsonBuilder.create();
 			for (Resource r : moduleResourceLoader.getResources(CONFIGURATION_METADATA_PATTERN)) {
 				builder.withJsonResource(r.getInputStream());
 			}
 			for (ConfigurationMetadataGroup group : builder.build().getAllGroups().values()) {
-				if (include || isWhiteListed(group, whiteListedClasses)) {
+				if (exhaustive || isWhiteListed(group, whiteListedClasses)) {
 					for (ConfigurationMetadataProperty property : group.getProperties().values()) {
 						if (!isDeprecatedError(property)) {
 							result.add(property);

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.core.io.ClassPathResource;
 
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
@@ -63,8 +62,8 @@ public class BootApplicationConfigurationMetadataResolverTests {
 				.listProperties(new ClassPathResource("apps/no-whitelist", getClass()));
 		List<ConfigurationMetadataProperty> full = resolver
 				.listProperties(new ClassPathResource("apps/no-whitelist", getClass()), true);
-		assertThat(properties.size(), greaterThan(0));
-		assertThat(properties.size(), is(full.size()));
+		assertThat(properties.size(), is(0));
+		assertThat(full.size(), is(3));
 	}
 
 	@Test
@@ -73,7 +72,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()));
 		List<ConfigurationMetadataProperty> full = resolver
 				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()), true);
-		assertThat(properties.size(), is(2));
+		assertThat(properties.size(), is(0));
 		assertThat(full.size(), is(2));
 	}
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -306,6 +306,13 @@ include::{snippets}/app-registry-documentation/get-single-application/http-reque
 
 
 
+[[api-guide-resources-app-registry-get-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/app-registry-documentation/get-single-application/request-parameters.adoc[]
+
+
+
 [[api-guide-resources-app-registry-get-path-parameters]]
 ===== Path Parameters
 

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
@@ -56,7 +56,7 @@ public interface AppRegistryCommon {
 	/**
 	 * @param name application name
 	 * @param type application type
-	 * @param type application version
+	 * @param version application version
 	 * @return the application with those name and type and default version
 	 */
 	default AppRegistration find(String name, ApplicationType type, String version) {

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryOperations.java
@@ -55,9 +55,10 @@ public interface AppRegistryOperations {
 	 *
 	 * @param name name of application
 	 * @param type application type
+	 * @param exhaustive return all metadata, including common Spring Boot properties
 	 * @return detailed information about an application registration
 	 */
-	DetailedAppRegistrationResource info(String name, ApplicationType type);
+	DetailedAppRegistrationResource info(String name, ApplicationType type, boolean exhaustive);
 
 	/**
 	 * Retrieve information about an application registration.
@@ -65,9 +66,10 @@ public interface AppRegistryOperations {
 	 * @param name name of application
 	 * @param type application type
 	 * @param version application version
+	 * @param exhaustive return all metadata, including common Spring Boot properties
 	 * @return detailed information about an application registration
 	 */
-	DetailedAppRegistrationResource info(String name, ApplicationType type, String version);
+	DetailedAppRegistrationResource info(String name, ApplicationType type, String version, boolean exhaustive);
 
 	/**
 	 * Register an application name and type with its Maven coordinates.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryTemplate.java
@@ -86,15 +86,15 @@ public class AppRegistryTemplate implements AppRegistryOperations {
 	}
 
 	@Override
-	public DetailedAppRegistrationResource info(String name, ApplicationType type) {
-		String uri = uriTemplate.toString() + "/{type}/{name}";
-		return restTemplate.getForObject(uri, DetailedAppRegistrationResource.class, type, name);
+	public DetailedAppRegistrationResource info(String name, ApplicationType type, boolean exhaustive) {
+		String uri = uriTemplate.toString() + "/{type}/{name}?exhaustive={exhaustive}";
+		return restTemplate.getForObject(uri, DetailedAppRegistrationResource.class, type, name, exhaustive);
 	}
 
 	@Override
-	public DetailedAppRegistrationResource info(String name, ApplicationType type, String version) {
-		String uri = uriTemplate.toString() + "/{type}/{name}/{version}";
-		return restTemplate.getForObject(uri, DetailedAppRegistrationResource.class, type, name, version);
+	public DetailedAppRegistrationResource info(String name, ApplicationType type, String version, boolean exhaustive) {
+		String uri = uriTemplate.toString() + "/{type}/{name}/{version}?exhaustive={exhaustive}";
+		return restTemplate.getForObject(uri, DetailedAppRegistrationResource.class, type, name, version, exhaustive);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Gary Russell
  * @author Patrick Peralta
  * @author Thomas Risberg
+ * @author Christian Tzolov
  */
 @RestController
 @RequestMapping("/apps")
@@ -154,12 +155,13 @@ public class AppRegistryController implements ResourceLoaderAware {
 	 *
 	 * @param type application type
 	 * @param name application name
+	 * @param exhaustive return all metadata, including common Spring Boot properties
 	 * @return detailed application information
 	 */
 	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public DetailedAppRegistrationResource info(@PathVariable("type") ApplicationType type,
-			@PathVariable("name") String name) {
+			@PathVariable("name") String name, @RequestParam(required = false, name = "exhaustive") boolean exhaustive) {
 		AppRegistration registration = appRegistry.find(name, type);
 		if (registration == null) {
 			throw new NoSuchAppRegistrationException(name, type);
@@ -167,7 +169,7 @@ public class AppRegistryController implements ResourceLoaderAware {
 		DetailedAppRegistrationResource result = new DetailedAppRegistrationResource(
 				assembler.toResource(registration));
 		List<ConfigurationMetadataProperty> properties = metadataResolver
-				.listProperties(appRegistry.getAppMetadataResource(registration));
+				.listProperties(appRegistry.getAppMetadataResource(registration), exhaustive);
 		for (ConfigurationMetadataProperty property : properties) {
 			result.addOption(property);
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryController.java
@@ -153,26 +153,18 @@ public class SkipperAppRegistryController {
 	@RequestMapping(value = "/{type}/{name}/{version:.+}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public DetailedAppRegistrationResource info(@PathVariable("type") ApplicationType type,
-			@PathVariable("name") String name, @PathVariable("version") String version) {
-		AppRegistration registration = appRegistryService.find(name, type, version);
-		if (registration == null) {
-			throw new NoSuchAppRegistrationException(name, type, version);
-		}
-		DetailedAppRegistrationResource result = new DetailedAppRegistrationResource(
-				assembler.toResource(registration));
-		List<ConfigurationMetadataProperty> properties = metadataResolver
-				.listProperties(appRegistryService.getAppMetadataResource(registration));
-		for (ConfigurationMetadataProperty property : properties) {
-			result.addOption(property);
-		}
-		return result;
+			@PathVariable("name") String name, @PathVariable("version") String version,
+			@RequestParam(required = false, name = "exhaustive") boolean exhaustive) {
+
+		return getInfo(type, name, version, exhaustive);
 	}
 
 	@Deprecated
 	@RequestMapping(value = "/{type}/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public DetailedAppRegistrationResource info(@PathVariable("type") ApplicationType type,
-			@PathVariable("name") String name) {
+	public DetailedAppRegistrationResource info(
+			@PathVariable("type") ApplicationType type, @PathVariable("name") String name,
+			@RequestParam(required = false, name = "exhaustive") boolean exhaustive) {
 		if (!this.appRegistryService.appExist(name, type)) {
 			throw new NoSuchAppRegistrationException(name, type);
 		}
@@ -180,7 +172,24 @@ public class SkipperAppRegistryController {
 			throw new RuntimeException(String.format("No default version exists for the app [%s:%s]", name, type));
 		}
 		String defaultVersion = this.appRegistryService.getDefaultApp(name, type).getVersion();
-		return info(type, name, defaultVersion);
+		return getInfo(type, name, defaultVersion, exhaustive);
+	}
+
+	private DetailedAppRegistrationResource getInfo(ApplicationType type,
+			String name, String version, Boolean allProperties) {
+
+		AppRegistration registration = appRegistryService.find(name, type, version);
+		if (registration == null) {
+			throw new NoSuchAppRegistrationException(name, type, version);
+		}
+		DetailedAppRegistrationResource result = new DetailedAppRegistrationResource(
+				assembler.toResource(registration));
+		List<ConfigurationMetadataProperty> properties = metadataResolver
+				.listProperties(appRegistryService.getAppMetadataResource(registration), allProperties);
+		for (ConfigurationMetadataProperty property : properties) {
+			result.addOption(property);
+		}
+		return result;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -194,7 +194,16 @@ public class AppRegistryControllerTests {
 	public void testListSingleApplication() throws Exception {
 		mockMvc.perform(get("/apps/source/time").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
-				.andExpect(jsonPath("type", is("source")));
+				.andExpect(jsonPath("type", is("source")))
+				.andExpect(jsonPath("$.options[*]", hasSize(6))); // white-listed properties anly
+	}
+
+	@Test
+	public void testListSingleApplicationExhaustive() throws Exception {
+		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
+				.andExpect(jsonPath("type", is("source")))
+				.andExpect(jsonPath("$.options[*]", hasSize(905)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryControllerTests.java
@@ -76,8 +76,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = TestDependencies.class, properties = {"spring.cloud.dataflow.features.skipper-enabled=true",
-		"spring.datasource.url=jdbc:h2:tcp://localhost:19092/mem:dataflow"})
+@SpringBootTest(classes = TestDependencies.class, properties = { "spring.cloud.dataflow.features.skipper-enabled=true",
+		"spring.datasource.url=jdbc:h2:tcp://localhost:19092/mem:dataflow" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Transactional
 public class SkipperAppRegistryControllerTests {
@@ -255,7 +255,16 @@ public class SkipperAppRegistryControllerTests {
 	public void testListSingleApplication() throws Exception {
 		mockMvc.perform(get("/apps/source/time").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
-				.andExpect(jsonPath("type", is("source")));
+				.andExpect(jsonPath("type", is("source")))
+				.andExpect(jsonPath("$.options[*]", hasSize(6)));
+	}
+
+	@Test
+	public void testListSingleApplicationExhaustive() throws Exception {
+		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
+				.andExpect(jsonPath("type", is("source")))
+				.andExpect(jsonPath("$.options[*]", hasSize(905)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/classic/ClassicAppRegistryCommands.java
@@ -86,21 +86,22 @@ public class ClassicAppRegistryCommands extends AbstractAppRegistryCommands impl
 
 	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
 	public List<Object> info(
-			@CliOption(mandatory = false, key = { "", "id" },
+			@CliOption(key = { "", "id" },
 					help = "id of the application to query in the form of 'type:name'") QualifiedApplicationName application,
-			@CliOption(mandatory = false, key = { "",
-					"name" }, help = "name of the application to unregister") String applicationName,
-			@CliOption(mandatory = false, key = {
-					"type" }, help = "type of the application to unregister") ApplicationType applicationType) {
+			@CliOption(key = { "",
+					"name" }, help = "name of the application to query") String applicationName,
+			@CliOption(key = {
+					"type" }, help = "type of the application to query") ApplicationType applicationType,
+			@CliOption(key = { "exhaustive" }, help = "return all metadata, including common Spring Boot properties",
+					specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean exhaustive) {
 		Assert.isTrue(assertAppInfoOptions(application, applicationName, applicationType),
 				"The options [<type>:<name>] and  [--name && --type] are mutually exclusive and "
 						+ "one of these should be specified to uniquely identify the application");
 		String name = (application != null) ? application.name : applicationName;
-		ApplicationType type = (application != null) ? application.type : applicationType;;
+		ApplicationType type = (application != null) ? application.type : applicationType;
 		List<Object> result = new ArrayList<>();
 		try {
-			DetailedAppRegistrationResource info =
-					appRegistryOperations().info(name, type);
+			DetailedAppRegistrationResource info = appRegistryOperations().info(name, type, exhaustive);
 			if (info != null) {
 				List<ConfigurationMetadataProperty> options = info.getOptions();
 				result.add(String.format("Information about %s application '%s':", type, name));

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/skipper/SkipperAppRegistryCommands.java
@@ -94,15 +94,17 @@ public class SkipperAppRegistryCommands extends AbstractAppRegistryCommands impl
 	@CliCommand(value = APPLICATION_INFO, help = "Get information about an application")
 	public List<Object> info(
 			@CliOption(mandatory = true, key = { "",
-					"name" }, help = "name of the application to unregister") String name,
+					"name" }, help = "name of the application to query") String name,
 			@CliOption(mandatory = true, key = {
-					"type" }, help = "type of the application to unregister") ApplicationType type,
-			@CliOption(key = { "version" }, help = "the version for the registered application") String version) {
+					"type" }, help = "type of the application to query") ApplicationType type,
+			@CliOption(key = { "version" }, help = "the version for the registered application") String version,
+			@CliOption(key = { "exhaustive" }, help = "return all metadata, including common Spring Boot properties",
+					specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean exhaustive) {
 		List<Object> result = new ArrayList<>();
 		try {
 			DetailedAppRegistrationResource info = StringUtils.hasText(version) ?
-					appRegistryOperations().info(name, type, version) :
-					appRegistryOperations().info(name, type);
+					appRegistryOperations().info(name, type, version, exhaustive) :
+					appRegistryOperations().info(name, type, exhaustive);
 			if (info != null) {
 				List<ConfigurationMetadataProperty> options = info.getOptions();
 				result.add(String.format("Information about %s application '%s':", type, name));

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ClassicAppRegistryCommandsTests.java
@@ -40,6 +40,8 @@ import org.springframework.shell.table.TableModel;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -109,8 +111,24 @@ public class ClassicAppRegistryCommandsTests {
 
 	@Test
 	public void testUnknownModule() {
-		List<Object> result = appRegistryCommands.info(null,"unknown", ApplicationType.processor);
-		assertEquals((String) result.get(0), "Application info is not available for processor:unknown");
+		List<Object> result = appRegistryCommands.info(null, "unknown", ApplicationType.processor, false);
+		assertEquals(result.get(0), "Application info is not available for processor:unknown");
+	}
+
+	@Test
+	public void testInfoExhaustive() {
+		String name = "foo";
+		ApplicationType type = ApplicationType.sink;
+		appRegistryCommands.info(null, name, type, true);
+		verify(appRegistryOperations).info(eq(name), eq(type), eq(true));
+	}
+
+	@Test
+	public void testInfoNotExhaustive() {
+		String name = "foo";
+		ApplicationType type = ApplicationType.sink;
+		appRegistryCommands.info(null, name, type, false);
+		verify(appRegistryOperations).info(eq(name), eq(type), eq(false));
 	}
 
 	@Test


### PR DESCRIPTION
Make the apps info return only the white listed properties by default. If no white listed properties are found an empty list is returned.
To return all (Spring Boot) properties set the exhaustive property to true.

  - Make MetadataResolver to always obey the exhaustive property.
  - Add an optional 'exhaustive' request parameter to the [Skipper]AppRegistryController#info (e.g /apps/{type}/{name}?exhaustive= )
  - Add an optional 'exhaustive' parameter to the SCDF shell app info command (both classic and skipper modes). Defaults to false.
  - Add tests to the MetadataResolver, [Skipper]AppRegistryControlle and Shell
  - Update the AppRegistry get info REST docs.

  Resolves #2424