### PR TITLE
Enable batch db initialization

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -22,6 +22,8 @@ spring:
     redis:
       repositories:
         enabled: false
+  batch:
+    initialize-schema: always
   jpa:
     properties:
       hibernate.id.new_generator_mappings: true


### PR DESCRIPTION
- Simply adding spring.batch.initialize-schema=always to dataflow-server-defaults.yml
  as that setting defaults to just embedded database.
- Fixes #2669