### PR TITLE
Cleanup TODOs as they pertain to CTR Task Parsing

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -156,9 +156,6 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 						.param("arguments", "--server.port=8080 --foo=bar"))
 				.andExpect(status().isCreated()));
 
-		// TODO: spring-cloud-task with lifecycle starting from 2.1.x creates
-		//       a default taskexecution and because of that we expect to start
-		//       from id 2
 		this.mockMvc.perform(
 				delete("/tasks/executions/{id}", "1"))
 				.andDo(print())

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/GraphGeneratorVisitor.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/GraphGeneratorVisitor.java
@@ -142,7 +142,6 @@ public class GraphGeneratorVisitor extends TaskVisitor {
 				}
 				tooMany++;
 			}
-			// TODO if still stuff to do we were probably in infinite loop
 		}
 	}
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskNode.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskNode.java
@@ -57,7 +57,6 @@ public class TaskNode extends AstNode {
 		this.name = name;
 		this.taskDSL = taskDSL;
 		this.sequences = sequences;
-		// TODO use inAppMode to police what can be called on this node?
 	}
 
 	/**

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
@@ -29,7 +29,6 @@ import java.util.Set;
  * <li>All target labels used on transitions must exist.
  * <li>Two references to the same app must be labeled to differentiate them
  * <li>Do not use split construct with only one flow inside
- * <li>TODO much more!
  * </ul>
  *
  * @author Andy Clement
@@ -159,7 +158,6 @@ public class TaskValidatorVisitor extends TaskVisitor {
 						DSLMessage.TASK_VALIDATION_TRANSITION_TARGET_LABEL_UNDEFINED);
 			}
 		}
-		// TODO Verify all secondary sequences are visited
 	}
 
 	private void pushProblem(int pos, DSLMessage message) {

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/dsl/graph/Graph.java
@@ -87,21 +87,6 @@ public class Graph {
 		return s.toString();
 	}
 
-	// TODO reactivate when we need to transmit this to the front end
-	// public String toJSON() {
-	// Graph g = new Graph(nodes, links, properties);
-	// ObjectMapper mapper = new ObjectMapper();
-	// mapper.setSerializationInclusion(Include.NON_NULL);
-	// try {
-	// return mapper.writeValueAsString(g);
-	// }
-	// catch (IOException e) {
-	// throw new IllegalStateException("Unexpected problem creating JSON from Graph", e);
-	// }
-	// }
-
-	// TODO this does not correctly handle use of secondary sequences yet
-
 	/**
 	 * Produce the DSL representation of the graph. To make this process easier we can
 	 * assume there is a START and an END node.

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -678,7 +678,7 @@ public class TaskParserTests {
 	@Test
 	public void transitionToSplit() {
 		String spec = "aa 'foo'->:split && bb && split: <cc || dd> && ee";
-		// TODO lets consider this a limitation for now.
+		// lets consider this a limitation for now.
 		assertGraph("[0:START][1:aa][2:bb][3:cc][4:dd][5:ee][6:END]" + "[0-1][1-2]['foo':1-3][2-3][2-4][3-5][4-5][5-6]",
 				spec);
 	}
@@ -751,9 +751,6 @@ public class TaskParserTests {
 		assertApps(ctn.getTaskApps(), "appA", "appB", "appC", "foo:appD", "appE");
 		tv.reset();
 		ctn.accept(tv);
-		// TODO slight nuance here. foo: above is considered the label for the second flow
-		// and for the app appD, is
-		// that a problem? Is the distinction necessary?
 		assertEquals(">SN[0] >F =F >TA =TA[appA] <TA >TA =TA[appB] >T =T[0->:foo] <T >T =T[*->appC] <T <TA <F <SN[0] "
 				+ ">SN[foo: 1] >F =F[foo:] >TA =TA[foo: appD] <TA >TA =TA[appE] <TA <F <SN[1]", tv.getString());
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/support/TaskletType.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/support/TaskletType.java
@@ -54,8 +54,6 @@ public enum TaskletType {
 	 */
 	UNKNOWN("", "");
 
-	// TODO: Add Hadoop Types
-
 	private final String className;
 
 	private final String displayName;


### PR DESCRIPTION
resolves #2883

Note 1:
// TODO slight nuance here. foo: above is considered the label for the second flow
// and for the app appD, is
// that a problem? Is the distinction necessary?
===> This distinction is not necessary.   So long as we have a target.

Note 2:
TODO lets consider this a limitation for now.
Create a story for this.
https://github.com/spring-cloud/spring-cloud-dataflow/issues/2885

Note 3: Removed dead code

// TODO: BOOT2 handle this custom ddl stuff
// @Bean
// @DependsOn({ "batchRepositoryInitializerForDefaultDB", "taskRepositoryInitializerForDB"
// })
// public AbstractDatabaseInitializer batchTaskIndexesDatabaseInitializer(DataSource
// dataSource,
// ResourceLoader resourceLoader) {
// return new BatchTaskIndexesDatabaseInitializer(dataSource, resourceLoader);
// }

Note: 4
Add support for inAppMode Flag
https://github.com/spring-cloud/spring-cloud-dataflow/issues/2885

Note: 5
TaskValidatorVisitor needs to valid secondary sequences
https://github.com/spring-cloud/spring-cloud-dataflow/issues/2885

Note: 6 remove Hadoop Types todo

Note 7: Removed TaskExecutionsDocumentation comment
This issue was fixed in the 2.1.RELEASE.  TODO was resolved

Note 8: need to handle infinite loop if present
https://github.com/spring-cloud/spring-cloud-dataflow/issues/2885