### PR TITLE
Encapsulate the Resource loading and related states.

### DIFF
--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.dataflow.configuration.metadata.BootApplication
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -103,7 +104,7 @@ public class BootVersionsCompletionProviderTests {
 		@Bean
 		public AppRegistry appRegistry() {
 			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-			return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
 
 				/*
 				 * Pretend there is a boot13 and boot14 source.

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -104,7 +105,7 @@ public class BootVersionsCompletionProviderTests {
 		@Bean
 		public AppRegistry appRegistry() {
 			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
+			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(new MavenProperties(), resourceLoader)) {
 
 				/*
 				 * Pretend there is a boot13 and boot14 source.

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.dataflow.configuration.metadata.BootApplication
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,7 +59,7 @@ public class CompletionTestsMocks {
 	@Bean
 	public AppRegistry appRegistry() {
 		final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-		return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+		return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
 			@Override
 			public AppRegistration find(String name, ApplicationType type) {
 				String filename = name + "-" + type;

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,7 +60,7 @@ public class CompletionTestsMocks {
 	@Bean
 	public AppRegistry appRegistry() {
 		final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-		return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
+		return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(new MavenProperties(), resourceLoader)) {
 			@Override
 			public AppRegistration find(String name, ApplicationType type) {
 				String filename = name + "-" + type;

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistry.java
@@ -30,11 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
-import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -76,16 +75,9 @@ public class AppRegistry extends AbstractAppRegistryCommon implements AppRegistr
 		}
 	};
 
-	public AppRegistry(UriRegistry uriRegistry, ResourceLoader resourceLoader) {
-		super(resourceLoader);
+	public AppRegistry(UriRegistry uriRegistry, AppResourceCommon appResourceService) {
+		super(appResourceService);
 		Assert.notNull(uriRegistry, "'uriRegistry' must not be null");
-		this.uriRegistry = uriRegistry;
-	}
-
-	public AppRegistry(UriRegistry uriRegistry, ResourceLoader resourceLoader, MavenProperties mavenProperties) {
-		super(resourceLoader, mavenProperties);
-		Assert.notNull(uriRegistry, "'uriRegistry' must not be null");
-		Assert.notNull(resourceLoader, "'resourceLoader' must not be null");
 		this.uriRegistry = uriRegistry;
 	}
 

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
@@ -95,4 +95,25 @@ public interface AppRegistryCommon {
 	 * @return the saved appRegistration
 	 */
 	AppRegistration save(AppRegistration app);
+
+	/**
+	 * @param resource
+	 * @return Returns the version for the provided resource
+	 */
+	String getResourceVersion(Resource resource);
+
+	/**
+	 * TODO
+	 * @param resource
+	 * @return
+	 */
+	String getResourceWithoutVersion(Resource resource);
+
+	/**
+	 * Returns the version for the given resource URI string.
+	 *
+	 * @param uriString String representation of the resource URI
+	 * @return the resource version
+	 */
+	String getResourceVersion(String uriString);
 }

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/AppRegistryCommon.java
@@ -97,21 +97,20 @@ public interface AppRegistryCommon {
 	AppRegistration save(AppRegistration app);
 
 	/**
-	 * @param resource
+	 * @param resource to retrieve the version for
 	 * @return Returns the version for the provided resource
 	 */
 	String getResourceVersion(Resource resource);
 
 	/**
-	 * TODO
-	 * @param resource
-	 * @return
+	 * Returns a string representing the resource with version subtracted
+	 * @param resource to be represented as string.
+	 * @return String representation of the resource.
 	 */
 	String getResourceWithoutVersion(Resource resource);
 
 	/**
 	 * Returns the version for the given resource URI string.
-	 *
 	 * @param uriString String representation of the resource URI
 	 * @return the resource version
 	 */

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
@@ -26,10 +26,9 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.AbstractAppRegistryCommon;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
-import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,10 +64,9 @@ public class DefaultAppRegistryService extends AbstractAppRegistryCommon impleme
 	private final AppRegistrationRepository appRegistrationRepository;
 
 	public DefaultAppRegistryService(AppRegistrationRepository appRegistrationRepository,
-			ResourceLoader resourceLoader, MavenProperties mavenProperties) {
-		super(resourceLoader, mavenProperties);
+			AppResourceCommon appResourceService) {
+		super(appResourceService);
 		Assert.notNull(appRegistrationRepository, "'appRegistrationRepository' must not be null");
-		Assert.notNull(resourceLoader, "'resourceLoader' must not be null");
 		this.appRegistrationRepository = appRegistrationRepository;
 	}
 

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.dataflow.registry.support;
 
 import java.io.File;
@@ -34,107 +35,32 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * @author Mark Pollack
- * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
  */
-public class ResourceUtils {
+public class AppResourceCommon {
 
 	/**
-	 * Parse the version number from a {@link UrlResource}. It can match a simple
-	 * {@code <artifactId>-<version>.jar} formatted name. For example, a resource ending in
-	 * {@code file-sink-rabbit-1.2.0.RELEASE.jar} will return {@code 1.2.0.RELEASE}. Snapshot
-	 * builds of the form {@code file-sink-rabbit-1.2.0.BUILD-SNAPSHOT.jar} and
-	 * {@code file-sink-rabbit-1.2.0-SNAPSHOT.jar} are also supported
-	 * @param urlResource
-	 * @return
+	 * the maven properties to use in case of maven resource
 	 */
-	public static String getUrlResourceVersion(UrlResource urlResource) {
-		Matcher m = getMatcher(urlResource);
-		return m.group(2) + m.group(3);
-	}
-
-	public static String getUrlResourceWithoutVersion(UrlResource urlResource) {
-		String version = getUrlResourceVersion(urlResource);
-		URI uri = getUri(urlResource);
-		String theRest = uri.toString().substring(0, uri.toString().indexOf("-" + version));
-		return theRest;
-	}
-
-	private static Matcher getMatcher(UrlResource urlResource) {
-		String fileNameNoExtension = getFileNameNoExtension(urlResource);
-		// Look for the last dash with a digit after it
-		Pattern pattern = Pattern.compile("(.*)-(\\d)(.*?)");
-		Matcher m = pattern.matcher(fileNameNoExtension);
-		Assert.isTrue(m.matches(), "Could not parse version from " + getUri(urlResource)
-				+ ", expected format is <artifactId>-<version>.jar");
-		return m;
-	}
-
-	private static String getFileNameNoExtension(UrlResource urlResource) {
-		URI uri = getUri(urlResource);
-		String uriPath = uri.getPath();
-		Assert.isTrue(StringUtils.hasText(uriPath), "URI path doesn't exist");
-		String lastSegment = new File(uriPath).getName();
-		Assert.isTrue(lastSegment.indexOf(".") != -1, "URI file name extension doesn't exist");
-		return lastSegment.substring(0, lastSegment.lastIndexOf("."));
-	}
-
-	private static URI getUri(UrlResource urlResource) {
-		URI uri;
-		try {
-			uri = urlResource.getURI();
-		}
-		catch (IOException e) {
-			throw new IllegalArgumentException("Could not get URI from " + urlResource.getDescription());
-		}
-		return uri;
-	}
+	private MavenProperties mavenProperties;
 
 	/**
-	 * Retrieve the corresponding {@link Resource} instance based on the URI String.
-	 * Maven properties are used if the URI corresponds to maven resource.
 	 *
-	 * @param uriString String representation of the resource URI
-	 * @param mavenProperties the maven properties to use in case of maven resource
-	 * @return the resource instance
 	 */
-	public static Resource getResource(String uriString, MavenProperties mavenProperties) {
-		Assert.isTrue(StringUtils.hasText(uriString), "Resource URI must not be empty");
-		try {
-			URI uri = new URI(uriString);
-			String scheme = uri.getScheme();
-			Assert.notNull(scheme, "a scheme (prefix) is required");
-			if (scheme.equals("maven")) {
-				String coordinates = uriString.replaceFirst("maven:\\/*", "");
-				MavenResource mavenResource = MavenResource.parse(coordinates, mavenProperties);
-				return mavenResource;
-			}
-			else if (scheme.equals("docker")) {
-				String dockerUri = uriString.replaceFirst("docker:\\/*", "");
-				return new DockerResource(dockerUri);
-			}
-			else {
-				ResourceLoader resourceLoader = null;
-				if (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https")) {
-					resourceLoader = new DefaultResourceLoader();
-				}
-				else {
-					resourceLoader = new DownloadingUrlResourceLoader();
-				}
-				return resourceLoader.getResource(uriString);
-			}
-		}
-		catch (URISyntaxException e) {
-			throw new RuntimeException(e);
-		}
+	private ResourceLoader resourceLoader;
+
+
+	public AppResourceCommon(MavenProperties mavenProperties, ResourceLoader resourceLoader) {
+		this.mavenProperties = mavenProperties;
+		this.resourceLoader = resourceLoader;
 	}
 
 	/**
-	 * Extracts the version from the resource. Supported resource types are {@link
-	 * MavenResource}, {@link DockerResource}, and {@link UrlResource}. @param resource to be
+	 * Extracts the version from the resource. Supported resource types are
+	 * MavenResource, {@link DockerResource}, and {@link UrlResource}. @param resource to be
 	 * used. @return the version the resource. @throws
 	 */
-	public static String getResourceVersion(Resource resource) {
+	public String getResourceVersion(Resource resource) {
 		Assert.notNull(resource, "resource must not be null");
 		if (resource instanceof MavenResource) {
 			MavenResource mavenResource = (MavenResource) resource;
@@ -153,31 +79,103 @@ public class ResourceUtils {
 		}
 	}
 
-	private static String getDockerImageTag(DockerResource dockerResource) {
+	private String getDockerImageTag(DockerResource dockerResource) {
 		try {
 			String uri = dockerResource.getURI().toString().substring("docker:".length());
 			DockerImage dockerImage = DockerImage.fromImageName(uri);
 			String tag = dockerImage.getTag();
 			Assert.isTrue(StringUtils.hasText(tag), "Could not extract tag from " +
-			dockerResource.getDescription());
+					dockerResource.getDescription());
 			return tag;
-		} catch (IOException e) {
-				throw new IllegalArgumentException(
-						"Docker Resource URI is not in expected format to extract version. " +
-								dockerResource.getDescription(),
-						e);
+		}
+		catch (IOException e) {
+			throw new IllegalArgumentException(
+					"Docker Resource URI is not in expected format to extract version. " +
+							dockerResource.getDescription(),
+					e);
 		}
 	}
 
 	/**
-	 * Returns the version for the given resource URI string.
-	 *
-	 * @param uriString String representation of the resource URI
-	 * @param mavenProperties the maven properties to use in case of maven resource
-	 * @return the resource version
+	 * Parse the version number from a {@link UrlResource}. It can match a simple
+	 * {@code <artifactId>-<version>.jar} formatted name. For example, a resource ending in
+	 * {@code file-sink-rabbit-1.2.0.RELEASE.jar} will return {@code 1.2.0.RELEASE}. Snapshot
+	 * builds of the form {@code file-sink-rabbit-1.2.0.BUILD-SNAPSHOT.jar} and
+	 * {@code file-sink-rabbit-1.2.0-SNAPSHOT.jar} are also supported
+	 * @param urlResource
+	 * @return
 	 */
-	public static String getResourceVersion(String uriString, MavenProperties mavenProperties) {
-		return ResourceUtils.getResourceVersion(getResource(uriString, mavenProperties));
+	String getUrlResourceVersion(UrlResource urlResource) {
+		Matcher m = getMatcher(urlResource);
+		return m.group(2) + m.group(3);
+	}
+
+	private Matcher getMatcher(UrlResource urlResource) {
+		String fileNameNoExtension = getFileNameNoExtension(urlResource);
+		// Look for the last dash with a digit after it
+		Pattern pattern = Pattern.compile("(.*)-(\\d)(.*?)");
+		Matcher m = pattern.matcher(fileNameNoExtension);
+		Assert.isTrue(m.matches(), "Could not parse version from " + getUri(urlResource)
+				+ ", expected format is <artifactId>-<version>.jar");
+		return m;
+	}
+
+	private String getFileNameNoExtension(UrlResource urlResource) {
+		URI uri = getUri(urlResource);
+		String uriPath = uri.getPath();
+		Assert.isTrue(StringUtils.hasText(uriPath), "URI path doesn't exist");
+		String lastSegment = new File(uriPath).getName();
+		Assert.isTrue(lastSegment.indexOf(".") != -1, "URI file name extension doesn't exist");
+		return lastSegment.substring(0, lastSegment.lastIndexOf("."));
+	}
+
+	private URI getUri(UrlResource urlResource) {
+		URI uri;
+		try {
+			uri = urlResource.getURI();
+		}
+		catch (IOException e) {
+			throw new IllegalArgumentException("Could not get URI from " + urlResource.getDescription());
+		}
+		return uri;
+	}
+
+	/**
+	 * Retrieve the corresponding {@link Resource} instance based on the URI String.
+	 * Maven properties are used if the URI corresponds to maven resource.
+	 *
+	 * @param resourceUri String representation of the resource URI
+	 * @return the resource instance
+	 */
+	public Resource getResource(String resourceUri) {
+		Assert.isTrue(StringUtils.hasText(resourceUri), "Resource URI must not be empty");
+		try {
+			URI uri = new URI(resourceUri);
+			String scheme = uri.getScheme();
+			Assert.notNull(scheme, "a scheme (prefix) is required");
+			if (scheme.equals("maven")) {
+				String coordinates = resourceUri.replaceFirst("maven:\\/*", "");
+				MavenResource mavenResource = MavenResource.parse(coordinates, mavenProperties);
+				return mavenResource;
+			}
+			else if (scheme.equals("docker")) {
+				String dockerUri = resourceUri.replaceFirst("docker:\\/*", "");
+				return new DockerResource(dockerUri);
+			}
+			else {
+				ResourceLoader resourceLoader = null;
+				if (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https")) {
+					resourceLoader = new DefaultResourceLoader();
+				}
+				else {
+					resourceLoader = new DownloadingUrlResourceLoader();
+				}
+				return resourceLoader.getResource(resourceUri);
+			}
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	/**
@@ -185,7 +183,7 @@ public class ResourceUtils {
 	 * @param resource to be used.
 	 * @return String representation of the resource.
 	 */
-	public static String getResourceWithoutVersion(Resource resource) {
+	public String getResourceWithoutVersion(Resource resource) {
 		Assert.notNull(resource, "resource must not be null");
 		if (resource instanceof MavenResource) {
 			MavenResource mavenResource = (MavenResource) resource;
@@ -206,7 +204,14 @@ public class ResourceUtils {
 		}
 	}
 
-	private static String getDockerImageWithoutVersion(DockerResource dockerResource) {
+	String getUrlResourceWithoutVersion(UrlResource urlResource) {
+		String version = getUrlResourceVersion(urlResource);
+		URI uri = getUri(urlResource);
+		String theRest = uri.toString().substring(0, uri.toString().indexOf("-" + version));
+		return theRest;
+	}
+
+	private String getDockerImageWithoutVersion(DockerResource dockerResource) {
 		try {
 			String uri = dockerResource.getURI().toString().substring("docker:".length());
 			DockerImage dockerImage = DockerImage.fromImageName(uri);
@@ -217,7 +222,8 @@ public class ResourceUtils {
 			}
 			sb.append(dockerImage.getNamespaceAndRepo());
 			return sb.toString();
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new IllegalArgumentException(
 					"Docker Resource URI is not in expected format to extract version. " +
 							dockerResource.getDescription(),
@@ -225,5 +231,16 @@ public class ResourceUtils {
 		}
 	}
 
+
+	public Resource getMetadataResource(URI appUri, URI metadataUri) {
+		if (metadataUri != null) {
+			return this.resourceLoader.getResource(metadataUri.toString());
+		}
+		else {
+			Resource appResource = this.getResource(appUri.toString());
+			// If the metadata URI is not set, only the archive type app resource can serve as the metadata resource
+			return (appResource instanceof DockerResource) ? null : appResource;
+		}
+	}
 
 }

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.core.io.ClassPathResource;
@@ -58,7 +59,7 @@ public class AppRegistryTests {
 
 	private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
-	private AppRegistry appRegistry = new AppRegistry(uriRegistry, new AppResourceCommon(null, resourceLoader));
+	private AppRegistry appRegistry = new AppRegistry(uriRegistry, new AppResourceCommon(new MavenProperties(), resourceLoader));
 
 	@Test
 	public void testNotFound() {

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/AppRegistryTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
@@ -57,7 +58,7 @@ public class AppRegistryTests {
 
 	private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
-	private AppRegistry appRegistry = new AppRegistry(uriRegistry, resourceLoader);
+	private AppRegistry appRegistry = new AppRegistry(uriRegistry, new AppResourceCommon(null, resourceLoader));
 
 	@Test
 	public void testNotFound() {

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -31,10 +31,11 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Christian Tzolov
  */
-public class ResourceUtilsTests {
+public class AppResourceCommonTests {
 
-	AppResourceCommon appResourceCommon = new AppResourceCommon(new MavenProperties(), null);
+	private AppResourceCommon appResourceCommon = new AppResourceCommon(new MavenProperties(), null);
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testBadNamedJars() throws Exception {

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/ResourceUtilsTests.java
@@ -34,23 +34,25 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public class ResourceUtilsTests {
 
+	AppResourceCommon appResourceCommon = new AppResourceCommon(new MavenProperties(), null);
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testBadNamedJars() throws Exception {
 		UrlResource urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit.jar");
-		ResourceUtils.getUrlResourceVersion(urlResource);
+		appResourceCommon.getUrlResourceVersion(urlResource);
 	}
 
 	public void testInvalidUrlResourceWithoutVersion() throws Exception {
 		UrlResource urlResource = new UrlResource("http://repo.spring"
 				+ ".io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar");
-		assertThat(ResourceUtils.getUrlResourceWithoutVersion(urlResource)).isEqualTo("1.2.0.RELEASE");
+		assertThat(appResourceCommon.getUrlResourceWithoutVersion(urlResource)).isEqualTo("1.2.0.RELEASE");
 	}
 
 	@Test
 	public void testInvalidURIPath() throws Exception {
 		UrlResource urlResource = new UrlResource("http://com.com-0.0.2-SNAPSHOT");
 		try {
-			ResourceUtils.getUrlResourceVersion(urlResource);
+			appResourceCommon.getUrlResourceVersion(urlResource);
 			fail("Excepted IllegalArgumentException for an invalid URI path");
 		}
 		catch (Exception e) {
@@ -61,7 +63,7 @@ public class ResourceUtilsTests {
 	@Test
 	public void testDockerUriString() throws Exception {
 		String dockerUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
-		Resource resource = ResourceUtils.getResource(dockerUri, null);
+		Resource resource = appResourceCommon.getResource(dockerUri);
 		assertThat(resource instanceof DockerResource);
 		assertThat(resource.getURI().toString().equals(dockerUri));
 	}
@@ -70,7 +72,7 @@ public class ResourceUtilsTests {
 	public void testResourceURIWithMissingFileNameExtension() throws Exception {
 		UrlResource urlResource = new UrlResource("http://com.com-0.0.2-SNAPSHOT/test");
 		try {
-			ResourceUtils.getUrlResourceVersion(urlResource);
+			appResourceCommon.getUrlResourceVersion(urlResource);
 			fail("Excepted IllegalArgumentException for an invalid URI path");
 		}
 		catch (Exception e) {
@@ -82,7 +84,7 @@ public class ResourceUtilsTests {
 	public void testInvalidUrlResourceURI() throws Exception {
 		UrlResource urlResource = new UrlResource("http://com.com-0.0.2-SNAPSHOT/test.zip");
 		try {
-			ResourceUtils.getUrlResourceVersion(urlResource);
+			appResourceCommon.getUrlResourceVersion(urlResource);
 			fail("Excepted IllegalArgumentException for an invalid URL resource URI");
 		}
 		catch (Exception e) {
@@ -94,52 +96,52 @@ public class ResourceUtilsTests {
 	public void testJars() throws MalformedURLException {
 		//Dashes in artifact name
 		UrlResource urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0.RELEASE.jar");
-		String version = ResourceUtils.getUrlResourceVersion(urlResource);
+		String version = appResourceCommon.getUrlResourceVersion(urlResource);
 		assertThat(version).isEqualTo("1.2.0.RELEASE");
 
-		String theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
+		String theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//No dashes in artfiact name - BUILD-SNAPSHOT
 		urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file/file-1.2.0.BUILD-SNAPSHOT.jar");
-		version = ResourceUtils.getUrlResourceVersion(urlResource);
+		version = appResourceCommon.getUrlResourceVersion(urlResource);
 		assertThat(version).isEqualTo("1.2.0.BUILD-SNAPSHOT");
-		theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
+		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file/file");
 
 		//No dashes in artfiact name - RELEASE
 		urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file/file-1.2.0.RELEASE.jar");
-		version = ResourceUtils.getUrlResourceVersion(urlResource);
+		version = appResourceCommon.getUrlResourceVersion(urlResource);
 		assertThat(version).isEqualTo("1.2.0.RELEASE");
-		theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
+		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file/file");
 
 		//Spring style snapshots naming scheme
 		urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0.BUILD-SNAPSHOT.jar");
-		version = ResourceUtils.getUrlResourceVersion(urlResource);
+		version = appResourceCommon.getUrlResourceVersion(urlResource);
 		assertThat(version).isEqualTo("1.2.0.BUILD-SNAPSHOT");
-		theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
+		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//Standard maven style naming scheme
 		urlResource = new UrlResource("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0-SNAPSHOT.jar");
-		version = ResourceUtils.getUrlResourceVersion(urlResource);
+		version = appResourceCommon.getUrlResourceVersion(urlResource);
 		assertThat(version).isEqualTo("1.2.0-SNAPSHOT");
-		theRest = ResourceUtils.getResourceWithoutVersion(urlResource);
+		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 	}
 
 	@Test
 	public void testGetResource() {
 		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
-		Resource resource = ResourceUtils.getResource(mavenUri, new MavenProperties());
+		Resource resource = appResourceCommon.getResource(mavenUri);
 		assertThat(resource).isInstanceOf(MavenResource.class);
 	}
 
 	@Test
 	public void testGetResourceVersion() {
 		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
-		String version = ResourceUtils.getResourceVersion(ResourceUtils.getResource(mavenUri, new MavenProperties()));
+		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(mavenUri));
 		assertThat(version).isEqualTo("1.3.0.RELEASE");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -59,6 +59,7 @@ import org.springframework.cloud.dataflow.registry.RdbmsUriRegistry;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
 import org.springframework.cloud.dataflow.registry.service.DefaultAppRegistryService;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.server.ConditionalOnSkipperDisabled;
 import org.springframework.cloud.dataflow.server.ConditionalOnSkipperEnabled;
 import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
@@ -293,6 +294,11 @@ public class DataFlowControllerAutoConfiguration {
 	}
 
 	@Bean
+	public AppResourceCommon appResourceCommon(MavenProperties mavenProperties, DelegatingResourceLoader delegatingResourceLoader) {
+		return new AppResourceCommon(mavenProperties, delegatingResourceLoader);
+	}
+
+	@Bean
 	@ConditionalOnBean(TaskDefinitionRepository.class)
 	public TaskDefinitionController taskDefinitionController(TaskExplorer taskExplorer,
 			TaskDefinitionRepository repository,
@@ -479,8 +485,8 @@ public class DataFlowControllerAutoConfiguration {
 
 		@Bean
 		public AppRegistryService appRegistryService(AppRegistrationRepository appRegistrationRepository,
-				DelegatingResourceLoader resourceLoader, MavenProperties mavenProperties) {
-			return new DefaultAppRegistryService(appRegistrationRepository, resourceLoader, mavenProperties);
+				AppResourceCommon appResourceService) {
+			return new DefaultAppRegistryService(appRegistrationRepository, appResourceService);
 		}
 
 		@Bean
@@ -525,9 +531,10 @@ public class DataFlowControllerAutoConfiguration {
 		public AppDeployerStreamDeployer appDeployerStreamDeployer(AppDeployer appDeployer,
 				DeploymentIdRepository deploymentIdRepository,
 				StreamDefinitionRepository streamDefinitionRepository,
-				StreamDeploymentRepository streamDeploymentRepository, ForkJoinPool appRegistryFJPFB) {
+				StreamDeploymentRepository streamDeploymentRepository, ForkJoinPool appRegistryFJPFB,
+				AppRegistry appRegistry) {
 			return new AppDeployerStreamDeployer(appDeployer, deploymentIdRepository, streamDefinitionRepository,
-					streamDeploymentRepository, appRegistryFJPFB);
+					streamDeploymentRepository, appRegistryFJPFB, appRegistry);
 		}
 
 		@Bean
@@ -542,9 +549,8 @@ public class DataFlowControllerAutoConfiguration {
 		}
 
 		@Bean
-		public AppRegistry appRegistry(UriRegistry uriRegistry, DelegatingResourceLoader resourceLoader,
-				MavenProperties mavenProperties) {
-			return new AppRegistry(uriRegistry, resourceLoader, mavenProperties);
+		public AppRegistry appRegistry(UriRegistry uriRegistry, AppResourceCommon appResourceService) {
+			return new AppRegistry(uriRegistry, appResourceService);
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -485,8 +485,8 @@ public class DataFlowControllerAutoConfiguration {
 
 		@Bean
 		public AppRegistryService appRegistryService(AppRegistrationRepository appRegistrationRepository,
-				AppResourceCommon appResourceService) {
-			return new DefaultAppRegistryService(appRegistrationRepository, appResourceService);
+				AppResourceCommon appResourceCommon) {
+			return new DefaultAppRegistryService(appRegistrationRepository, appResourceCommon);
 		}
 
 		@Bean
@@ -549,8 +549,8 @@ public class DataFlowControllerAutoConfiguration {
 		}
 
 		@Bean
-		public AppRegistry appRegistry(UriRegistry uriRegistry, AppResourceCommon appResourceService) {
-			return new AppRegistry(uriRegistry, appResourceService);
+		public AppRegistry appRegistry(UriRegistry uriRegistry, AppResourceCommon appResourceCommon) {
+			return new AppRegistry(uriRegistry, appResourceCommon);
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/SkipperAppRegistryController.java
@@ -43,7 +43,6 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
 import org.springframework.cloud.dataflow.registry.service.DefaultAppRegistryService;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
-import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
 import org.springframework.cloud.dataflow.rest.SkipperStream;
 import org.springframework.cloud.dataflow.rest.resource.AppRegistrationResource;
 import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationResource;
@@ -217,7 +216,7 @@ public class SkipperAppRegistryController {
 	public void register(@PathVariable("type") ApplicationType type, @PathVariable("name") String name,
 			@RequestParam("uri") String uri, @RequestParam(name = "metadata-uri", required = false) String metadataUri,
 			@RequestParam(value = "force", defaultValue = "false") boolean force) {
-		String version = ResourceUtils.getResourceVersion(uri, this.mavenProperties);
+		String version = this.appRegistryService.getResourceVersion(uri);
 		this.register(type, name, version, uri, metadataUri, force);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DockerRegistryValidator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DockerRegistryValidator.java
@@ -26,10 +26,11 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.registry.support.DockerImage;
-import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
 import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -53,6 +54,7 @@ public class DockerRegistryValidator {
 	private static final String DOCKER_REGISTRY_TAGS_PATH = "/%s/tags/";
 	private static final String USER_NAME_KEY = "username";
 	private static final String PASSWORD_KEY = "password";
+	private final AppResourceCommon appResourceCommon;
 
 	private DockerAuth dockerAuth;
 	private RestTemplate restTemplate;
@@ -66,18 +68,19 @@ public class DockerRegistryValidator {
 		this.dockerResource = dockerResource;
 		this.restTemplate = configureRestTemplate();
 		this.dockerAuth = getDockerAuth();
+		this.appResourceCommon =  new AppResourceCommon(new MavenProperties(), null);
 	}
 
 	/**
 	 * Verifies that the image is present.
-	 *
+	 *JobDependencies.java
 	 * @return true if image is present.
 	 */
 	public boolean isImagePresent() {
 		boolean result = false;
 		try {
 			DockerResult dockerResult = getDockerImageInfo();
-			String resourceTag = ResourceUtils.getResourceVersion(this.dockerResource);
+			String resourceTag = this.appResourceCommon.getResourceVersion(this.dockerResource);
 			if (dockerResult.getCount() > 0) {
 				for (DockerTag tag : dockerResult.getResults()) {
 					if (tag.getName().equals(resourceTag)) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployer.java
@@ -38,7 +38,7 @@ import org.json.JSONObject;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
-import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
@@ -94,19 +94,27 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 	 */
 	private final ForkJoinPool forkJoinPool;
 
+	/**
+	 *
+	 */
+	private final AppRegistry appRegistry;
+
 	public AppDeployerStreamDeployer(AppDeployer appDeployer, DeploymentIdRepository deploymentIdRepository,
 			StreamDefinitionRepository streamDefinitionRepository,
-			StreamDeploymentRepository streamDeploymentRepository, ForkJoinPool forkJoinPool) {
+			StreamDeploymentRepository streamDeploymentRepository, ForkJoinPool forkJoinPool,
+			AppRegistry appRegistry) {
 		Assert.notNull(appDeployer, "AppDeployer must not be null");
 		Assert.notNull(deploymentIdRepository, "DeploymentIdRepository must not be null");
 		Assert.notNull(streamDefinitionRepository, "StreamDefinitionRepository must not be null");
 		Assert.notNull(streamDeploymentRepository, "StreamDeploymentRepository must not be null");
 		Assert.notNull(forkJoinPool, "ForkJoinPool must not be null");
+		Assert.notNull(appRegistry, "AppRegistryService must not be null");
 		this.appDeployer = appDeployer;
 		this.deploymentIdRepository = deploymentIdRepository;
 		this.streamDefinitionRepository = streamDefinitionRepository;
 		this.streamDeploymentRepository = streamDeploymentRepository;
 		this.forkJoinPool = forkJoinPool;
+		this.appRegistry = appRegistry;
 	}
 
 	public void deployStream(StreamDeploymentRequest streamDeploymentRequest) {
@@ -135,7 +143,7 @@ public class AppDeployerStreamDeployer implements StreamDeployer {
 		Map<String, String> appVersions = new HashMap<>();
 		for (AppDeploymentRequest appDeploymentRequest : streamDeploymentRequest.getAppDeploymentRequests()) {
 			deploymentProperties.put(appDeploymentRequest.getDefinition().getName(), appDeploymentRequest.getDeploymentProperties());
-			appVersions.put(appDeploymentRequest.getDefinition().getName(), ResourceUtils.getResourceVersion(appDeploymentRequest.getResource()));
+			appVersions.put(appDeploymentRequest.getDefinition().getName(), this.appRegistry.getResourceVersion(appDeploymentRequest.getResource()));
 		}
 		StreamDeployment streamDeployment = new StreamDeployment(streamDeploymentRequest.getStreamName(),
 				new JSONObject(deploymentProperties).toString());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -47,7 +47,6 @@ import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
-import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
 import org.springframework.cloud.dataflow.rest.SkipperStream;
 import org.springframework.cloud.dataflow.server.controller.NoSuchAppException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
@@ -286,7 +285,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	private void validateAllAppsRegistered(StreamDeploymentRequest streamDeploymentRequest) {
 		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(streamDeploymentRequest.getStreamName());
 		for (AppDeploymentRequest adr : streamDeploymentRequest.getAppDeploymentRequests()) {
-			String version = ResourceUtils.getResourceVersion(adr.getResource());
+			String version = this.appRegistryService.getResourceVersion(adr.getResource());
 			validateAppVersionIsRegistered(getRegisteredName(streamDefinition, adr.getDefinition().getName()), adr, version);
 		}
 	}
@@ -378,11 +377,11 @@ public class SkipperStreamDeployer implements StreamDeployer {
 		metadataMap.put("name", packageName);
 
 		// Add spec
-		String resourceWithoutVersion = ResourceUtils.getResourceWithoutVersion(appDeploymentRequest.getResource());
+		String resourceWithoutVersion = this.appRegistryService.getResourceWithoutVersion(appDeploymentRequest.getResource());
 		specMap.put("resource", resourceWithoutVersion);
 		specMap.put("applicationProperties", appDeploymentRequest.getDefinition().getProperties());
 		specMap.put("deploymentProperties", appDeploymentRequest.getDeploymentProperties());
-		String version = ResourceUtils.getResourceVersion(appDeploymentRequest.getResource());
+		String version = this.appRegistryService.getResourceVersion(appDeploymentRequest.getResource());
 		// Add version, including possible override via deploymentProperties - hack to store version in cmdline args
 		if (appDeploymentRequest.getCommandlineArguments().size() == 1) {
 			specMap.put("version", appDeploymentRequest.getCommandlineArguments().get(0));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.server.repository.InMemoryStreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
@@ -123,7 +124,7 @@ public class TabOnTapCompletionProviderTests {
 		@Bean
 		public AppRegistry appRegistry() {
 			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-			return new AppRegistry(new InMemoryUriRegistry(), resourceLoader) {
+			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
 				@Override
 				public AppRegistration find(String name, ApplicationType type) {
 					String filename = name + "-" + type;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
@@ -41,6 +41,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.server.repository.InMemoryStreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -124,7 +125,7 @@ public class TabOnTapCompletionProviderTests {
 		@Bean
 		public AppRegistry appRegistry() {
 			final ResourceLoader resourceLoader = new FileSystemResourceLoader();
-			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(null, resourceLoader)) {
+			return new AppRegistry(new InMemoryUriRegistry(), new AppResourceCommon(new MavenProperties(), resourceLoader)) {
 				@Override
 				public AppRegistration find(String name, ApplicationType type) {
 					String filename = name + "-" + type;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -59,6 +59,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobServ
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.registry.InMemoryUriRegistry;
 import org.springframework.cloud.deployer.resource.registry.UriRegistry;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -258,7 +259,7 @@ public class JobDependencies {
 
 	@Bean
 	public AppRegistry appRegistry() {
-		return new AppRegistry(uriRegistry(), new AppResourceCommon(null, new DefaultResourceLoader()));
+		return new AppRegistry(uriRegistry(), new AppResourceCommon(new MavenProperties(), new DefaultResourceLoader()));
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConf
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
 import org.springframework.cloud.dataflow.server.audit.repository.AuditRecordRepository;
 import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
@@ -257,7 +258,7 @@ public class JobDependencies {
 
 	@Bean
 	public AppRegistry appRegistry() {
-		return new AppRegistry(uriRegistry(), new DefaultResourceLoader());
+		return new AppRegistry(uriRegistry(), new AppResourceCommon(null, new DefaultResourceLoader()));
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/AppDeployerStreamDeployerTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDeployment;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
@@ -46,7 +47,8 @@ public class AppDeployerStreamDeployerTests {
 				appDeployer, mock(DeploymentIdRepository.class),
 				mock(StreamDefinitionRepository.class),
 				mock(StreamDeploymentRepository.class),
-				mock(ForkJoinPool.class));
+				mock(ForkJoinPool.class),
+				mock(AppRegistry.class));
 
 		RuntimeEnvironmentInfo info = appDeployerStreamDeployer.environmentInfo();
 
@@ -59,7 +61,8 @@ public class AppDeployerStreamDeployerTests {
 				mock(AppDeployer.class), mock(DeploymentIdRepository.class),
 				mock(StreamDefinitionRepository.class),
 				mock(StreamDeploymentRepository.class),
-				mock(ForkJoinPool.class));
+				mock(ForkJoinPool.class),
+				mock(AppRegistry.class));
 
 		appDeployerStreamDeployer.getStreamInfo("myStream");
 	}
@@ -76,7 +79,8 @@ public class AppDeployerStreamDeployerTests {
 				mock(AppDeployer.class), mock(DeploymentIdRepository.class),
 				streamDefinitionRepository,
 				streamDeploymentRepository,
-				mock(ForkJoinPool.class));
+				mock(ForkJoinPool.class),
+				mock(AppRegistry.class));
 
 		appDeployerStreamDeployer.getStreamInfo("myStream");
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
@@ -19,7 +19,7 @@ import java.net.MalformedURLException;
 
 import org.junit.Test;
 
-import org.springframework.cloud.dataflow.registry.support.ResourceUtils;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.resource.maven.MavenResource;
 import org.springframework.core.io.Resource;
@@ -35,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ResourceUtilsTests {
 
+	private AppResourceCommon appResourceService = new AppResourceCommon(null, null);
+
 	@Test
 	public void testMavenResourceProcessing() {
 		MavenResource mavenResource = new MavenResource.Builder()
@@ -42,49 +44,49 @@ public class ResourceUtilsTests {
 				.groupId("org.springframework.cloud.task.app")
 				.version("1.0.0.RELEASE")
 				.build();
-		String resourceWithoutVersion = ResourceUtils.getResourceWithoutVersion(mavenResource);
+		String resourceWithoutVersion = appResourceService.getResourceWithoutVersion(mavenResource);
 		assertThat(resourceWithoutVersion).isEqualTo("maven://org.springframework.cloud.task.app:timestamp-task");
-		assertThat(ResourceUtils.getResourceVersion(mavenResource)).isEqualTo("1.0.0.RELEASE");
+		assertThat(appResourceService.getResourceVersion(mavenResource)).isEqualTo("1.0.0.RELEASE");
 	}
 
 	@Test
 	public void testDockerResourceProcessing() {
 		DockerResource dockerResource = new DockerResource("springcloudstream/file-source-kafka-10:1.2.0.RELEASE");
-		assertThat(ResourceUtils.getResourceWithoutVersion(dockerResource)).isEqualTo("docker:springcloudstream/file-source-kafka-10");
-		assertThat(ResourceUtils.getResourceVersion(dockerResource)).isEqualTo("1.2.0.RELEASE");
+		assertThat(appResourceService.getResourceWithoutVersion(dockerResource)).isEqualTo("docker:springcloudstream/file-source-kafka-10");
+		assertThat(appResourceService.getResourceVersion(dockerResource)).isEqualTo("1.2.0.RELEASE");
 	}
 
 	@Test
 	public void testDockerResourceProcessingWithHostIP() {
 		DockerResource dockerResource = new DockerResource("192.168.99.100:80/myrepo/rabbitsink:current");
-		assertThat(ResourceUtils.getResourceWithoutVersion(dockerResource)).isEqualTo("docker:192.168.99.100:80/myrepo/rabbitsink");
-		assertThat(ResourceUtils.getResourceVersion(dockerResource)).isEqualTo("current");
+		assertThat(appResourceService.getResourceWithoutVersion(dockerResource)).isEqualTo("docker:192.168.99.100:80/myrepo/rabbitsink");
+		assertThat(appResourceService.getResourceVersion(dockerResource)).isEqualTo("current");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidDockerResourceProcessing() {
 		DockerResource dockerResource = new DockerResource("springcloudstream:file-source-kafka-10:1.2.0.RELEASE");
-		ResourceUtils.getResourceWithoutVersion(dockerResource);
+		appResourceService.getResourceWithoutVersion(dockerResource);
 	}
 
 	@Test
 	public void testFileResourceProcessing() throws MalformedURLException {
 		Resource resource = new UrlResource("file:/springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
-		assertThat(ResourceUtils.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10");
-		assertThat(ResourceUtils.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
+		assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10");
+		assertThat(appResourceService.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
 
 		resource = new UrlResource("file:/springcloudstream/file-source-kafka-10-1.2.0.BUILD-SNAPSHOT.jar");
-		assertThat(ResourceUtils.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10");
-		assertThat(ResourceUtils.getResourceVersion(resource)).isEqualTo("1.2.0.BUILD-SNAPSHOT");
+		assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("file:/springcloudstream/file-source-kafka-10");
+		assertThat(appResourceService.getResourceVersion(resource)).isEqualTo("1.2.0.BUILD-SNAPSHOT");
 
 		resource = new UrlResource("http://springcloudstream/file-source-kafka-10-1.2.0.RELEASE.jar");
-		assertThat(ResourceUtils.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka-10");
-		assertThat(ResourceUtils.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
+		assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/file-source-kafka-10");
+		assertThat(appResourceService.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testFileResourceWithoutVersion() throws MalformedURLException {
 		Resource resource = new UrlResource("http://springcloudstream/filesourcekafkacrap.jar");
-		assertThat(ResourceUtils.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/filesourcekafkacrap.jar");
+		assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("http://springcloudstream/filesourcekafkacrap.jar");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
@@ -35,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ResourceUtilsTests {
 
-	private AppResourceCommon appResourceService = new AppResourceCommon(null, null);
+	private AppResourceCommon appResourceService = new AppResourceCommon(new MavenProperties(), null);
 
 	@Test
 	public void testMavenResourceProcessing() {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -98,6 +98,7 @@ public class SkipperStreamDeployerTests {
 		MavenResource timeResource = new MavenResource.Builder()
 				.artifactId("time-source-rabbit").groupId("org.springframework.cloud.stream.app")
 				.version("1.2.0.RELEASE").build();
+		when(appRegistryService.getResourceVersion(timeResource)).thenReturn(timeResource.getVersion());
 		AppDeploymentRequest timeAppDeploymentRequest = new AppDeploymentRequest(timeAppDefinition, timeResource);
 
 		List<AppDeploymentRequest> appDeploymentRequests = Arrays.asList(timeAppDeploymentRequest);
@@ -250,6 +251,7 @@ public class SkipperStreamDeployerTests {
 		MavenResource timeResource = new MavenResource.Builder()
 				.artifactId("time-source-rabbit").groupId("org.springframework.cloud.stream.app")
 				.version("1.2.0.RELEASE").build();
+		when(appRegistryService.getResourceVersion(timeResource)).thenReturn(timeResource.getVersion());
 		AppDeploymentRequest timeAppDeploymentRequest = new AppDeploymentRequest(timeAppDefinition, timeResource);
 
 		HashMap<String, String> logAppProps = new HashMap<>();
@@ -258,6 +260,7 @@ public class SkipperStreamDeployerTests {
 		MavenResource logResource = new MavenResource.Builder()
 				.artifactId("log-sink-rabbit").groupId("org.springframework.cloud.stream.app")
 				.version("1.2.0.RELEASE").build();
+		when(appRegistryService.getResourceVersion(logResource)).thenReturn(logResource.getVersion());
 		AppDeploymentRequest logAppDeploymentRequest = new AppDeploymentRequest(logAppDefinition, logResource);
 
 		List<AppDeploymentRequest> appDeploymentRequests = Arrays.asList(logAppDeploymentRequest, timeAppDeploymentRequest);


### PR DESCRIPTION
   - Introduce a stateful AppResourceCommon that includes the ResourceUtils methods along with MavenProperties and ResourceLoader instances.
   - Remove the direct usage of MavenProperties and ResourceLoader across the classes and make use of the AppResourceCommon instead.
   - Update the bean configurations to instantiate AppResourceCommon bean and inject it in all beans that operate with Resources.
   - Remove ResourceUtils.
   - Fix affected tests.

  Resolves #1873