### PR TITLE
Revise "Applications" table for correctness

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -29,7 +29,7 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_task[timestamp]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http]
@@ -39,14 +39,14 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
 
-|link:https://github.com/spring-cloud-stream-app-starters/loggregator[loggregator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-loggregator-source[loggregator]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp]
 |
@@ -112,7 +112,7 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire]
-|link:https://github.com/spring-cloud-stream-app-starters/tasklaunchrequest-transform[tasklaunchrequest-transform]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tasklaunchrequest-transform[tasklaunchrequest-transform]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp]
 |
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -1,146 +1,146 @@
-\[[applications]]
- = Applications
+[[applications]]
+= Applications
 
- [partintro]
- --
- A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] starter apps for various data integration and processing scenarios to facilitate learning and experimentation. The table below includes the pre-built applications at a glance. For more details, review how to <<index.adoc#supported-apps-and-tasks, register supported applications>>.
- --
+[partintro]
+--
+A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] starter apps for various data integration and processing scenarios to facilitate learning and experimentation. The table below includes the pre-built applications at a glance. For more details, review how to <<index.adoc#supported-apps-and-tasks, register supported applications>>.
+--
 
- == Available Applications
- [width="100%",frame="topbot",options="header",subs=attributes]
- |======================
- |Source |Processor |Sink |Task
+== Available Applications
+[width="100%",frame="topbot",options="header",subs=attributes]
+|======================
+|Source |Processor |Sink |Task
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt] ~(1.3.x,2.0.x,2.1.x)~
- |spark-yarn ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt] ~(1.3.x,2.0.x,2.1.x)~
+|spark-yarn ~(deprecated)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log] ~(1.3.x,2.0.x,2.1.x)~
- |spark-cluster ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log] ~(1.3.x,2.0.x,2.1.x)~
+|spark-cluster ~(deprecated)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform] ~(1.3.x,2.0.x,2.1.x)~
- |task-launcher-yarn ~(deprecated)~
- |spark-client ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform] ~(1.3.x,2.0.x,2.1.x)~
+|task-launcher-yarn ~(deprecated)~
+|spark-client ~(deprecated)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput] ~(1.3.x,2.0.x,2.1.x)~
- |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput] ~(1.3.x,2.0.x,2.1.x)~
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp] ~(1.3.x,2.0.x,2.1.x)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http] ~(1.3.x,2.0.x,2.1.x)~
- |task-launcher-local ~(deprecated)~
- |jdbchdfs-local ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http] ~(1.3.x,2.0.x,2.1.x)~
+|task-launcher-local ~(deprecated)~
+|jdbchdfs-local ~(deprecated)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb] ~(1.3.x,2.0.x,2.1.x)~
- |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb] ~(1.3.x,2.0.x,2.1.x)~
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner] ~(1.3.x,2.0.x,2.1.x)~
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset] ~(1.3.x,2.0.x,2.1.x)~
- |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset] ~(1.3.x,2.0.x,2.1.x)~
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch] ~(1.3.x,2.0.x,2.1.x)~
 
- |loggregator ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp] ~(1.3.x,2.0.x,2.1.x)~
- |
+|loggregator ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(1.3.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(1.3.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
- |link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
+|link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire] ~(1.3.x,2.0.x,2.1.x)~
- |tasklaunchrequest-transform ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire] ~(1.3.x,2.0.x,2.1.x)~
+|tasklaunchrequest-transform ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection] ~(1.3.x,2.0.x,2.1.x)~
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter] ~(1.3.x,2.0.x,2.1.x)~
- |
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |
- |
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs] ~(1.3.x,2.0.x,2.1.x)~
- |
+|
+|
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |
- |
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp] ~(1.3.x,2.0.x,2.1.x)~
- |
+|
+|
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |
- |
- |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire] ~(1.3.x,2.0.x,2.1.x)~
- |
+|
+|
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire] ~(1.3.x,2.0.x,2.1.x)~
+|
 
- |
- |
- |task-launcher-cloudfoundry ~(deprecated)~
- |
- |======================
+|
+|
+|task-launcher-cloudfoundry ~(deprecated)~
+|
+|======================
 
- NOTE: Each of the applications listed in the table above include the supported version(s) in parenthesis. For example, the
- `sftp-sink` is available for the versions 1.3.x, 2.0.x, and 2.1.x.
+NOTE: Each of the applications listed in the table above include the supported version(s) in parenthesis. For example, the
+`sftp-sink` is available for the versions 1.3.x, 2.0.x, and 2.1.x.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -1,143 +1,146 @@
-[[applications]]
-= Applications
+\[[applications]]
+ = Applications
 
-[partintro]
---
-A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] starter apps for various data integration and processing scenarios to facilitate learning and experimentation. The table below includes the pre-built applications at a glance. For more details, review how to <<index.adoc#supported-apps-and-tasks, register supported applications>>.
---
+ [partintro]
+ --
+ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-starters/[stream] and link:http://cloud.spring.io/spring-cloud-task-app-starters/[task/batch] starter apps for various data integration and processing scenarios to facilitate learning and experimentation. The table below includes the pre-built applications at a glance. For more details, review how to <<index.adoc#supported-apps-and-tasks, register supported applications>>.
+ --
 
-== Available Applications
-[width="100%",frame="topbot",options="header",subs=attributes]
-|======================
-|Source |Processor |Sink |Task
+ == Available Applications
+ [width="100%",frame="topbot",options="header",subs=attributes]
+ |======================
+ |Source |Processor |Sink |Task
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_spark_yarn_task[spark-yarn]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt] ~(1.3.x,2.0.x,2.1.x)~
+ |spark-yarn ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_spark_cluster_task[spark-cluster]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log] ~(1.3.x,2.0.x,2.1.x)~
+ |spark-cluster ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform]
-|task-launcher-yarn
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/html/spring-cloud-task-modules-spark-client.html[spark-client]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform] ~(1.3.x,2.0.x,2.1.x)~
+ |task-launcher-yarn ~(deprecated)~
+ |spark-client ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput] ~(1.3.x,2.0.x,2.1.x)~
+ |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp] ~(1.3.x,2.0.x,2.1.x)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http]
-|task-launcher-local
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_jdbchdfs_task[jdbchdfs-local]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http] ~(1.3.x,2.0.x,2.1.x)~
+ |task-launcher-local ~(deprecated)~
+ |jdbchdfs-local ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb] ~(1.3.x,2.0.x,2.1.x)~
+ |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner] ~(1.3.x,2.0.x,2.1.x)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset] ~(1.3.x,2.0.x,2.1.x)~
+ |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch] ~(1.3.x,2.0.x,2.1.x)~
 
-|loggregator
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp]
-|
+ |loggregator ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pmml-processor[pmml]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(1.3.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt]
-|tasklaunchrequest-transform
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client]
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail]
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc]
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gpfdist-sink[gpfdist]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
+ |link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire]
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire] ~(1.3.x,2.0.x,2.1.x)~
+ |tasklaunchrequest-transform ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file]
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter]
-|
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection] ~(1.3.x,2.0.x,2.1.x)~
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs]
-|
+ |
+ |
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp]
-|
+ |
+ |
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire]
-|
+ |
+ |
+ |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire] ~(1.3.x,2.0.x,2.1.x)~
+ |
 
-|
-|
-|task-launcher-cloudfoundry
-|
-|======================
+ |
+ |
+ |task-launcher-cloudfoundry ~(deprecated)~
+ |
+ |======================
+
+ NOTE: Each of the applications listed in the table above include the supported version(s) in parenthesis. For example, the
+ `sftp-sink` is available for the versions 1.3.x, 2.0.x, and 2.1.x.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -11,129 +11,129 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |======================
 |Source |Processor |Sink |Task
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt]
 |spark-yarn ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log]
 |spark-cluster ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform]
 |task-launcher-yarn ~(deprecated)~
 |spark-client ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput] ~(1.3.x,2.0.x,2.1.x)~
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_task[timestamp]
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http]
 |task-launcher-local ~(deprecated)~
 |jdbchdfs-local ~(deprecated)~
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb] ~(1.3.x,2.0.x,2.1.x)~
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset] ~(1.3.x,2.0.x,2.1.x)~
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/Clark.RELEASE/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
 
-|loggregator ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp] ~(1.3.x,2.0.x,2.1.x)~
+|link:https://github.com/spring-cloud-stream-app-starters/loggregator[loggregator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(1.3.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(only:2.1.x)~
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
 |link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire] ~(1.3.x,2.0.x,2.1.x)~
-|tasklaunchrequest-transform ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire]
+|link:https://github.com/spring-cloud-stream-app-starters/tasklaunchrequest-transform[tasklaunchrequest-transform]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp]
 |
 
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection] ~(1.3.x,2.0.x,2.1.x)~
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter] ~(1.3.x,2.0.x,2.1.x)~
-|
-
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter]
 |
 
 |
 |
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs]
 |
 
 |
 |
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire] ~(1.3.x,2.0.x,2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp]
+|
+
+|
+|
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire]
 |
 
 |
@@ -142,5 +142,6 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |
 |======================
 
-NOTE: Each of the applications listed in the table above include the supported version(s) in parenthesis. For example, the
-`sftp-sink` is available for the versions 1.3.x, 2.0.x, and 2.1.x.
+NOTE: The above table includes Applications that are compatible with two versions of Spring Boot and Spring Cloud Stream
+releases. Darwin-release-train _(Spring Boot 2.0.x + Spring Cloud Stream 2.0.x)_ and Einstein-release-train
+_(Spring Boot 2.1.x + Spring Cloud Stream 2.1.x)_, respectively.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/architecture.adoc
@@ -98,7 +98,7 @@ endif::omit-tasks-docs[]
 [[arch-comparison]]
 === Comparison to Other Platform Architectures
 
-Spring Cloud Data Flow’s architectural style is different than other Stream and Batch processing platforms.  For example in Apache Spark, Apache Flink, and Google Cloud Dataflow, applications run on a dedicated compute engine cluster.  The nature of the compute engine gives these platforms a richer environment for performing complex calculations on the data as compared to Spring Cloud Data Flow, but it introduces the complexity of another execution environment that is often not needed when creating data-centric applications.  That does not mean you cannot do real-time data computations when using Spring Cloud Data Flow.  Refer to the section <<arch-analytics, Analytics>>, which describes the integration of Redis to handle common counting-based use cases.  Spring Cloud Stream also supports using Reactive APIs such as https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_reactive_programming_support[Project Reactor and RxJava] which can be useful for creating functional style applications that contain time-sliding-window and moving-average functionality.  Similarly, Spring Cloud Stream also supports the development of applications in that use the https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_kafka_streams_binding_capabilities_of_spring_cloud_stream[Kafka Streams] API.
+Spring Cloud Data Flow’s architectural style is different than other Stream and Batch processing platforms.  For example in Apache Spark, Apache Flink, and Google Cloud Dataflow, applications run on a dedicated compute engine cluster.  The nature of the compute engine gives these platforms a richer environment for performing complex calculations on the data as compared to Spring Cloud Data Flow, but it introduces the complexity of another execution environment that is often not needed when creating data-centric applications.  That does not mean you cannot do real-time data computations when using Spring Cloud Data Flow. Spring Cloud Stream also supports using Reactive APIs such as https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_reactive_programming_support[Project Reactor and RxJava] which can be useful for creating functional style applications that contain time-sliding-window and moving-average functionality.  Similarly, Spring Cloud Stream also supports the development of applications in that use the https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_kafka_streams_binding_capabilities_of_spring_cloud_stream[Kafka Streams] API.
 
 Apache Storm, Hortonworks DataFlow, and Spring Cloud Data Flow’s predecessor, Spring XD, use a dedicated application execution cluster, unique to each product, that determines where your code should run on the cluster and performs health checks to ensure that long-lived applications are restarted if they fail.  Often, framework-specific interfaces are required in order to correctly “plug in” to the cluster’s execution framework.
 
@@ -116,7 +116,7 @@ The Data Flow Server provides the following functionality:
 [[arch-data-flow-server-endpoints]]
 === Endpoints
 
-The Data Flow Server uses an embedded servlet container and exposes REST endpoints for creating, deploying, undeploying, and destroying streams and tasks, querying runtime state, analytics, and the like. The Data Flow Server is implemented by using Spring’s MVC framework and the link:https://github.com/spring-projects/spring-hateoas[Spring HATEOAS] library to create REST representations that follow the HATEOAS principle, as shown in the following image:
+The Data Flow Server uses an embedded servlet container and exposes REST endpoints for creating, deploying, undeploying, and destroying streams and tasks, querying runtime state and the like. The Data Flow Server is implemented by using Spring’s MVC framework and the link:https://github.com/spring-projects/spring-hateoas[Spring HATEOAS] library to create REST representations that follow the HATEOAS principle, as shown in the following image:
 
 .The Spring Cloud Data Flow Server
 image::{dataflow-asciidoc}/images/dataflow-server-arch.png[The Spring Cloud Data Flow Server Architecture, scaledwidth="100%"]
@@ -248,16 +248,6 @@ The Spring Cloud Task programming model provides:
 See the <<spring-cloud-dataflow-task,Tasks>> section for more information.
 
 endif::omit-tasks-docs[]
-
-[[arch-analytics]]
-== Analytics
-Spring Cloud Data Flow is aware of certain Sink applications that write counter data to Redis and provides a REST endpoint to read counter data.  The types of counters supported are as follows:
-
-* link:https://github.com/spring-cloud-stream-app-starters/counter/tree/master/spring-cloud-starter-stream-sink-counter[Counter]: Counts the number of messages it receives, optionally storing counts in a separate store such as Redis.
-* link:https://github.com/spring-cloud-stream-app-starters/field-value-counter/tree/master/spring-cloud-starter-stream-sink-field-value-counter[Field Value Counter]: Counts occurrences of unique values for a named field in a message payload.
-* link:https://github.com/spring-cloud-stream-app-starters/aggregate-counter/tree/master/spring-cloud-starter-stream-sink-aggregate-counter[Aggregate Counter]: Stores total counts but also retains the total count values for each minute, hour, day, and month.
-
-Note that the timestamp used in the aggregate counter can come from a field in the message itself so that out-of-order messages are properly accounted.
 
 [[arch-runtime]]
 == Runtime

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
@@ -11,16 +11,13 @@ Data Flow server offers a specific set of features that you can enable or disabl
 
 * Streams
 * Tasks
-* Analytics
 
 You can enable or disable these features by setting the following boolean properties when you launch the Data Flow server:
 
 * `spring.cloud.dataflow.features.streams-enabled`
 * `spring.cloud.dataflow.features.tasks-enabled`
-* `spring.cloud.dataflow.features.analytics-enabled`
 
 By default, all features are enabled.
-Note: Since the analytics feature is enabled by default, the Data Flow server is expected to have a valid Redis store available as its analytic repository (we provide a default implementation of analytics based on Redis). This also means that the Data Flow server's `health` depends on the redis store availability as well. If you do not want to enable HTTP endpoints to read analytics data written to Redis, you can disable the analytics feature by using the `spring.cloud.dataflow.features.analytics-enabled` property to `false`.
 
 The REST endpoint (`/features`) provides information on the enabled and disabled features.
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-kubernetes.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-kubernetes.adoc
@@ -10,19 +10,15 @@ Data Flow server offers specific set of features that can be enabled or disabled
 
 * Streams
 * Tasks
-* Analytics
 * Schedules
 
 You can enable or disable these features by setting the following boolean environment variables when launching the Data Flow server:
 
 * `SPRING_CLOUD_DATAFLOW_FEATURES_STREAMS_ENABLED`
 * `SPRING_CLOUD_DATAFLOW_FEATURES_TASKS_ENABLED`
-* `SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED`
 * `SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED`
 
 By default, all the features are enabled.
-
-NOTE: Since the analytics feature is enabled by default, the Data Flow server is expected to have a valid Redis store available as an analytics repository. Consequently, we provide a default implementation of analytics based on Redis. This also means that the Data Flow server's `health` depends on the redis store availability as well. If you do not want to enable HTTP endpoints to read analytics data written to Redis, you can disable the analytics feature by setting the property mentioned earlier to `false`.
 
 The `/features` REST endpoint provides information on the features that have been enabled and disabled.
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
@@ -14,21 +14,15 @@ Sprig Cloud Data Flow Server offers specific set of features that can be enabled
 
 * Streams (requires Skipper)
 * Tasks
-* Analytics
 * Task Scheduler
 
 One can enable and disable these features by setting the following boolean properties when launching the Data Flow server:
 
 * `spring.cloud.dataflow.features.streams-enabled`
 * `spring.cloud.dataflow.features.tasks-enabled`
-* `spring.cloud.dataflow.features.analytics-enabled`
 * `spring.cloud.dataflow.features.schedules-enabled`
 
-By default, stream (requires Skipper), tasks, and analytics are enabled and Task Scheduler is disabled by default.
-
-NOTE: Since the analytics feature is enabled by default, the Data Flow Server expects to have a valid Redis store available to server as the analytic repository, because Spring Cloud Data Flow provides a default implementation of analytics based on Redis.
-This also means that the Data Flow Server's `health` depends on the redis store availability as well.
-If you do not want Data Flow's endpoints to read analytics data written to Redis, then disable the analytics feature by setting the property mentioned above.
+By default, stream (requires Skipper), and tasks are enabled and Task Scheduler is disabled by default.
 
 The REST `/about` endpoint provides information on the features that have been enabled and disabled.
 
@@ -1134,7 +1128,7 @@ and need to be  {spring-boot-docs-reference}/htmlsingle/#production-ready-custom
 If you enable sensitive endpoints, you should also <<configuration-local-security,secure the Data Flow server's endpoints>> so that information is not inadvertently exposed to unauthenticated users.
 The local Data Flow server has security disabled by default, so all actuator endpoints are available.
 
-The Data Flow server requires a relational database, and, if the feature toggle for analytics is enabled, a Redis server is also required.
+The Data Flow server requires a relational database.
 The Data Flow server autoconfigures the https://github.com/spring-projects/spring-boot/blob/v{spring-boot-version}/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/DataSourceHealthIndicator.java[DataSourceHealthIndicator] and https://github.com/spring-projects/spring-boot/blob/v{spring-boot-version}/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/RedisHealthIndicator.java[RedisHealthIndicator] if needed.
 The health of these two services is incorporated to the overall health status of the server through the `health` endpoint.
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
@@ -18,7 +18,6 @@ ifndef::omit-tasks-docs[]
 * *Tasks*: The Tasks tab lets you list, create, launch, schedule and, destroy Task Definitions.
 endif::omit-tasks-docs[]
 * *Jobs*: The Jobs tab lets you perform batch job related functions.
-* *Analytics*: The Analytics tab lets you create data visualizations for the various analytics applications.
 
 Upon starting Spring Cloud Data Flow, the dashboard is available at:
 
@@ -421,24 +420,6 @@ On this screen you can perform the following actions:
 
 * Delete a schedule
 * Get details for a schedule
-
-[[dashboard-analytics]]
-== Analytics
-
-The Analytics page of the Dashboard provides the following data visualization capabilities for the various analytics applications available in Spring Cloud Data Flow:
-
-* Counters
-* Field-Value Counters
-* Aggregate Counters
-
-For example, if you create a stream with a link:https://github.com/spring-cloud-stream-app-starters/counter/tree/master/spring-cloud-starter-stream-sink-counter[Counter] application, you can create the corresponding graph from within the Dashboard tab.
-To do so:
-
-. Under `Metric Type`, select `Counters` from the select box.
-. Under `Stream`, select `tweetcount`.
-. Under `Visualization`, select the desired chart option, `Bar Chart`.
-
-Using the icons to the right, you can add additional charts to the Dashboard, re-arange the order of created dashboards, or remove data visualizations.
 
 [[dashboard-auditing]]
 == Auditing

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
@@ -7,26 +7,13 @@
 The Spring Cloud Data Flow server deploys task tasks (short-lived applications) and via Skipper deploys streams (long-lived applications) to Cloud Foundry.
 The server is a lightweight Spring Boot application. It can run on Cloud Foundry or your laptop, but it is more common to run the server in Cloud Foundry.
 
-Spring Cloud Data Flow requires a few data services to perform streaming, task/batch processing, and analytics.
+Spring Cloud Data Flow requires a few data services to perform streaming and task/batch processing.
 You have two options when you provision Spring Cloud Data Flow and related services on Cloud Foundry:
 
 * The simplest (and automated) method is to use the link:https://network.pivotal.io/products/p-dataflow[Spring Cloud Data Flow for PCF] tile.
 This is an opinionated tile for Pivotal Cloud Foundry.
 It automatically provisions the server and the required data services, thus simplifying the overall getting-started experience. You can read more about the installation link:http://docs.pivotal.io/scdf/[here].
 * Alternatively, you can provision all the components manually. The following section goes into the specifics of how to do so.
-
-==== Provision a Redis Service Instance on Cloud Foundry
-A Redis instance is required for analytics apps and is typically bound to such apps when you create an analytics stream by using setting deployment properties set on a per-application basis
-
-You can use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
-For example, you can use link:https://run.pivotal.io/[Pivotal Web Services], as the following example shows:
-
-====
-[source]
-----
-cf create-service rediscloud 30mb redis
-----
-====
 
 ==== Provision a Rabbit Service Instance on Cloud Foundry
 RabbitMQ is used as a messaging middleware between streaming apps and is bound to each deployed streaming app.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
@@ -314,7 +314,7 @@ If you would like to register all out-of-the-box stream applications built with 
 ====
 [source]
 ----
-dataflow:>app import --uri http://bit.ly/Darwin-SR1-stream-applications-rabbit-maven
+dataflow:>app import --uri http://bit.ly/Darwin-SR3-stream-applications-rabbit-maven
 ----
 ====
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
@@ -14,7 +14,6 @@ This section covers how to install the Spring Cloud Data Flow Server on a Kubern
 Spring Cloud Data Flow depends on a few services and their availability.
 For example, we need an RDBMS service for the application registry, stream and task repositories, and task management.
 For streaming pipelines, we also need link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] server for lifecycle management and a messaging middleware option, such as Apache Kafka or RabbitMQ.
-In addition, if the analytics features are in use, we need a Redis service.
 
 IMPORTANT: This guide describes setting up an environment for testing Spring Cloud Data Flow on Google Kubernetes Engine and is not meant to be a definitive guide for setting up a production environment. Feel free to adjust the suggestions to fit your test setup. Remember that a production environment requires much more consideration for persistent storage of message queues, high availability, security, and other concerns.
 
@@ -144,32 +143,9 @@ Run the following command to start the MySQL service:
 kubectl create -f src/kubernetes/mysql/
 ----
 ====
++
 You can use `kubectl get all -l app=mysql` to verify that the deployment, pod, and service resources are running.
 You can use `kubectl delete all,pvc,secrets -l app=mysql` to clean up afterwards.
-+
-. Deploy Redis.
-+
-The Redis service is used for the analytics functionality.
-Run the following command to start the Redis service:
-+
-====
-[source,bash]
-----
-kubectl create -f src/kubernetes/redis/
-----
-====
-+
-[NOTE]
-====
-If you do not need the analytics functionality, you can turn this feature off by setting `SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED` to `false` in the `src/kubernetes/server/server-deployment.yaml` file.
-If you do not install the Redis service, you should also remove the Redis configuration settings from the following files depending on your message broker:
-
-* RabbitMQ: `src/kubernetes/server/server-config-rabbit.yaml`
-* Kafka: `src/kubernetes/server/server-config-kafka.yaml`
-====
-+
-You can use `kubectl get all -l app=redis` to verify that the deployment, pod, and service resources are running.
-You can use `kubectl delete all -l app=redis` to clean up afterwards.
 +
 . Deploy the Metrics Collector.
 +

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
@@ -18,8 +18,6 @@ You need Java 8 to run and to build you need to have Maven.
 You need to have an RDBMS for storing stream definition and deployment properties and task/batch job states.
 By default, the Data Flow server uses embedded H2 database for this purpose but you can easily configure the server to use another external database.
 
-You also need to have link:https://redis.io[Redis] running if you are running any streams that involve analytics applications. Redis may also be required to run the unit/integration tests.
-
 For the deployed streams applications communicate, either link:http://www.rabbitmq.com[RabbitMQ] or link:http://kafka.apache.org[Kafka] needs to be installed.
 
 For deploying, upgrading and rolling back applications in Streams at runtime, you should install the Spring Cloud Skipper server as well.
@@ -126,7 +124,7 @@ NOTE: Some stream applications may open a port, for example `http --server.port=
 [[getting-started-local-customizing-spring-cloud-dataflow-docker]]
 ==== Docker Compose Customization
 
-Out of the box Spring Cloud Data Flow will use the H2 embedded database for storing state, Kafka for communication and no analytics.
+Out of the box Spring Cloud Data Flow will use the H2 embedded database for storing state, Kafka for communication.
 Customizations can be made to these components by editing the `docker-compose.yml` file as described below.
 
 . [[getting-started-local-customizing-spring-cloud-dataflow-docker-mysql]]To use MySQL rather than the H2 embedded database, add the following configuration under the `services` section:
@@ -204,30 +202,9 @@ with:
 And finally, modify the `app-import` service definition `command` attribute to replace `http://bit.ly/Celsius-SR3-stream-applications-kafka-10-maven` with `http://bit.ly/Celsius-SR3-stream-applications-rabbit-maven`.
 +
 
-. [[getting-started-local-customizing-spring-cloud-dataflow-docker-redis]]To enable analytics using redis as a backend, add the following configuration under the `services` section:
-+
-[source,yaml,subs=attributes]
-----
-  redis:
-    image: redis:2.8
-    expose:
-      - "6379"
-----
-+
-Then add the following entries to the `environment` block of the `dataflow-server` service definition:
-+
-[source,yaml,subs=attributes]
-----
-      - spring.cloud.dataflow.applicationProperties.stream.spring.redis.host=redis
-      - spring.redis.host=redis
-----
-+
-
 . To enable Metrics support, the following modifications need to be made.
 +
-First, after the `zookeeper` service definition add Redis as described in <<getting-started-customizing-spring-cloud-dataflow-docker-redis,Enable analytics using Redis>>.
-+
-Then add the metrics collector after the `skipper-server` service definition:
+Add the metrics collector after the `skipper-server` service definition:
 +
 [source,yaml,options=nowrap,subs=attributes]
 ----

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -15,8 +15,8 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :spring-cloud-task-version: 2.0.0.RELEASE
 :spring-batch-version: 4.1.0.RELEASE
 :spring-boot-docs-reference: https://docs.spring.io/spring-boot/docs/2.1.1.RELEASE/reference
-:scs-app-starters-docs: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR2/reference/html
-:scs-app-starters-docs-htmlsingle: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR2/reference/htmlsingle
+:scs-app-starters-docs: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR3/reference/html
+:scs-app-starters-docs-htmlsingle: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR3/reference/htmlsingle
 :github-repo: spring-cloud/spring-cloud-dataflow
 :github-code: https://github.com/{github-repo}
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -15,8 +15,8 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :spring-cloud-task-version: 2.0.0.RELEASE
 :spring-batch-version: 4.1.0.RELEASE
 :spring-boot-docs-reference: https://docs.spring.io/spring-boot/docs/2.1.1.RELEASE/reference
-:scs-app-starters-docs: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR3/reference/html
-:scs-app-starters-docs-htmlsingle: https://docs.spring.io/spring-cloud-stream-app-starters/docs/Darwin.SR3/reference/htmlsingle
+:scs-app-starters-docs: https://docs.spring.io/spring-cloud-stream-app-starters/docs/current/reference/html
+:scs-app-starters-docs-htmlsingle: https://docs.spring.io/spring-cloud-stream-app-starters/docs/current/reference/htmlsingle
 :github-repo: spring-cloud/spring-cloud-dataflow
 :github-code: https://github.com/{github-repo}
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/samples.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/samples.adoc
@@ -24,9 +24,6 @@ The samples are part of a separate https://github.com/spring-cloud/spring-cloud-
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#_batch_job_on_cloud_foundry[Batch Job on Cloud Foundry]
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#_batch_file_ingest[Batch File Ingest]
 
-.Analytics
-* https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#spring-cloud-data-flow-samples-twitter-analytics-overview[Twitter Analytics]
-
 .Data Science
 * https://docs.spring.io/spring-cloud-dataflow-samples/docs/current/reference/htmlsingle/#_species_prediction[Species Prediction]
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -342,36 +342,14 @@ An attempt to update the `mysource` to version `0.0.1` (not registered) will fai
 ==== Register Supported Applications and Tasks
 For convenience, we have the static files with application-URIs (for both maven and docker) available
 for all the out-of-the-box stream and task/batch app-starters. You can point to this file and import
-all the application-URIs in bulk. Otherwise, as explained previously, you can register them individually or have your own custom property file with only the required application-URIs in it. It is recommended, however, to have a "`focused`" list of desired application-URIs in a custom property file.
+all the application-URIs in bulk. Otherwise, as explained previously, you can register them individually or have your own
+custom property file with only the required application-URIs in it. It is recommended, however, to have a "`focused`"
+list of desired application-URIs in a custom property file.
 
-The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 1.3.x
-and Spring Boot 1.5.x:
+===== Sprfing Cloud Stream App Starters
 
-[width="100%",frame="topbot",options="header"]
-|======================
-|Artifact Type |Stable Release |SNAPSHOT Release
-
-|RabbitMQ + Maven
-|http://bit.ly/Celsius-SR3-stream-applications-rabbit-maven
-|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-rabbit-maven
-
-|RabbitMQ + Docker
-|http://bit.ly/Celsius-SR3-stream-applications-rabbit-docker
-|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-rabbit-docker
-
-|Kafka 0.10 + Maven
-|http://bit.ly/Celsius-SR3-stream-applications-kafka-10-maven
-|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-kafka-10-maven
-
-|Kafka 0.10 + Docker
-|http://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker
-|http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-kafka-10-docker
-|======================
-
-The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.0.x
+The following table includes the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.0.x
 and Spring Boot 2.0.x:
-
-NOTE: App Starter actuator endpoints are secured by default.  You can disable security by deploying streams with the property `app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`.  On Kubernetes refer to the section <<getting-started-kubernetes-probes, Liveness and readiness probes>> to configure security for actuator endpoints.
 
 [width="100%",frame="topbot",options="header"]
 |======================
@@ -394,49 +372,45 @@ NOTE: App Starter actuator endpoints are secured by default.  You can disable se
 |http://bit.ly/Darwin-BUILD-SNAPSHOT-stream-applications-kafka-docker
 |======================
 
-The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.1.x
+The following table includes the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.1.x
 and Spring Boot 2.1.x:
-
-NOTE: App Starter actuator endpoints are secured by default.  You can disable security by deploying streams with the property `app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`.  On Kubernetes refer to the section <<getting-started-kubernetes-probes, Liveness and readiness probes>> to configure security for actuator endpoints.
 
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |RabbitMQ + Maven
-|http://bit.ly/Einstein-M2-stream-applications-rabbit-maven
+|http://bit.ly/Einstein-RC1-stream-applications-rabbit-maven
 |http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-maven
 
 |RabbitMQ + Docker
-|http://bit.ly/Einstein-M2-stream-applications-rabbit-docker
+|http://bit.ly/Einstein-RC1-stream-applications-rabbit-docker
 |http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-docker
 
 |Apache Kafka + Maven
-|http://bit.ly/Einstein-M2-stream-applications-kafka-maven
+|http://bit.ly/Einstein-RC1-stream-applications-kafka-maven
 |http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-maven
 
 |Apache Kafka + Docker
-|http://bit.ly/Einstein-M2-stream-applications-kafka-docker
+|http://bit.ly/Einstein-RC1-stream-applications-kafka-docker
 |http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-docker
 |======================
 
-The following table include the available Task Application Starters based on Spring Cloud Task 1.2.x and Spring Boot 1.5.x:
 
-[width="100%",frame="topbot",options="header"]
-|======================
-|Artifact Type |Stable Release |SNAPSHOT Release
+NOTE: App Starter actuator endpoints are secured by default. You can disable security by deploying streams with the
+property `app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`.
+On Kubernetes refer to the section <<getting-started-kubernetes-probes, Liveness and readiness probes>> to configure
+security for actuator endpoints.
 
-|Maven
-|http://bit.ly/Clark-SR1-task-applications-maven
-|http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-maven
+NOTE: Starting with Spring Cloud Stream 2.1 GA release, we now have robust interoperability with Spring Cloud Function
+programming model. Building on that, with Einstein release-train, it is now possible to pick a few Stream App
+Starters, and compose them into a single application using the functional-style programming model. Check out the
+https://spring.io/blog/2019/01/09/composed-function-support-in-spring-cloud-data-flow["Composed Function Support in
+Spring Cloud Data Flow"] blog to learn more about the developer and orchestration-experience with an example.
 
-|Docker
-|http://bit.ly/Clark-SR1-task-applications-docker
-|http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-docker
-|======================
+===== Spring Cloud Task App Starters
 
-
-The following table include the available Task Application Starters based on Spring Cloud Task 2.0.x and Spring Boot 2.0.x:
+The following table includes the available Task Application Starters based on Spring Cloud Task 2.0.x and Spring Boot 2.0.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
@@ -451,18 +425,18 @@ The following table include the available Task Application Starters based on Spr
 |http://bit.ly/Dearborn-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
-The following table include the available Task Application Starters based on Spring Cloud Task 2.1.x and Spring Boot 2.1.x:
+The following table includes the available Task Application Starters based on Spring Cloud Task 2.1.x and Spring Boot 2.1.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Milestone Release |SNAPSHOT Release
 
 |Maven
-|http://bit.ly/Elston-M1-task-applications-maven
+|http://bit.ly/Elston-RC1-task-applications-maven
 |http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-maven
 
 |Docker
-|http://bit.ly/Elston-M1-task-applications-docker
+|http://bit.ly/Elston-RC1-task-applications-docker
 |http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-docker
 |======================
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -344,7 +344,8 @@ For convenience, we have the static files with application-URIs (for both maven 
 for all the out-of-the-box stream and task/batch app-starters. You can point to this file and import
 all the application-URIs in bulk. Otherwise, as explained previously, you can register them individually or have your own custom property file with only the required application-URIs in it. It is recommended, however, to have a "`focused`" list of desired application-URIs in a custom property file.
 
-The following table lists the bit.ly links to the available Stream Application Starters based on Spring Boot 1.5.x:
+The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 1.3.x
+and Spring Boot 1.5.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
@@ -367,7 +368,8 @@ The following table lists the bit.ly links to the available Stream Application S
 |http://bit.ly/Celsius-BUILD-SNAPSHOT-stream-applications-kafka-10-docker
 |======================
 
-The following table lists the bit.ly links to the available Stream Application Starters based on Spring Boot 2.0.x:
+The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.0.x
+and Spring Boot 2.0.x:
 
 NOTE: App Starter actuator endpoints are secured by default.  You can disable security by deploying streams with the property `app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`.  On Kubernetes refer to the section <<getting-started-kubernetes-probes, Liveness and readiness probes>> to configure security for actuator endpoints.
 
@@ -383,16 +385,42 @@ NOTE: App Starter actuator endpoints are secured by default.  You can disable se
 |http://bit.ly/Darwin-SR2-stream-applications-rabbit-docker
 |http://bit.ly/Darwin-BUILD-SNAPSHOT-stream-applications-rabbit-docker
 
-|Kafka 0.11 and above + Maven
+|Apache Kafka + Maven
 |http://bit.ly/Darwin-SR2-stream-applications-kafka-maven
 |http://bit.ly/Darwin-BUILD-SNAPSHOT-stream-applications-kafka-maven
 
-|Kafka 0.11 and above + Docker
+|Apache Kafka + Docker
 |http://bit.ly/Darwin-SR2-stream-applications-kafka-docker
 |http://bit.ly/Darwin-BUILD-SNAPSHOT-stream-applications-kafka-docker
 |======================
 
-The following table lists the available Task Application Starters:
+The following table include the bit.ly links to the available Stream Application Starters based on Spring Cloud Stream 2.1.x
+and Spring Boot 2.1.x:
+
+NOTE: App Starter actuator endpoints are secured by default.  You can disable security by deploying streams with the property `app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`.  On Kubernetes refer to the section <<getting-started-kubernetes-probes, Liveness and readiness probes>> to configure security for actuator endpoints.
+
+[width="100%",frame="topbot",options="header"]
+|======================
+|Artifact Type |Stable Release |SNAPSHOT Release
+
+|RabbitMQ + Maven
+|http://bit.ly/Einstein-M2-stream-applications-rabbit-maven
+|http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-maven
+
+|RabbitMQ + Docker
+|http://bit.ly/Einstein-M2-stream-applications-rabbit-docker
+|http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-docker
+
+|Apache Kafka + Maven
+|http://bit.ly/Einstein-M2-stream-applications-kafka-maven
+|http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-maven
+
+|Apache Kafka + Docker
+|http://bit.ly/Einstein-M2-stream-applications-kafka-docker
+|http://bit.ly/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-docker
+|======================
+
+The following table include the available Task Application Starters based on Spring Cloud Task 1.2.x and Spring Boot 1.5.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
@@ -405,6 +433,37 @@ The following table lists the available Task Application Starters:
 |Docker
 |http://bit.ly/Clark-SR1-task-applications-docker
 |http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-docker
+|======================
+
+
+The following table include the available Task Application Starters based on Spring Cloud Task 2.0.x and Spring Boot 2.0.x:
+
+[width="100%",frame="topbot",options="header"]
+|======================
+|Artifact Type |Stable Release |SNAPSHOT Release
+
+|Maven
+|http://bit.ly/Dearborn-SR1-task-applications-maven
+|http://bit.ly/Dearborn-BUILD-SNAPSHOT-task-applications-maven
+
+|Docker
+|http://bit.ly/Dearborn-SR1-task-applications-docker
+|http://bit.ly/Dearborn-BUILD-SNAPSHOT-task-applications-docker
+|======================
+
+The following table include the available Task Application Starters based on Spring Cloud Task 2.1.x and Spring Boot 2.1.x:
+
+[width="100%",frame="topbot",options="header"]
+|======================
+|Artifact Type |Milestone Release |SNAPSHOT Release
+
+|Maven
+|http://bit.ly/Elston-M1-task-applications-maven
+|http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-maven
+
+|Docker
+|http://bit.ly/Elston-M1-task-applications-docker
+|http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
 You can find more information about the available task starters in the http://cloud.spring.io/spring-cloud-task-app-starters/[Task App Starters Project Page] and


### PR DESCRIPTION
This proposal attempts to,
- include version information for each of the released applications
- include the last 3 release-train bit.ly links 
- default to Darwin.SR3 where possible

**UPDATE:**
- The scope of this PR has changed, and I've attempted to remove "Analytics" section from all the places in the reference guide in preparation for spring-cloud/spring-cloud-dataflow#2828. 
- I intentionally didn't touch anything pertaining to Metrics Collector, since that will be covered via spring-cloud/spring-cloud-dataflow#2605 
- I didn't clean up Redis from K8s deployment YAMLs since we have a separate story for it, but when we do, we may have to revisit the docs for correctness

Resolves spring-cloud/spring-cloud-dataflow#2832