### PR TITLE
Produce error if single char stream element arg value is special char

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskTokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,10 @@ class TaskTokenizer extends AbstractTokenizer {
 					// here we consume everything up to the next special char.
 					// This allows SpEL expressions to be used without quoting in many
 					// situations.
+					// If the next char is a special char then the argument value is missing
+					if (isArgValueIdentifierTerminator(ch, false)) {
+						raiseException(DSLMessage.EXPECTED_ARGUMENT_VALUE, ch);
+					}
 					lexArgValueIdentifier();
 				}
 				justProcessedEquals = false;

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/Tokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ class Tokenizer extends AbstractTokenizer {
 					// here we consume everything up to the next special char.
 					// This allows SpEL expressions to be used without quoting in many
 					// situations.
+					// If the next char is a special char then the argument value is missing
+					if (isArgValueIdentifierTerminator(ch, false)) {
+						raiseException(DSLMessage.EXPECTED_ARGUMENT_VALUE, ch);
+					}
 					lexArgValueIdentifier();
 				}
 				justProcessedEquals = false;

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/StreamParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/StreamParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,23 @@ public class StreamParserTests {
 		assertEquals("[(AppNode:aaa --bbb=ccc:0>15)(AppNode:bbb:18>21)]", sn.stringify(true));
 		ArgumentNode argumentNode = sn.getAppNodes().get(0).getArguments()[0];
 		assertEquals("ccc", argumentNode.getValue());
+	}
+
+	@Test
+	public void shortArgValues_2499() {
+		// This is the expected result when an argument value is missing:
+		checkForParseError("aaa --bbb= --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 11);
+		// From AbstractTokenizer.isArgValueIdentifierTerminator these are the 'special chars' that should
+		// terminate an argument value if not quoted:
+		// "|"   ";"   "\0"   " "   "\t"   ">"   "\r"   "\n"
+		// (\0 is the sentinel, wouldn't expect that in user data)
+		checkForParseError("aaa --bbb=| --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		checkForParseError("aaa --bbb=; --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		checkForParseError("aaa --bbb=> --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		// Not sure the tabs/etc here and handled quite right during tokenization but it does error as expected
+		checkForParseError("aaa --bbb=	 --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 12);
+		checkForParseError("aaa --bbb=\t --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 12);
+		checkForParseError("aaa --bbb=\n --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
 	}
 
 	// Just to make the testing easier the parser supports stream naming easier.

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,6 +222,23 @@ public class TaskParserTests {
 	public void errorCases04() {
 		checkForParseError("foo bar=yyy", DSLMessage.TASK_MORE_INPUT, 4, "bar");
 		checkForParseError("foo bar", DSLMessage.TASK_MORE_INPUT, 4, "bar");
+	}
+
+	@Test
+	public void shortArgValues_2499() {
+		// This is the expected result when an argument value is missing:
+		checkForParseError("aaa --bbb= --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 11);
+		// From AbstractTokenizer.isArgValueIdentifierTerminator these are the 'special chars' that should
+		// terminate an argument value if not quoted:
+		// "|"   ";"   "\0"   " "   "\t"   ">"   "\r"   "\n"
+		// (\0 is the sentinel, wouldn't expect that in user data)
+		checkForParseError("aaa --bbb=| --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		checkForParseError("aaa --bbb=; --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		checkForParseError("aaa --bbb=> --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 10);
+		// Not sure the tabs/etc here and handled quite right during tokenization but it does error as expected
+		checkForParseError("aaa --bbb=	 --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 12);
+		checkForParseError("aaa --bbb=\t --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 12);
+		checkForParseError("aaa --bbb=\n --ccc=ddd", DSLMessage.EXPECTED_ARGUMENT_VALUE, 12);
 	}
 
 	@Test


### PR DESCRIPTION
Without this change the system was not consistent in how it treated
special characters in argument values (e.g. | or >). They were
not treated as special if they were the first character in the
argument value (e.g. 'app --param=|'). When used like that they
should still be treated as special (i.e. end of stream def) and
so an error should come out about a missing argument value. If
they are truly the argument value they should be quoted.

Resolves #2499