### PR TITLE
Add new-issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,46 @@
+<!-- Thanks for the interest in Spring Cloud Data Flow! Before you create a new issue, please answer the following question.-->
+
+**Is this a "Bug Report" or "Feature Request"?** _(choose one and remove the irrelevant sections before submitting the issue)_:
+
+<!--
+If this is a "Bug Report", please:
+
+**Describe**
+A clear and concise description of what the bug is. Additionally, it'd help if you can include the logs and entire stacktrace including the "caused by". _(see [GitHub Mardown](https://guides.github.com/features/mastering-markdown/) for logs/code formatting guidelines)_
+
+**Release versions**
+There's an [API](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's [About](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard) tab, so make sure to include the copied JSON in the bug report.
+
+**Custom Apps**
+If your Stream or Task data pipeline include custom apps and there's a problem associated with it, it'd be good to review the sample App and the release versions in use. Make sure to include the register, create, and deploy/launch DSL commands for completeness.
+
+**To Reproduce**
+Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It'd help us to relate to the problem more easily. 
+
+**Screenshots**
+Where applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.
+
+
+
+
+If this is a "Feature Request", please:
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or explanation about the feature request here.
+
+-->
+
+
+**If there's anything else that you'd like to share and it is not included in the template above, please describe it here:**

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,21 +1,21 @@
-<!-- Thanks for the interest in Spring Cloud Data Flow! Before you create a new issue, please answer the following question.-->
+<!-- Thanks for your interest in Spring Cloud Data Flow! Before you create a new issue, please answer the following question.-->
 
-**Is this a "Bug Report" or "Feature Request"?** (choose one and remove the irrelevant sections before submitting the issue):
+**Is this a "Bug Report" or "Feature Request"?** (choose one and remove the irrelevant sections before you submit the issue):
 
 <!--
-If this is a "Bug Report", please:
+If this is a "Bug Report", please provide the following information:
 
-Describe:
-A clear and concise description of what the bug is. Additionally, it'd help if you can include the logs and entire stacktrace including the "caused by". (see GitHub-Markdown docs at: https://guides.github.com/features/mastering-markdown for logs/code formatting guidelines)_
+Description:
+A clear and concise description of what the bug is. Additionally, it would help if you could include the logs and the entire stacktrace, including the "caused by" portion. (see GitHub-Markdown docs at: https://guides.github.com/features/mastering-markdown for logs/code formatting guidelines)_
 
 Release versions:
-There's an API (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's About tab (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard), so make sure to include the copied JSON in the bug report.
+There is an API (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information, including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's About tab (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard). Please be sure to include the copied JSON in the bug report.
 
-Custom Apps:
-If your Stream or Task data pipeline includes custom apps and there's a problem associated with it, it'd be good to review the sample-app (add a link to GitHub repo) and the release versions in use. Make sure to also share the register, create, and deploy/launch DSL commands for completeness.
+Custom apps:
+If your Stream or Task data pipeline includes custom apps and there is a problem associated with it, please review the sample-app (add a link to the GitHub repo) and the release versions in use. Also, please be sure to share the register, create, and deploy/launch DSL commands for completeness.
 
-To Reproduce:
-Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It'd help us to relate to the problem more easily. 
+Steps to reproduce:
+Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It can help us to relate to the problem more easily. 
 
 Screenshots:
 Where applicable, add screenshots to help explain your problem.
@@ -25,16 +25,17 @@ Add any other context about the problem here.
 
 -
 
-If this is a "Feature Request", please:
+If this is a "Feature Request", please provide the following information:
 
-Is your feature request related to a problem? Please describe:
-A clear and concise description of what the problem is. 
+Problem description:
+Is your feature request related to a problem? Please provide
+a clear and concise description of what the problem is. 
 
-Describe the solution you'd like:
-A clear and concise description of what you want to happen.
+Solution description:
+Describe the solution you would like. We need a clear and concise description of what you want to happen. Also, have you considered cases outside the expected flow (edge cases)? What should happen in those cases?
 
-Describe alternatives you've considered:
-A clear and concise description of any alternative solutions or features you've considered.
+Description of alternatives
+Describe alternatives you have considered: We need a clear and concise description of any alternative solutions or features you have considered.
 
 Additional context:
 Add any other context or explanation about the feature request here.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -17,7 +17,7 @@ If your Stream or Task data pipeline includes custom apps and there's a problem 
 To Reproduce:
 Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It'd help us to relate to the problem more easily. 
 
-creenshots:
+Screenshots:
 Where applicable, add screenshots to help explain your problem.
 
 Additional context:

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is. Additionally, it'd help if y
 There's an [API](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's [About](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard) tab, so make sure to include the copied JSON in the bug report.
 
 **Custom Apps**
-If your Stream or Task data pipeline include custom apps and there's a problem associated with it, it'd be good to review the sample App and the release versions in use. Make sure to include the register, create, and deploy/launch DSL commands for completeness.
+If your Stream or Task data pipeline includes custom apps and there's a problem associated with it, it'd be good to review the sample-app (add a link to GitHub repo) and the release versions in use. Make sure to also share the register, create, and deploy/launch DSL commands for completeness.
 
 **To Reproduce**
 Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It'd help us to relate to the problem more easily. 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,43 +1,42 @@
 <!-- Thanks for the interest in Spring Cloud Data Flow! Before you create a new issue, please answer the following question.-->
 
-**Is this a "Bug Report" or "Feature Request"?** _(choose one and remove the irrelevant sections before submitting the issue)_:
+**Is this a "Bug Report" or "Feature Request"?** (choose one and remove the irrelevant sections before submitting the issue):
 
 <!--
 If this is a "Bug Report", please:
 
-**Describe**
-A clear and concise description of what the bug is. Additionally, it'd help if you can include the logs and entire stacktrace including the "caused by". _(see [GitHub Mardown](https://guides.github.com/features/mastering-markdown/) for logs/code formatting guidelines)_
+Describe:
+A clear and concise description of what the bug is. Additionally, it'd help if you can include the logs and entire stacktrace including the "caused by". (see GitHub-Markdown docs at: https://guides.github.com/features/mastering-markdown for logs/code formatting guidelines)_
 
-**Release versions**
-There's an [API](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's [About](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard) tab, so make sure to include the copied JSON in the bug report.
+Release versions:
+There's an API (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's About tab (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard), so make sure to include the copied JSON in the bug report.
 
-**Custom Apps**
+Custom Apps:
 If your Stream or Task data pipeline includes custom apps and there's a problem associated with it, it'd be good to review the sample-app (add a link to GitHub repo) and the release versions in use. Make sure to also share the register, create, and deploy/launch DSL commands for completeness.
 
-**To Reproduce**
+To Reproduce:
 Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It'd help us to relate to the problem more easily. 
 
-**Screenshots**
+creenshots:
 Where applicable, add screenshots to help explain your problem.
 
-**Additional context**
+Additional context:
 Add any other context about the problem here.
 
-
-
+-
 
 If this is a "Feature Request", please:
 
-**Is your feature request related to a problem? Please describe.**
+Is your feature request related to a problem? Please describe:
 A clear and concise description of what the problem is. 
 
-**Describe the solution you'd like**
+Describe the solution you'd like:
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+Describe alternatives you've considered:
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+Additional context:
 Add any other context or explanation about the feature request here.
 
 -->


### PR DESCRIPTION
I'd like to propose a new-issue template to guide the users to complete/share/upload the relevant details before submitting a new issue. There are two different paths the users can take and the assumption is that they'd delete the irrelevant sections when opening a new issue.

Based on [GitHub's guide](https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/), I'm adding the template to the `.github` folder. 

Once when it is available in the repo, we would then be able to see it show up when creating a new issue. In other words, I wasn't able to verify it yet.