### PR TITLE
Resolves task executing before task exec info is committed [2.0.x]

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -160,12 +160,13 @@ public class TaskConfiguration {
 			ApplicationConfigurationMetadataResolver metadataResolver,
 			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
 			TaskRepository taskRepository,
-			TaskExecutionInfoService taskExecutionInfoService) {
+			TaskExecutionInfoService taskExecutionInfoService,
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, metadataResolver, auditRecordService,
 				dataflowServerUri, commonApplicationProperties,
 				taskRepository,
-				taskExecutionInfoService);
+				taskExecutionInfoService, dataSource, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -205,14 +205,16 @@ public class JobDependencies {
 	@Bean
 	public TaskExecutionService taskService(LauncherRepository launcherRepository,
 			ApplicationConfigurationMetadataResolver metadataResolver,
-			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
+			AuditRecordService auditRecordService,
+			CommonApplicationProperties commonApplicationProperties,
 			TaskRepository taskRepository,
-			TaskExecutionInfoService taskExecutionInfoService) {
+			TaskExecutionInfoService taskExecutionInfoService,
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, metadataResolver, auditRecordService,
 				null, commonApplicationProperties,
 				taskRepository,
-				taskExecutionInfoService);
+				taskExecutionInfoService, dataSource, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -77,6 +77,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
@@ -212,12 +213,13 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 			ApplicationConfigurationMetadataResolver metadataResolver,
 			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
 			TaskRepository taskRepository,
-			TaskExecutionInfoService taskExecutionInfoService) {
+			TaskExecutionInfoService taskExecutionInfoService,
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, metadataResolver, auditRecordService,
 				null, commonApplicationProperties,
 				taskRepository,
-				taskExecutionInfoService);
+				taskExecutionInfoService, dataSource, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
+import javax.sql.DataSource;
+
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.springframework.batch.core.StepExecution;
@@ -140,6 +142,7 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -486,12 +489,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			ApplicationConfigurationMetadataResolver metadataResolver,
 			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
 			TaskRepository taskRepository,
-			TaskExecutionInfoService taskExecutionInfoService) {
+			TaskExecutionInfoService taskExecutionInfoService,
+			PlatformTransactionManager transactionManager, DataSource dataSource) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, metadataResolver, auditRecordService,
 				null, commonApplicationProperties,
 				taskRepository,
-				taskExecutionInfoService);
+				taskExecutionInfoService, dataSource, transactionManager);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +62,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
@@ -139,6 +142,9 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 	@Autowired
 	AuditRecordService auditRecordService;
+
+	@Autowired
+	DataSource dataSource;
 
 	@TestPropertySource(properties = { "spring.cloud.dataflow.task.maximum-concurrent-tasks=10" })
 	@AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -231,7 +237,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 					mock(LauncherRepository.class), this.metadataResolver,
 					auditRecordService, null, this.commonApplicationProperties,
 					taskRepository,
-					taskExecutionInfoService);
+					taskExecutionInfoService, this.dataSource,
+					mock(PlatformTransactionManager.class));
 			try {
 				taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>(), "default");
 			}
@@ -266,7 +273,6 @@ public abstract class DefaultTaskExecutionServiceTests {
 	@TestPropertySource(properties = { "spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
 			"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere" })
 	@AutoConfigureTestDatabase(replace = Replace.ANY)
-
 	public static class ComposedTaskTests extends DefaultTaskExecutionServiceTests {
 
 		@Autowired

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.AppRegistration;
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.AuditActionType;
+import org.springframework.cloud.dataflow.core.AuditOperationType;
+import org.springframework.cloud.dataflow.core.AuditRecord;
+import org.springframework.cloud.dataflow.core.Launcher;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
+import org.springframework.cloud.dataflow.server.job.LauncherRepository;
+import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
+import org.springframework.cloud.dataflow.server.service.TaskDeleteService;
+import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoService;
+import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.TaskSaveService;
+import org.springframework.cloud.dataflow.server.service.TaskValidationService;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.deployer.spi.task.TaskStatus;
+import org.springframework.cloud.task.repository.TaskExplorer;
+import org.springframework.cloud.task.repository.TaskRepository;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Glenn Renfro
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TaskServiceDependencies.class }, properties = {
+		"spring.main.allow-bean-definition-overriding=true" })
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class DefaultTaskExecutionServiceTransactionTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private final static String BASE_TASK_NAME = "myTask";
+
+	private final static String TASK_NAME_ORIG = BASE_TASK_NAME + "_ORIG";
+
+	@Autowired
+	TaskRepository taskRepository;
+
+	@Autowired
+	DataSourceProperties dataSourceProperties;
+
+	@Autowired
+	TaskDefinitionRepository taskDefinitionRepository;
+
+	@Autowired
+	AppRegistryService appRegistry;
+
+	@Autowired
+	TaskLauncher taskLauncher;
+
+	@Autowired
+	TaskSaveService taskSaveService;
+
+	@Autowired
+	TaskDeleteService taskDeleteService;
+
+	@Autowired
+	TaskExecutionInfoService taskExecutionInfoService;
+
+	@Autowired
+	TaskExecutionService taskExecutionService;
+
+	@Autowired
+	TaskExplorer taskExplorer;
+
+	@Autowired
+	ApplicationConfigurationMetadataResolver metadataResolver;
+
+	@Autowired
+	CommonApplicationProperties commonApplicationProperties;
+
+	@Autowired
+	LauncherRepository launcherRepository;
+
+	@Autowired
+	TaskValidationService taskValidationService;
+
+	@Autowired
+	AuditRecordService auditRecordService;
+
+	@Autowired
+	DataSource dataSource;
+
+	@Autowired
+	PlatformTransactionManager platformTransactionManager;
+
+	@Autowired
+	TaskConfigurationProperties taskConfigurationProperties;
+
+	private TaskExecutionService transactionTaskService;
+
+		@Before
+		public void setupMocks() {
+			this.launcherRepository.save(new Launcher("default", "local", new TaskLauncherStub(dataSource)));
+			this.taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
+			this.taskDefinitionRepository.findAll();
+
+			this.transactionTaskService = new DefaultTaskExecutionService(
+					this.launcherRepository, this.metadataResolver,
+					new AuditRecordServiceStub(), null, this.commonApplicationProperties,
+					taskRepository,
+					taskExecutionInfoService, dataSource,
+					platformTransactionManager
+			);
+		}
+
+		@Test
+		@DirtiesContext
+		public void executeSingleTaskTransactionTest() {
+			initializeSuccessfulRegistry(this.appRegistry);
+			assertEquals(1L, this.transactionTaskService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>(),
+					"default"));
+		}
+
+	private static class TaskLauncherStub implements TaskLauncher {
+		private String result = "0";
+
+		private DataSource dataSource;
+
+		private TaskLauncherStub(DataSource dataSource) {
+			this.dataSource = dataSource;
+		}
+
+		@Override
+		public String launch(AppDeploymentRequest request) {
+			JdbcTemplate template = new JdbcTemplate(this.dataSource);
+			result = String.valueOf(template.queryForObject("select count(*) from task_execution", Integer.class));
+			return result;
+		}
+
+		@Override
+		public void cancel(String id) {
+
+		}
+
+		@Override
+		public TaskStatus status(String id) {
+			return null;
+		}
+
+		@Override
+		public void cleanup(String id) {
+
+		}
+
+		@Override
+		public void destroy(String appName) {
+
+		}
+
+		@Override
+		public RuntimeEnvironmentInfo environmentInfo() {
+			return null;
+		}
+
+		public String getResult() {
+			return result;
+		}
+	}
+
+	private static class AuditRecordServiceStub implements AuditRecordService {
+
+		@Override
+		public AuditRecord populateAndSaveAuditRecord(AuditOperationType auditOperationType, AuditActionType auditActionType, String correlationId, String data) {
+			return null;
+		}
+
+		@Override
+		public AuditRecord populateAndSaveAuditRecordUsingMapData(AuditOperationType auditOperationType, AuditActionType auditActionType, String correlationId, Map<String, Object> data) {
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		@Override
+		public Page<AuditRecord> findAuditRecordByAuditOperationTypeAndAuditActionType(Pageable pageable, AuditActionType[] actions, AuditOperationType[] operations) {
+			return null;
+		}
+
+		@Override
+		public Optional<AuditRecord> findById(Long id) {
+			return Optional.empty();
+		}
+	}
+
+	private static void initializeSuccessfulRegistry(AppRegistryService appRegistry) {
+		when(appRegistry.find(anyString(), any(ApplicationType.class))).thenReturn(
+				new AppRegistration("some-name", ApplicationType.task, URI.create("http://helloworld")));
+		when(appRegistry.getAppResource(any())).thenReturn(new FileSystemResource("src/test/resources/apps/foo-task"));
+		when(appRegistry.getAppMetadataResource(any())).thenReturn(null);
+	}
+}


### PR DESCRIPTION
One interesting note on the tests.  There were artifacts in the database that required a `DirtiesContext` before the class.   


resolves #2692