### PR TITLE
Added an index page to serve as a starting point for three guides

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index-multi.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index-multi.adoc
@@ -1,12 +1,11 @@
 = Spring Cloud Data Flow Reference Guides
-
+:scdf-core-git: master
+:dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/edit/master/spring-cloud-dataflow-docs/src/main/asciidoc
+https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/edit/master/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
 Spring Cloud Data Flow can run locally, on Cloud Foundry, or on Kubernetes. The following
 guides describe how to use Spring Cloud Data Flow in each case:
 
-
 [horizontal]
-<<local.adoc,Local>> :: How to use Spring Cloud Data Flow from a local server.
-<<kubernetes.adoc,Kubernetes>> :: How to use Spring Cloud Data Flow from a Kubernetes
-server.
-<<cloud-foundry.adoc,Cloud Foundry>> :: How to use Spring Cloud Data Flow from a Cloud
-Foundry server.
+https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc[Local] :: How to use Spring Cloud Data Flow from a local server.
+https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-server-kubernetes/master/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/index.adoc[Kubernetes] :: How to use Spring Cloud Data Flow from a Kubernetes server.
+https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/master/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc[Cloud Foundry] :: How to use Spring Cloud Data Flow from a Cloud Foundry server.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index-multi.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index-multi.adoc
@@ -1,0 +1,12 @@
+= Spring Cloud Data Flow Reference Guides
+
+Spring Cloud Data Flow can run locally, on Cloud Foundry, or on Kubernetes. The following
+guides describe how to use Spring Cloud Data Flow in each case:
+
+
+[horizontal]
+<<local.adoc,Local>> :: How to use Spring Cloud Data Flow from a local server.
+<<kubernetes.adoc,Kubernetes>> :: How to use Spring Cloud Data Flow from a Kubernetes
+server.
+<<cloud-foundry.adoc,Cloud Foundry>> :: How to use Spring Cloud Data Flow from a Cloud
+Foundry server.


### PR DESCRIPTION
Per a discussion with Sabby, I am adding a file called index-multi.adoc. It contains links to three files that will hold the reference documentation for Spring Cloud Data Flow under local, Kubernetes, and Cloud Foundry. At present, those files do not exist, so the links are placeholders for the moment.

Resolves  #2614.