### PR TITLE
Add support for wildcards in stream destination names

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,7 @@ public enum DSLMessage {
 	TASK_ARGUMENTS_NOT_ALLOWED_UNLESS_IN_APP_MODE(Kind.ERROR, 168, "arguments not allowed unless parser is in app mode"), //
 	DONT_MIX_PIPE_AND_COMMA(Kind.ERROR, 169, "do not mix '|' and ',' when specifying a set of applications"), //
 	DONT_USE_COMMA_WITH_CHANNELS(Kind.ERROR, 170, "do not use comma delimiter between apps in a stream, use '|'"), //
+	UNEXPECTED_DATA_IN_DESTINATION_NAME(Kind.ERROR, 171, "unexpected data in destination name ''{0}''"), //
 	;
 
 	private Kind kind;

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DestinationNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DestinationNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.core.dsl;
 
-import java.util.List;
-
 import org.springframework.util.Assert;
 
 /**
@@ -29,25 +27,15 @@ import org.springframework.util.Assert;
  */
 public class DestinationNode extends AstNode {
 
-	private final List<String> nameComponents;
+	private final String destinationName;
 
 	private final ArgumentNode[] arguments;
 
-	private final String destinationName;
-
-	public DestinationNode(int startPos, int endPos, List<String> nameComponents, ArgumentNode[] arguments) {
+	public DestinationNode(int startPos, int endPos, String destinationName, ArgumentNode[] arguments) {
 		super(startPos, endPos);
-		Assert.notEmpty(nameComponents, "'nameComponents' must not be null or empty");
-		this.nameComponents = nameComponents;
+		Assert.notNull(destinationName, "'destinationName' must not be null");
 		this.arguments = arguments;
-		StringBuilder s = new StringBuilder();
-		for (int t = 0, max = nameComponents.size(); t < max; t++) {
-			if (t != 0) {
-				s.append(".");
-			}
-			s.append(nameComponents.get(t));
-		}
-		this.destinationName = s.toString();
+		this.destinationName = destinationName;
 	}
 
 	@Override
@@ -78,7 +66,7 @@ public class DestinationNode extends AstNode {
 	}
 
 	public DestinationNode copyOf() {
-		return new DestinationNode(super.startPos, super.endPos, nameComponents, arguments);
+		return new DestinationNode(super.startPos, super.endPos, destinationName, arguments);
 	}
 
 	ArgumentNode[] getArguments() {

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TokenKind.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TokenKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ public enum TokenKind {
 	REFERENCE("@"),
 	DOT("."),
 	LITERAL_STRING,
+	SLASH("/"),
+	HASH("#"),
 	COMMA(",");
 
 	char[] tokenChars;

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,15 @@ class Tokenizer extends AbstractTokenizer {
 					break;
 				case ':':
 					pushCharToken(TokenKind.COLON);
+					break;
+				case '/':
+					pushCharToken(TokenKind.SLASH);
+					break;
+				case '#':
+					pushCharToken(TokenKind.HASH);
+					break;
+				case '*':
+					pushCharToken(TokenKind.STAR);
 					break;
 				case ';':
 					pushCharToken(TokenKind.SEMICOLON);

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/NodeTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/NodeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.dataflow.core.dsl;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Test;
@@ -24,12 +23,13 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 public class NodeTests {
 
 	@Test
 	public void testDestinationNodeDestinationName(){
-		DestinationNode node = new DestinationNode(0, 0, Arrays.asList(new String[]{"foo", "bar", "bazz"}), null);
+		DestinationNode node = new DestinationNode(0, 0, "foo.bar.bazz", null);
 		assertEquals("foo.bar.bazz", node.getDestinationName());
 	}
 
@@ -37,7 +37,7 @@ public class NodeTests {
 	public void testDestinationNodeToString(){
 		ArgumentNode an1 = new ArgumentNode("foo", "bar", 0, 4);
 		ArgumentNode an2 = new ArgumentNode("abc", "'xyz'", 0, 4);
-		DestinationNode node = new DestinationNode(0, 4, Arrays.asList(new String[]{"foo", "bar", "bazz"}), new ArgumentNode[]{an1, an2});
+		DestinationNode node = new DestinationNode(0, 4, "foo.bar.bazz", new ArgumentNode[]{an1, an2});
 		System.out.println(node.stringify());
 		assertEquals(":foo.bar.bazz", node.toString());
 	}
@@ -48,9 +48,9 @@ public class NodeTests {
 		ArgumentNode an2 = new ArgumentNode("abc", "'xyz'", 0, 4);
 		AppNode appNode = new AppNode(null, "bar", 0, 2, new ArgumentNode[]{an1, an2});
 
-		DestinationNode sourceDNode = new DestinationNode(0, 0, Arrays.asList(new String[]{"source", "bar", "bazz"}), null);
+		DestinationNode sourceDNode = new DestinationNode(0, 0, "source.bar.bazz", null);
 		SourceDestinationNode source = new SourceDestinationNode(sourceDNode, 4);
-		DestinationNode sinkDNode = new DestinationNode(0, 0, Arrays.asList(new String[]{"sink", "bar", "bazz"}), null);
+		DestinationNode sinkDNode = new DestinationNode(0, 0, "sink.bar.bazz", null);
 		SinkDestinationNode sink = new SinkDestinationNode(sinkDNode, 4);
 		StreamNode sNode = new StreamNode(null, "myStream", Collections.singletonList(appNode), source, sink);
 		assertEquals("myStream = :source.bar.bazz > bar --foo=bar --abc='xyz' > :sink.bar.bazz", sNode.toString());


### PR DESCRIPTION
This adds support in the parser/tokenizer to allow stream destination
names to include slash(/), star(*) or hash(#). Extra tests added and
minor refactoring (simplification) to DestinationNode.

Fixes #2425 
Fixes #2430