### PR TITLE
Add qualified prefix for task platform name

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -197,7 +197,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			this.launcherRepository.save(new Launcher("anotherPlatform", "local", taskLauncher));
 			assertEquals(1L, this.taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>()));
 			Map<String, String> deploymentProperties = new HashMap<>();
-			deploymentProperties.put(DefaultTaskExecutionService.TASK_PLATFORM_NAME, "anotherPlatform");
+			deploymentProperties.put("app.demo."+ DefaultTaskExecutionService.TASK_PLATFORM_NAME, "anotherPlatform");
 			boolean errorCaught = false;
 			try {
 				this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, new LinkedList<>());


### PR DESCRIPTION
 - Since validation of task deployment properties is bound to happen (via Dashboard),
we always need the qualified prefix for the task platform name
 - Update test

Resolves #2818