### PR TITLE
Adjust from comma to double pipe for separating unbound stream apps

### DIFF
--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AddAppOptionsExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,8 @@ class AddAppOptionsExpansionStrategy implements ExpansionStrategy {
 	public boolean addProposals(String text, StreamDefinition streamDefinition, int detailLevel,
 			List<CompletionProposal> collector) {
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp,streamDefinition.getAppDefinitions().size() > 1));
 
 		if (appRegistration != null) {
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AppsAfterDoublePipeRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/AppsAfterDoublePipeRecoveryStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.completion;
+
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.StreamDefinition;
+import org.springframework.cloud.dataflow.core.dsl.CheckPointedParseException;
+import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
+import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+
+/**
+ * Provides completions for the case where the user has entered a comma symbol and an
+ * unbound app reference is expected next.
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Andy Clement
+ */
+public class AppsAfterDoublePipeRecoveryStrategy
+		extends StacktraceFingerprintingRecoveryStrategy<CheckPointedParseException> {
+	private final AppRegistryCommon appRegistry;
+	AppsAfterDoublePipeRecoveryStrategy(AppRegistryCommon appRegistry) {
+		super(CheckPointedParseException.class, "foo ||", "foo || ");
+		this.appRegistry = appRegistry;
+	}
+	@Override
+	public void addProposals(String dsl, CheckPointedParseException exception, int detailLevel,
+			List<CompletionProposal> collector) {
+		StreamDefinition streamDefinition = new StreamDefinition("__dummy",
+				exception.getExpressionStringUntilCheckpoint());
+		CompletionProposal.Factory proposals = CompletionProposal.expanding(dsl);
+		for (AppRegistration appRegistration : appRegistry.findAll()) {
+			if (appRegistration.getType() == ApplicationType.app) {
+				String expansion = CompletionUtils.maybeQualifyWithLabel(appRegistration.getName(), streamDefinition);
+				collector.add(proposals.withSeparateTokens(expansion,
+						"Continue stream definition with a " + appRegistration.getType()));
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ public class CompletionConfiguration {
 				emptyStartYieldsAppsRecoveryStrategy(), expandOneDashToTwoDashesRecoveryStrategy(),
 				configurationPropertyNameAfterDashDashRecoveryStrategy(),
 				unfinishedConfigurationPropertyNameRecoveryStrategy(), destinationNameYieldsAppsRecoveryStrategy(),
-				appsAfterPipeRecoveryStrategy(), configurationPropertyValueHintRecoveryStrategy());
+				appsAfterPipeRecoveryStrategy(), appsAfterDoublePipeRecoveryStrategy(),
+				configurationPropertyValueHintRecoveryStrategy());
 		List<ExpansionStrategy> expansionStrategies = Arrays.asList(addAppOptionsExpansionStrategy(),
 				pipeIntoOtherAppsExpansionStrategy(), unfinishedAppNameExpansionStrategy(),
 				// Make sure this one runs last, as it may clear already computed
@@ -64,7 +65,7 @@ public class CompletionConfiguration {
 
 	@Bean
 	public RecoveryStrategy<?> emptyStartYieldsAppsRecoveryStrategy() {
-		return new EmptyStartYieldsSourceAppsRecoveryStrategy(appRegistry);
+		return new EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy(appRegistry);
 	}
 
 	@Bean
@@ -85,6 +86,11 @@ public class CompletionConfiguration {
 	@Bean
 	public RecoveryStrategy<?> appsAfterPipeRecoveryStrategy() {
 		return new AppsAfterPipeRecoveryStrategy(appRegistry);
+	}
+
+	@Bean
+	public RecoveryStrategy<?> appsAfterDoublePipeRecoveryStrategy() {
+		return new AppsAfterDoublePipeRecoveryStrategy(appRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/CompletionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,8 @@ public class CompletionUtils {
 	 * Return the type(s) a given stream app definition <em>could</em> have, in the
 	 * context of code completion.
 	 */
-	static ApplicationType[] determinePotentialTypes(StreamAppDefinition appDefinition) {
+	static ApplicationType[] determinePotentialTypes(StreamAppDefinition appDefinition,
+			boolean multipleAppsInStreamDefinition) {
 		Set<String> properties = appDefinition.getProperties().keySet();
 		if (properties.contains(BindingPropertyKeys.INPUT_DESTINATION)) {
 			// Can't be source. For the purpose of completion, being the last app
@@ -69,9 +70,15 @@ public class CompletionUtils {
 			else {
 				return new ApplicationType[] { ApplicationType.processor, ApplicationType.sink };
 			}
-		} // MUST be source
+		}
 		else {
-			return new ApplicationType[] { ApplicationType.source };
+			// Multiple apps and no binding properties indicates unbound app sequence (a,b,c)
+			if (multipleAppsInStreamDefinition) {
+				return new ApplicationType[] { ApplicationType.app };
+			}
+			else {
+				return new ApplicationType[] { ApplicationType.source, ApplicationType.app };
+			}
 		}
 	}
 

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyNameAfterDashDashRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,9 @@ class ConfigurationPropertyNameAfterDashDashRecoveryStrategy
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
 
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp,  streamDefinition.getAppDefinitions().size() > 1));
+
 		if (appRegistration != null) {
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());
 			this.collectorSupport.addPropertiesProposals(safe, "", appRegistration, alreadyPresentOptions, collector, detailLevel);

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,8 @@ public class ConfigurationPropertyValueHintExpansionStrategy implements Expansio
 		StreamAppDefinition lastApp = parseResult.getDeploymentOrderIterator().next();
 		String alreadyTyped = lastApp.getProperties().get(propertyName);
 
-		AppRegistration lastAppRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration lastAppRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, parseResult.getAppDefinitions().size() > 1));
 		if (lastAppRegistration != null) {
 			return this.collectorSupport.addAlreadyTypedValueHintsProposals(text, lastAppRegistration, collector, propertyName, valueHintProviders, alreadyTyped);
 		}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/ConfigurationPropertyValueHintRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,8 @@ public class ConfigurationPropertyValueHintRecoveryStrategy
 		String safe = exception.getExpressionStringUntilCheckpoint();
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
-		return this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		return this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 	}
 
 	private String recoverPropertyName(CheckPointedParseException exception) {

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
  * @author Eric Bottard
  * @author Mark Fisher
  */
-class EmptyStartYieldsSourceAppsRecoveryStrategy
+class EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy
 		extends StacktraceFingerprintingRecoveryStrategy<IllegalArgumentException> {
 
 	private final AppRegistryCommon registry;
 
-	public EmptyStartYieldsSourceAppsRecoveryStrategy(AppRegistryCommon registry) {
+	public EmptyStartYieldsSourceOrUnboundAppsRecoveryStrategy(AppRegistryCommon registry) {
 		super(IllegalArgumentException.class, "");
 		this.registry = registry;
 	}
@@ -43,8 +43,8 @@ class EmptyStartYieldsSourceAppsRecoveryStrategy
 			List<CompletionProposal> proposals) {
 		CompletionProposal.Factory completionFactory = CompletionProposal.expanding(dsl);
 		for (AppRegistration app : this.registry.findAll()) {
-			if (app.getType() == ApplicationType.source) {
-				proposals.add(completionFactory.withSeparateTokens(app.getName(), "Start with a source app"));
+			if (app.getType() == ApplicationType.source || app.getType() == ApplicationType.app) {
+				proposals.add(completionFactory.withSeparateTokens(app.getName(), "Start with a source app or an unbounded streaming app"));
 			}
 		}
 	}

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedAppNameExpansionStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedAppNameExpansionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class UnfinishedAppNameExpansionStrategy implements ExpansionStrategy {
 		CompletionProposal.Factory proposals = CompletionProposal.expanding(text);
 
 		List<ApplicationType> validTypesAtThisPosition = Arrays
-				.asList(CompletionUtils.determinePotentialTypes(lastApp));
+				.asList(CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 
 		for (AppRegistration appRegistration : appRegistry.findAll()) {
 			String candidateName = appRegistration.getName();

--- a/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameRecoveryStrategy.java
+++ b/spring-cloud-dataflow-completion/src/main/java/org/springframework/cloud/dataflow/completion/UnfinishedConfigurationPropertyNameRecoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,8 @@ public class UnfinishedConfigurationPropertyNameRecoveryStrategy
 		StreamDefinition streamDefinition = new StreamDefinition("__dummy", safe);
 		StreamAppDefinition lastApp = streamDefinition.getDeploymentOrderIterator().next();
 
-		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(), CompletionUtils.determinePotentialTypes(lastApp));
+		AppRegistration appRegistration = this.collectorSupport.findAppRegistration(lastApp.getName(),
+				CompletionUtils.determinePotentialTypes(lastApp, streamDefinition.getAppDefinitions().size() > 1));
 		if (appRegistration != null) {
 			String startsWith = ProposalsCollectorSupportUtils.computeStartsWith(exception);
 			Set<String> alreadyPresentOptions = new HashSet<>(lastApp.getProperties().keySet());

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,9 @@ public class StreamCompletionProviderTests {
 
 	@Test
 	// <TAB> => file,http,etc
-	public void testEmptyStartShouldProposeSourceApps() {
-		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
+	public void testEmptyStartShouldProposeSourceOrUnboundApps() {
+		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange")),
+			Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
 		assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
 	}
 
@@ -65,6 +66,21 @@ public class StreamCompletionProviderTests {
 		assertThat(completionProvider.complete("h", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
 		assertThat(completionProvider.complete("ht", 1), hasItems(Proposals.proposalThat(is("http"))));
 		assertThat(completionProvider.complete("ht", 1), not(hasItems(Proposals.proposalThat(is("hdfs")))));
+	}
+
+	@Test
+	public void testUnfinishedUnboundAppNameShouldReturnCompletions2() {
+		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("o", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("oran", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		assertThat(completionProvider.complete("orange", 1), hasItems(Proposals.proposalThat(is("orange --expression=")),
+				Proposals.proposalThat(is("orange --fooble=")),Proposals.proposalThat(is("orange --expresso="))));
+		assertThat(completionProvider.complete("o1: orange||", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		assertThat(completionProvider.complete("o1: orange|| ", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		assertThat(completionProvider.complete("o1: orange ||", 1), hasItems(Proposals.proposalThat(is("o1: orange || orange"))));
+		assertThat(completionProvider.complete("o1: orange|| or", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		assertThat(completionProvider.complete("http | o", 1), empty());
+		assertThat(completionProvider.complete("http|| o", 1), hasItems(Proposals.proposalThat(is("http|| orange"))));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,0 +1,1 @@
+configuration-properties.classes=foo.bar.BasicProperties

--- a/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-completion/src/test/resources/org/springframework/cloud/dataflow/completion/apps/orange-app/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,32 @@
+{
+  "groups": [
+    {
+      "name": "basic",
+      "type": "foo.bar.BasicProperties",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "basic.expression",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.fooble",
+      "type": "org.springframework.expression.Expression",
+      "description": "A predicate to evaluate",
+      "sourceType": "foo.bar.BasicProperties",
+      "defaultValue": "true"
+    },
+    {
+      "name": "basic.expresso",
+      "type": "org.springframework.cloud.dataflow.completion.Expresso",
+      "description": "A property of type enum and whose name starts like 'expression'",
+      "sourceType": "foo.bar.BasicProperties"
+    }
+  ],
+  "hints": []
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinitionToDslConverter.java
@@ -103,7 +103,7 @@ public class StreamDefinitionToDslConverter {
 				if (appDefinition.getApplicationType() != ApplicationType.app) {
 					dslBuilder.append(" | ");
 				} else {
-					dslBuilder.append(" , ");
+					dslBuilder.append(" || ");
 				}
 			}
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AbstractTokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/AbstractTokenizer.java
@@ -216,7 +216,7 @@ public abstract class AbstractTokenizer {
 	protected boolean isArgValueIdentifierTerminator(char ch, boolean quoteOpen) {
 		return (ch == '|' && !quoteOpen) || (ch == ';' && !quoteOpen) || ch == '\0' || (ch == ' ' && !quoteOpen)
 				|| (ch == '\t' && !quoteOpen) || (ch == '>' && !quoteOpen) || (ch == '\r' && !quoteOpen)
-				|| (ch == '\n' && !quoteOpen) || (ch == ',' && !quoteOpen);
+				|| (ch == '\n' && !quoteOpen);
 	}
 
 	/**

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/DSLMessage.java
@@ -113,8 +113,8 @@ public enum DSLMessage {
 	TASK_VALIDATION_SPLIT_WITH_ONE_FLOW(Kind.ERROR, 167,
 			"unnecessary use of split construct when only one flow to execute" + " in parallel"), //
 	TASK_ARGUMENTS_NOT_ALLOWED_UNLESS_IN_APP_MODE(Kind.ERROR, 168, "arguments not allowed unless parser is in app mode"), //
-	DONT_MIX_PIPE_AND_COMMA(Kind.ERROR, 169, "do not mix '|' and ',' when specifying a set of applications"), //
-	DONT_USE_COMMA_WITH_CHANNELS(Kind.ERROR, 170, "do not use comma delimiter between apps in a stream, use '|'"), //
+	DONT_MIX_PIPE_AND_DOUBLEPIPE(Kind.ERROR, 169, "do not mix '|' and '||' when specifying a list of applications"), //
+	DONT_USE_DOUBLEPIPE_WITH_CHANNELS(Kind.ERROR, 170, "do not use '||' between source/processor/sink apps in a stream, use '|'"), //
 	UNEXPECTED_DATA_IN_DESTINATION_NAME(Kind.ERROR, 171, "unexpected data in destination name ''{0}''"), //
 	;
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SplitNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/SplitNode.java
@@ -52,7 +52,7 @@ public class SplitNode extends LabelledTaskNode {
 			for (int i = 0; i < parallelTaskApps.size(); i++) {
 				LabelledTaskNode jn = parallelTaskApps.get(i);
 				if (i > 0) {
-					s.append(" ").append(TokenKind.OROR.tokenChars).append(" ");
+					s.append(" ").append(TokenKind.DOUBLEPIPE.tokenChars).append(" ");
 				}
 				s.append(jn.stringify(includePositionInfo));
 			}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamNode.java
@@ -81,7 +81,7 @@ public class StreamNode extends AstNode {
 			s.append(appNode.toString());
 			if (m + 1 < appNodes.size()) {
 				if (appNode.isUnboundStreamApp()) {
-					s.append(" , ");
+					s.append(" || ");
 				}
 				else {
 					s.append(" | ");

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamParser.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/StreamParser.java
@@ -379,18 +379,18 @@ public class StreamParser extends AppParser {
 			Token t = tokens.peek();
 			if (t.kind == TokenKind.PIPE) {
 				if (usedListDelimiter >= 0) {
-					tokens.raiseException(t.startPos, DSLMessage.DONT_MIX_PIPE_AND_COMMA);
+					tokens.raiseException(t.startPos, DSLMessage.DONT_MIX_PIPE_AND_DOUBLEPIPE);
 				}
 				usedStreamDelimiter = t.startPos;
 				tokens.next();
 				appNodes.add(eatApp());
 			}
-			else if (t.kind == TokenKind.COMMA) {
+			else if (t.kind == TokenKind.DOUBLEPIPE) {
 				if (preceedingSourceChannelSpecified) {
-					tokens.raiseException(t.startPos, DSLMessage.DONT_USE_COMMA_WITH_CHANNELS);
+					tokens.raiseException(t.startPos, DSLMessage.DONT_USE_DOUBLEPIPE_WITH_CHANNELS);
 				}
 				if (usedStreamDelimiter >= 0) {
-					tokens.raiseException(t.startPos, DSLMessage.DONT_MIX_PIPE_AND_COMMA);
+					tokens.raiseException(t.startPos, DSLMessage.DONT_MIX_PIPE_AND_DOUBLEPIPE);
 				}
 				usedListDelimiter = t.startPos;
 				tokens.next();
@@ -403,7 +403,7 @@ public class StreamParser extends AppParser {
 		}
 		boolean isFollowedBySinkChannel = tokens.peek(TokenKind.GT);
 		if (isFollowedBySinkChannel && usedListDelimiter >= 0) {
-			tokens.raiseException(usedListDelimiter, DSLMessage.DONT_USE_COMMA_WITH_CHANNELS);
+			tokens.raiseException(usedListDelimiter, DSLMessage.DONT_USE_DOUBLEPIPE_WITH_CHANNELS);
 		}
 		for (AppNode appNode: appNodes) {
 			appNode.setUnboundStreamApp(!preceedingSourceChannelSpecified && !isFollowedBySinkChannel && (usedStreamDelimiter < 0));

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskParser.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskParser.java
@@ -175,7 +175,7 @@ public class TaskParser extends AppParser {
 		List<LabelledTaskNode> flows = new ArrayList<>();
 		Token startSplit = eat(TokenKind.LT);
 		flows.add(parseTaskNode());
-		while (maybeEat(TokenKind.OROR)) {
+		while (maybeEat(TokenKind.DOUBLEPIPE)) {
 			flows.add(parseTaskNode());
 		}
 		Token endSplit = eat(TokenKind.GT);

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskTokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskTokenizer.java
@@ -71,8 +71,8 @@ class TaskTokenizer extends AbstractTokenizer {
 					}
 					break;
 				case '|':
-					if (isTwoCharToken(TokenKind.OROR)) {
-						pushPairToken(TokenKind.OROR);
+					if (isTwoCharToken(TokenKind.DOUBLEPIPE)) {
+						pushPairToken(TokenKind.DOUBLEPIPE);
 					}
 					else {
 						raiseException(DSLMessage.TASK_DOUBLE_OR_REQUIRED);

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TokenKind.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TokenKind.java
@@ -30,7 +30,7 @@ public enum TokenKind {
 	EQUALS("="),
 	AND("&"),
 	ANDAND("&&"),
-	OROR("||"),
+	DOUBLEPIPE("||"),
 	ARROW("->"),
 	PIPE("|"),
 	OPEN_PAREN("("),
@@ -45,8 +45,7 @@ public enum TokenKind {
 	DOT("."),
 	LITERAL_STRING,
 	SLASH("/"),
-	HASH("#"),
-	COMMA(",");
+	HASH("#");
 
 	char[] tokenChars;
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
@@ -63,7 +63,12 @@ class Tokenizer extends AbstractTokenizer {
 					pushCharToken(TokenKind.AND);
 					break;
 				case '|':
-					pushCharToken(TokenKind.PIPE);
+					if (isTwoCharToken(TokenKind.DOUBLEPIPE)) {
+						pushPairToken(TokenKind.DOUBLEPIPE);
+					}
+					else {
+						pushCharToken(TokenKind.PIPE);
+					}
 					break;
 				case ' ':
 				case '\t':
@@ -79,9 +84,6 @@ class Tokenizer extends AbstractTokenizer {
 					break;
 				case '>':
 					pushCharToken(TokenKind.GT);
-					break;
-				case ',':
-					pushCharToken(TokenKind.COMMA);
 					break;
 				case ':':
 					pushCharToken(TokenKind.COLON);

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -62,10 +62,10 @@ public class StreamDefinitionTests {
 	public void testLongRunningNonStreamApps() {
 		StreamDefinition sd = new StreamDefinition("something","aaa");
 		assertEquals(ApplicationType.app, sd.getAppDefinitions().get(0).getApplicationType());
-		sd = new StreamDefinition("something","aaa, bbb");
+		sd = new StreamDefinition("something","aaa|| bbb");
 		assertEquals(ApplicationType.app, sd.getAppDefinitions().get(0).getApplicationType());
 		assertEquals(ApplicationType.app, sd.getAppDefinitions().get(1).getApplicationType());
-		sd = new StreamDefinition("something","aaa --aaa=bbb , bbb");
+		sd = new StreamDefinition("something","aaa --aaa=bbb || bbb");
 		assertEquals(ApplicationType.app, sd.getAppDefinitions().get(0).getApplicationType());
 		assertEquals(ApplicationType.app, sd.getAppDefinitions().get(1).getApplicationType());
 	}

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -193,9 +193,7 @@ public class TaskParserTests {
 		// checkForParseError("foo | transform --expression=''Hello, world!'' | bar",
 		// DSLMessage.UNEXPECTED_DATA, 37);
 		// but now it points to the !
-		// But with the changes to have comma as a character that can terminate a non
-		// quoted literal (for supporting app lists), it now points to 30 again.
-		checkForParseError("transform --expression=''Hello, world!''", DSLMessage.TASK_UNEXPECTED_DATA, 30);
+		checkForParseError("transform --expression=''Hello, world!''", DSLMessage.TASK_UNEXPECTED_DATA, 37);
 	}
 
 	@Test


### PR DESCRIPTION
This adjusts the syntax so that between unbounded stream apps
you need to use ||, for example: aaa || bbb
This is contrast to regular stream apps that continue to use
single pipe: aaa | bbb
You cannot use channels with unbounded stream apps and all the tests
and errors messages related to the previous comma syntax have been
updated to reflect the new syntax.

I have also merged in the PR I created that handles content
assist for unbounded stream apps and adjusted that to use the new
syntax.

Resolves spring-cloud/spring-cloud-dataflow#2587
Resolves spring-cloud/spring-cloud-dataflow#2592