### PR TITLE
Update Stream DSL after rollback

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -262,7 +262,8 @@ public class DefaultStreamService implements StreamService {
 	@Override
 	public void rollbackStream(String streamName, int releaseVersion) {
 		Assert.isTrue(StringUtils.hasText(streamName), "Stream name must not be null");
-		this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
+		Release release = this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
+		updateStreamDefinitionFromReleaseManifest(streamName, release.getManifest().getData());
 		this.auditRecordService.populateAndSaveAuditRecord(AuditOperationType.STREAM, AuditActionType.ROLLBACK,
 				streamName, "Rollback to version: " + releaseVersion);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -263,7 +263,9 @@ public class DefaultStreamService implements StreamService {
 	public void rollbackStream(String streamName, int releaseVersion) {
 		Assert.isTrue(StringUtils.hasText(streamName), "Stream name must not be null");
 		Release release = this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
-		updateStreamDefinitionFromReleaseManifest(streamName, release.getManifest().getData());
+		if (release != null && release.getManifest() != null) {
+			updateStreamDefinitionFromReleaseManifest(streamName, release.getManifest().getData());
+		}
 		this.auditRecordService.populateAndSaveAuditRecord(AuditOperationType.STREAM, AuditActionType.ROLLBACK,
 				streamName, "Rollback to version: " + releaseVersion);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -557,8 +557,11 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	 * @param streamName the name of the stream to rollback
 	 * @param releaseVersion the version of the stream to rollback to
 	 */
-	public void rollbackStream(String streamName, int releaseVersion) {
-		this.skipperClient.rollback(new RollbackRequest(streamName, releaseVersion));
+	public Release rollbackStream(String streamName, int releaseVersion) {
+		RollbackRequest rollbackRequest = new RollbackRequest();
+		rollbackRequest.setReleaseName(streamName);
+		rollbackRequest.setVersion(releaseVersion);
+		return this.skipperClient.rollback(rollbackRequest);
 	}
 
 	public String manifest(String name, int version) {

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-rollbackManifest.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-rollbackManifest.yml
@@ -1,0 +1,44 @@
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
+    trigger.fixed-delay: 100
+    spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.output.destination: ticktock.time
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: ticktock
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    log.level: DEBUG
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: ticktock.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: ticktock

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests-rollbackManifest.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests-rollbackManifest.yml
@@ -1,0 +1,44 @@
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
+    trigger.fixed-delay: 100
+    spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.output.destination: ticktock.time
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: ticktock
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    log.level: DEBUG
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: ticktock.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: ticktock


### PR DESCRIPTION
  - Change the rollback method to return rolledback release
  - Use RollbackRequest instead of deprecated one
  - Update the stream DSL after the rollback is complete

Resolves #2636