### PR TITLE
Revisit use of Optional in repositories

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditRecordService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/AuditRecordService.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.audit.service;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.cloud.dataflow.server.audit.domain.AuditActionType;
 import org.springframework.cloud.dataflow.server.audit.domain.AuditOperationType;
@@ -94,6 +95,6 @@ public interface AuditRecordService {
 	 * @param id Must not be null/
 	 * @return Audit Record
 	 */
-	AuditRecord findOne(Long id);
+	Optional<AuditRecord> findById(Long id);
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/DefaultAuditRecordService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/audit/service/DefaultAuditRecordService.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.audit.service;
 
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -110,7 +111,7 @@ public class DefaultAuditRecordService implements AuditRecordService {
 	}
 
 	@Override
-	public AuditRecord findOne(Long id) {
-		return this.auditRecordRepository.findById(id).orElse(null);
+	public Optional<AuditRecord> findById(Long id) {
+		return this.auditRecordRepository.findById(id);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/completion/TapOnDestinationRecoveryStrategy.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/completion/TapOnDestinationRecoveryStrategy.java
@@ -65,7 +65,8 @@ public class TapOnDestinationRecoveryStrategy implements RecoveryStrategy<ParseE
 
 		StreamDefinition streamDefinition = null;
 		if (StringUtils.hasText(streamName)) {
-			streamDefinition = streamDefinitionRepository.findOne(streamName);
+			// streamDefinition = streamDefinitionRepository.findOne(streamName);
+			streamDefinition = streamDefinitionRepository.findById(streamName).orElse(null);
 		}
 		// User has started to type an app name, or at least the stream name is valid
 		if (streamDefinition != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AuditRecordController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AuditRecordController.java
@@ -99,10 +99,8 @@ public class AuditRecordController {
 	@RequestMapping(value = "/{id}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public AuditRecordResource display(@PathVariable("id") Long id) {
-		AuditRecord auditRecord = this.auditRecordService.findOne(id);
-		if (auditRecord == null) {
-			throw new NoSuchAuditRecordException(id);
-		}
+		AuditRecord auditRecord = this.auditRecordService.findById(id)
+				.orElseThrow(() -> new NoSuchAuditRecordException(id));
 		return new Assembler(new PageImpl<>(Collections.singletonList(auditRecord))).toResource(auditRecord);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentController.java
@@ -98,10 +98,8 @@ public class StreamDeploymentController {
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	public ResponseEntity<Void> undeploy(@PathVariable("name") String name) {
-		StreamDefinition stream = this.repository.findOne(name);
-		if (stream == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		this.repository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 		this.streamService.undeployStream(name);
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
@@ -125,10 +123,8 @@ public class StreamDeploymentController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.CREATED)
 	public StreamDeploymentResource info(@PathVariable("name") String name) {
-		StreamDefinition streamDefinition = this.repository.findOne(name);
-		if (streamDefinition == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		StreamDefinition streamDefinition = this.repository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 		StreamDeployment streamDeployment = this.streamService.info(name);
 		Map<StreamDefinition, DeploymentState> streamDeploymentStates =
 				this.streamService.state(Arrays.asList(streamDefinition));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -167,10 +167,8 @@ public class TaskDefinitionController {
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public TaskDefinitionResource display(@PathVariable("name") String name) {
-		TaskDefinition definition = repository.findOne(name);
-		if (definition == null) {
-			throw new NoSuchTaskDefinitionException(name);
-		}
+		TaskDefinition definition = this.repository.findById(name)
+				.orElseThrow(() -> new NoSuchTaskDefinitionException(name));
 		final TaskExecution taskExecution = this.explorer.getLatestTaskExecutionForTaskName(name);
 
 		if (taskExecution != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -121,9 +121,8 @@ public class TaskExecutionController {
 	@ResponseStatus(HttpStatus.OK)
 	public PagedResources<TaskExecutionResource> retrieveTasksByName(@RequestParam("name") String taskName,
 			Pageable pageable, PagedResourcesAssembler<TaskJobExecutionRel> assembler) {
-		if (this.taskDefinitionRepository.findOne(taskName) == null) {
-			throw new NoSuchTaskDefinitionException(taskName);
-		}
+		this.taskDefinitionRepository.findById(taskName)
+				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskName));
 		Page<TaskExecution> taskExecutions = this.explorer.findTaskExecutionsByName(taskName, pageable);
 		Page<TaskJobExecutionRel> result = getPageableRelationships(taskExecutions, pageable);
 		return assembler.toResource(result, this.taskAssembler);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DeploymentIdRepository.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.repository;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 /**
@@ -42,7 +44,7 @@ public interface DeploymentIdRepository extends org.springframework.data.reposit
 	 * @param key the app deployment key
 	 * @return the identifier
 	 */
-	String findOne(String key);
+	Optional<String> findByKey(String key);
 
 	/**
 	 * Delete the entries associated with the app deployment key.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsDeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsDeploymentIdRepository.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.server.repository;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Optional;
 
 import javax.sql.DataSource;
 
@@ -60,7 +61,7 @@ public class RdbmsDeploymentIdRepository extends AbstractRdbmsKeyValueRepository
 	}
 
 	@Override
-	public String findOne(String key) {
-		return findById(key).orElse(null);
+	public Optional<String> findByKey(String key) {
+		return findById(key);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepository.java
@@ -46,7 +46,7 @@ public class RdbmsStreamDefinitionRepository extends AbstractRdbmsKeyValueReposi
 	@Override
 	public <S extends StreamDefinition> S save(S definition) {
 		Assert.notNull(definition, "definition must not be null");
-		if (exists(definition.getName())) {
+		if (existsById(definition.getName())) {
 			throw new DuplicateStreamDefinitionException(String.format(
 					"Cannot create stream %s because another one has already " + "been created with the same name",
 					definition.getName()));
@@ -59,6 +59,6 @@ public class RdbmsStreamDefinitionRepository extends AbstractRdbmsKeyValueReposi
 	@Override
 	public void delete(StreamDefinition definition) {
 		Assert.notNull(definition, "definition must not null");
-		delete(definition.getName());
+		deleteById(definition.getName());
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/RdbmsTaskDefinitionRepository.java
@@ -47,7 +47,7 @@ public class RdbmsTaskDefinitionRepository extends AbstractRdbmsKeyValueReposito
 	@Override
 	public <S extends TaskDefinition> S save(S definition) {
 		Assert.notNull(definition, "definition must not be null");
-		if (exists(definition.getName())) {
+		if (existsById(definition.getName())) {
 			throw new DuplicateTaskException(String.format(
 					"Cannot register task %s because another one has already " + "been registered with the same name",
 					definition.getName()));
@@ -60,15 +60,13 @@ public class RdbmsTaskDefinitionRepository extends AbstractRdbmsKeyValueReposito
 	@Override
 	public void delete(TaskDefinition definition) {
 		Assert.notNull(definition, "definition must not null");
-		delete(definition.getName());
+		deleteById(definition.getName());
 	}
 
 	@Override
 	public TaskDefinition findByNameRequired(String name) {
-		TaskDefinition definition = this.findOne(name);
-		if (definition == null) {
-			throw new NoSuchTaskDefinitionException(name);
-		}
-		return definition;
+		return this.findById(name).orElseThrow(() ->
+			new NoSuchTaskDefinitionException(name)
+		);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
@@ -31,28 +31,4 @@ import org.springframework.stereotype.Repository;
 public interface StreamDefinitionRepository extends PagingAndSortingRepository<StreamDefinition, String> {
 
 	Page<StreamDefinition> findByNameLike(SearchPageable searchPageable);
-
-	default StreamDefinition findOne(String id) {
-		return (StreamDefinition) findById(id).orElse(null);
-	}
-
-	default void delete(String id) {
-		deleteById(id);
-	}
-
-	default boolean exists(String id) {
-		return existsById(id);
-	}
-
-	default Iterable<StreamDefinition> save(Iterable<StreamDefinition> entities) {
-		return saveAll(entities);
-	}
-
-	default Iterable<StreamDefinition> findAll(Iterable<String> ids) {
-		return findAllById(ids);
-	}
-
-	default void delete(Iterable<StreamDefinition> entities) {
-		deleteAll(entities);
-	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
@@ -30,30 +30,6 @@ public interface TaskDefinitionRepository extends PagingAndSortingRepository<Tas
 
 	Page<TaskDefinition> findByNameLike(SearchPageable searchPageable);
 
-	default TaskDefinition findOne(String id) {
-		return findById(id).orElse(null);
-	}
-
-	default void delete(String id) {
-		deleteById(id);
-	}
-
-	default boolean exists(String id) {
-		return existsById(id);
-	}
-
-	default Iterable<TaskDefinition> save(Iterable<TaskDefinition> entities) {
-		return saveAll(entities);
-	}
-
-	default Iterable<TaskDefinition> findAll(Iterable<String> ids) {
-		return findAllById(ids);
-	}
-
-	default void delete(Iterable<TaskDefinition> entities) {
-		deleteAll(entities);
-	}
-
 	/**
 	 * Performs a findByName query and throws an exception if the name is not found.
 	 * @param name the name of the task definition

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/AbstractStreamService.java
@@ -96,6 +96,7 @@ public abstract class AbstractStreamService implements StreamService {
 		this.auditServiceUtils = new AuditServiceUtils();
 	}
 
+	@Override
 	public StreamDefinition createStream(String streamName, String dsl, boolean deploy) {
 		StreamDefinition streamDefinition = createStreamDefinition(streamName, dsl);
 		List<String> errorMessages = new ArrayList<>();
@@ -144,10 +145,8 @@ public abstract class AbstractStreamService implements StreamService {
 		if (deploymentProperties == null) {
 			deploymentProperties = new HashMap<>();
 		}
-		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(name);
-		if (streamDefinition == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 
 		DeploymentState status = this.doCalculateStreamState(name);
 
@@ -171,12 +170,10 @@ public abstract class AbstractStreamService implements StreamService {
 
 	@Override
 	public void deleteStream(String name) {
-		final StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(name);
-		if (streamDefinition == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		final StreamDefinition streamDefinition = this.streamDefinitionRepository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 		this.undeployStream(name);
-		this.streamDefinitionRepository.delete(name);
+		this.streamDefinitionRepository.deleteById(name);
 
 		auditRecordService.populateAndSaveAuditRecord(
 				AuditOperationType.STREAM, AuditActionType.DELETE,
@@ -201,10 +198,8 @@ public abstract class AbstractStreamService implements StreamService {
 	@Override
 	public List<StreamDefinition> findRelatedStreams(String name, boolean nested) {
 		Set<StreamDefinition> relatedDefinitions = new LinkedHashSet<>();
-		StreamDefinition currentStreamDefinition = streamDefinitionRepository.findOne(name);
-		if (currentStreamDefinition == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		StreamDefinition currentStreamDefinition = streamDefinitionRepository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 		Iterable<StreamDefinition> definitions = streamDefinitionRepository.findAll();
 		List<StreamDefinition> result = new ArrayList<>(findRelatedDefinitions(currentStreamDefinition, definitions,
 				relatedDefinitions, nested));
@@ -253,11 +248,8 @@ public abstract class AbstractStreamService implements StreamService {
 
 	@Override
 	public StreamDefinition findOne(String streamDefinitionName) {
-		StreamDefinition definition = streamDefinitionRepository.findOne(streamDefinitionName);
-		if (definition == null) {
-			throw new NoSuchStreamDefinitionException(streamDefinitionName);
-		}
-		return definition;
+		return streamDefinitionRepository.findById(streamDefinitionName)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(streamDefinitionName));
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -109,10 +109,8 @@ public class DefaultSchedulerService implements SchedulerService {
 			List<String> commandLineArgs) {
 		Assert.hasText(taskDefinitionName, "The provided taskName must not be null or empty.");
 		Assert.notNull(taskDeploymentProperties, "The provided taskDeploymentProperties must not be null.");
-		TaskDefinition taskDefinition = this.taskDefinitionRepository.findOne(taskDefinitionName);
-		if (taskDefinition == null) {
-			throw new NoSuchTaskDefinitionException(taskDefinitionName);
-		}
+		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskDefinitionName)
+				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
 		TaskParser taskParser = new TaskParser(taskDefinition.getName(), taskDefinition.getDslText(), true, true);
 		TaskNode taskNode = taskParser.parse();
 		// if composed task definition replace definition with one composed task
@@ -223,10 +221,8 @@ public class DefaultSchedulerService implements SchedulerService {
 	}
 
 	protected Resource getTaskResource(String taskDefinitionName) {
-		TaskDefinition taskDefinition = this.taskDefinitionRepository.findOne(taskDefinitionName);
-		if (taskDefinition == null) {
-			throw new NoSuchTaskDefinitionException(taskDefinitionName);
-		}
+		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskDefinitionName)
+				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
 		AppRegistration appRegistration = null;
 		if (TaskServiceUtils.isComposedTaskDefinition(taskDefinition.getDslText())) {
 			appRegistration = this.registry.find(taskConfigurationProperties.getComposedTaskRunnerName(),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
@@ -139,7 +139,8 @@ public class DefaultSkipperStreamService extends AbstractStreamService implement
 
 	@Override
 	public void undeployStream(String streamName) {
-		final StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(streamName);
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findById(streamName)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(streamName));
 
 		this.skipperStreamDeployer.undeployStream(streamName);
 
@@ -160,7 +161,8 @@ public class DefaultSkipperStreamService extends AbstractStreamService implement
 			appManifestMap.put(name, am);
 		}
 
-		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(streamName);
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findById(streamName)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(streamName));
 
 		LinkedList<StreamAppDefinition> updatedStreamAppDefinitions = new LinkedList<>();
 		for (StreamAppDefinition appDefinition : streamDefinition.getAppDefinitions()) {
@@ -194,10 +196,8 @@ public class DefaultSkipperStreamService extends AbstractStreamService implement
 	public void updateStream(String streamName, String releaseName, PackageIdentifier packageIdentifier,
 			Map<String, String> updateProperties, boolean force, List<String> appNames) {
 
-		StreamDefinition streamDefinition = this.streamDefinitionRepository.findOne(streamName);
-		if (streamDefinition == null) {
-			throw new NoSuchStreamDefinitionException(streamName);
-		}
+		StreamDefinition streamDefinition = this.streamDefinitionRepository.findById(streamName)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(streamName));
 
 		String updateYaml = convertPropertiesToSkipperYaml(streamDefinition, updateProperties);
 		Release release = this.skipperStreamDeployer.upgradeStream(releaseName, packageIdentifier, updateYaml,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -216,13 +216,8 @@ public class DefaultTaskJobService implements TaskJobService {
 		}
 
 		TaskExecution taskExecution = this.taskExplorer.getTaskExecution(taskJobExecution.getTaskId());
-
-		TaskDefinition taskDefinition = this.taskDefinitionRepository.findOne(taskExecution.getTaskName());
-
-		if (taskDefinition == null) {
-			throw new NoSuchTaskDefinitionException(taskExecution.getTaskName());
-		}
-
+		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskExecution.getTaskName())
+				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskExecution.getTaskName()));
 		taskService.executeTask(taskDefinition.getName(), taskDefinition.getProperties(), taskExecution.getArguments());
 	}
 
@@ -267,7 +262,6 @@ public class DefaultTaskJobService implements TaskJobService {
 	private boolean isTaskDefined(JobExecution jobExecution) {
 		TaskExecution taskExecution = taskExplorer
 				.getTaskExecution(taskExplorer.getTaskExecutionIdByJobExecutionId(jobExecution.getId()));
-		TaskDefinition definition = taskDefinitionRepository.findOne(taskExecution.getTaskName());
-		return (definition != null);
+		return taskDefinitionRepository.findById(taskExecution.getTaskName()).isPresent();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DefaultStreamValidationService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DefaultStreamValidationService.java
@@ -45,10 +45,8 @@ public class DefaultStreamValidationService extends DefaultValidationService imp
 
 	@Override
 	public ValidationStatus validateStream(String name) {
-		StreamDefinition definition = streamDefinitionRepository.findOne(name);
-		if (definition == null) {
-			throw new NoSuchStreamDefinitionException(name);
-		}
+		StreamDefinition definition = streamDefinitionRepository.findById(name)
+				.orElseThrow(() -> new NoSuchStreamDefinitionException(name));
 		ValidationStatus validationStatus = new ValidationStatus(
 				definition.getName(),
 				definition.getDslText());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -170,7 +170,7 @@ public class StreamControllerTests {
 		mockMvc.perform(post("/streams/definitions/").param("name", "myStream").param("definition", "time | log")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals("time | log", myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(2, myStream.getAppDefinitions().size());
@@ -191,7 +191,7 @@ public class StreamControllerTests {
 				.param("definition", "time --some.password=foobar --another-secret=kenny | log")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream2");
+		StreamDefinition myStream = repository.findById("myStream2").get();
 		final List<AuditRecord> auditRecords = auditRecordRepository.findAll();
 
 		assertEquals(1, auditRecords.size());
@@ -463,7 +463,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		StreamAppDefinition timeDefinition = myStream.getAppDefinitions().get(0);
 		StreamAppDefinition logDefinition = myStream.getAppDefinitions().get(1);
 		assertEquals("time", timeDefinition.getName());
@@ -483,7 +483,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(3, myStream.getAppDefinitions().size());
@@ -512,7 +512,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(1, myStream.getAppDefinitions().size());
@@ -531,7 +531,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(2, myStream.getAppDefinitions().size());
@@ -556,7 +556,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(1, myStream.getAppDefinitions().size());
@@ -574,7 +574,7 @@ public class StreamControllerTests {
 				.param("definition", definition)
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(2, myStream.getAppDefinitions().size());
@@ -601,7 +601,7 @@ public class StreamControllerTests {
 				.param("deploy", "true").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isCreated());
 		assertEquals(1, repository.count());
-		StreamDefinition myStream = repository.findOne("myStream");
+		StreamDefinition myStream = repository.findById("myStream").get();
 		assertEquals(definition, myStream.getDslText());
 		assertEquals("myStream", myStream.getName());
 		assertEquals(1, myStream.getAppDefinitions().size());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.server.controller;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -152,7 +153,7 @@ public class StreamDeploymentControllerTests {
 				new JSONObject(streamDeploymentProperties).toString());
 		Map<StreamDefinition, DeploymentState> streamDeploymentStates = new HashMap<>();
 		streamDeploymentStates.put(streamDefinition, DeploymentState.deployed);
-		when(this.streamDefinitionRepository.findOne(streamDefinition.getName())).thenReturn(streamDefinition);
+		when(this.streamDefinitionRepository.findById(streamDefinition.getName())).thenReturn(Optional.of(streamDefinition));
 		when(this.skipperStreamService.info(streamDefinition.getName())).thenReturn(streamDeployment);
 		when(this.skipperStreamService.state(anyListOf(StreamDefinition.class))).thenReturn(streamDeploymentStates);
 		StreamDeploymentResource streamDeploymentResource = this.controller.info(streamDefinition.getName());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -166,7 +166,7 @@ public class TaskControllerTests {
 
 		assertEquals(1, repository.count());
 
-		TaskDefinition myTask = repository.findOne("myTask");
+		TaskDefinition myTask = repository.findById("myTask").get();
 
 		assertEquals(1, myTask.getProperties().size());
 		assertEquals("myTask", myTask.getProperties().get("spring.cloud.task.name"));
@@ -193,7 +193,7 @@ public class TaskControllerTests {
 
 		assertEquals(1, repository.count());
 
-		TaskDefinition myTask = repository.findOne("myTask");
+		TaskDefinition myTask = repository.findById("myTask").get();
 
 		assertEquals("bar", myTask.getProperties().get("foo"));
 		assertEquals("baz", myTask.getProperties().get("bar"));
@@ -212,13 +212,13 @@ public class TaskControllerTests {
 
 		assertEquals(3, repository.count());
 
-		TaskDefinition myTask1 = repository.findOne("myTask-t1");
+		TaskDefinition myTask1 = repository.findById("myTask-t1").get();
 		assertEquals("bar rab", myTask1.getProperties().get("foo"));
 		assertEquals("task --foo='bar rab'", myTask1.getDslText());
 		assertEquals("task", myTask1.getRegisteredAppName());
 		assertEquals("myTask-t1", myTask1.getName());
 
-		TaskDefinition myTask2 = repository.findOne("myTask-t2");
+		TaskDefinition myTask2 = repository.findById("myTask-t2").get();
 		assertEquals("one two", myTask2.getProperties().get("foo"));
 		assertEquals("task --foo='one two'", myTask2.getDslText());
 		assertEquals("task", myTask2.getRegisteredAppName());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/AbstractTaskDefinitionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/AbstractTaskDefinitionTests.java
@@ -27,10 +27,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -50,7 +49,7 @@ public abstract class AbstractTaskDefinitionTests {
 		repository.save(new TaskDefinition("task2", "myTask"));
 		repository.save(new TaskDefinition("task3", "myTask"));
 
-		assertEquals(definition, repository.findOne("task1"));
+		assertThat(repository.findById("task1")).hasValue(definition);
 	}
 
 	@Test
@@ -92,26 +91,26 @@ public abstract class AbstractTaskDefinitionTests {
 		definitions.add(new TaskDefinition("task1", "myTask"));
 
 		repository.save(new TaskDefinition("task1", "myTask"));
-		repository.save(definitions);
+		repository.saveAll(definitions);
 	}
 
 	@Test
 	public void testFindOneNoneFound() {
-		assertNull(repository.findOne("notFound"));
+		assertThat(repository.findById("notfound")).isEmpty();
 
 		initializeRepository();
 
-		assertNull(repository.findOne("notFound"));
+		assertThat(repository.findById("notfound")).isEmpty();
 	}
 
 	@Test
 	public void testExists() {
-		assertFalse(repository.exists("exists"));
+		assertFalse(repository.existsById("exists"));
 
 		repository.save(new TaskDefinition("exists", "myExists"));
 
-		assertTrue(repository.exists("exists"));
-		assertFalse(repository.exists("nothere"));
+		assertTrue(repository.existsById("exists"));
+		assertFalse(repository.existsById("nothere"));
 	}
 
 	@Test
@@ -141,7 +140,7 @@ public abstract class AbstractTaskDefinitionTests {
 		names.add("task1");
 		names.add("task2");
 
-		Iterable<TaskDefinition> items = repository.findAll(names);
+		Iterable<TaskDefinition> items = repository.findAllById(names);
 
 		int count = 0;
 		for (@SuppressWarnings("unused")
@@ -163,42 +162,42 @@ public abstract class AbstractTaskDefinitionTests {
 
 	@Test
 	public void testDeleteNotFound() {
-		repository.delete("notFound");
+		repository.deleteById("notFound");
 	}
 
 	@Test
 	public void testDelete() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("task2"));
+		assertThat(repository.findById("task2")).isNotEmpty();
 
-		repository.delete("task2");
+		repository.deleteById("task2");
 
-		assertNull(repository.findOne("task2"));
+		assertThat(repository.findById("task2")).isEmpty();
 	}
 
 	@Test
 	public void testDeleteDefinition() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("task2"));
+		assertThat(repository.findById("task2")).isNotEmpty();
 
 		repository.delete(new TaskDefinition("task2", "myTask"));
 
-		assertNull(repository.findOne("task2"));
+		assertThat(repository.findById("task2")).isEmpty();
 	}
 
 	@Test
 	public void testDeleteMultipleDefinitions() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("task1"));
-		assertNotNull(repository.findOne("task2"));
+		assertThat(repository.findById("task1")).isNotEmpty();
+		assertThat(repository.findById("task2")).isNotEmpty();
 
-		repository.delete(Arrays.asList(new TaskDefinition("task1", "myTask"), new TaskDefinition("task2", "myTask")));
+		repository.deleteAll(Arrays.asList(new TaskDefinition("task1", "myTask"), new TaskDefinition("task2", "myTask")));
 
-		assertNull(repository.findOne("task1"));
-		assertNull(repository.findOne("task2"));
+		assertThat(repository.findById("task1")).isEmpty();
+		assertThat(repository.findById("task2")).isEmpty();
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepository.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.server.repository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.util.Assert;
@@ -42,8 +43,8 @@ public class InMemoryDeploymentIdRepository implements DeploymentIdRepository {
 	}
 
 	@Override
-	public String findOne(String key) {
-		return deployments.get(key);
+	public Optional<String> findByKey(String key) {
+		return Optional.ofNullable(deployments.get(key));
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryDeploymentIdRepositoryTests.java
@@ -56,24 +56,24 @@ public class InMemoryDeploymentIdRepositoryTests {
 		repository.save(appDeploymentKey2, "id2");
 		repository.save(appDeploymentKey5, "id3");
 
-		String findOne1 = repository.findOne(appDeploymentKey1);
+		String findOne1 = repository.findByKey(appDeploymentKey1).get();
 		assertThat(findOne1, notNullValue());
 		assertThat(findOne1, is("id1"));
-		String findOne2 = repository.findOne(appDeploymentKey3);
+		String findOne2 = repository.findByKey(appDeploymentKey3).get();
 		assertThat(findOne2, notNullValue());
 		assertThat(findOne2, is("id1"));
 
-		String findOne3 = repository.findOne(appDeploymentKey2);
+		String findOne3 = repository.findByKey(appDeploymentKey2).get();
 		assertThat(findOne3, notNullValue());
 		assertThat(findOne3, is("id2"));
-		String findOne4 = repository.findOne(appDeploymentKey4);
+		String findOne4 = repository.findByKey(appDeploymentKey4).get();
 		assertThat(findOne4, notNullValue());
 		assertThat(findOne4, is("id2"));
 
-		String findOne5 = repository.findOne(appDeploymentKey5);
+		String findOne5 = repository.findByKey(appDeploymentKey5).get();
 		assertThat(findOne5, notNullValue());
 		assertThat(findOne5, is("id3"));
-		String findOne6 = repository.findOne(appDeploymentKey6);
+		String findOne6 = repository.findByKey(appDeploymentKey6).get();
 		assertThat(findOne6, notNullValue());
 		assertThat(findOne6, is("id3"));
 	}
@@ -93,8 +93,8 @@ public class InMemoryDeploymentIdRepositoryTests {
 		repository.save(appDeploymentKey2, "id2");
 		repository.save(appDeploymentKey3, "id3");
 		repository.delete(appDeploymentKey1);
-		assertThat(repository.findOne(appDeploymentKey1), nullValue());
-		assertThat(repository.findOne(appDeploymentKey2), notNullValue());
-		assertThat(repository.findOne(appDeploymentKey3), notNullValue());
+		assertThat(repository.findByKey(appDeploymentKey1).orElse(null), nullValue());
+		assertThat(repository.findByKey(appDeploymentKey2).get(), notNullValue());
+		assertThat(repository.findByKey(appDeploymentKey3).get(), notNullValue());
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryStreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryStreamDefinitionRepository.java
@@ -76,11 +76,6 @@ public class InMemoryStreamDefinitionRepository implements StreamDefinitionRepos
 	}
 
 	@Override
-	public StreamDefinition findOne(String name) {
-		return definitions.get(name);
-	}
-
-	@Override
 	public boolean existsById(String name) {
 		return definitions.containsKey(name);
 	}
@@ -112,13 +107,8 @@ public class InMemoryStreamDefinitionRepository implements StreamDefinitionRepos
 	}
 
 	@Override
-	public void delete(String name) {
-		definitions.remove(name);
-	}
-
-	@Override
 	public void delete(StreamDefinition definition) {
-		delete(definition.getName());
+		deleteById(definition.getName());
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryTaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/InMemoryTaskDefinitionRepository.java
@@ -78,11 +78,6 @@ public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepositor
 	}
 
 	@Override
-	public TaskDefinition findOne(String name) {
-		return definitions.get(name);
-	}
-
-	@Override
 	public boolean existsById(String name) {
 		return definitions.containsKey(name);
 	}
@@ -114,13 +109,8 @@ public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepositor
 	}
 
 	@Override
-	public void delete(String name) {
-		definitions.remove(name);
-	}
-
-	@Override
 	public void delete(TaskDefinition definition) {
-		delete(definition.getName());
+		deleteById(definition.getName());
 	}
 
 	@Override
@@ -142,11 +132,6 @@ public class InMemoryTaskDefinitionRepository implements TaskDefinitionRepositor
 
 	@Override
 	public TaskDefinition findByNameRequired(String name) {
-		TaskDefinition definition = this.findOne(name);
-		if (definition == null) {
-			throw new NoSuchTaskDefinitionException(name);
-		}
-		return definition;
+		return this.findById(name).orElseThrow(() -> new NoSuchTaskDefinitionException(name));
 	}
-
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsDeploymentIdRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsDeploymentIdRepositoryTests.java
@@ -63,7 +63,7 @@ public class RdbmsDeploymentIdRepositoryTests {
 		repository.save("key1", "time.1");
 		repository.save("key2", "log.0");
 
-		assertEquals("log.0", repository.findOne("key2"));
+		assertEquals("log.0", repository.findByKey("key2").get());
 	}
 
 	@Test
@@ -71,9 +71,9 @@ public class RdbmsDeploymentIdRepositoryTests {
 		repository.save("key1", "time.1");
 		repository.save("key2", "log.0");
 
-		assertEquals("log.0", repository.findOne("key2"));
+		assertEquals("log.0", repository.findByKey("key2").get());
 		repository.delete("key2");
-		assertNull(repository.findOne("key2"));
+		assertNull(repository.findByKey("key2").orElse(null));
 	}
 
 	@Configuration

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepositoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/RdbmsStreamDefinitionRepositoryTests.java
@@ -44,11 +44,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Glenn Renfro
@@ -84,9 +82,9 @@ public class RdbmsStreamDefinitionRepositoryTests {
 		repository.save(definition2);
 		repository.save(definition3);
 
-		assertEquals(definition1, repository.findOne("stream1"));
-		assertEquals(definition2, repository.findOne("stream2"));
-		assertEquals(definition3, repository.findOne("stream3"));
+		assertThat(repository.findById("stream1")).hasValue(definition1);
+		assertThat(repository.findById("stream2")).hasValue(definition2);
+		assertThat(repository.findById("stream3")).hasValue(definition3);
 	}
 
 	@Test
@@ -128,26 +126,26 @@ public class RdbmsStreamDefinitionRepositoryTests {
 		definitions.add(new StreamDefinition("stream1", "time | log"));
 
 		repository.save(new StreamDefinition("stream1", "time | log"));
-		repository.save(definitions);
+		repository.saveAll(definitions);
 	}
 
 	@Test
 	public void testFindOneNoneFound() {
-		assertNull(repository.findOne("notFound"));
+		assertThat(repository.findById("notfound")).isEmpty();
 
 		initializeRepository();
 
-		assertNull(repository.findOne("notFound"));
+		assertThat(repository.findById("notfound")).isEmpty();
 	}
 
 	@Test
 	public void testExists() {
-		assertFalse(repository.exists("exists"));
+		assertThat(repository.existsById("exists")).isFalse();
 
 		repository.save(new StreamDefinition("exists", "time | log"));
 
-		assertTrue(repository.exists("exists"));
-		assertFalse(repository.exists("nothere"));
+		assertThat(repository.existsById("exists")).isTrue();
+		assertThat(repository.existsById("nothere")).isFalse();
 	}
 
 	@Test
@@ -177,7 +175,7 @@ public class RdbmsStreamDefinitionRepositoryTests {
 		names.add("stream1");
 		names.add("stream2");
 
-		Iterable<StreamDefinition> items = repository.findAll(names);
+		Iterable<StreamDefinition> items = repository.findAllById(names);
 
 		int count = 0;
 		for (@SuppressWarnings("unused")
@@ -199,43 +197,43 @@ public class RdbmsStreamDefinitionRepositoryTests {
 
 	@Test
 	public void testDeleteNotFound() {
-		repository.delete("notFound");
+		repository.deleteById("notFound");
 	}
 
 	@Test
 	public void testDelete() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream2")).isNotEmpty();
 
-		repository.delete("stream2");
+		repository.deleteById("stream2");
 
-		assertNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream2")).isEmpty();
 	}
 
 	@Test
 	public void testDeleteDefinition() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream2")).isNotEmpty();
 
 		repository.delete(new StreamDefinition("stream2", "time | log"));
 
-		assertNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream2")).isEmpty();
 	}
 
 	@Test
 	public void testDeleteMultipleDefinitions() {
 		initializeRepository();
 
-		assertNotNull(repository.findOne("stream1"));
-		assertNotNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream1")).isNotEmpty();
+		assertThat(repository.findById("stream2")).isNotEmpty();
 
-		repository.delete(Arrays.asList(new StreamDefinition("stream1", "time | log"),
+		repository.deleteAll(Arrays.asList(new StreamDefinition("stream1", "time | log"),
 				new StreamDefinition("stream2", "time | log")));
 
-		assertNull(repository.findOne("stream1"));
-		assertNull(repository.findOne("stream2"));
+		assertThat(repository.findById("stream1")).isEmpty();
+		assertThat(repository.findById("stream2")).isEmpty();
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.After;
@@ -299,7 +300,7 @@ public class DefaultSchedulerServiceTests {
 
 		TaskDefinition taskDefinition = new TaskDefinition(BASE_DEFINITION_NAME, "timestamp");
 
-		when(mockTaskDefinitionRepository.findOne(BASE_DEFINITION_NAME)).thenReturn(taskDefinition);
+		when(mockTaskDefinitionRepository.findById(BASE_DEFINITION_NAME)).thenReturn(Optional.of(taskDefinition));
 		when(mockAppRegistryCommon.find(taskDefinition.getRegisteredAppName(), ApplicationType.task))
 				.thenReturn(new AppRegistration());
 		when(((DefaultSchedulerService)mockSchedulerService).getTaskResource(BASE_DEFINITION_NAME))

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests.java
@@ -172,10 +172,10 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		// Create stream
 		StreamDefinition streamDefinition = new StreamDefinition("ticktock",
 				"time --fixed-delay=100 | log --level=DEBUG");
-		this.streamDefinitionRepository.delete(streamDefinition.getName());
+		this.streamDefinitionRepository.deleteById(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
-		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findOne("ticktock");
+		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionBeforeDeploy.getDslText())
 				.isEqualTo("time --fixed-delay=100 | log --level=DEBUG");
 
@@ -194,7 +194,7 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 
 		streamService.deployStream("ticktock", deploymentProperties);
 
-		StreamDefinition streamDefinitionAfterDeploy = this.streamDefinitionRepository.findOne("ticktock");
+		StreamDefinition streamDefinitionAfterDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionAfterDeploy.getDslText())
 				.isEqualTo("time --trigger.fixed-delay=100 | log --log.level=DEBUG");
 	}
@@ -205,14 +205,14 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		// Create stream
 		StreamDefinition streamDefinition = new StreamDefinition("ticktock",
 				"time --fixed-delay=100 | log --level=DEBUG");
-		this.streamDefinitionRepository.delete(streamDefinition.getName());
+		this.streamDefinitionRepository.deleteById(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
 		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));
 
 		streamService.deployStream("ticktock", createSkipperDeploymentProperties());
 
-		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findOne("ticktock");
+		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionBeforeDeploy.getDslText())
 				.isEqualTo("time --fixed-delay=100 | log --level=DEBUG");
 
@@ -230,7 +230,7 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		streamService.updateStream("ticktock",
 				new UpdateStreamRequest("ticktock", new PackageIdentifier(), deploymentProperties));
 
-		StreamDefinition streamDefinitionAfterDeploy = this.streamDefinitionRepository.findOne("ticktock");
+		StreamDefinition streamDefinitionAfterDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionAfterDeploy.getDslText())
 				.isEqualTo("time --trigger.fixed-delay=200 | log --log.level=INFO");
 	}
@@ -241,7 +241,7 @@ public class DefaultSkipperStreamServiceIntegrationTests {
 		// Create stream
 		StreamDefinition streamDefinition = new StreamDefinition("ticktock",
 				"time --fixed-delay=100 | log --level=DEBUG");
-		this.streamDefinitionRepository.delete(streamDefinition.getName());
+		this.streamDefinitionRepository.deleteById(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
 		when(skipperClient.status(eq("ticktock"))).thenThrow(new ReleaseNotFoundException(""));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -112,7 +113,7 @@ public class DefaultSkipperStreamServiceTests {
 		this.skipperStreamDefinitions.add(streamDefinition2);
 		this.skipperStreamDefinitions.add(streamDefinition3);
 		this.skipperStreamDefinitions.add(streamDefinition4);
-		when(streamDefinitionRepository.findOne("test2")).thenReturn(streamDefinition2);
+		when(streamDefinitionRepository.findById("test2")).thenReturn(Optional.of(streamDefinition2));
 	}
 
 	@Test
@@ -286,7 +287,7 @@ public class DefaultSkipperStreamServiceTests {
 
 		StreamDefinition streamDefinition = new StreamDefinition("test1", "time | log");
 
-		when(streamDefinitionRepository.findOne(streamDefinition.getName())).thenReturn(streamDefinition);
+		when(streamDefinitionRepository.findById(streamDefinition.getName())).thenReturn(Optional.of(streamDefinition));
 
 		List<AppDeploymentRequest> appDeploymentRequests = Arrays.asList(mock(AppDeploymentRequest.class));
 		when(appDeploymentRequestCreator.createRequests(streamDefinition, new HashMap<>()))

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpgradeStreamTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceUpgradeStreamTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.dataflow.server.service.impl;
 
+import java.util.Optional;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -62,7 +64,7 @@ public class DefaultSkipperStreamServiceUpgradeStreamTests {
 	@Test
 	public void verifyUpgradeStream() {
 		if (!PlatformUtils.isWindows()) {
-			when(streamDefinitionRepository.findOne("test2")).thenReturn(streamDefinition2);
+			when(streamDefinitionRepository.findById("test2")).thenReturn(Optional.of(streamDefinition2));
 
 			final UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest(streamDeployment2.getStreamName(), null, null);
 			streamService.updateStream(streamDeployment2.getStreamName(), updateStreamRequest);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -495,14 +495,13 @@ public abstract class DefaultTaskServiceTests {
 
 	private static void verifyTaskExistsInRepo(String taskName, String dsl,
 		TaskDefinitionRepository taskDefinitionRepository) {
-		TaskDefinition taskDefinition = taskDefinitionRepository.findOne(taskName);
+		TaskDefinition taskDefinition = taskDefinitionRepository.findById(taskName).get();
 		assertThat(taskDefinition.getName(), is(equalTo(taskName)));
 		assertThat(taskDefinition.getDslText(), is(equalTo(dsl)));
 	}
 
 	private static boolean wasTaskDefinitionCreated(String taskName,
 		TaskDefinitionRepository taskDefinitionRepository) {
-		TaskDefinition taskDefinition = taskDefinitionRepository.findOne(taskName);
-		return taskDefinition != null;
+		return taskDefinitionRepository.findById(taskName).isPresent();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
 import org.junit.Test;
@@ -117,7 +118,7 @@ public class SkipperStreamDeployerTests {
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				streamDefinitionRepository, appRegistryService, mock(ForkJoinPool.class));
 
-		when(streamDefinitionRepository.findOne("test1")).thenReturn(new StreamDefinition("test1", "t1: time | log"));
+		when(streamDefinitionRepository.findById("test1")).thenReturn(Optional.of(new StreamDefinition("test1", "t1: time | log")));
 		skipperStreamDeployer.deployStream(streamDeploymentRequest);
 
 		ArgumentCaptor<UploadRequest> uploadRequestCaptor = ArgumentCaptor.forClass(UploadRequest.class);
@@ -280,7 +281,7 @@ public class SkipperStreamDeployerTests {
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				streamDefinitionRepository, appRegistryService, mock(ForkJoinPool.class));
 
-		when(streamDefinitionRepository.findOne("test1")).thenReturn(new StreamDefinition("test1", "t1: time | log"));
+		when(streamDefinitionRepository.findById("test1")).thenReturn(Optional.of(new StreamDefinition("test1", "t1: time | log")));
 
 		skipperStreamDeployer.deployStream(streamDeploymentRequest);
 	}
@@ -298,7 +299,7 @@ public class SkipperStreamDeployerTests {
 		StreamDefinition streamDefinition = new StreamDefinition("foo", "foo|bar");
 
 		// Stream is defined
-		when(streamDefinitionRepository.findOne(streamDefinition.getName())).thenReturn(null);
+		when(streamDefinitionRepository.findById(streamDefinition.getName())).thenReturn(Optional.ofNullable(null));
 
 		// Stream is undeployed
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenThrow(new ReleaseNotFoundException(""));
@@ -392,7 +393,7 @@ public class SkipperStreamDeployerTests {
 		StreamDefinition streamDefinition = new StreamDefinition("foo", "foo|bar");
 
 		// Stream is defined
-		when(streamDefinitionRepository.findOne(streamDefinition.getName())).thenReturn(streamDefinition);
+		when(streamDefinitionRepository.findById(streamDefinition.getName())).thenReturn(Optional.of(streamDefinition));
 
 		// Stream is undeployed
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenThrow(new ReleaseNotFoundException(""));


### PR DESCRIPTION
- Remove temprorary default methods added as
  workaround in origin boot2 PR.
- Change repository methods to align to use Optional
  with method types changed in spring data.
- Try to align custom repo interfaces to also use Optional
  where data is accessed via id/key.
- Fixes #2539