### PR TITLE
Fix flyway scripts for new task_deployment table

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2BeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2BeforeBaseline.java
@@ -185,6 +185,7 @@ public class Db2BeforeBaseline extends AbstractBaselineCallback {
 
 	@Override
 	public List<SqlCommand> createTaskDeploymentTable() {
-		return null;
+		return Arrays.asList(SqlCommand.from(
+				V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V1__Initial_Setup.java
@@ -71,14 +71,14 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
 			"create table task_deployment (\n" +
-					"  id bigint not null,\n" +
-					"  object_version bigint,\n" +
-					"  task_deployment_id varchar(255) not null,\n" +
-					"  task_definition_name varchar(255) not null,\n" +
-					"  platform_name varchar(255) not null,\n" +
-					"  created_on datetime,\n" +
-					"  primary key (id)\n" +
-					");";
+			"  id bigint not null,\n" +
+			"  object_version bigint,\n" +
+			"  task_deployment_id varchar(255) not null,\n" +
+			"  task_definition_name varchar(255) not null,\n" +
+			"  platform_name varchar(255) not null,\n" +
+			"  created_on timestamp,\n" +
+			"  primary key (id)\n" +
+			")";
 
 	public final static String CREATE_TASK_EXECUTION_TABLE =
 			"CREATE TABLE TASK_EXECUTION (\n" +

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlBeforeBaseline.java
@@ -182,6 +182,7 @@ public class MysqlBeforeBaseline extends AbstractBaselineCallback {
 
 	@Override
 	public List<SqlCommand> createTaskDeploymentTable() {
-		return Arrays.asList(SqlCommand.from(V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
+		return Arrays.asList(SqlCommand.from(
+				V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V1__Initial_Setup.java
@@ -50,18 +50,6 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 			"  primary key (id)\n" +
 			")";
 
-	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
-			"create table task_deployment (\n" +
-					"  id bigint not null,\n" +
-					"  object_version bigint,\n" +
-					"  task_deployment_id varchar(255) not null,\n" +
-					"  task_definition_name varchar(255) not null,\n" +
-					"  platform_name varchar(255) not null,\n" +
-					"  created_on datetime,\n" +
-					"  primary key (id)\n" +
-					");";
-
-
 	public final static String CREATE_AUDIT_RECORDS_TABLE =
 			"create table audit_records (\n" +
 			"  id bigint not null,\n" +
@@ -86,6 +74,17 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 			"  definition_name varchar(255) not null,\n" +
 			"  definition longtext,\n" +
 			"  primary key (definition_name)\n" +
+			")";
+
+	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
+			"create table task_deployment (\n" +
+			"  id bigint not null,\n" +
+			"  object_version bigint,\n" +
+			"  task_deployment_id varchar(255) not null,\n" +
+			"  task_definition_name varchar(255) not null,\n" +
+			"  platform_name varchar(255) not null,\n" +
+			"  created_on datetime,\n" +
+			"  primary key (id)\n" +
 			")";
 
 	public final static String CREATE_TASK_EXECUTION_TABLE =

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleBeforeBaseline.java
@@ -185,7 +185,7 @@ public class OracleBeforeBaseline extends AbstractBaselineCallback {
 
 	@Override
 	public List<SqlCommand> createTaskDeploymentTable() {
-		return null;
+		return Arrays.asList(SqlCommand.from(
+				V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
 	}
-
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V1__Initial_Setup.java
@@ -71,14 +71,14 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
 			"create table task_deployment (\n" +
-					"  id bigint not null,\n" +
-					"  object_version bigint,\n" +
-					"  task_deployment_id varchar(255) not null,\n" +
-					"  task_definition_name varchar(255) not null,\n" +
-					"  platform_name varchar(255) not null,\n" +
-					"  created_on datetime,\n" +
-					"  primary key (id)\n" +
-					");";
+			"  id number(19,0) not null,\n" +
+			"  object_version number(19,0),\n" +
+			"  task_deployment_id varchar2(255 char) not null,\n" +
+			"  task_definition_name varchar2(255 char) not null,\n" +
+			"  platform_name varchar2(255 char) not null,\n" +
+			"  created_on timestamp,\n" +
+			"  primary key (id)\n" +
+			")";
 
 	public final static String CREATE_TASK_EXECUTION_TABLE =
 			"CREATE TABLE TASK_EXECUTION (\n" +

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresBeforeBaseline.java
@@ -194,6 +194,7 @@ public class PostgresBeforeBaseline extends AbstractBaselineCallback {
 
 	@Override
 	public List<SqlCommand> createTaskDeploymentTable() {
-		return null;
+		return Arrays.asList(SqlCommand.from(
+				V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V1__Initial_Setup.java
@@ -70,14 +70,14 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
 			"create table task_deployment (\n" +
-					"  id bigint not null,\n" +
-					"  object_version bigint,\n" +
-					"  task_deployment_id varchar(255) not null,\n" +
-					"  task_definition_name varchar(255) not null,\n" +
-					"  platform_name varchar(255) not null,\n" +
-					"  created_on datetime,\n" +
-					"  primary key (id)\n" +
-					");";
+			"  id int8 not null,\n" +
+			"  object_version int8,\n" +
+			"  task_deployment_id varchar(255) not null,\n" +
+			"  task_definition_name varchar(255) not null,\n" +
+			"  platform_name varchar(255) not null,\n" +
+			"  created_on timestamp,\n" +
+			"  primary key (id)\n" +
+			")";
 
 	public final static String CREATE_TASK_EXECUTION_TABLE =
 			"CREATE TABLE TASK_EXECUTION (\n" +

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlBeforeBaseline.java
@@ -182,6 +182,7 @@ public class MsSqlBeforeBaseline extends AbstractBaselineCallback {
 
 	@Override
 	public List<SqlCommand> createTaskDeploymentTable() {
-		return null;
+		return Arrays.asList(SqlCommand.from(
+				V1__Initial_Setup.CREATE_TASK_DEPLOYMENT_TABLE));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V1__Initial_Setup.java
@@ -71,14 +71,14 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_TASK_DEPLOYMENT_TABLE =
 			"create table task_deployment (\n" +
-					"  id bigint not null,\n" +
-					"  object_version bigint,\n" +
-					"  task_deployment_id varchar(255) not null,\n" +
-					"  task_definition_name varchar(255) not null,\n" +
-					"  platform_name varchar(255) not null,\n" +
-					"  created_on datetime,\n" +
-					"  primary key (id)\n" +
-					");";
+			"  id bigint not null,\n" +
+			"  object_version bigint,\n" +
+			"  task_deployment_id varchar(255) not null,\n" +
+			"  task_definition_name varchar(255) not null,\n" +
+			"  platform_name varchar(255) not null,\n" +
+			"  created_on datetime2,\n" +
+			"  primary key (id)\n" +
+			")";
 
 	public final static String CREATE_TASK_EXECUTION_TABLE =
 			"CREATE TABLE TASK_EXECUTION (\n" +


### PR DESCRIPTION
- As newly modified scripts are only valid for mysql and
  essentially broken for postgres, db2, oracle and sqlserver
  add missing references to all *BeforeBaseline#createBatchTables()
  functions.
- Also fix all V1__Inital_Setup#CREATE_TASK_DEFINITIONS_TABLE scripts
  to have a correct format for each databases which needs to follow
  what SchemaGenerationTests creates as you can't just create one for
  mysql and copy those over to other db's.
- Generic polish for sql's.
- Fixes #2816