### PR TITLE
Task execution resource exitCode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
 		<spring-cloud-skipper.version>1.1.0.RELEASE</spring-cloud-skipper.version>
 
-		<spring-cloud-task.version>1.3.0.RELEASE</spring-cloud-task.version>
+		<spring-cloud-task.version>1.3.1.BUILD-SNAPSHOT</spring-cloud-task.version>
 
 		<!-- Note: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
 		     are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  *
  * @author Glenn Renfro
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
 public class TaskExecutionResource extends ResourceSupport {
 
@@ -44,7 +45,7 @@ public class TaskExecutionResource extends ResourceSupport {
 	/**
 	 * The recorded exit code for the task.
 	 */
-	private int exitCode;
+	private Integer exitCode;
 
 	/**
 	 * User defined name for the task.
@@ -145,7 +146,7 @@ public class TaskExecutionResource extends ResourceSupport {
 	 * @return the int containing the exit code of the task application upon completion.
 	 * Default is 0.
 	 */
-	public int getExitCode() {
+	public Integer getExitCode() {
 		return exitCode;
 	}
 
@@ -203,12 +204,8 @@ public class TaskExecutionResource extends ResourceSupport {
 			return TaskExecutionStatus.RUNNING;
 		}
 		else {
-			if (this.exitCode == 0) {
-				return TaskExecutionStatus.COMPLETE;
-			}
-			else {
-				return TaskExecutionStatus.ERROR;
-			}
+			return (this.exitCode == null) ? TaskExecutionStatus.RUNNING :
+					((this.exitCode == 0) ? TaskExecutionStatus.COMPLETE : TaskExecutionStatus.ERROR);
 		}
 	}
 

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.springframework.cloud.task.repository.TaskExecution;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Provides tests for the {@link TaskExecutionResourceTests} class.
@@ -50,6 +51,7 @@ public class TaskExecutionResourceTests {
 		taskExecution.setStartTime(new Date());
 		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
 		assertEquals(TaskExecutionStatus.RUNNING, taskExecutionResource.getTaskExecutionStatus());
+		assertNull(taskExecutionResource.getExitCode());
 	}
 
 	@Test


### PR DESCRIPTION
  - Change the `exitCode` type to `Integer`
  - Update the code to handle the TaskExecutionStatus based on `exitCode`

Resolves #2510