### PR TITLE
Refactor DefaultTaskExecutionService's constructor

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -60,6 +60,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecuti
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncher;
@@ -165,18 +166,25 @@ public class TaskConfiguration {
 	}
 
 	@Bean
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,
+				metadataResolver, dataflowServerUri);
+	}
+
+	@Bean
 	public TaskExecutionService taskService(LauncherRepository launcherRepository,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
+			AuditRecordService auditRecordService,
 			TaskRepository taskRepository,
 			TaskExecutionInfoService taskExecutionInfoService,
 			TaskDeploymentRepository taskDeploymentRepository,
-			TaskExecutionCreationService taskExecutionRepositoryService) {
+			TaskExecutionCreationService taskExecutionRepositoryService,
+			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator) {
 		return new DefaultTaskExecutionService(
-				launcherRepository, metadataResolver, auditRecordService,
-				dataflowServerUri, commonApplicationProperties,
-				taskRepository,
-				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService);
+				launcherRepository, auditRecordService, taskRepository,
+				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService,
+				taskAppDeploymentRequestCreator);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -166,7 +166,7 @@ public class TaskConfiguration {
 	}
 
 	@Bean
-	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+	public TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
 			CommonApplicationProperties commonApplicationProperties,
 			ApplicationConfigurationMetadataResolver metadataResolver) {
 		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -20,11 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
-import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.AuditActionType;
 import org.springframework.cloud.dataflow.core.AuditOperationType;
 import org.springframework.cloud.dataflow.core.Launcher;
@@ -32,14 +30,11 @@ import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.TaskDeployment;
 import org.springframework.cloud.dataflow.rest.util.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
-import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
-import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionCreationService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
-import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.repository.TaskExecution;
@@ -72,13 +67,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 */
 	private final LauncherRepository launcherRepository;
 
-	private final WhitelistProperties whitelistProperties;
-
-	private final String dataflowServerUri;
-
 	private final TaskExecutionCreationService taskExecutionRepositoryService;
-
-	private final CommonApplicationProperties commonApplicationProperties;
 
 	protected final AuditRecordService auditRecordService;
 
@@ -93,6 +82,8 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 
 	private final ArgumentSanitizer argumentSanitizer = new ArgumentSanitizer();
 
+	private final TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator;
+
 	public static final String TASK_DEFINITION_DSL_TEXT = "taskDefinitionDslText";
 
 	public static final String TASK_DEPLOYMENT_PROPERTIES = "taskDeploymentProperties";
@@ -105,43 +96,36 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 * Initializes the {@link DefaultTaskExecutionService}.
 	 *
 	 * @param launcherRepository the repository of task launcher used to launch task apps.
-	 * @param metaDataResolver the metadata resolver
 	 * @param auditRecordService the audit record service
-	 * @param dataflowServerUri the URI of the data flow server
-	 * @param commonApplicationProperties the common application properties for all tasks
 	 * @param taskRepository the repository to use for accessing and updating task executions
 	 * @param taskDeploymentRepository the repository to track task deployment
 	 * @param taskExecutionInfoService the service used to setup a task execution
 	 * @param taskExecutionRepositoryService the service used to create the task execution
 	 */
 	public DefaultTaskExecutionService(LauncherRepository launcherRepository,
-			ApplicationConfigurationMetadataResolver metaDataResolver,
 			AuditRecordService auditRecordService,
-			String dataflowServerUri, CommonApplicationProperties commonApplicationProperties,
 			TaskRepository taskRepository,
 			TaskExecutionInfoService taskExecutionInfoService,
 			TaskDeploymentRepository taskDeploymentRepository,
-			TaskExecutionCreationService taskExecutionRepositoryService) {
+			TaskExecutionCreationService taskExecutionRepositoryService,
+			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator) {
 		Assert.notNull(launcherRepository, "launcherRepository must not be null");
-		Assert.notNull(metaDataResolver, "metaDataResolver must not be null");
 		Assert.notNull(auditRecordService, "auditRecordService must not be null");
-		Assert.notNull(commonApplicationProperties, "commonApplicationProperties must not be null");
 		Assert.notNull(taskExecutionInfoService, "taskDefinitionRetriever must not be null");
 		Assert.notNull(taskRepository, "taskRepository must not be null");
 		Assert.notNull(taskExecutionInfoService, "taskExecutionInfoService must not be null");
 		Assert.notNull(taskDeploymentRepository, "taskDeploymentRepository must not be null");
 		Assert.notNull(taskExecutionRepositoryService, "taskExecutionRepositoryService must not be null");
-
+		Assert.notNull(taskAppDeploymentRequestCreator, "taskAppDeploymentRequestCreator must not be null");
 
 		this.launcherRepository = launcherRepository;
-		this.whitelistProperties = new WhitelistProperties(metaDataResolver);
 		this.auditRecordService = auditRecordService;
-		this.dataflowServerUri = dataflowServerUri;
-		this.commonApplicationProperties = commonApplicationProperties;
 		this.taskRepository = taskRepository;
 		this.taskExecutionInfoService = taskExecutionInfoService;
 		this.taskDeploymentRepository = taskDeploymentRepository;
 		this.taskExecutionRepositoryService = taskExecutionRepositoryService;
+		this.taskAppDeploymentRequestCreator = taskAppDeploymentRequestCreator;
+
 	}
 
 	@Override
@@ -164,7 +148,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 
 		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
 
-		TaskLauncher taskLauncher = findTaskLaucher(platformName);
+		TaskLauncher taskLauncher = findTaskLauncher(platformName);
 
 		TaskDeployment existingTaskDeployment =
 				taskDeploymentRepository.findTopByTaskDefinitionNameOrderByCreatedOnAsc(taskName);
@@ -178,29 +162,10 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 		}
 		TaskExecutionInformation taskExecutionInformation = taskExecutionInfoService
 				.findTaskExecutionInformation(taskName, taskDeploymentProperties);
-		TaskDefinition taskDefinition = taskExecutionInformation.getTaskDefinition();
-		String registeredAppName = taskDefinition.getRegisteredAppName();
 		TaskExecution taskExecution = taskExecutionRepositoryService.createTaskExecution(taskName);
 
-		Map<String, String> appDeploymentProperties = new HashMap<>(commonApplicationProperties.getTask());
-		appDeploymentProperties.putAll(
-				TaskServiceUtils.extractAppProperties(registeredAppName,
-						taskExecutionInformation.getTaskDeploymentProperties()));
-
-		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
-				.extractAndQualifyDeployerProperties(taskExecutionInformation.getTaskDeploymentProperties(),
-						registeredAppName);
-		if (StringUtils.hasText(this.dataflowServerUri) && taskExecutionInformation.isComposed()) {
-			TaskServiceUtils.updateDataFlowUriIfNeeded(this.dataflowServerUri, appDeploymentProperties,
-					commandLineArgs);
-		}
-		AppDefinition revisedDefinition = TaskServiceUtils.mergeAndExpandAppProperties(taskDefinition,
-				taskExecutionInformation.getMetadataResource(),
-				appDeploymentProperties, this.whitelistProperties);
-		List<String> updatedCmdLineArgs = this.updateCommandLineArgs(commandLineArgs, taskExecution);
-		AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition,
-				taskExecutionInformation.getAppResource(),
-				deployerDeploymentProperties, updatedCmdLineArgs);
+		AppDeploymentRequest request = this.taskAppDeploymentRequestCreator.
+				createRequest(taskExecution, taskExecutionInformation, commandLineArgs);
 
 		String id = taskLauncher.launch(request);
 		if (!StringUtils.hasText(id)) {
@@ -216,13 +181,15 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 
 		this.auditRecordService.populateAndSaveAuditRecordUsingMapData(
 				AuditOperationType.TASK, AuditActionType.DEPLOY,
-				taskDefinition.getName(),
-				getAudited(taskDefinition, taskExecutionInformation.getTaskDeploymentProperties(), updatedCmdLineArgs));
+				taskExecutionInformation.getTaskDefinition().getName(),
+				getAudited(taskExecutionInformation.getTaskDefinition(),
+						taskExecutionInformation.getTaskDeploymentProperties(),
+						request.getCommandlineArguments()));
 
 		return taskExecution.getExecutionId();
 	}
 
-	private TaskLauncher findTaskLaucher(String platformName) {
+	private TaskLauncher findTaskLauncher(String platformName) {
 		Launcher launcher = this.launcherRepository.findByName(platformName);
 		if (launcher == null) {
 			List<String> launcherNames =
@@ -253,13 +220,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 				this.argumentSanitizer.sanitizeProperties(taskDeploymentProperties));
 		auditedData.put(COMMAND_LINE_ARGS, this.argumentSanitizer.sanitizeArguments(commandLineArgs));
 		return auditedData;
-	}
-
-	private List<String> updateCommandLineArgs(List<String> commandLineArgs, TaskExecution taskExecution) {
-		return Stream
-				.concat(commandLineArgs.stream().filter(a -> !a.startsWith("--spring.cloud.task.executionid=")),
-						Stream.of("--spring.cloud.task.executionid=" + taskExecution.getExecutionId()))
-				.collect(Collectors.toList());
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -37,9 +37,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * Create the list of {@link AppDeploymentRequest}s
- * from a {@link org.springframework.cloud.dataflow.core.TaskDefinition} and
- * deployment properties map.
+ * Create a {@link AppDeploymentRequest} from a
+ * {@link org.springframework.cloud.dataflow.core.TaskDefinition} and deployment
+ * properties map.
  *
  * @author Glenn Renfro
  */
@@ -56,9 +56,9 @@ public class TaskAppDeploymentRequestCreator {
 	/**
 	 * Initializes the {@link TaskAppDeploymentRequestCreator}.
 	 *
+	 * @param commonApplicationProperties the common application properties for all tasks
 	 * @param metaDataResolver the metadata resolver
 	 * @param dataflowServerUri the URI of the data flow server
-	 * @param commonApplicationProperties the common application properties for all tasks
 	 */
 	public TaskAppDeploymentRequestCreator(CommonApplicationProperties commonApplicationProperties,
 			ApplicationConfigurationMetadataResolver metaDataResolver,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Create the list of {@link AppDeploymentRequest}s
+ * from a {@link org.springframework.cloud.dataflow.core.TaskDefinition} and
+ * deployment properties map.
+ *
+ * @author Glenn Renfro
+ */
+public class TaskAppDeploymentRequestCreator {
+
+	private static Log logger = LogFactory.getLog(TaskAppDeploymentRequestCreator.class);
+
+	private final CommonApplicationProperties commonApplicationProperties;
+
+	private final WhitelistProperties whitelistProperties;
+
+	private final String dataflowServerUri;
+
+	/**
+	 * Initializes the {@link TaskAppDeploymentRequestCreator}.
+	 *
+	 * @param metaDataResolver the metadata resolver
+	 * @param dataflowServerUri the URI of the data flow server
+	 * @param commonApplicationProperties the common application properties for all tasks
+	 */
+	public TaskAppDeploymentRequestCreator(CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metaDataResolver,
+			String dataflowServerUri) {
+		Assert.notNull(commonApplicationProperties, "commonApplicationProperties must not be null");
+		Assert.notNull(metaDataResolver, "metaDataResolver must not be null");
+
+		this.commonApplicationProperties = commonApplicationProperties;
+		this.whitelistProperties = new WhitelistProperties(metaDataResolver);
+		this.dataflowServerUri = dataflowServerUri;
+	}
+
+
+
+	/**
+	 * Create a {@link AppDeploymentRequest} from the provided
+	 * {@link TaskExecutionInformation}, {@link TaskExecution}.
+	 * @return an instance of {@link AppDeploymentRequest}
+	 */
+	public AppDeploymentRequest createRequest(
+			TaskExecution taskExecution,
+			TaskExecutionInformation taskExecutionInformation,
+			List<String> commandLineArgs) {
+		TaskDefinition taskDefinition = taskExecutionInformation.getTaskDefinition();
+		String registeredAppName = taskDefinition.getRegisteredAppName();
+		Map<String, String> appDeploymentProperties = new HashMap<>(commonApplicationProperties.getTask());
+		appDeploymentProperties.putAll(
+				TaskServiceUtils.extractAppProperties(registeredAppName,
+						taskExecutionInformation.getTaskDeploymentProperties()));
+
+		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
+				.extractAndQualifyDeployerProperties(taskExecutionInformation.getTaskDeploymentProperties(),
+						registeredAppName);
+		if (StringUtils.hasText(this.dataflowServerUri) && taskExecutionInformation.isComposed()) {
+			TaskServiceUtils.updateDataFlowUriIfNeeded(this.dataflowServerUri, appDeploymentProperties,
+					commandLineArgs);
+		}
+		AppDefinition revisedDefinition = TaskServiceUtils.mergeAndExpandAppProperties(taskDefinition,
+				taskExecutionInformation.getMetadataResource(),
+				appDeploymentProperties, this.whitelistProperties);
+
+		List<String> updatedCmdLineArgs = this.updateCommandLineArgs(commandLineArgs, taskExecution);
+		AppDeploymentRequest request = new AppDeploymentRequest(revisedDefinition,
+				taskExecutionInformation.getAppResource(),
+				deployerDeploymentProperties, updatedCmdLineArgs);
+
+		logger.debug("Created AppDeploymentRequest = " + request.toString() + " AppDefinition = "
+				+ request.getDefinition().toString());
+		return request;
+	}
+
+	private List<String> updateCommandLineArgs(List<String> commandLineArgs, TaskExecution taskExecution) {
+		return Stream
+				.concat(commandLineArgs.stream().filter(a -> !a.startsWith("--spring.cloud.task.executionid=")),
+						Stream.of("--spring.cloud.task.executionid=" + taskExecution.getExecutionId()))
+				.collect(Collectors.toList());
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -69,6 +69,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecuti
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
@@ -216,18 +217,25 @@ public class JobDependencies {
 	}
 
 	@Bean
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,
+				metadataResolver, null);
+	}
+
+	@Bean
 	public TaskExecutionService taskService(LauncherRepository launcherRepository,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
-			TaskRepository taskRepository,
+			AuditRecordService auditRecordService, TaskRepository taskRepository,
 			TaskExecutionInfoService taskExecutionInfoService,
 			TaskDeploymentRepository taskDeploymentRepository,
-			TaskExecutionCreationService taskExecutionRepositoryService) {
+			TaskExecutionCreationService taskExecutionRepositoryService,
+			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator) {
 		return new DefaultTaskExecutionService(
-				launcherRepository, metadataResolver, auditRecordService,
-				null, commonApplicationProperties,
+				launcherRepository, auditRecordService,
 				taskRepository,
-				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService);
+				taskExecutionInfoService, taskDeploymentRepository,
+				taskExecutionRepositoryService, taskAppDeploymentRequestCreator);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -56,6 +56,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecuti
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -217,19 +218,24 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,
+				metadataResolver, null);
+	}
+
+	@Bean
 	public TaskExecutionService defaultTaskService(LauncherRepository launcherRepository,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
-			TaskRepository taskRepository,
+			AuditRecordService auditRecordService, TaskRepository taskRepository,
 			TaskExecutionInfoService taskExecutionInfoService,
 			TaskDeploymentRepository taskDeploymentRepository,
-			TaskExecutionCreationService taskExecutionRepositoryService) {
+			TaskExecutionCreationService taskExecutionRepositoryService,
+			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator) {
 		return new DefaultTaskExecutionService(
-				launcherRepository, metadataResolver, auditRecordService,
-				null, commonApplicationProperties,
-				taskRepository,
+				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository,
-				taskExecutionRepositoryService);
+				taskExecutionRepositoryService, taskAppDeploymentRequestCreator);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -218,7 +218,7 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+	public TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
 			CommonApplicationProperties commonApplicationProperties,
 			ApplicationConfigurationMetadataResolver metadataResolver) {
 		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -103,6 +103,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecuti
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultStreamValidationService;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
@@ -450,18 +451,25 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator(
+			CommonApplicationProperties commonApplicationProperties,
+			ApplicationConfigurationMetadataResolver metadataResolver) {
+		return new TaskAppDeploymentRequestCreator(commonApplicationProperties,
+				metadataResolver, null);
+	}
+
+	@Bean
 	public TaskExecutionService taskService(LauncherRepository launcherRepository,
-			ApplicationConfigurationMetadataResolver metadataResolver,
-			AuditRecordService auditRecordService, CommonApplicationProperties commonApplicationProperties,
+			AuditRecordService auditRecordService,
 			TaskRepository taskRepository,
 			TaskExecutionInfoService taskExecutionInfoService,
 			TaskDeploymentRepository taskDeploymentRepository,
-			TaskExecutionCreationService taskExecutionRepositoryService) {
+			TaskExecutionCreationService taskExecutionRepositoryService,
+			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator) {
 		return new DefaultTaskExecutionService(
-				launcherRepository, metadataResolver, auditRecordService,
-				null, commonApplicationProperties,
-				taskRepository,
-				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService);
+				launcherRepository, auditRecordService, taskRepository,
+				taskExecutionInfoService, taskDeploymentRepository,
+				taskExecutionRepositoryService, taskAppDeploymentRequestCreator);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -34,14 +34,12 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
-import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.AppRegistration;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.TaskDeployment;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
-import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.repository.DuplicateTaskException;
@@ -130,12 +128,6 @@ public abstract class DefaultTaskExecutionServiceTests {
 	TaskExplorer taskExplorer;
 
 	@Autowired
-	ApplicationConfigurationMetadataResolver metadataResolver;
-
-	@Autowired
-	CommonApplicationProperties commonApplicationProperties;
-
-	@Autowired
 	LauncherRepository launcherRepository;
 
 	@Autowired
@@ -149,6 +141,9 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 	@Autowired
 	TaskExecutionCreationService taskExecutionRepositoryService;
+
+	@Autowired
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator;
 
 	@TestPropertySource(properties = { "spring.cloud.dataflow.task.maximum-concurrent-tasks=10" })
 	@AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -258,11 +253,9 @@ public abstract class DefaultTaskExecutionServiceTests {
 					this.dataSourceProperties, this.appRegistry, this.taskExplorer,
 					mock(TaskDefinitionRepository.class), new TaskConfigurationProperties());
 			TaskExecutionService taskExecutionService = new DefaultTaskExecutionService(
-					launcherRepository, this.metadataResolver,
-					auditRecordService, null, this.commonApplicationProperties,
-					taskRepository,
+					launcherRepository, auditRecordService, taskRepository,
 					taskExecutionInfoService, mock(TaskDeploymentRepository.class),
-					taskExecutionRepositoryService);
+					taskExecutionRepositoryService, taskAppDeploymentRequestCreator);
 			try {
 				taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 			}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
@@ -36,7 +36,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
-import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.AppRegistration;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.AuditActionType;
@@ -45,7 +44,6 @@ import org.springframework.cloud.dataflow.core.AuditRecord;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
-import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
@@ -101,12 +99,6 @@ public class DefaultTaskExecutionServiceTransactionTests {
 	TaskExecutionInfoService taskExecutionInfoService;
 
 	@Autowired
-	ApplicationConfigurationMetadataResolver metadataResolver;
-
-	@Autowired
-	CommonApplicationProperties commonApplicationProperties;
-
-	@Autowired
 	LauncherRepository launcherRepository;
 
 	@Autowired
@@ -118,6 +110,9 @@ public class DefaultTaskExecutionServiceTransactionTests {
 	@Autowired
 	TaskExecutionCreationService taskExecutionRepositoryService;
 
+	@Autowired
+	TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator;
+
 	private TaskExecutionService transactionTaskService;
 
 	@Before
@@ -126,11 +121,9 @@ public class DefaultTaskExecutionServiceTransactionTests {
 		this.taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
 		this.taskDefinitionRepository.findAll();
 		this.transactionTaskService = new DefaultTaskExecutionService(
-				launcherRepository, this.metadataResolver,
-				auditRecordService, null, this.commonApplicationProperties,
-				taskRepository,
+				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, mock(TaskDeploymentRepository.class),
-				taskExecutionRepositoryService);
+				taskExecutionRepositoryService, taskAppDeploymentRequestCreator);
 
 	}
 


### PR DESCRIPTION
resolves #2768

When creating the TaskAppDeploymentRequestCreator I couldn't see the need for creating a service with @Transactional.
It could be referring to the creation of the TaskExecution that does require a new transaction, however this transaction information is required by the Auditing and for post task launch request processing.  Similarly TaskExecutionInformation is required for both request creation and auditing.