### PR TITLE
Int casts from long in pageable job queries are being checked

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.dataflow.server.repository.NoSuchStreamDefiniti
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskBatchException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchTaskExecutionException;
+import org.springframework.cloud.dataflow.server.service.impl.OffsetOutOfBoundsException;
 import org.springframework.cloud.scheduler.spi.core.CreateScheduleException;
 import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpStatus;
@@ -174,7 +175,7 @@ public class RestControllerAdvice {
 	 */
 	@ExceptionHandler({ MissingServletRequestParameterException.class, HttpMessageNotReadableException.class,
 			UnsatisfiedServletRequestParameterException.class, MethodArgumentTypeMismatchException.class,
-			InvalidStreamDefinitionException.class, CreateScheduleException.class })
+			InvalidStreamDefinitionException.class, CreateScheduleException.class, OffsetOutOfBoundsException.class })
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ResponseBody
 	public VndErrors onClientGenericBadRequest(Exception e) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -87,7 +87,7 @@ public class DefaultTaskJobService implements TaskJobService {
 		Assert.notNull(pageable, "pageable must not be null");
 		// TODO: BOOT2 check what to do with long to int cast for offset
 		List<JobExecution> jobExecutions = new ArrayList<>(
-				jobService.listJobExecutions((int) pageable.getOffset(), pageable.getPageSize()));
+				jobService.listJobExecutions(getPageOffset(pageable), pageable.getPageSize()));
 		for (JobExecution jobExecution : jobExecutions) {
 			Collection<StepExecution> stepExecutions = jobService.getStepExecutions(jobExecution.getId());
 			List<StepExecution> validStepExecutions = new ArrayList<>();
@@ -101,12 +101,11 @@ public class DefaultTaskJobService implements TaskJobService {
 		return getTaskJobExecutionsForList(jobExecutions);
 	}
 
-
 	@Override
 	public List<TaskJobExecution> listJobExecutionsWithStepCount(Pageable pageable) throws NoSuchJobExecutionException {
 		Assert.notNull(pageable, "pageable must not be null");
 		List<JobExecutionWithStepCount> jobExecutions = new ArrayList<>(
-				jobService.listJobExecutionsWithStepCount((int)pageable.getOffset(), pageable.getPageSize()));
+				jobService.listJobExecutionsWithStepCount(getPageOffset(pageable), pageable.getPageSize()));
 		return getTaskJobExecutionsWithStepCountForList(jobExecutions);
 	}
 
@@ -116,7 +115,7 @@ public class DefaultTaskJobService implements TaskJobService {
 		Assert.notNull(jobName, "jobName must not be null");
 		// TODO: BOOT2 check what to do with long to int cast for offset
 		return getTaskJobExecutionsForList(
-				jobService.listJobExecutionsForJob(jobName, (int) pageable.getOffset(), pageable.getPageSize()));
+				jobService.listJobExecutionsForJob(jobName, getPageOffset(pageable), pageable.getPageSize()));
 	}
 
 	@Override
@@ -124,7 +123,7 @@ public class DefaultTaskJobService implements TaskJobService {
 		Assert.notNull(pageable, "pageable must not be null");
 		Assert.notNull(jobName, "jobName must not be null");
 		return getTaskJobExecutionsWithStepCountForList(
-				jobService.listJobExecutionsForJobWithStepCount(jobName, (int) pageable.getOffset(), pageable.getPageSize()));
+				jobService.listJobExecutionsForJobWithStepCount(jobName, getPageOffset(pageable), pageable.getPageSize()));
 	}
 
 	@Override
@@ -140,7 +139,7 @@ public class DefaultTaskJobService implements TaskJobService {
 		Assert.notNull(jobName, "jobName must not be null");
 		List<JobInstanceExecutions> taskJobInstances = new ArrayList<>();
 		// TODO: BOOT2 check what to do with long to int cast for offset
-		for (JobInstance jobInstance : jobService.listJobInstances(jobName, (int) pageable.getOffset(),
+		for (JobInstance jobInstance : jobService.listJobInstances(jobName, getPageOffset(pageable),
 				pageable.getPageSize())) {
 			taskJobInstances.add(getJobInstanceExecution(jobInstance));
 		}
@@ -238,6 +237,13 @@ public class DefaultTaskJobService implements TaskJobService {
 		return taskExecutionId;
 	}
 
+
+	private int getPageOffset(Pageable pageable) {
+		if(pageable.getOffset() > (long)Integer.MAX_VALUE) {
+			throw new OffsetOutOfBoundsException("The pageable offset requested for this query is greater than MAX_INT.") ;
+		}
+		return (int)pageable.getOffset();
+	}
 
 	private JobInstanceExecutions getJobInstanceExecution(JobInstance jobInstance) throws NoSuchJobException {
 		Assert.notNull(jobInstance, "jobInstance must not be null");

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/OffsetOutOfBoundsException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/OffsetOutOfBoundsException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+
+/**
+ * Exception thrown when a user requests a page & size combination that creates
+ * an offset  that is greater than  {@link Integer#MAX_VALUE}.
+ *
+ * @author Glenn Renfro
+ */
+public class OffsetOutOfBoundsException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public OffsetOutOfBoundsException(String message) {
+		super(message);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -42,6 +42,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
@@ -172,11 +173,23 @@ public class JobExecutionControllerTests {
 	}
 
 	@Test
+	public void testGetAllExecutionsPageOffsetLargerThanIntMaxValue() throws Exception {
+		verify5XXErrorIsThrownForPageOffsetError(get("/jobs/executions/"));
+		verifyBorderCaseForMaxInt(get("/jobs/executions/"));
+	}
+
+	@Test
 	public void testGetExecutionsByName() throws Exception {
 		mockMvc.perform(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG).accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content[0].jobExecution.jobInstance.jobName", is(JobExecutionUtils.JOB_NAME_ORIG)))
 				.andExpect(jsonPath("$.content", hasSize(1)));
+	}
+
+	@Test
+	public void testGetExecutionsByNamePageOffsetLargerThanIntMaxValue() throws Exception {
+		verify5XXErrorIsThrownForPageOffsetError(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG));
+		verifyBorderCaseForMaxInt(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG));
 	}
 
 	@Test
@@ -187,6 +200,7 @@ public class JobExecutionControllerTests {
 				.andExpect(jsonPath("$.content[1].jobExecution.jobInstance.jobName", is(JobExecutionUtils.JOB_NAME_FOOBAR)))
 				.andExpect(jsonPath("$.content", hasSize(2)));
 	}
+
 
 	@Test
 	public void testGetExecutionsByNameNotFound() throws Exception {
@@ -201,5 +215,18 @@ public class JobExecutionControllerTests {
 		jobExecution.setStatus(BatchStatus.STOPPED);
 		jobExecution.setEndTime(new Date());
 		jobRepository.update(jobExecution);
+	}
+
+	private void verify5XXErrorIsThrownForPageOffsetError(MockHttpServletRequestBuilder builder) throws Exception{
+		mockMvc.perform(builder.param("page", String.valueOf(Integer.MAX_VALUE))
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().is4xxClientError())
+				.andReturn().getResponse().getContentAsString()
+				.contains("OffsetOutOfBoundsException");
+	}
+	private void verifyBorderCaseForMaxInt(MockHttpServletRequestBuilder builder) throws Exception {
+		mockMvc.perform(builder.param("page", String.valueOf(Integer.MAX_VALUE - 1 ))
+				.param("size", "1")
+				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk());
 	}
 }


### PR DESCRIPTION
According to the notes we need to return a qualified exception if the user attempts a query with offest greater than MAX_INT

resolves #2549