### PR TITLE
Adding spring-cloud-dataflow-shell jar to springcloud/spring-cloud-dataflow-server Docker image

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
@@ -124,6 +124,19 @@ NOTE: Some stream applications may open a port, for example `http --server.port=
 
 
 [[getting-started-local-customizing-spring-cloud-dataflow-docker]]
+
+==== Spring Cloud Data Flow Shell
+
+For convenience and as an alternative to use of the Spring Cloud Data Flow Dashboard, Spring Cloud Data Flow Shell is also included on the springcloud/spring-cloud-dataflow-server Docker image.
+To use it, open another console window and type as follows:
+
+[source,bash]
+----
+$ docker exec -it dataflow-server java -jar shell.jar
+----
+
+Use of Spring Cloud Data Flow Shell is further described in <<shell,Shell>>.
+
 ==== Docker Compose Customization
 
 Out of the box Spring Cloud Data Flow will use the H2 embedded database for storing state, Kafka for communication and no analytics.

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -166,8 +166,11 @@
 						  </tags>
 						<from>springcloud/openjdk:latest</from>
 						<volumes>
-						  <volume>/tmp</volume>
+							<volume>/tmp</volume>
 						</volumes>
+						<env>
+							<LANG>C.UTF-8</LANG>
+						</env>
 						<entryPoint>
 						  <exec>
 							<arg>java</arg>
@@ -176,7 +179,9 @@
 						  </exec>
 						</entryPoint>
 						<assembly>
-						  <descriptor>assembly.xml</descriptor>
+							<name>maven</name>
+							<descriptor>assembly.xml</descriptor>
+							<targetDir>/</targetDir>
 						</assembly>
 					  </build>
 					</image>

--- a/spring-cloud-dataflow-server/src/main/docker/assembly.xml
+++ b/spring-cloud-dataflow-server/src/main/docker/assembly.xml
@@ -8,8 +8,15 @@
 			<includes>
 				<include>org.springframework.cloud:spring-cloud-dataflow-server</include>
 			</includes>
-			<outputDirectory>.</outputDirectory>
+			<outputDirectory>maven</outputDirectory>
 			<outputFileNameMapping>spring-cloud-dataflow-server.jar</outputFileNameMapping>
 		</dependencySet>
 	</dependencySets>
+	<files>
+		<file>
+			<source>../spring-cloud-dataflow-shell/target/spring-cloud-dataflow-shell-${project.version}.jar</source>
+			<outputDirectory>.</outputDirectory>
+			<destName>shell.jar</destName>
+		</file>
+	</files>
 </assembly>


### PR DESCRIPTION
Adding spring-cloud-dataflow-shell.jar to springcloud/spring-cloud-dataflow-server Docker image for convenience.

Resolves #2795.