### PR TITLE
[1.7.x] Update Stream DSL after rollback

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamService.java
@@ -226,7 +226,10 @@ public class DefaultSkipperStreamService extends AbstractStreamService implement
 	@Override
 	public void rollbackStream(String streamName, int releaseVersion) {
 		Assert.isTrue(StringUtils.hasText(streamName), "Stream name must not be null");
-		this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
+		Release release = this.skipperStreamDeployer.rollbackStream(streamName, releaseVersion);
+		if (release != null && release.getManifest() != null) {
+			updateStreamDefinitionFromReleaseManifest(streamName, release.getManifest().getData());
+		}
 		this.auditRecordService.populateAndSaveAuditRecord(AuditOperationType.STREAM, AuditActionType.ROLLBACK,
 				streamName, "Rollback to version: " + releaseVersion);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -545,8 +545,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	 * @param streamName the name of the stream to rollback
 	 * @param releaseVersion the version of the stream to rollback to
 	 */
-	public void rollbackStream(String streamName, int releaseVersion) {
-		this.skipperClient.rollback(streamName, releaseVersion);
+	public Release rollbackStream(String streamName, int releaseVersion) {
+		return this.skipperClient.rollback(streamName, releaseVersion);
 	}
 
 	public String manifest(String name, int version) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.service.impl;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,11 +49,14 @@ import org.springframework.cloud.dataflow.server.repository.StreamDeploymentRepo
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultStreamValidationService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.StreamDeploymentRequest;
+import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StreamUtils;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -186,12 +190,17 @@ public class DefaultSkipperStreamServiceTests {
 	}
 
 	@Test
-	public void verifyRollbackStream() {
+	public void verifyRollbackStream() throws Exception {
 		StreamDefinition streamDefinition2 = new StreamDefinition("test2", "time | log");
-		StreamDeployment streamDeployment2 = new StreamDeployment(streamDefinition2.getName(), "");
-		when(this.streamDeploymentRepository.findOne(streamDeployment2.getStreamName())).thenReturn(streamDeployment2);
-
 		verifyNoMoreInteractions(this.skipperStreamDeployer);
+		Release release = new Release();
+		Manifest manifest = new Manifest();
+		String rollbackReleaseManifestData = StreamUtils.copyToString(
+				TestResourceUtils.qualifiedResource(getClass(), "rollbackManifest.yml").getInputStream(),
+				Charset.defaultCharset());
+		manifest.setData(rollbackReleaseManifestData);
+		release.setManifest(manifest);
+		when(this.skipperStreamDeployer.rollbackStream(streamDefinition2.getName(), 0)).thenReturn(release);
 		this.defaultSkipperStreamService.rollbackStream(streamDefinition2.getName(), 0);
 		verify(this.skipperStreamDeployer, times(1)).rollbackStream(streamDefinition2.getName(), 0);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-rollbackManifest.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceIntegrationTests-rollbackManifest.yml
@@ -1,0 +1,44 @@
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
+    trigger.fixed-delay: 100
+    spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.output.destination: ticktock.time
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: ticktock
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    log.level: DEBUG
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: ticktock.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: ticktock

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests-rollbackManifest.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultSkipperStreamServiceTests-rollbackManifest.yml
@@ -1,0 +1,44 @@
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.key: ticktock.time.${spring.cloud.application.guid}
+    trigger.fixed-delay: 100
+    spring.cloud.stream.bindings.output.producer.requiredGroups: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.output.destination: ticktock.time
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: ticktock
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.key: ticktock.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: ticktock
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    log.level: DEBUG
+    spring.cloud.dataflow.stream.name: ticktock
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: ticktock.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: ticktock


### PR DESCRIPTION
  - Change the rollback method to return rolledback release
  - Use RollbackRequest instead of deprecated one
  - Update the stream DSL after the rollback is complete
  - Add test for update after rollback
  - Fix rollbackStream service test
  - Fix NPE on release during rollback

Resolves #2636