### PR TITLE
Schedules with an invalid cron expression will return a 400

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -40,6 +40,7 @@ import org.springframework.cloud.dataflow.server.repository.NoSuchTaskBatchExcep
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskExecutionException;
 import org.springframework.cloud.dataflow.server.support.ApplicationDoesNotExistException;
+import org.springframework.cloud.scheduler.spi.core.CreateScheduleException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -174,7 +175,7 @@ public class RestControllerAdvice {
 	 */
 	@ExceptionHandler({ MissingServletRequestParameterException.class, HttpMessageNotReadableException.class,
 			UnsatisfiedServletRequestParameterException.class, MethodArgumentTypeMismatchException.class,
-			InvalidStreamDefinitionException.class })
+			InvalidStreamDefinitionException.class, CreateScheduleException.class })
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ResponseBody
 	public VndErrors onClientGenericBadRequest(Exception e) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -585,6 +585,8 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 
 
 	public static class SimpleTestScheduler implements Scheduler {
+		public static final String INVALID_CRON_EXPRESSION = "BAD";
+
 		List<ScheduleInfo> schedules = new ArrayList<>();
 
 		@Override
@@ -593,6 +595,10 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			schedule.setScheduleName(scheduleRequest.getScheduleName());
 			schedule.setScheduleProperties(scheduleRequest.getSchedulerProperties());
 			schedule.setTaskDefinitionName(scheduleRequest.getDefinition().getName());
+			if(schedule.getScheduleProperties().containsKey("spring.cloud.scheduler.cron.expression") &&
+					schedule.getScheduleProperties().get("spring.cloud.scheduler.cron.expression").equals(INVALID_CRON_EXPRESSION)) {
+				throw new CreateScheduleException("Invalid Cron Expression",new IllegalArgumentException());
+			}
 			List<ScheduleInfo> scheduleInfos = schedules.stream().filter(s -> s.getScheduleName().
 					equals(scheduleRequest.getScheduleName())).
 					collect(Collectors.toList());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -156,6 +156,16 @@ public class TaskSchedulerControllerTests {
 	}
 
 	@Test
+	public void testCreateScheduleBadCron() throws Exception {
+		this.registry.register("task.testApp", new URI("file:src/test/resources/apps/foo-task"));
+		repository.save(new TaskDefinition("testDefinition", "testApp"));
+		mockMvc.perform(post("/tasks/schedules/").param("taskDefinitionName", "testDefinition").
+				param("scheduleName", "myScheduleBadCron").
+				param("properties", "scheduler.cron.expression="+TestDependencies.SimpleTestScheduler.INVALID_CRON_EXPRESSION)
+				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+	}
+
+	@Test
 	public void testRemoveSchedule() throws Exception {
 		this.registry.register("task.testApp", new URI("file:src/test/resources/apps/foo-task"));
 		repository.save(new TaskDefinition("testDefinition", "testApp"));


### PR DESCRIPTION
Before it would return a 500 error.
Primary change is that all schedule that fail to create should throw a CreateScheduleException as the platform validates the cron expression.