### PR TITLE
Polish dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
 		<spring-shell.version>1.2.0.RELEASE</spring-shell.version>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-lang.version>2.4</commons-lang.version>
-		<mariadb-java-client.version>2.4.0</mariadb-java-client.version>
 
 		<jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
@@ -160,11 +159,6 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>${commons-lang.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.mariadb.jdbc</groupId>
-				<artifactId>mariadb-java-client</artifactId>
-				<version>${mariadb-java-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -14,17 +14,15 @@
 	<description>Spring Cloud Data Flow Dependencies BOM designed to support consumption of Spring Cloud Data Flow from
 		the Spring Initializr.
 	</description>
+	<properties>
+		<mariadb.version>2.4.0</mariadb.version>
+	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
 				<artifactId>mariadb-java-client</artifactId>
-				<version>${mariadb-java-client.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.zaxxer</groupId>
-				<artifactId>HikariCP</artifactId>
-				<version>3.1.0</version>
+				<version>${mariadb.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-registry/pom.xml
+++ b/spring-cloud-dataflow-registry/pom.xml
@@ -51,7 +51,6 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>3.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -148,7 +148,6 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>${mariadb-java-client.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Remove explicit hikari version as it's managed by boot which
  brings in 3.2.0 instead of 3.1.0 we've been hardcoding.
- As we use newer maria version than boot manages, define
  it in spring-cloud-dataflow-dependencies using same
  property version name as boot uses.
- This now allows a custom build to use just
  spring-cloud-starter-dataflow-server-local and
  spring-cloud-dataflow-dependencies
- Fixes #2845