### PR TITLE
Streams search results are incomplete

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class StreamDefinitionController {
 	@ResponseStatus(HttpStatus.OK)
 	public PagedResources<StreamDefinitionResource> list(Pageable pageable,
 			@RequestParam(required = false) String search, PagedResourcesAssembler<StreamDefinition> assembler) {
-		Page<StreamDefinition> streamDefinitions = this.streamService.findDefinitionByNameLike(pageable, search);
+		Page<StreamDefinition> streamDefinitions = this.streamService.findDefinitionByNameContains(pageable, search);
 		return assembler.toResource(streamDefinitions, new Assembler(streamDefinitions));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/StreamDefinitionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StreamDefinitionRepository extends PagingAndSortingRepository<StreamDefinition, String> {
 
-	Page<StreamDefinition> findByNameLike(String name, Pageable pageable);
+	Page<StreamDefinition> findByNameContains(String name, Pageable pageable);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/StreamService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,12 +142,12 @@ public interface StreamService {
 	List<StreamDefinition> findRelatedStreams(String name, boolean nested);
 
 	/**
-	 * Find stream definitions where the findByTaskNameLike parameter
+	 * Find stream definitions where the findByTaskNameContains parameter
 	 * @param pageable Pagination information
-	 * @param search the findByTaskNameLike parameter to use
+	 * @param search the findByTaskNameContains parameter to use
 	 * @return Page of stream definitions
 	 */
-	Page<StreamDefinition> findDefinitionByNameLike(Pageable pageable, String search);
+	Page<StreamDefinition> findDefinitionByNameContains(Pageable pageable, String search);
 
 	/**
 	 * Find a stream definition by name.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -513,10 +513,10 @@ public class DefaultStreamService implements StreamService {
 	 * @param search the findByTaskNameLike parameter to use
 	 * @return Page of stream definitions
 	 */
-	public Page<StreamDefinition> findDefinitionByNameLike(Pageable pageable, String search) {
+	public Page<StreamDefinition> findDefinitionByNameContains(Pageable pageable, String search) {
 		Page<StreamDefinition> streamDefinitions;
 		if (search != null) {
-			streamDefinitions = streamDefinitionRepository.findByNameLike(search, pageable);
+			streamDefinitions = streamDefinitionRepository.findByNameContains(search, pageable);
 		}
 		else {
 			streamDefinitions = streamDefinitionRepository.findAll(pageable);


### PR DESCRIPTION
In StreamDefinitionRepository function called findByNameLike changed to findByNameContains. Due to this modification, we can eliminate '%' character using in UI.

![1](https://user-images.githubusercontent.com/19280914/52164607-3a176c00-26f4-11e9-905d-8adcb5d3668d.png)
![2](https://user-images.githubusercontent.com/19280914/52164608-3a176c00-26f4-11e9-8c6b-6acc4b42a22a.png)


@ilayaperumalg I have just created a short PR to show what should we change.

resolves #2793