### PR TITLE
[ON HOLD] Add support for content assist and unbound apps

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 class AddAppOptionsExpansionStrategy implements ExpansionStrategy {
 
@@ -47,7 +48,8 @@ class AddAppOptionsExpansionStrategy implements ExpansionStrategy {
 	public boolean addProposals(String text, StreamDefinition streamDefinition, int detailLevel,
 			List<CompletionProposal> collector) {
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp,streamDefinition.getAppDefinitions().size() > 1));
 
 		if (appRegistration != null) {
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AppsAfterCommaRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AppsAfterCommaRecoveryStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
+import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+
+/**
+ * Provides completions for the case where the user has entered a comma symbol and an
+ * unbound app reference is expected next.
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class AppsAfterCommaRecoveryStrategy
+		extends StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
+
+	private final AppRegistryCommon appRegistry;
+
+	AppsAfterCommaRecoveryStrategy(AppRegistryCommon appRegistry) {
+		super(CheckPointedParseException.class, "foo ,", "foo , ");
+		this.appRegistry = appRegistry;
+	}
+
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception, int detailLevel,
+			List<CompletionProposal> collector) {
+
+		StreamDefinition streamDefinition = new StreamDefinition("__dummy",
+				exception.getExpressionStringUntilCheckpoint());
+
+		CompletionProposal.Factory proposals = CompletionProposal.expanding(dsl);
+
+		for (AppRegistration appRegistration : appRegistry.findAll()) {
+			if (appRegistration.getType() == ApplicationType.app) {
+				String expansion = CompletionUtils.maybeQualifyWithLabel(appRegistration.getName(), streamDefinition);
+				collector.add(proposals.withSeparateTokens(expansion,
+						"Continue stream definition with a " + appRegistration.getType()));
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Import;
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
+ * @author Andy Clement
  */
 @Configuration
 @Import({ ApplicationConfigurationMetadataResolverAutoConfiguration.class })
@@ -51,7 +52,8 @@ public class CompletionConfiguration {
 				emptyStartYieldsAppsRecoveryStrategy(), expandOneDashToTwoDashesRecoveryStrategy(),
 				configurationPropertyNameAfterDashDashRecoveryStrategy(),
 				unfinishedConfigurationPropertyNameRecoveryStrategy(), destinationNameYieldsAppsRecoveryStrategy(),
-				appsAfterPipeRecoveryStrategy(), configurationPropertyValueHintRecoveryStrategy());
+				appsAfterPipeRecoveryStrategy(), appsAfterCommaRecoveryStrategy(),
+				configurationPropertyValueHintRecoveryStrategy());
 		List<ExpansionStrategy> expansionStrategies = Arrays.asList(addAppOptionsExpansionStrategy(),
 				pipeIntoOtherAppsExpansionStrategy(), unfinishedAppNameExpansionStrategy(),
 				// Make sure this one runs last, as it may clear already computed
@@ -64,7 +66,7 @@ public class CompletionConfiguration {
 
 	@Bean
 	public RecoveryStrategy<?> emptyStartYieldsAppsRecoveryStrategy() {
-		return new EmptyStartYieldsSourceAppsRecoveryStrategy(appRegistry);
+		return new EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy(appRegistry);
 	}
 
 	@Bean
@@ -85,6 +87,11 @@ public class CompletionConfiguration {
 	@Bean
 	public RecoveryStrategy<?> appsAfterPipeRecoveryStrategy() {
 		return new AppsAfterPipeRecoveryStrategy(appRegistry);
+	}
+
+	@Bean
+	public RecoveryStrategy<?> appsAfterCommaRecoveryStrategy() {
+		return new AppsAfterCommaRecoveryStrategy(appRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.cloud.dataflow.core.TaskPropertyKeys;
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Andy Clement
  */
 public class CompletionUtils {
 
@@ -55,7 +56,7 @@ public class CompletionUtils {
 	 * Return the type(s) a given stream app definition <em>could</em> have, in the
 	 * context of code completion.
 	 */
-	static ApplicationType[] determinePotentialTypes(StreamAppDefinition appDefinition) {
+	static ApplicationType[] determinePotentialTypes(StreamAppDefinition appDefinition, boolean multipleAppsInStreamDefinition) {
 		Set<String> properties = appDefinition.getProperties().keySet();
 		if (properties.contains(BindingPropertyKeys.INPUT_DESTINATION)) {
 			// Can't be source. For the purpose of completion, being the last app
@@ -69,9 +70,15 @@ public class CompletionUtils {
 			else {
 				return new ApplicationType[] { ApplicationType.processor, ApplicationType.sink };
 			}
-		} // MUST be source
+		}
 		else {
-			return new ApplicationType[] { ApplicationType.source };
+			// Multiple apps and no binding properties indicates unbound app sequence (a,b,c)
+			if (multipleAppsInStreamDefinition) {
+				return new ApplicationType[] { ApplicationType.app };
+			}
+			else {
+				return new ApplicationType[] { ApplicationType.source, ApplicationType.app };
+			}
 		}
 	}
 

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 class ConfigurationPropertyNameAfterDashDashRecoveryStrategy
 		extends StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
@@ -54,7 +55,8 @@ class ConfigurationPropertyNameAfterDashDashRecoveryStrategy
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
 
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp,  streamDefinition.getAppDefinitions().size() > 1));
 		if (appRegistration != null) {
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());
 			this.collectorSupport.addPropertiesProposals(safe, "", appRegistration, alreadyPresentOptions, collector, detailLevel);

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 public class ConfigurationPropertyValueHintExpansionStrategy implements ExpansionStrategy {
 
@@ -65,7 +66,8 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 		StreamAppDefinition lastApp = parseResult.getDeploymentOrderIterator().next();
 		String alreadyTyped = lastApp.getProperties().get(propertyName);
 
-		AppRegistration lastAppRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration lastAppRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, parseResult.getAppDefinitions().size() > 1));
 		if (lastAppRegistration != null) {
 			return this.collectorSupport.addAlreadyTypedValueHintsProposals(text, lastAppRegistration, collector, propertyName, valueHintProviders, alreadyTyped);
 		}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 public class ConfigurationPropertyValueHintRecoveryStrategy
 		extends StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
@@ -67,7 +68,8 @@ public class ConfigurationPropertyValueHintRecoveryStrategy
 		String safe = exception.getExpressionStringUntilCheckpoint();
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
-		return this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		return this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 	}
 
 	private String recoverPropertyName(CheckPointedParseException exception) {

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,14 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Andy Clement
  */
-class EmptyStartYieldsSourceAppsRecoveryStrategy
+class EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy
 		extends StacktraceFingerprintingRecoveryStrategy<IllegalArgumentException> {
 
 	private final AppRegistryCommon registry;
 
-	public EmptyStartYieldsSourceAppsRecoveryStrategy(AppRegistryCommon registry) {
+	public EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy(AppRegistryCommon registry) {
 		super(IllegalArgumentException.class, "");
 		this.registry = registry;
 	}
@@ -43,8 +44,8 @@ class EmptyStartYieldsSourceAppsRecoveryStrategy
 			List<CompletionProposal> proposals) {
 		CompletionProposal.Factory completionFactory = CompletionProposal.expanding(dsl);
 		for (AppRegistration app : this.registry.findAll()) {
-			if (app.getType() == ApplicationType.source) {
-				proposals.add(completionFactory.withSeparateTokens(app.getName(), "Start with a source app"));
+			if (app.getType() == ApplicationType.source || app.getType() == ApplicationType.app) {
+				proposals.add(completionFactory.withSeparateTokens(app.getName(), "Start with a source app or an unbound app"));
 			}
 		}
 	}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedAppNameExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedAppNameExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Andy Clement
  */
 public class UnfinishedAppNameExpansionStrategy implements ExpansionStrategy {
 
@@ -59,7 +60,7 @@ public class UnfinishedAppNameExpansionStrategy implements ExpansionStrategy {
 		CompletionProposal.Factory proposals = CompletionProposal.expanding(text);
 
 		List<ApplicationType> validTypesAtThisPosition = Arrays
-				.asList(CompletionUtils.determinePotentialTypes(lastApp));
+				.asList(CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 
 		for (AppRegistration appRegistration : appRegistry.findAll()) {
 			String candidateName = appRegistration.getName();

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Andy Clement
  */
 public class UnfinishedConfigurationPropertyNameRecoveryStrategy
 		extends StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
@@ -54,7 +55,8 @@ public class UnfinishedConfigurationPropertyNameRecoveryStrategy
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
 
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 		if (appRegistration != null) {
 			String startsWith = ProposalsCollectorSupportUtils.computeStartsWith(exception);
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertThat;
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Andy Clement
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { CompletionConfiguration.class, CompletionTestsMocks.class })
@@ -54,8 +55,8 @@ public class StreamCompletionProviderTests {
 
 	@Test
 	// <TAB> => file,http,etc
-	public void testEmptyStartShouldProposeSourceApps() {
-		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
+	public void testEmptyStartShouldProposeSourceOrUnboundApps() {
+		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange")), Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
 		assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
 	}
 
@@ -65,6 +66,19 @@ public class StreamCompletionProviderTests {
 		assertThat(completionProvider.complete("h", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
 		assertThat(completionProvider.complete("ht", 1), hasItems(Proposals.proposalThat(is("http"))));
 		assertThat(completionProvider.complete("ht", 1), not(hasItems(Proposals.proposalThat(is("hdfs")))));
+	}
+
+	@Test
+	public void testUnfinishedUnboundAppNameShouldReturnCompletions2() {
+		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("o", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("oran", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("o1: orange,", 1), hasItems(Proposals.proposalThat(is("o1: orange, orange"))));
+		assertThat(completionProvider.complete("o1: orange, ", 1), hasItems(Proposals.proposalThat(is("o1: orange, orange"))));
+		assertThat(completionProvider.complete("o1: orange ,", 1), hasItems(Proposals.proposalThat(is("o1: orange , orange"))));
+		assertThat(completionProvider.complete("o1: orange, or", 1), hasItems(Proposals.proposalThat(is("o1: orange, orange"))));
+		assertThat(completionProvider.complete("http | o", 1), empty());
+		assertThat(completionProvider.complete("http, o", 1), hasItems(Proposals.proposalThat(is("http, orange"))));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,1 @@
+configuration-properties.classes=foo.bar.BasicProperties

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,32 @@
+{
+  "groups": [
+    {
+      "name": "basic",
+      "type": "foo.bar.BasicProperties",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "basic.expression",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.fooble",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.expresso",
+      "type": "org.springframework.cloud.dataflow.completion.Expresso",
+      "description": "A property of type enum and whose name starts like 'expression'",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
Basically add new completion strategies for ApplicationType.app
and when commas are used in the DSL text.

Fixes spring-cloud/spring-cloud-dataflow-ui#952
Fixes spring-cloud/spring-cloud-dataflow#2592