### PR TITLE
Fix Asciidoctor warnings

### DIFF
--- a/spring-cloud-dataflow-docs/pom.xml
+++ b/spring-cloud-dataflow-docs/pom.xml
@@ -164,6 +164,9 @@
 								<skipper-branch-or-tag>${skipper-branch-or-tag}</skipper-branch-or-tag>
 								<github-tag>${github-tag}</github-tag>
 								<local-server-image-tag>${local-server-image-tag}</local-server-image-tag>
+
+								<scdf-core-version>${org.springframework.cloud:spring-cloud-dataflow-core:jar.version}</scdf-core-version>
+								<cf-deployer-branch-or-tag>${cf-deployer-branch-or-tag}</cf-deployer-branch-or-tag>
 							</attributes>
 						</configuration>
 						<executions>
@@ -286,6 +289,8 @@
 
 										<var name="local-server-image-tag" value="${project.version}" />
 										<propertyregex property="local-server-image-tag" override="true" input="${local-server-image-tag}" regexp=".*SNAPSHOT" replace="latest" />
+
+										<propertyregex property="cf-deployer-branch-or-tag" override="true" input="${spring-cloud-deployer-cloudfoundry.version}" regexp=".*\.(?:M\d+|RC\d+|RELEASE)" select="v\0" defaultValue="master" />
 									</target>
 								</configuration>
 							</execution>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
@@ -77,7 +77,7 @@ cf set-env dataflow-server SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_CLOUDFOUNDRY_ACCO
 =====
 
 TIP: All the properties mentioned above are `@ConfigurationProperties` of the
-Cloud Foundry deployer. See link:https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/blob/{deployer-branch-or-tag}/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java[CloudFoundryDeploymentProperties.java] for more information.
+Cloud Foundry deployer. See link:https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/blob/{cf-deployer-branch-or-tag}/src/main/java/org/springframework/cloud/deployer/spi/cloudfoundry/CloudFoundryDeploymentProperties.java[CloudFoundryDeploymentProperties.java] for more information.
 
 [[configuration-app-names-cloud-foundry]]
 === Application Names and Prefixes

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
@@ -301,7 +301,7 @@ The following example shows how to start the Data Flow Shell:
 ====
 [source,bash,subs=attributes]
 ----
-$ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+$ java -jar spring-cloud-dataflow-shell-{scdf-core-version}.jar
 ----
 ====
 
@@ -381,7 +381,7 @@ The following example shows how to start the Data Flow shell for the Data Flow s
 ====
 [source,bash,subs=attributes]
 ----
-$ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+$ java -jar spring-cloud-dataflow-shell-{scdf-core-version}.jar
 ----
 ====
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
@@ -225,7 +225,7 @@ $ kubectl delete serviceaccount scdf-sa
 . Deploy Skipper
 +
 Data Flow delegates to Skipper the streams lifecycle management. Deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to enable the stream management features.
-For more details, see link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[Spring Cloud Skipper Reference Guide] for a complete overview.
+For more details, see link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version}/reference/htmlsingle/#overview[Spring Cloud Skipper Reference Guide] for a complete overview.
 +
 The deployment is defined in the `src/kubernetes/skipper/skipper-deployment.yaml` file.
 To control what version of Skipper gets deployed, modify the tag used for the Docker image in the container specification, as the following example shows:
@@ -243,7 +243,7 @@ To control what version of Skipper gets deployed, modify the tag used for the Do
 ====
 +
 NOTE: Skipper includes the concept of link:https://docs.spring.io/spring-cloud-skipper/docs/current/reference/htmlsingle/#using-platforms[platforms], so it is important to define the "`accounts`" based on the project preferences.
-More details are in the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[Spring Cloud Skipper Reference Guide].
+More details are in the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version}/reference/htmlsingle/#overview[Spring Cloud Skipper Reference Guide].
 +
 If you would like to use RabbitMQ as the messaging middleware, apply the following:
 +
@@ -611,9 +611,9 @@ This section describes how to create streams (using Skipper). To do so:
 ====
 [source,bash,subs=attributes]
 ----
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{scdf-core-version}/spring-cloud-dataflow-shell-{scdf-core-version}.jar
 
-java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+java -jar spring-cloud-dataflow-shell-{scdf-core-version}.jar
 ----
 ====
 +
@@ -633,7 +633,7 @@ You should see the following startup message from the shell:
  | |_| | (_| | || (_| | |  _| | | (_) \ V  V /    / / / / / /
  |____/ \__,_|\__\__,_| |_|   |_|\___/ \_/\_/    /_/_/_/_/_/
 
-{dataflow-project-version}
+{scdf-core-version}
 
 Welcome to the Spring Cloud Data Flow shell. For assistance hit TAB or type "help".
 server-unknown:>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -21,7 +21,16 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :github-repo: spring-cloud/spring-cloud-dataflow
 :github-code: https://github.com/{github-repo}
 
+
 :dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/asciidoc
+
+:docker-http-source-rabbit-version: 1.3.1.RELEASE
+:docker-time-source-rabbit-version: 1.3.1.RELEASE
+:docker-log-sink-rabbit-version: 1.3.1.RELEASE
+:docker-log-sink-kafka-version: 1.3.1.RELEASE
+:docker-http-source-kafka-version: 1.3.1.RELEASE
+:docker-time-source-kafka-version: 1.3.1.RELEASE
+:docker-timestamp-task-version: 1.3.1.RELEASE
 
 ifdef::backend-html5[]
 


### PR DESCRIPTION
The reported issue included a bunch of missing doc-elements, and likewise, the build warnings associated with them. 

I attempted to clean them up in this proposal. Following are the revised properties.

- Add missing references for:
```
docker-time-source-rabbit-version
docker-log-sink-kafka-version
docker-log-sink-rabbit-version
docker-time-source-kafka-version
docker-http-source-rabbit-version
docker-http-source-kafka-version
docker-timestamp-task-version
```
- Change `dataflow-project-version` to `scdf-core-version` 

- Change `skipper-core-version` to `skipper-version` (reused existing element)

- Change `dataflow-version-type-lowercase` to `version-type-lowercase` (reused existing element)

- Add `cf-deployer-branch-or-tag` (made it cf-deployer specific given the usage pattern)

With all the above changes, I still see the following warnings, but they are false-alarms!

```
asciidoctor: WARNING: skipping reference to missing attribute: dataflow_version
asciidoctor: WARNING: skipping reference to missing attribute: host_app_folder
asciidoctor: WARNING: skipping reference to missing attribute: host_app_folder
asciidoctor: WARNING: skipping reference to missing attribute: middlewareservicename
asciidoctor: WARNING: skipping reference to missing attribute: services
```

1) "dataflow_version" - used as "${DATAFLOW_VERSION}" and it does get replaced with a value after the build.
2) "host_app_folder" - used as "${HOST_APP_FOLDER}", but there's explanation as to what to be done in the NOTE.
3) "middlewareservicename" - used in YAML sample, but there's explanation as to what to be done.
3) "services" - used in YAML sample, but there's explanation as to what to be done.

I used: `./mvnw clean package -DskipTests -P full -pl spring-cloud-dataflow-docs -am` to build the project.

Resolves #2728