### PR TITLE
Register LocalSchedulerAutoConfiguration to spring.factories and fix …

### DIFF
--- a/spring-cloud-dataflow-server-local-autoconfig/pom.xml
+++ b/spring-cloud-dataflow-server-local-autoconfig/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>spring-cloud-deployer-local</artifactId>
 			<version>${spring-cloud-deployer.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalSchedulerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalSchedulerAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.autoconfigure.local;
 import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.dataflow.server.config.features.SchedulerConfiguration;
 import org.springframework.cloud.scheduler.spi.core.ScheduleInfo;
 import org.springframework.cloud.scheduler.spi.core.ScheduleRequest;
@@ -26,15 +25,12 @@ import org.springframework.cloud.scheduler.spi.core.Scheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 /**
  * @author Mark Pollack
  */
 @Configuration
-@Conditional({ SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
-@Profile("!cloud") // Server not deployed on CF
-@ConditionalOnProperty(name = "kubernetes.service.host", matchIfMissing = true) // Server not deployed on K8s
+@Conditional({ OnLocalPlatform.class, SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
 public class LocalSchedulerAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/OnLocalPlatform.java
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/OnLocalPlatform.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.autoconfigure.local;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.context.annotation.ConfigurationCondition;
+
+/**
+ * When Server in not deployed neither on CF nor on K8s it is considered to be on a Local platform.
+ *
+ * @author Christian Tzolov
+ */
+public class OnLocalPlatform extends NoneNestedConditions {
+
+	public OnLocalPlatform() {
+		super(ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnProperty(name = "kubernetes.service.host")
+	static class OnKubernetesPlatform {
+	}
+
+	@ConditionalOnCloudPlatform(CloudPlatform.CLOUD_FOUNDRY)
+	static class OnCloudFoundryPlatform {
+	}
+}

--- a/spring-cloud-dataflow-server-local-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.cloud.dataflow.autoconfigure.local.LocalDataFlowServerAutoConfiguration
+  org.springframework.cloud.dataflow.autoconfigure.local.LocalDataFlowServerAutoConfiguration, \
+  org.springframework.cloud.dataflow.autoconfigure.local.LocalSchedulerAutoConfiguration

--- a/spring-cloud-dataflow-server-local-autoconfig/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.autoconfigure.local;
+
+import io.pivotal.reactor.scheduler.ReactorSchedulerClient;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
+import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.dataflow.server.config.cloudfoundry.DataSourceCloudConfig;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundry2630AndLaterTaskLauncher;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
+import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundrySchedulerProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = AbstractSchedulerPerPlatformTest.AutoConfigurationApplication.class)
+@DirtiesContext
+public abstract class AbstractSchedulerPerPlatformTest {
+
+	@Autowired
+	protected ApplicationContext context;
+
+	@Configuration
+	@EnableAutoConfiguration(exclude = { LocalDataFlowServerAutoConfiguration.class,
+			CloudFoundryDeployerAutoConfiguration.class, DataSourceCloudConfig.class })
+	public static class AutoConfigurationApplication {
+
+
+		@Configuration
+		@ConditionalOnCloudPlatform(CloudPlatform.CLOUD_FOUNDRY)
+		public static class CloudFoundryMockConfig {
+			@MockBean
+			protected CloudFoundrySchedulerProperties cloudFoundrySchedulerProperties;
+
+			@Bean
+			@Primary
+			public ReactorSchedulerClient reactorSchedulerClient() {
+				return Mockito.mock(ReactorSchedulerClient.class);
+			}
+
+			@Bean
+			@Primary
+			public CloudFoundryOperations cloudFoundryOperations() {
+				return Mockito.mock(CloudFoundryOperations.class);
+			}
+
+			@Bean
+			@Primary
+			public CloudFoundryConnectionProperties cloudFoundryConnectionProperties() {
+				return Mockito.mock(CloudFoundryConnectionProperties.class);
+			}
+
+			@Bean
+			@Primary
+			public CloudFoundry2630AndLaterTaskLauncher cloudFoundry2630AndLaterTaskLauncher() {
+				return Mockito.mock(CloudFoundry2630AndLaterTaskLauncher.class);
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-local-autoconfig/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.autoconfigure.local;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.cloud.scheduler.spi.core.Scheduler;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(Enclosed.class)
+public class SchedulerPerPlatformTest {
+
+	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=false" })
+	public static class AllSchedulerDisabledTests extends AbstractSchedulerPerPlatformTest {
+
+		@Test(expected = NoSuchBeanDefinitionException.class)
+		public void testLocalSchedulerEnabled() {
+			assertFalse(context.getEnvironment().containsProperty("kubernetes.service.host"));
+			assertFalse(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+			context.getBean(Scheduler.class);
+		}
+	}
+
+	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=true" })
+	public static class LocalSchedulerTests extends AbstractSchedulerPerPlatformTest {
+
+		@Test
+		public void testLocalSchedulerEnabled() {
+			assertFalse("K8s should be disabled", context.getEnvironment().containsProperty("kubernetes.service.host"));
+			assertFalse("CF should be disabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+
+			Scheduler scheduler = context.getBean(Scheduler.class);
+
+			assertNotNull(scheduler);
+			assertTrue(scheduler.getClass().getName().contains("LocalSchedulerAutoConfiguration"));
+		}
+	}
+
+	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=true",
+			"kubernetes.service.host=dummy" })
+	public static class KubernetesSchedulerActivatedTests extends AbstractSchedulerPerPlatformTest {
+
+		@Test
+		public void testLocalSchedulerEnabled() {
+			assertTrue("K8s should be enabled", context.getEnvironment().containsProperty("kubernetes.service.host"));
+			assertFalse("CF should be disabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+
+			Scheduler scheduler = context.getBean(Scheduler.class);
+
+			assertNotNull(scheduler);
+			assertTrue(scheduler.getClass().getName().contains("KubernetesScheduler"));
+		}
+
+	}
+
+	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=true",
+			"VCAP_APPLICATION=dummy" })
+	public static class CloudFoundrySchedulerActivatedTests extends AbstractSchedulerPerPlatformTest {
+
+		@Test
+		public void testLocalSchedulerEnabled() {
+			assertFalse("K8s should be disabled", context.getEnvironment().containsProperty("kubernetes.service.host"));
+			assertTrue("CF should be enabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+
+			Scheduler scheduler = context.getBean(Scheduler.class);
+
+			assertNotNull(scheduler);
+			assertTrue(scheduler.getClass().getName().contains("CloudFoundryAppScheduler"));
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-local-autoconfig/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-cloud-dataflow-server-local-autoconfig/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
…activation conditions

  - Define an OnLocalPlatform condition that enables LocalSchedulerAutoConfiguration only if the K8s and CF platforms are not active.
  - Add the LocalSchedulerAutoConfiguration to the spring.factories.
  - Add tests to ensure that the LocalSchedulerAutoConfiguration auto-configuration works and that scheduler enabling conditions work per platfomrs.

 Resolves #2708 #2704