### PR TITLE
Remove explicit dep definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,12 +150,6 @@
 				<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
 				<version>${spring-cloud-common-security-config.version}</version>
 			</dependency>
-			<!-- looks like starter doesn't override version pulled by skipper? do this temporarily for now -->
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-common-security-config-web</artifactId>
-				<version>${spring-cloud-common-security-config.version}</version>
-			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>


### PR DESCRIPTION
- Looks like it's not needed anymore to re-define
  spring-cloud-common-security-config-web in a main pom. I believe
  trouble during a boot2 works was that dependencies we horrible
  broken some still being on boot1, etc.
- Maven dep tree is now same when this is removed from pom.
- Fixes #2537