### PR TITLE
Update streams.adoc with escaped example link

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -890,7 +890,7 @@ The `transform` application processes the Tuple data and sends the processed dat
 
 Consider the following example of sending some data to the `http` application:
 
-`dataflow:>http post --data {"hello":"world","something":"somethingelse"} --contentType application/json --target http://localhost:<http-port>`
+`dataflow:>http post --data {"hello":"world","something":"somethingelse"} --contentType application/json --target \http://localhost:<http-port>`
 
 At the log application, you see the content as follows:
 


### PR DESCRIPTION
Asciidoc tries to render this example link, creating invalid XML for downstream processing, as the `>` is converted to `&gt;`, however the link attribute generated in XML will cut off before the `;`, causing build errors.  Because this is an invalid link to begin with, escaping it.

Before escaping:
```xml
<literal>dataflow:&gt;http post --data {"hello":"world","something":"somethingelse"} --contentType application/json --target <link xlink:href="http://localhost:&lt;http-port&gt">localhost:&lt;http-port&gt</link>;</literal>
```

After escaping:
```xml
<literal>dataflow:&gt;http post --data {"hello":"world","something":"somethingelse"} --contentType application/json --target http://localhost:&lt;http-port&gt;</literal>
```