### PR TITLE
Silence hibernate clob error with postgres

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -17,6 +17,8 @@ logging:
     org.springframework.boot.autoconfigure.security: 'INFO'
     # The following INFO is to log the embedded tomcat port
     org.springframework.boot.web.embedded.tomcat: 'INFO'
+    # Silence annoying exception trace logged on info level - gh-2750
+    org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl: 'WARN'
 spring:
   data:
     redis:


### PR DESCRIPTION
- As postgres driver we use doesn't support PgConnection.createClob(),
  during a startup exception is thrown on INFO level basically just
  for notification, silence this by changing log level for that
  class to WARN.
- github.com/spring-cloud/spring-cloud-dataflow/issues/2750 has links
  to github.com/pgjdbc/pgjdbc/issues/1102 with more discussion about
  this.
- Fixes #2750