### PR TITLE
Resolves issue where task launches before setup is complete [1.7.x]

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -100,10 +100,12 @@ public class TaskConfiguration {
 			ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskConfigurationProperties taskConfigurationProperties, DeploymentIdRepository deploymentIdRepository,
 			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
-			TaskValidationService taskValidationService, PlatformTransactionManager transactionManager) {
+			TaskValidationService taskValidationService, PlatformTransactionManager transactionManager,
+			DataSource dataSource) {
 		return new DefaultTaskService(dataSourceProperties, repository, taskExplorer, taskExecutionRepository, registry,
 				taskLauncher, metadataResolver, taskConfigurationProperties, deploymentIdRepository, auditRecordService,
-				dataflowServerUri, commonApplicationProperties, taskValidationService, transactionManager);
+				dataflowServerUri, commonApplicationProperties, taskValidationService,
+				transactionManager, dataSource);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -100,10 +100,10 @@ public class TaskConfiguration {
 			ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskConfigurationProperties taskConfigurationProperties, DeploymentIdRepository deploymentIdRepository,
 			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
-			TaskValidationService taskValidationService) {
+			TaskValidationService taskValidationService, PlatformTransactionManager transactionManager) {
 		return new DefaultTaskService(dataSourceProperties, repository, taskExplorer, taskExecutionRepository, registry,
 				taskLauncher, metadataResolver, taskConfigurationProperties, deploymentIdRepository, auditRecordService,
-				dataflowServerUri, commonApplicationProperties, taskValidationService);
+				dataflowServerUri, commonApplicationProperties, taskValidationService, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskService.java
@@ -429,7 +429,7 @@ public class DefaultTaskService implements TaskService {
 
 		private TaskExecution taskExecution;
 
-		Map<String, String> launchTaskDeploymentProperties;
+		private Map<String, String> launchTaskDeploymentProperties;
 
 
 		public RequestCriteria(AppDeploymentRequest appDeploymentRequest,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -175,10 +175,11 @@ public class JobDependencies {
 			TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
 			DeploymentIdRepository deploymentIdRepository, AuditRecordService auditRecordService,
 			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-			PlatformTransactionManager transactionManager) {
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskService(new DataSourceProperties(), repository, explorer, taskRepository(), registry,
 				taskLauncher, metadataResolver, new TaskConfigurationProperties(), deploymentIdRepository,
-				auditRecordService, null, commonApplicationProperties, taskValidationService, transactionManager);
+				auditRecordService, null, commonApplicationProperties, taskValidationService,
+				transactionManager, dataSource);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -80,6 +80,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
@@ -173,10 +174,11 @@ public class JobDependencies {
 	public TaskService taskService(TaskDefinitionRepository repository, TaskExplorer explorer, AppRegistry registry,
 			TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
 			DeploymentIdRepository deploymentIdRepository, AuditRecordService auditRecordService,
-			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService) {
+			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+			PlatformTransactionManager transactionManager) {
 		return new DefaultTaskService(new DataSourceProperties(), repository, explorer, taskRepository(), registry,
 				taskLauncher, metadataResolver, new TaskConfigurationProperties(), deploymentIdRepository,
-				auditRecordService, null, commonApplicationProperties, taskValidationService);
+				auditRecordService, null, commonApplicationProperties, taskValidationService, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -59,6 +59,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import static org.mockito.Matchers.anyString;
@@ -178,11 +179,12 @@ public class TaskServiceDependencies {
 			TaskExplorer taskExplorer, TaskRepository taskExecutionRepository, AppRegistry appRegistry,
 			TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskConfigurationProperties taskConfigurationProperties, AuditRecordService auditRecordService,
-			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService) {
+			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+			PlatformTransactionManager transactionManager) {
 		return new DefaultTaskService(this.dataSourceProperties, taskDefinitionRepository, taskExplorer,
 				taskExecutionRepository, appRegistry, taskLauncher, metadataResolver, taskConfigurationProperties,
 				new InMemoryDeploymentIdRepository(), auditRecordService, null, commonApplicationProperties,
-				taskValidationService);
+				taskValidationService, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -180,11 +180,11 @@ public class TaskServiceDependencies {
 			TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskConfigurationProperties taskConfigurationProperties, AuditRecordService auditRecordService,
 			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-			PlatformTransactionManager transactionManager) {
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskService(this.dataSourceProperties, taskDefinitionRepository, taskExplorer,
 				taskExecutionRepository, appRegistry, taskLauncher, metadataResolver, taskConfigurationProperties,
 				new InMemoryDeploymentIdRepository(), auditRecordService, null, commonApplicationProperties,
-				taskValidationService, transactionManager);
+				taskValidationService, transactionManager, dataSource);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -129,6 +129,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -419,21 +420,23 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	public TaskDefinitionController taskDefinitionController(TaskExplorer explorer, TaskDefinitionRepository repository,
 			DeploymentIdRepository deploymentIdRepository, ApplicationConfigurationMetadataResolver metadataResolver,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
-			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService) {
+			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+			PlatformTransactionManager transactionManager) {
 		return new TaskDefinitionController(explorer, repository,
 				taskService(metadataResolver, taskRepository(), deploymentIdRepository, appRegistry,
 						/* delegatingResourceLoader, */auditRecordService, commonApplicationProperties,
-						taskValidationService));
+						taskValidationService, transactionManager));
 	}
 
 	@Bean
 	public TaskExecutionController taskExecutionController(TaskExplorer explorer,
 			ApplicationConfigurationMetadataResolver metadataResolver, DeploymentIdRepository deploymentIdRepository,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
-			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService) {
+			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+			PlatformTransactionManager transactionManager) {
 		return new TaskExecutionController(
 				explorer, taskService(metadataResolver, taskRepository(), deploymentIdRepository, appRegistry,
-						auditRecordService, commonApplicationProperties, taskValidationService),
+						auditRecordService, commonApplicationProperties, taskValidationService, transactionManager),
 				taskDefinitionRepository());
 	}
 
@@ -489,11 +492,12 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	public TaskService taskService(ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskRepository taskExecutionRepository, DeploymentIdRepository deploymentIdRepository,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
-			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService) {
+			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+			PlatformTransactionManager transactionManager) {
 		return new DefaultTaskService(new DataSourceProperties(), taskDefinitionRepository(), taskExplorer(),
 				taskExecutionRepository, appRegistry, taskLauncher(), metadataResolver,
 				new TaskConfigurationProperties(), deploymentIdRepository, auditRecordService, null,
-				commonApplicationProperties, taskValidationService);
+				commonApplicationProperties, taskValidationService, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
+import javax.sql.DataSource;
+
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -421,11 +423,11 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			DeploymentIdRepository deploymentIdRepository, ApplicationConfigurationMetadataResolver metadataResolver,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
 			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-			PlatformTransactionManager transactionManager) {
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new TaskDefinitionController(explorer, repository,
 				taskService(metadataResolver, taskRepository(), deploymentIdRepository, appRegistry,
 						/* delegatingResourceLoader, */auditRecordService, commonApplicationProperties,
-						taskValidationService, transactionManager));
+						taskValidationService, transactionManager, dataSource));
 	}
 
 	@Bean
@@ -433,10 +435,11 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			ApplicationConfigurationMetadataResolver metadataResolver, DeploymentIdRepository deploymentIdRepository,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
 			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-			PlatformTransactionManager transactionManager) {
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new TaskExecutionController(
-				explorer, taskService(metadataResolver, taskRepository(), deploymentIdRepository, appRegistry,
-						auditRecordService, commonApplicationProperties, taskValidationService, transactionManager),
+				explorer, taskService(metadataResolver, taskRepository(), deploymentIdRepository,
+				appRegistry, auditRecordService, commonApplicationProperties,
+				taskValidationService, transactionManager, dataSource),
 				taskDefinitionRepository());
 	}
 
@@ -493,11 +496,12 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			TaskRepository taskExecutionRepository, DeploymentIdRepository deploymentIdRepository,
 			AppRegistryCommon appRegistry, AuditRecordService auditRecordService,
 			CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-			PlatformTransactionManager transactionManager) {
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskService(new DataSourceProperties(), taskDefinitionRepository(), taskExplorer(),
 				taskExecutionRepository, appRegistry, taskLauncher(), metadataResolver,
 				new TaskConfigurationProperties(), deploymentIdRepository, auditRecordService, null,
-				commonApplicationProperties, taskValidationService, transactionManager);
+				commonApplicationProperties, taskValidationService, transactionManager,
+				dataSource);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -129,6 +131,9 @@ public abstract class DefaultTaskServiceTests {
 		@Autowired
 		private AuditRecordService auditRecordService;
 
+		@Autowired
+		private DataSource dataSource;
+
 		@Before
 		public void setupMockMVC() {
 			taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
@@ -202,7 +207,8 @@ public abstract class DefaultTaskServiceTests {
 					mock(TaskDefinitionRepository.class), this.taskExplorer, this.taskExecutionRepository,
 					this.appRegistry, this.taskLauncher, this.metadataResolver, new TaskConfigurationProperties(),
 					new InMemoryDeploymentIdRepository(), auditRecordService, null, this.commonApplicationProperties,
-					this.taskValidationService, mock(PlatformTransactionManager.class));
+					this.taskValidationService, mock(PlatformTransactionManager.class),
+					this.dataSource);
 			try {
 				taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 			}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTests.java
@@ -57,6 +57,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
@@ -201,7 +202,7 @@ public abstract class DefaultTaskServiceTests {
 					mock(TaskDefinitionRepository.class), this.taskExplorer, this.taskExecutionRepository,
 					this.appRegistry, this.taskLauncher, this.metadataResolver, new TaskConfigurationProperties(),
 					new InMemoryDeploymentIdRepository(), auditRecordService, null, this.commonApplicationProperties,
-					this.taskValidationService);
+					this.taskValidationService, mock(PlatformTransactionManager.class));
 			try {
 				taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 			}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTransactionTests.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.registry.AppRegistry;
+import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
+import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
+import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
+import org.springframework.cloud.dataflow.server.audit.domain.AuditActionType;
+import org.springframework.cloud.dataflow.server.audit.domain.AuditOperationType;
+import org.springframework.cloud.dataflow.server.audit.domain.AuditRecord;
+import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentIdRepository;
+import org.springframework.cloud.dataflow.server.repository.RdbmsTaskDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
+import org.springframework.cloud.dataflow.server.repository.support.DataflowRdbmsInitializer;
+import org.springframework.cloud.dataflow.server.service.TaskService;
+import org.springframework.cloud.dataflow.server.service.TaskValidationService;
+import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import org.springframework.cloud.task.repository.TaskExplorer;
+import org.springframework.cloud.task.repository.TaskRepository;
+import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
+import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
+import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
+import org.springframework.cloud.task.repository.support.TaskRepositoryInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Glenn Renfro
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {EmbeddedDataSourceConfiguration.class, DefaultTaskServiceTransactionTests.TaskServiceDelayDependencies.class})
+@EnableConfigurationProperties({CommonApplicationProperties.class, TaskConfigurationProperties.class, DockerValidatorProperties.class})
+public class DefaultTaskServiceTransactionTests {
+
+	private final static String BASE_TASK_NAME = "myTask";
+
+	private final static String TASK_NAME_ORIG = BASE_TASK_NAME + "_ORIG";
+
+	@Autowired
+	private TaskDefinitionRepository taskDefinitionRepository;
+
+	@Autowired
+	private AppRegistry appRegistry;
+
+	@Autowired
+	private TaskLauncherStub taskLauncher;
+
+	@Autowired
+	private TaskService taskService;
+
+	@Before
+	public void setupMockMVC() {
+		taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
+	}
+
+	@Test
+	@DirtiesContext
+	public void executeSingleTaskTest() {
+		initializeSuccessfulRegistry(appRegistry);
+		this.taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
+		assertThat(taskLauncher.getResult(), is(equalTo("1")));
+	}
+
+	private static void initializeSuccessfulRegistry(AppRegistry appRegistry) {
+		when(appRegistry.find(anyString(), any(ApplicationType.class))).thenReturn(
+				new AppRegistration("some-name", ApplicationType.task, URI.create("http://helloworld")));
+		when(appRegistry.getAppResource(any())).thenReturn(new FileSystemResource("src/test/resources/apps/foo-task"));
+		when(appRegistry.getAppMetadataResource(any())).thenReturn(null);
+	}
+
+	public static class TaskServiceDelayDependencies {
+
+		@Autowired
+		DataSourceProperties dataSourceProperties;
+
+		@Bean
+		public TaskRepositoryInitializer taskExecutionRepository(DataSource dataSource) {
+			TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer();
+			taskRepositoryInitializer.setDataSource(dataSource);
+			return taskRepositoryInitializer;
+		}
+
+		@Bean
+		public TaskDefinitionRepository taskDefinitionRepository(DataSource dataSource) {
+			return new RdbmsTaskDefinitionRepository(dataSource);
+		}
+
+		@Bean
+		public TaskValidationService taskValidationService(AppRegistryCommon appRegistryCommon,
+				DockerValidatorProperties dockerValidatorProperties,
+				TaskDefinitionRepository taskDefinitionRepository,
+				TaskConfigurationProperties taskConfigurationProperties) {
+			return new DefaultTaskValidationService(appRegistryCommon,
+					dockerValidatorProperties,
+					taskDefinitionRepository,
+					taskConfigurationProperties.getComposedTaskRunnerName());
+		}
+
+
+		@Bean
+		public TaskRepository taskRepository(TaskExecutionDaoFactoryBean daoFactoryBean) {
+			return new SimpleTaskRepository(daoFactoryBean);
+		}
+
+		@Bean
+		public AuditRecordService auditRecordService() {
+			return new AuditRecordServiceStub();
+		}
+
+		@Bean
+		public TaskExplorer taskExplorer(TaskExecutionDaoFactoryBean daoFactoryBean) {
+			return new SimpleTaskExplorer(daoFactoryBean);
+		}
+
+		@Bean
+		public TaskExecutionDaoFactoryBean taskExecutionDaoFactoryBean(DataSource dataSource) {
+			return new TaskExecutionDaoFactoryBean(dataSource);
+		}
+
+		@Bean
+		public AppRegistry appRegistry() {
+			return mock(AppRegistry.class);
+		}
+
+		@Bean
+		public ResourceLoader resourceLoader() {
+			ResourceLoader resourceLoader = mock(ResourceLoader.class);
+			when(resourceLoader.getResource(anyString())).thenReturn(mock(Resource.class));
+			return resourceLoader;
+		}
+
+		@Bean
+		TaskLauncher taskLauncher(DataSource dataSource) {
+			return new TaskLauncherStub(dataSource);
+
+		}
+
+		@Bean
+		ApplicationConfigurationMetadataResolver metadataResolver() {
+			return mock(ApplicationConfigurationMetadataResolver.class);
+		}
+
+		@Bean
+		public DataflowRdbmsInitializer definitionRepositoryInitializer(DataSource dataSource) {
+			DataflowRdbmsInitializer definitionRepositoryInitializer = new DataflowRdbmsInitializer(featuresProperties());
+			definitionRepositoryInitializer.setDataSource(dataSource);
+			return definitionRepositoryInitializer;
+		}
+
+		@Bean
+		public FeaturesProperties featuresProperties() {
+			return new FeaturesProperties();
+		}
+
+		@Bean
+		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
+			return new DataSourceTransactionManager(dataSource);
+		}
+
+		@Bean
+		public DefaultTaskService defaultTaskService(TaskDefinitionRepository taskDefinitionRepository,
+				TaskExplorer taskExplorer, TaskRepository taskExecutionRepository, AppRegistry appRegistry,
+				TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
+				TaskConfigurationProperties taskConfigurationProperties, AuditRecordService auditRecordService,
+				CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
+				PlatformTransactionManager transactionManager) {
+			return new DefaultTaskService(this.dataSourceProperties, taskDefinitionRepository, taskExplorer,
+					taskExecutionRepository, appRegistry, taskLauncher, metadataResolver, taskConfigurationProperties,
+					new InMemoryDeploymentIdRepository(), auditRecordService, null, commonApplicationProperties,
+					taskValidationService, transactionManager);
+		}
+
+	}
+
+	private static class TaskLauncherStub implements TaskLauncher {
+		private String result = "0";
+
+		private DataSource dataSource;
+
+		private TaskLauncherStub(DataSource dataSource) {
+			this.dataSource = dataSource;
+		}
+
+		@Override
+		public String launch(AppDeploymentRequest request) {
+			JdbcTemplate template = new JdbcTemplate(this.dataSource);
+			result = String.valueOf(template.queryForObject("select count(*) from task_execution", Integer.class));
+			return result;
+		}
+
+		@Override
+		public void cancel(String id) {
+
+		}
+
+		@Override
+		public TaskStatus status(String id) {
+			return null;
+		}
+
+		@Override
+		public void cleanup(String id) {
+
+		}
+
+		@Override
+		public void destroy(String appName) {
+
+		}
+
+		@Override
+		public RuntimeEnvironmentInfo environmentInfo() {
+			return null;
+		}
+
+		public String getResult() {
+			return result;
+		}
+	}
+
+	private static class AuditRecordServiceStub implements AuditRecordService {
+
+		@Override
+		public AuditRecord populateAndSaveAuditRecord(AuditOperationType auditOperationType, AuditActionType auditActionType, String correlationId, String data) {
+			return null;
+		}
+
+		@Override
+		public AuditRecord populateAndSaveAuditRecordUsingMapData(AuditOperationType auditOperationType, AuditActionType auditActionType, String correlationId, Map<String, Object> data) {
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		@Override
+		public Page<AuditRecord> findAuditRecordByAuditOperationTypeAndAuditActionType(Pageable pageable, AuditActionType[] actions, AuditOperationType[] operations) {
+			return null;
+		}
+
+		@Override
+		public AuditRecord findOne(Long id) {
+			return null;
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskServiceTransactionTests.java
@@ -36,7 +36,6 @@ import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConf
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.registry.AppRegistry;
-import org.springframework.cloud.dataflow.registry.AppRegistryCommon;
 import org.springframework.cloud.dataflow.registry.domain.AppRegistration;
 import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
 import org.springframework.cloud.dataflow.server.audit.domain.AuditActionType;
@@ -44,32 +43,21 @@ import org.springframework.cloud.dataflow.server.audit.domain.AuditOperationType
 import org.springframework.cloud.dataflow.server.audit.domain.AuditRecord;
 import org.springframework.cloud.dataflow.server.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
-import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.repository.InMemoryDeploymentIdRepository;
-import org.springframework.cloud.dataflow.server.repository.RdbmsTaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
-import org.springframework.cloud.dataflow.server.repository.support.DataflowRdbmsInitializer;
 import org.springframework.cloud.dataflow.server.service.TaskService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
-import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
-import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
-import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
-import org.springframework.cloud.task.repository.support.TaskRepositoryInitializer;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -79,7 +67,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
@@ -87,7 +74,7 @@ import static org.mockito.Mockito.when;
  * @author Glenn Renfro
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {EmbeddedDataSourceConfiguration.class, DefaultTaskServiceTransactionTests.TaskServiceDelayDependencies.class})
+@SpringBootTest(classes = {EmbeddedDataSourceConfiguration.class, TaskServiceDependencies.class})
 @EnableConfigurationProperties({CommonApplicationProperties.class, TaskConfigurationProperties.class, DockerValidatorProperties.class})
 public class DefaultTaskServiceTransactionTests {
 
@@ -102,21 +89,51 @@ public class DefaultTaskServiceTransactionTests {
 	private AppRegistry appRegistry;
 
 	@Autowired
-	private TaskLauncherStub taskLauncher;
+	private DataSourceProperties dataSourceProperties;
 
 	@Autowired
-	private TaskService taskService;
+	private TaskExplorer taskExplorer;
+
+	@Autowired
+	private TaskRepository taskExecutionRepository;
+
+	@Autowired
+	private ApplicationConfigurationMetadataResolver metadataResolver;
+
+	@Autowired
+	private TaskConfigurationProperties taskConfigurationProperties;
+
+	@Autowired
+	private CommonApplicationProperties commonApplicationProperties;
+
+	@Autowired
+	private TaskValidationService taskValidationService;
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@Autowired
+	private DataSource dataSource;
+
+	private TaskService transactionTaskService;
+
+	private TaskLauncherStub taskLauncher;
 
 	@Before
 	public void setupMockMVC() {
 		taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
+		this.taskLauncher = new TaskLauncherStub(this.dataSource);
+		this.transactionTaskService = new DefaultTaskService(this.dataSourceProperties, taskDefinitionRepository, taskExplorer,
+				taskExecutionRepository, appRegistry, taskLauncher, metadataResolver, taskConfigurationProperties,
+				new InMemoryDeploymentIdRepository(), new AuditRecordServiceStub(), null, commonApplicationProperties,
+				taskValidationService, transactionManager);
 	}
 
 	@Test
 	@DirtiesContext
 	public void executeSingleTaskTest() {
 		initializeSuccessfulRegistry(appRegistry);
-		this.taskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
+		this.transactionTaskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 		assertThat(taskLauncher.getResult(), is(equalTo("1")));
 	}
 
@@ -125,110 +142,6 @@ public class DefaultTaskServiceTransactionTests {
 				new AppRegistration("some-name", ApplicationType.task, URI.create("http://helloworld")));
 		when(appRegistry.getAppResource(any())).thenReturn(new FileSystemResource("src/test/resources/apps/foo-task"));
 		when(appRegistry.getAppMetadataResource(any())).thenReturn(null);
-	}
-
-	public static class TaskServiceDelayDependencies {
-
-		@Autowired
-		DataSourceProperties dataSourceProperties;
-
-		@Bean
-		public TaskRepositoryInitializer taskExecutionRepository(DataSource dataSource) {
-			TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer();
-			taskRepositoryInitializer.setDataSource(dataSource);
-			return taskRepositoryInitializer;
-		}
-
-		@Bean
-		public TaskDefinitionRepository taskDefinitionRepository(DataSource dataSource) {
-			return new RdbmsTaskDefinitionRepository(dataSource);
-		}
-
-		@Bean
-		public TaskValidationService taskValidationService(AppRegistryCommon appRegistryCommon,
-				DockerValidatorProperties dockerValidatorProperties,
-				TaskDefinitionRepository taskDefinitionRepository,
-				TaskConfigurationProperties taskConfigurationProperties) {
-			return new DefaultTaskValidationService(appRegistryCommon,
-					dockerValidatorProperties,
-					taskDefinitionRepository,
-					taskConfigurationProperties.getComposedTaskRunnerName());
-		}
-
-
-		@Bean
-		public TaskRepository taskRepository(TaskExecutionDaoFactoryBean daoFactoryBean) {
-			return new SimpleTaskRepository(daoFactoryBean);
-		}
-
-		@Bean
-		public AuditRecordService auditRecordService() {
-			return new AuditRecordServiceStub();
-		}
-
-		@Bean
-		public TaskExplorer taskExplorer(TaskExecutionDaoFactoryBean daoFactoryBean) {
-			return new SimpleTaskExplorer(daoFactoryBean);
-		}
-
-		@Bean
-		public TaskExecutionDaoFactoryBean taskExecutionDaoFactoryBean(DataSource dataSource) {
-			return new TaskExecutionDaoFactoryBean(dataSource);
-		}
-
-		@Bean
-		public AppRegistry appRegistry() {
-			return mock(AppRegistry.class);
-		}
-
-		@Bean
-		public ResourceLoader resourceLoader() {
-			ResourceLoader resourceLoader = mock(ResourceLoader.class);
-			when(resourceLoader.getResource(anyString())).thenReturn(mock(Resource.class));
-			return resourceLoader;
-		}
-
-		@Bean
-		TaskLauncher taskLauncher(DataSource dataSource) {
-			return new TaskLauncherStub(dataSource);
-
-		}
-
-		@Bean
-		ApplicationConfigurationMetadataResolver metadataResolver() {
-			return mock(ApplicationConfigurationMetadataResolver.class);
-		}
-
-		@Bean
-		public DataflowRdbmsInitializer definitionRepositoryInitializer(DataSource dataSource) {
-			DataflowRdbmsInitializer definitionRepositoryInitializer = new DataflowRdbmsInitializer(featuresProperties());
-			definitionRepositoryInitializer.setDataSource(dataSource);
-			return definitionRepositoryInitializer;
-		}
-
-		@Bean
-		public FeaturesProperties featuresProperties() {
-			return new FeaturesProperties();
-		}
-
-		@Bean
-		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-			return new DataSourceTransactionManager(dataSource);
-		}
-
-		@Bean
-		public DefaultTaskService defaultTaskService(TaskDefinitionRepository taskDefinitionRepository,
-				TaskExplorer taskExplorer, TaskRepository taskExecutionRepository, AppRegistry appRegistry,
-				TaskLauncher taskLauncher, ApplicationConfigurationMetadataResolver metadataResolver,
-				TaskConfigurationProperties taskConfigurationProperties, AuditRecordService auditRecordService,
-				CommonApplicationProperties commonApplicationProperties, TaskValidationService taskValidationService,
-				PlatformTransactionManager transactionManager) {
-			return new DefaultTaskService(this.dataSourceProperties, taskDefinitionRepository, taskExplorer,
-					taskExecutionRepository, appRegistry, taskLauncher, metadataResolver, taskConfigurationProperties,
-					new InMemoryDeploymentIdRepository(), auditRecordService, null, commonApplicationProperties,
-					taskValidationService, transactionManager);
-		}
-
 	}
 
 	private static class TaskLauncherStub implements TaskLauncher {


### PR DESCRIPTION
In this case a transaction is created and completes before the task is launched.
Then a transaction is created to capture audit information after the task is launched.

resolves #2744 for 1.7.x