### PR TITLE
Database migration from classic mode

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractBaselineCallback.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractBaselineCallback.java
@@ -71,6 +71,7 @@ public abstract class AbstractBaselineCallback extends AbstractCallback {
 			logger.info("Detected old Data Flow schema, doing baseline.");
 			commands.addAll(dropIndexes());
 			commands.addAll(changeAppRegistrationTable());
+			commands.addAll(changeUriRegistryTable());
 			commands.addAll(changeStreamDefinitionsTable());
 			commands.addAll(changeTaskDefinitionsTable());
 			commands.addAll(changeAuditRecordsTable());
@@ -95,6 +96,13 @@ public abstract class AbstractBaselineCallback extends AbstractCallback {
 	 * @return the list of sql commands
 	 */
 	public abstract List<SqlCommand> changeAppRegistrationTable();
+
+	/**
+	 * Change uri registry table.
+	 *
+	 * @return the list of sql commands
+	 */
+	public abstract List<SqlCommand> changeUriRegistryTable();
 
 	/**
 	 * Change stream definitions table.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractMigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractMigrateUriRegistrySqlCommand.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
+import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Base implementation for a {@link SqlCommand} copying data from
+ * {@code URI_REGISTRY} table into {@code app_registration} table.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractMigrateUriRegistrySqlCommand extends SqlCommand {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractMigrateUriRegistrySqlCommand.class);
+
+	@Override
+	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
+		boolean migrate = false;
+		try {
+			jdbcTemplate.execute("select 1 from URI_REGISTRY");
+			migrate = true;
+			logger.info("Detected URI_REGISTRY, migrating");
+		} catch (Exception e) {
+			logger.info("Didn't detected URI_REGISTRY, skipping migration from URI_REGISTRY to app_registration");
+		}
+
+		if (migrate) {
+			updateAppRegistration(jdbcTemplate, createAppRegistrationMigrationData(jdbcTemplate));
+			dropUriRegistryTable(jdbcTemplate);
+		}
+	}
+
+	@Override
+	public boolean canHandleInJdbcTemplate() {
+		return true;
+	}
+
+	/**
+	 * Update app registration. Actual database implementation of this method is
+	 * required to insert data based on list of
+	 * {@code AppRegistrationMigrationData}'s and keep {@code hibernate_sequence}
+	 * up-to-date.
+	 *
+	 * @param jdbcTemplate the jdbc template
+	 * @param data the data
+	 */
+	protected abstract void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data);
+
+	/**
+	 * Creates a migration data from URI_REGISTRY table to get inserted
+	 * into app_registration table. We're working on a raw data level
+	 * thus no use hibernate, spring repositories nor entity classes.
+	 *
+	 * @param jdbcTemplate the jdbc template
+	 * @return the list
+	 */
+	protected List<AppRegistrationMigrationData> createAppRegistrationMigrationData(JdbcTemplate jdbcTemplate) {
+		Map<String, AppRegistrationMigrationData> data = new HashMap<>();
+		// to get version using same existing logic
+		AppResourceCommon arc = new AppResourceCommon(new MavenProperties(), new DelegatingResourceLoader());
+		// track that we only add default version for one by just giving it to first one
+		// just to be on a safe side
+		Collection<String> defaultVersions = new HashSet<>();
+
+		// format for old URI_REGISTRY is:
+		// +-------------------------------+-------------------------------------------------------------------------------------------------+
+		// | NAME                          | URI                                                                                             |
+		// +-------------------------------+-------------------------------------------------------------------------------------------------+
+		// | processor.bridge              | maven://org.springframework.cloud.stream.app:bridge-processor-rabbit:2.0.1.RELEASE              |
+		// | processor.bridge.metadata     | maven://org.springframework.cloud.stream.app:bridge-processor-rabbit:jar:metadata:2.0.1.RELEASE |
+		//
+		// this needs to go to a new app_registration table structure where
+		// uri and metadata and other fields are within same record.
+		// AppRegistrationMigrationData is base of that info which then
+		// gets actually updates with updateAppRegistration method.
+
+		jdbcTemplate.query("select NAME, URI from URI_REGISTRY", rs -> {
+			AppRegistrationMigrationData armd;
+			String name = rs.getString(1);
+			String uri = rs.getString(2);
+			// we assume i.e processor.bridge and processor.bridge.metadata belong together
+			String[] split = name.split("\\.");
+			if (split.length == 2 || split.length == 3) {
+				String key = split[0] + split[1];
+				armd = data.getOrDefault(key, new AppRegistrationMigrationData());
+				if (!defaultVersions.contains(key)) {
+					armd.setDefaultVersion(true);
+					defaultVersions.add(key);
+				}
+				if (split.length == 2) {
+					// we got *.* first
+					armd.setName(split[1]);
+					armd.setType(ApplicationType.valueOf(split[0]).ordinal());
+					armd.setUri(uri);
+					armd.setVersion(arc.getResourceVersion(arc.getResource(uri)));
+				}
+				else {
+					// we got *.*.metadata first
+					armd.setName(split[1]);
+					armd.setType(ApplicationType.valueOf(split[0]).ordinal());
+					armd.setMetadataUri(uri);
+				}
+				// either *.* or *.*.metadata, put it to map, either initial
+				// insert or update
+				data.put(key, armd);
+			}
+		});
+
+		return new ArrayList<>(data.values());
+	}
+
+	/**
+	 * Drop uri registry table.
+	 *
+	 * @param jdbcTemplate the jdbc template
+	 */
+	protected void dropUriRegistryTable(JdbcTemplate jdbcTemplate) {
+		jdbcTemplate.execute("drop table URI_REGISTRY");
+	}
+
+	/**
+	 * Raw migration data from uri registry into app registration.
+	 */
+	protected static class AppRegistrationMigrationData {
+
+		private String name;
+		private int type;
+		private String version;
+		private String uri;
+		private String metadataUri;
+		private boolean defaultVersion;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getType() {
+			return type;
+		}
+
+		public void setType(int type) {
+			this.type = type;
+		}
+
+		public String getVersion() {
+			return version;
+		}
+
+		public void setVersion(String version) {
+			this.version = version;
+		}
+
+		public String getUri() {
+			return uri;
+		}
+
+		public void setUri(String uri) {
+			this.uri = uri;
+		}
+
+		public String getMetadataUri() {
+			return metadataUri;
+		}
+
+		public void setMetadataUri(String metadataUri) {
+			this.metadataUri = metadataUri;
+		}
+
+		public boolean isDefaultVersion() {
+			return defaultVersion;
+		}
+
+		public void setDefaultVersion(boolean defaultVersion) {
+			this.defaultVersion = defaultVersion;
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/SqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/SqlCommand.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
+import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * Class keeping a sql command and its possible suppressing sql codes together.
@@ -48,6 +51,10 @@ public class SqlCommand {
 	 */
 	public static SqlCommand from(String command, int suppressedErrorCode) {
 		return new SqlCommand(command, suppressedErrorCode);
+	}
+
+	public SqlCommand() {
+		this(null, null);
 	}
 
 	/**
@@ -87,5 +94,25 @@ public class SqlCommand {
 	 */
 	public List<Integer> getSuppressedErrorCodes() {
 		return suppressedErrorCodes;
+	}
+
+	/**
+	 * Checks if this command can handle execution directly
+	 * in a given jdbc template.
+	 *
+	 * @return true, if command can handle jdbc template
+	 */
+	public boolean canHandleInJdbcTemplate() {
+		return false;
+	}
+
+	/**
+	 * Handle command in a given jdbc template.
+	 *
+	 * @param jdbcTemplate the jdbc template
+	 */
+	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
+		// expected to get handled in a sub-class
+		throw new UnsupportedOperationException("Not supported in a base class");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2BeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2BeforeBaseline.java
@@ -142,6 +142,12 @@ public class Db2BeforeBaseline extends AbstractBaselineCallback {
 	}
 
 	@Override
+	public List<SqlCommand> changeUriRegistryTable() {
+		return Arrays.asList(
+				new Db2MigrateUriRegistrySqlCommand());
+	}
+
+	@Override
 	public List<SqlCommand> changeStreamDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_STREAM_DEFINITIONS_TMP_TABLE),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2MigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/Db2MigrateUriRegistrySqlCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.db2;
+
+import java.util.List;
+
+import org.postgresql.core.SqlCommand;
+
+import org.springframework.cloud.dataflow.server.db.migration.AbstractMigrateUriRegistrySqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@code db2} related {@link SqlCommand} for migrating data from
+ * {@code URI_REGISTRY} into {@code app_registration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class Db2MigrateUriRegistrySqlCommand extends AbstractMigrateUriRegistrySqlCommand {
+
+	@Override
+	protected void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data) {
+		for (AppRegistrationMigrationData d : data) {
+			Long nextVal = jdbcTemplate.queryForObject("values next value for hibernate_sequence", Long.class);
+			jdbcTemplate.update(
+					"insert into app_registration (id, object_version, default_version, metadata_uri, name, type, uri, version) values (?,?,?,?,?,?,?,?)",
+					nextVal, 0, d.isDefaultVersion() ? 1 : 0, d.getMetadataUri(), d.getName(), d.getType(), d.getUri(),
+					d.getVersion());
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlBeforeBaseline.java
@@ -139,6 +139,12 @@ public class MysqlBeforeBaseline extends AbstractBaselineCallback {
 	}
 
 	@Override
+	public List<SqlCommand> changeUriRegistryTable() {
+		return Arrays.asList(
+				new MysqlMigrateUriRegistrySqlCommand());
+	}
+
+	@Override
 	public List<SqlCommand> changeStreamDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_STREAM_DEFINITIONS_TMP_TABLE),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlMigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/MysqlMigrateUriRegistrySqlCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.mysql;
+
+import java.util.List;
+
+import org.postgresql.core.SqlCommand;
+
+import org.springframework.cloud.dataflow.server.db.migration.AbstractMigrateUriRegistrySqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@code mysql} related {@link SqlCommand} for migrating data from
+ * {@code URI_REGISTRY} into {@code app_registration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class MysqlMigrateUriRegistrySqlCommand extends AbstractMigrateUriRegistrySqlCommand {
+
+	@Override
+	protected void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data) {
+		// get value from hibernate sequence table and update it later
+		// depending on how many updates we did
+		long nextVal = jdbcTemplate.queryForObject("select next_val as id_val from hibernate_sequence", Long.class);
+		long nextValUpdates = nextVal;
+		for (AppRegistrationMigrationData d : data) {
+			jdbcTemplate.update(
+					"insert into app_registration (id, object_version, default_version, metadata_uri, name, type, uri, version) values (?,?,?,?,?,?,?,?)",
+					nextValUpdates++, 0, d.isDefaultVersion() ? 1 : 0, d.getMetadataUri(), d.getName(), d.getType(),
+					d.getUri(), d.getVersion());
+		}
+		jdbcTemplate.update("update hibernate_sequence set next_val= ? where next_val=?", nextValUpdates, nextVal);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V1__Initial_Setup.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V1__Initial_Setup.java
@@ -31,11 +31,13 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_HIBERNATE_SEQUENCE_TABLE =
 			"create table if not exists hibernate_sequence (\n" +
-			"  next_val bigint\n" +
+			"    next_val bigint\n" +
 			")";
 
 	public final static String INSERT_HIBERNATE_SEQUENCE_TABLE =
-			"insert into hibernate_sequence values ( 1 )";
+			"insert into hibernate_sequence (next_val)\n" +
+			"    select * from (select 1 as next_val) as temp\n" +
+			"    where not exists(select * from hibernate_sequence)";
 
 	public final static String CREATE_APP_REGISTRATION_TABLE =
 			"create table app_registration (\n" +

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleBeforeBaseline.java
@@ -142,6 +142,12 @@ public class OracleBeforeBaseline extends AbstractBaselineCallback {
 	}
 
 	@Override
+	public List<SqlCommand> changeUriRegistryTable() {
+		return Arrays.asList(
+				new OracleMigrateUriRegistrySqlCommand());
+	}
+
+	@Override
 	public List<SqlCommand> changeStreamDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_STREAM_DEFINITIONS_TMP_TABLE),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleMigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/OracleMigrateUriRegistrySqlCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.oracle;
+
+import java.util.List;
+
+import org.postgresql.core.SqlCommand;
+
+import org.springframework.cloud.dataflow.server.db.migration.AbstractMigrateUriRegistrySqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@code oracle} related {@link SqlCommand} for migrating data from
+ * {@code URI_REGISTRY} into {@code app_registration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class OracleMigrateUriRegistrySqlCommand extends AbstractMigrateUriRegistrySqlCommand {
+
+	@Override
+	protected void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data) {
+		for (AppRegistrationMigrationData d : data) {
+			Long nextVal = jdbcTemplate.queryForObject("select hibernate_sequence.nextval from dual", Long.class);
+			jdbcTemplate.update(
+					"insert into app_registration (id, object_version, default_version, metadata_uri, name, type, uri, version) values (?,?,?,?,?,?,?,?)",
+					nextVal, 0, d.isDefaultVersion() ? 1 : 0, d.getMetadataUri(), d.getName(), d.getType(), d.getUri(),
+					d.getVersion());
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresBeforeBaseline.java
@@ -62,12 +62,6 @@ public class PostgresBeforeBaseline extends AbstractBaselineCallback {
 	public final static String CREATE_STREAM_DEFINITIONS_TMP_TABLE =
 			V1__Initial_Setup.CREATE_STREAM_DEFINITIONS_TABLE.replaceFirst("stream_definitions", "stream_definitions_tmp");
 
-	public final static String INSERT_STREAM_DEFINITIONS_DATA =
-			"insert into\n" +
-			"  stream_definitions_tmp (definition_name, definition) \n" +
-			"  select DEFINITION_NAME, DEFINITION\n" +
-			"  from STREAM_DEFINITIONS";
-
 	public final static String DROP_STREAM_DEFINITIONS_TABLE =
 			"drop table STREAM_DEFINITIONS";
 
@@ -76,12 +70,6 @@ public class PostgresBeforeBaseline extends AbstractBaselineCallback {
 
 	public final static String CREATE_TASK_DEFINITIONS_TMP_TABLE =
 			V1__Initial_Setup.CREATE_TASK_DEFINITIONS_TABLE.replaceFirst("task_definitions", "task_definitions_tmp");
-
-	public final static String INSERT_TASK_DEFINITIONS_DATA =
-			"insert into\n" +
-			"  task_definitions_tmp (definition_name, definition) \n" +
-			"  select DEFINITION_NAME, DEFINITION\n" +
-			"  from TASK_DEFINITIONS";
 
 	public final static String DROP_TASK_DEFINITIONS_TABLE =
 			"drop table TASK_DEFINITIONS";
@@ -151,10 +139,17 @@ public class PostgresBeforeBaseline extends AbstractBaselineCallback {
 	}
 
 	@Override
+	public List<SqlCommand> changeUriRegistryTable() {
+		return Arrays.asList(
+				new PostgresMigrateUriRegistrySqlCommand());
+	}
+
+	@Override
 	public List<SqlCommand> changeStreamDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_STREAM_DEFINITIONS_TMP_TABLE),
-				SqlCommand.from(INSERT_STREAM_DEFINITIONS_DATA),
+				// need to run copy command programmatically
+				new PostgresMigrateStreamDefinitionsSqlCommand(),
 				SqlCommand.from(DROP_STREAM_DEFINITIONS_TABLE),
 				SqlCommand.from(RENAME_STREAM_DEFINITIONS_TMP_TABLE));
 	}
@@ -163,7 +158,8 @@ public class PostgresBeforeBaseline extends AbstractBaselineCallback {
 	public List<SqlCommand> changeTaskDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_TASK_DEFINITIONS_TMP_TABLE),
-				SqlCommand.from(INSERT_TASK_DEFINITIONS_DATA),
+				// need to run copy command programmatically
+				new PostgresMigrateTaskDefinitionsSqlCommand(),
 				SqlCommand.from(DROP_TASK_DEFINITIONS_TABLE),
 				SqlCommand.from(RENAME_TASK_DEFINITIONS_TMP_TABLE));
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateStreamDefinitionsSqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateStreamDefinitionsSqlCommand.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.postgresql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.cloud.dataflow.server.db.migration.SqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.support.SqlLobValue;
+import org.springframework.jdbc.support.lob.DefaultLobHandler;
+
+/**
+ * {@link SqlCommand} copying data from {@code STREAM_DEFINITIONS} table into
+ * {@code stream_definitions_tmp} table handling correct way to use CLOB with
+ * postgres.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class PostgresMigrateStreamDefinitionsSqlCommand extends SqlCommand {
+
+	@Override
+	public boolean canHandleInJdbcTemplate() {
+		return true;
+	}
+
+	@Override
+	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
+		Boolean autoCommit = null;
+		try {
+			autoCommit = connection.getAutoCommit();
+		} catch (SQLException e) {
+			throw new RuntimeException("cannot access connection autocommit setting", e);
+		}
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(false);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+
+		Map<String, String> data = new HashMap<>();
+
+		jdbcTemplate.query("select DEFINITION_NAME, DEFINITION from STREAM_DEFINITIONS", rs -> {
+			data.put(rs.getString(1), rs.getString(2));
+		});
+
+		DefaultLobHandler lobHandler = new DefaultLobHandler();
+		lobHandler.setWrapAsLob(true);
+
+		for (Entry<String, String> d : data.entrySet()) {
+			jdbcTemplate.update("insert into stream_definitions_tmp (definition_name, definition) values (?,?)",
+					new Object[] { d.getKey(), new SqlLobValue(d.getValue(), lobHandler) },
+					new int[] { Types.VARCHAR, Types.CLOB });
+		}
+
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(autoCommit);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateTaskDefinitionsSqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateTaskDefinitionsSqlCommand.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.postgresql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.cloud.dataflow.server.db.migration.SqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.support.SqlLobValue;
+import org.springframework.jdbc.support.lob.DefaultLobHandler;
+
+/**
+ * {@link SqlCommand} copying data from {@code TASK_DEFINITIONS} table into
+ * {@code task_definitions_tmp} table handling correct way to use CLOB with
+ * postgres.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class PostgresMigrateTaskDefinitionsSqlCommand extends SqlCommand {
+
+	@Override
+	public boolean canHandleInJdbcTemplate() {
+		return true;
+	}
+
+	@Override
+	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
+		Boolean autoCommit = null;
+		try {
+			autoCommit = connection.getAutoCommit();
+		} catch (SQLException e) {
+			throw new RuntimeException("cannot access connection autocommit setting", e);
+		}
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(false);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+
+		Map<String, String> data = new HashMap<>();
+
+		jdbcTemplate.query("select DEFINITION_NAME, DEFINITION from TASK_DEFINITIONS", rs -> {
+			data.put(rs.getString(1), rs.getString(2));
+		});
+
+		DefaultLobHandler lobHandler = new DefaultLobHandler();
+		lobHandler.setWrapAsLob(true);
+
+		for (Entry<String, String> d : data.entrySet()) {
+			jdbcTemplate.update("insert into task_definitions_tmp (definition_name, definition) values (?,?)", new Object[] {
+					d.getKey(), new SqlLobValue(d.getValue(), lobHandler)
+			}, new int[] {
+					Types.VARCHAR, Types.CLOB
+			});
+		}
+
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(autoCommit);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/PostgresMigrateUriRegistrySqlCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.postgresql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+
+import org.postgresql.core.SqlCommand;
+
+import org.springframework.cloud.dataflow.server.db.migration.AbstractMigrateUriRegistrySqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.support.SqlLobValue;
+import org.springframework.jdbc.support.lob.DefaultLobHandler;
+
+/**
+ * {@code postgres} related {@link SqlCommand} for migrating data from
+ * {@code URI_REGISTRY} into {@code app_registration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class PostgresMigrateUriRegistrySqlCommand extends AbstractMigrateUriRegistrySqlCommand {
+
+	@Override
+	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
+		// we need to disable connection autocommit for this operation
+		// as with postgres a CLOB cannot be inserted with autocommit enabled.
+
+		// TODO: should think if this same autocommit logic could get extracted to
+		//       to some sort of base impl as it's used in PostgresMigrateTaskDefinitionsSqlCommand
+		//       and PostgresMigrateStreamDefinitionsSqlCommand in a same way
+
+		Boolean autoCommit = null;
+		try {
+			autoCommit = connection.getAutoCommit();
+		} catch (SQLException e) {
+			throw new RuntimeException("cannot access connection autocommit setting", e);
+		}
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(false);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+		super.handle(jdbcTemplate, connection);
+		if (autoCommit != null) {
+			try {
+				connection.setAutoCommit(autoCommit);
+			} catch (SQLException e) {
+				throw new RuntimeException("cannot access connection autocommit setting", e);
+			}
+		}
+	}
+
+	@Override
+	protected void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data) {
+		DefaultLobHandler lobHandler = new DefaultLobHandler();
+		lobHandler.setWrapAsLob(true);
+		for (AppRegistrationMigrationData d : data) {
+			Long nextVal = jdbcTemplate.queryForObject("select nextval('hibernate_sequence')", Long.class);
+			jdbcTemplate.update(
+					"insert into app_registration (id, object_version, default_version, metadata_uri, name, type, uri, version) values (?,?,?,?,?,?,?,?)",
+					new Object[] { nextVal, 0, d.isDefaultVersion(), new SqlLobValue(d.getMetadataUri(), lobHandler),
+							d.getName(), d.getType(), new SqlLobValue(d.getUri(), lobHandler), d.getVersion() },
+					new int[] { Types.BIGINT, Types.BIGINT, Types.BOOLEAN, Types.CLOB, Types.VARCHAR, Types.INTEGER,
+							Types.CLOB, Types.VARCHAR });
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlBeforeBaseline.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlBeforeBaseline.java
@@ -139,6 +139,12 @@ public class MsSqlBeforeBaseline extends AbstractBaselineCallback {
 	}
 
 	@Override
+	public List<SqlCommand> changeUriRegistryTable() {
+		return Arrays.asList(
+				new MsSqlMigrateUriRegistrySqlCommand());
+	}
+
+	@Override
 	public List<SqlCommand> changeStreamDefinitionsTable() {
 		return Arrays.asList(
 				SqlCommand.from(CREATE_STREAM_DEFINITIONS_TMP_TABLE),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlMigrateUriRegistrySqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/MsSqlMigrateUriRegistrySqlCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.sqlserver;
+
+import java.util.List;
+
+import org.postgresql.core.SqlCommand;
+
+import org.springframework.cloud.dataflow.server.db.migration.AbstractMigrateUriRegistrySqlCommand;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * {@code mssql} related {@link SqlCommand} for migrating data from
+ * {@code URI_REGISTRY} into {@code app_registration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class MsSqlMigrateUriRegistrySqlCommand extends AbstractMigrateUriRegistrySqlCommand {
+
+	@Override
+	protected void updateAppRegistration(JdbcTemplate jdbcTemplate, List<AppRegistrationMigrationData> data) {
+		for (AppRegistrationMigrationData d : data) {
+			Long nextVal = jdbcTemplate.queryForObject("select next value for hibernate_sequence", Long.class);
+			jdbcTemplate.update(
+					"insert into app_registration (id, object_version, default_version, metadata_uri, name, type, uri, version) values (?,?,?,?,?,?,?,?)",
+					nextVal, 0, d.isDefaultVersion() ? 1 : 0, d.getMetadataUri(), d.getName(), d.getType(), d.getUri(),
+					d.getVersion());
+		}
+	}
+}


### PR DESCRIPTION
- As mysql don't have a real sequence, initial value
  needs to be inserted. This change makes sure that
  we only insert value once and that value will be 1.
  Similar fix will also be done on a skipper side.
- Fix clob handling with postgres.
- New base impl AbstractMigrateUriRegistrySqlCommand which
  all db's implement to support migration from URI_REGISTRY
  to app_registration table.
- Fixes #2863
- Fixes #2826
- Fixes #2868