### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Description:
+A clear and concise description of what the bug is. Additionally, it would help if you could include the logs and the entire stacktrace, including the "caused by" portion. (see GitHub-Markdown docs at: https://guides.github.com/features/mastering-markdown for logs/code formatting guidelines)
+
+Release versions:
+There is an API (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#api-guide-resources-server-meta-retrieving) to gather SCDF's system information, including the dependent projects and the associated versions. Alternatively, you can capture this information from the Dashboard's About tab (http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#dashboard). Please be sure to include the copied JSON in the bug report.
+
+Custom apps:
+If your Stream or Task data pipeline includes custom apps and there is a problem associated with it, please share the sample-app (add a link to the GitHub repo) and the release versions in use. Also, please be sure to share the register, create, and deploy/launch DSL commands for completeness.
+
+Steps to reproduce:
+Include the steps to reproduce the behavior. Better yet, if you have a reproducible sample, please attach it in the issue. It can help us to relate to the problem more easily.
+
+Screenshots:
+Where applicable, add screenshots to help explain your problem.
+
+Additional context:
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+Problem description:
+Is your feature request related to a problem? Please provide a clear and concise description of what the problem is. 
+
+Solution description:
+Describe the solution you would like. We need a clear and concise description of what you want to happen. Also, have you considered cases outside the expected flow (edge cases)? What should happen in those cases?
+
+Description of alternatives:
+Describe alternatives you have considered: We need a clear and concise description of any alternative solutions or features you have considered.
+
+Additional context:
+Add any other context or explanation about the feature request here.


### PR DESCRIPTION
This proposal adds "Bug Report" and "Feature Request" as two different issue templates. 

It supersedes what was originally attempted via https://github.com/spring-cloud/spring-cloud-dataflow/pull/2496.