### PR TITLE
Upgrade mariadb driver to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-lang.version>2.4</commons-lang.version>
+		<mariadb-java-client.version>2.4.0</mariadb-java-client.version>
+
 		<jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
 		<checkstyle.config.location>src/checkstyle/checkstyle.xml</checkstyle.config.location>
@@ -158,6 +160,11 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>${commons-lang.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mariadb.jdbc</groupId>
+				<artifactId>mariadb-java-client</artifactId>
+				<version>${mariadb-java-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
 				<artifactId>mariadb-java-client</artifactId>
-				<version>2.2.5</version>
+				<version>${mariadb-java-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.zaxxer</groupId>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/task-developer-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/task-developer-guide.adoc
@@ -258,6 +258,7 @@ To do so:
 <dependency>
   <groupId>org.mariadb.jdbc</groupId>
   <artifactId>mariadb-java-client</artifactId>
+  <version>2.4.0</version>
 </dependency>
 ----
 . From your command line set up the database connection properties for MySql for example

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -148,6 +148,7 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
+			<version>${mariadb-java-client.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Note that if the <dependency/> was not added to the root pom, there was a build error relating to the substitution of ${mariadb-java-client.version} when building the kubernetes-platform.

Fixes #2835