### PR TITLE
gh-2461 Implement audit-trail advice for SchedulerService

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -44,6 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Janne Valkealahti
  * @author Christian Tzolov
+ * @author Gunnar Hillert
  */
 public final class DeploymentPropertiesUtils {
 
@@ -71,7 +73,7 @@ public final class DeploymentPropertiesUtils {
 	 * @return the Map of parsed key value pairs
 	 */
 	public static Map<String, String> parse(String s) {
-		Map<String, String> deploymentProperties = new HashMap<>();
+		Map<String, String> deploymentProperties = new LinkedHashMap<>();
 		List<String> pairs = parseParamList(s, ",");
 
 		// add what we got, addKeyValuePairAsProperty

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditRecordService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditRecordService.java
@@ -95,4 +95,5 @@ public interface AuditRecordService {
 	 * @return Audit Record
 	 */
 	AuditRecord findOne(Long id);
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditServiceUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.audit.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.server.controller.support.ArgumentSanitizer;
+import org.springframework.cloud.scheduler.spi.core.ScheduleRequest;
+import org.springframework.util.Assert;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class AuditServiceUtils {
+
+	public static final String STREAM_DEFINITION_DSL_TEXT = "streamDefinitionDslText";
+
+	public static final String TASK_DEFINITION_DSL_TEXT = "taskDefinitionDslText";
+	public static final String TASK_DEFINITION_NAME = "taskDefinitionName";
+	public static final String TASK_DEFINITION_PROPERTIES = "taskDefinitionProperties";
+
+	public static final String DEPLOYMENT_PROPERTIES = "deploymentProperties";
+	public static final String COMMANDLINE_ARGUMENTS = "commandlineArguments";
+
+	private final ArgumentSanitizer argumentSanitizer;
+
+	public AuditServiceUtils() {
+		this.argumentSanitizer = new ArgumentSanitizer();
+	}
+
+	public String convertStreamDefinitionToAuditData(StreamDefinition streamDefinition) {
+		return this.argumentSanitizer.sanitizeStream(streamDefinition);
+	}
+
+	public Map<String, Object> convertStreamDefinitionToAuditData(
+			StreamDefinition streamDefinition,
+			Map<String, String> deploymentProperties) {
+
+		final Map<String, Object> auditedData = new HashMap<>(2);
+		auditedData.put(STREAM_DEFINITION_DSL_TEXT, this.argumentSanitizer.sanitizeStream(streamDefinition));
+		auditedData.put(DEPLOYMENT_PROPERTIES, this.argumentSanitizer.sanitizeProperties(deploymentProperties));
+		return auditedData;
+	}
+
+	public Map<String, Object> convertScheduleRequestToAuditData(ScheduleRequest scheduleRequest) {
+		Assert.notNull(scheduleRequest, "scheduleRequest must not be null");
+		Assert.hasText(scheduleRequest.getScheduleName(), "The scheduleName of the scheduleRequest must not be null or empty");
+		Assert.notNull(scheduleRequest.getDefinition(), "The task definition of the scheduleRequest must not be null");
+
+		final Map<String, Object> auditedData = new HashMap<>(3);
+		auditedData.put(TASK_DEFINITION_NAME, scheduleRequest.getDefinition().getName());
+
+		if (scheduleRequest.getDefinition().getProperties() != null) {
+			auditedData.put(TASK_DEFINITION_PROPERTIES, argumentSanitizer.sanitizeProperties(scheduleRequest.getDefinition().getProperties()));
+		}
+
+		if (scheduleRequest.getDeploymentProperties() != null) {
+			auditedData.put(DEPLOYMENT_PROPERTIES, argumentSanitizer.sanitizeProperties(scheduleRequest.getDeploymentProperties()));
+		}
+
+		if (scheduleRequest.getCommandlineArguments() != null) {
+			auditedData.put(COMMANDLINE_ARGUMENTS, argumentSanitizer.sanitizeArguments(scheduleRequest.getCommandlineArguments()));
+		}
+		return auditedData;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
+import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
@@ -40,6 +41,7 @@ import org.springframework.core.io.ResourceLoader;
  * Establishes the {@link SchedulerService} instance to be used by SCDF.
  *
  * @author Glenn Renfro
+ * @author Gunnar Hillert
  */
 
 @Configuration
@@ -58,11 +60,12 @@ public class SchedulerConfiguration {
 			TaskConfigurationProperties taskConfigurationProperties,
 			DataSourceProperties dataSourceProperties,
 			ApplicationConfigurationMetadataResolver metaDataResolver,
-			SchedulerServiceProperties schedulerServiceProperties) {
+			SchedulerServiceProperties schedulerServiceProperties,
+			AuditRecordService auditRecordService) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				scheduler, taskDefinitionRepository, registry, resourceLoader,
 				taskConfigurationProperties, dataSourceProperties,
-				this.dataflowServerUri, metaDataResolver, schedulerServiceProperties);
+				this.dataflowServerUri, metaDataResolver, schedulerServiceProperties, auditRecordService);
 	}
 
 	public static class SchedulerConfigurationPropertyChecker extends AllNestedConditions {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/ArgumentSanitizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.controller.support;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -26,11 +28,13 @@ import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.core.StreamDefinitionToDslConverter;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Sanitizes potentially sensitive keys for a specific command line arg.
  *
  * @author Glenn Renfro
+ * @author Gunnar Hillert
  */
 public class ArgumentSanitizer {
 	private static final String[] REGEX_PARTS = { "*", "$", "^", "+" };
@@ -95,10 +99,12 @@ public class ArgumentSanitizer {
 	 * @return the argument with a potentially sanitized value
 	 */
 	public String sanitize(String key, String value) {
-		for (Pattern pattern : this.keysToSanitize) {
-			if (pattern.matcher(key).matches()) {
-				value = REDACTION_STRING;
-				break;
+		if (StringUtils.hasText(value)) {
+			for (Pattern pattern : this.keysToSanitize) {
+				if (pattern.matcher(key).matches()) {
+					value = REDACTION_STRING;
+					break;
+				}
 			}
 		}
 		return value;
@@ -140,10 +146,28 @@ public class ArgumentSanitizer {
 	 */
 	public Map<String, String> sanitizeProperties(Map<String, String> properties) {
 		if (!CollectionUtils.isEmpty(properties)) {
-			return properties.entrySet().stream()
-					.collect(Collectors.toMap(e -> e.getKey(), e -> this.sanitize(e.getKey(), e.getValue())));
+			final Map<String, String> sanitizedProperties = new LinkedHashMap<>(properties.size());
+			for (Map.Entry<String, String > property : properties.entrySet()) {
+				sanitizedProperties.put(property.getKey(), this.sanitize(property.getKey(), property.getValue()));
+			}
+			return sanitizedProperties;
 		}
 		return properties;
+	}
+
+	/**
+	 * For all sensitive arguments (e.g. key names containing words like password, secret,
+	 * key, token) replace the value with '*****' string
+	 */
+	public List<String> sanitizeArguments(List<String> arguments) {
+		if (!CollectionUtils.isEmpty(arguments)) {
+			final List<String> sanitizedArguments = new ArrayList<>(arguments.size());
+			for (String argument : arguments) {
+				sanitizedArguments.add(this.sanitize(argument));
+			}
+			return sanitizedArguments;
+		}
+		return arguments;
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AppDeployerStreamService.java
@@ -96,7 +96,7 @@ public class AppDeployerStreamService extends AbstractStreamService {
 		this.appDeployerStreamDeployer.undeployStream(streamName);
 		auditRecordService.populateAndSaveAuditRecord(
 				AuditOperationType.STREAM, AuditActionType.UNDEPLOY,
-				streamDefinition.getName(), this.argumentSanitizer.sanitizeStream(streamDefinition));
+				streamDefinition.getName(), this.auditServiceUtils.convertStreamDefinitionToAuditData(streamDefinition));
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -38,7 +38,6 @@ import org.springframework.cloud.dataflow.server.audit.domain.AuditOperationType
 import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
-import org.springframework.cloud.dataflow.server.controller.support.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.server.repository.DeploymentIdRepository;
 import org.springframework.cloud.dataflow.server.repository.DeploymentKey;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
@@ -97,8 +96,6 @@ public class DefaultTaskService implements TaskService {
 	 * The {@link AppRegistry} this service will use to look up task app URIs.
 	 */
 	private final AppRegistryCommon registry;
-
-	protected final ArgumentSanitizer argumentSanitizer;
 
 	private final TaskDefinitionRepository taskDefinitionRepository;
 
@@ -171,7 +168,6 @@ public class DefaultTaskService implements TaskService {
 		this.commonApplicationProperties = commonApplicationProperties;
 		this.auditRecordService = auditRecordService;
 		this.taskValidationService = taskValidationService;
-		this.argumentSanitizer = new ArgumentSanitizer();
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -191,13 +191,14 @@ public class TaskServiceDependencies {
 			AppRegistry registry, ResourceLoader resourceLoader,
 			DataSourceProperties dataSourceProperties,
 			ApplicationConfigurationMetadataResolver metaDataResolver,
-			SchedulerServiceProperties schedulerServiceProperties) {
+			SchedulerServiceProperties schedulerServiceProperties,
+			AuditRecordService auditRecordService) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				scheduler, taskDefinitionRepository,
 				registry, resourceLoader,
 				new TaskConfigurationProperties(),
 				dataSourceProperties, null,
-				metaDataResolver, schedulerServiceProperties);
+				metaDataResolver, schedulerServiceProperties, auditRecordService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -506,13 +506,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			Scheduler scheduler, TaskDefinitionRepository taskDefinitionRepository,
 			AppRegistryCommon registry, ResourceLoader resourceLoader,
 			DataSourceProperties dataSourceProperties,
-			ApplicationConfigurationMetadataResolver metaDataResolver) {
+			ApplicationConfigurationMetadataResolver metaDataResolver, AuditRecordService auditRecordService) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				scheduler, taskDefinitionRepository,
 				registry, resourceLoader,
 				new TaskConfigurationProperties(),
 				dataSourceProperties, null,
-				metaDataResolver, new SchedulerServiceProperties());
+				metaDataResolver, new SchedulerServiceProperties(), auditRecordService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -163,8 +163,8 @@ public class StreamControllerTests {
 
 		final AuditRecord auditRecord = auditRecords.get(0);
 
-		assertEquals("time --some.password=foobar --another-secret=kenny | log", myStream.getDslText()); //FIXME ordering issue
-		assertEquals("time --another-secret='******' --some.password='******' | log", auditRecord.getAuditData());
+		assertEquals("time --some.password=foobar --another-secret=kenny | log", myStream.getDslText());
+		assertEquals("time --some.password='******' --another-secret='******' | log", auditRecord.getAuditData());
 		assertEquals("myStream2", auditRecord.getCorrelationId());
 		assertEquals(AuditOperationType.STREAM, auditRecord.getAuditOperation());
 		assertEquals(AuditActionType.CREATE, auditRecord.getAuditAction());
@@ -601,8 +601,8 @@ public class StreamControllerTests {
 		final AuditRecord auditRecord1 = auditRecords.get(0);
 		final AuditRecord auditRecord2 = auditRecords.get(1);
 
-		assertEquals("time --another-secret='******' --some.password='******' | log", auditRecord1.getAuditData()); //FIXME ordering issue
-		assertEquals("time --another-secret='******' --some.password='******' | log", auditRecord2.getAuditData()); //FIXME ordering issue
+		assertEquals("time --some.password='******' --another-secret='******' | log", auditRecord1.getAuditData());
+		assertEquals("time --some.password='******' --another-secret='******' | log", auditRecord2.getAuditData());
 		assertEquals("myStream1234", auditRecord1.getCorrelationId());
 		assertEquals("myStream1234", auditRecord2.getCorrelationId());
 
@@ -721,7 +721,7 @@ public class StreamControllerTests {
 		assertEquals(1, auditRecords.size());
 		final AuditRecord auditRecord = auditRecords.get(0);
 
-		assertEquals("{\"streamDefinitionDslText\":\"time --another-secret='******' --some.password='******' | log\",\"deploymentProperties\":{}}", auditRecord.getAuditData()); //FIXME ordering issue
+		assertEquals("{\"streamDefinitionDslText\":\"time --some.password='******' --another-secret='******' | log\",\"deploymentProperties\":{}}", auditRecord.getAuditData());
 
 		assertEquals("myStreamDeploy", auditRecord.getCorrelationId());
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.dataflow.registry.AppRegistry;
 import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
+import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
@@ -293,7 +294,8 @@ public class DefaultSchedulerServiceTests {
 		SchedulerService mockSchedulerService = new DefaultSchedulerService(mock(CommonApplicationProperties.class),
 				mockScheduler, mockTaskDefinitionRepository, mockAppRegistryCommon, mock(ResourceLoader.class),
 				mock(TaskConfigurationProperties.class), mock(DataSourceProperties.class), "uri",
-				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class));
+				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
+				mock(AuditRecordService.class));
 
 		TaskDefinition taskDefinition = new TaskDefinition(BASE_DEFINITION_NAME, "timestamp");
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.support;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +50,24 @@ public class ArgumentSanitizerTest {
 		}
 	}
 
+	@Test
+	public void testSanitizeArguments() {
+		final List<String> arguments = new ArrayList<>();
+
+		for (String key : keys) {
+			arguments.add("--" + key + "=foo");
+		}
+
+		final List<String> sanitizedArguments = sanitizer.sanitizeArguments(arguments);
+
+		Assert.assertEquals(keys.length, sanitizedArguments.size());
+
+		int order = 0;
+		for(String sanitizedString : sanitizedArguments) {
+			Assert.assertEquals("--" + keys[order] + "=******", sanitizedString);
+			order++;
+		}
+	}
 
 	@Test
 	public void testMultipartProperty() {
@@ -63,7 +84,7 @@ public class ArgumentSanitizerTest {
 
 	@Test
 	public void testStreamPropertyOrder() {
-		Assert.assertEquals("time --another-secret='******' --some.password='******' | log",  //FIXME Order should be "time --some.password='******' --another-secret='******' | log"
+		Assert.assertEquals("time --some.password='******' --another-secret='******' | log",
 				sanitizer.sanitizeStream(new StreamDefinition("stream", "time --some.password=foobar --another-secret=kenny | log")));
 	}
 


### PR DESCRIPTION
* Add tests
* Fix properties ordering issue in `ArgumentSanitizer`
* Add helper method to `ArgumentSanitizer`
* Add AuditServiceUtils to encapsulate ArgumentSanitizer (gh-2477)

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2370
resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2477
