### PR TITLE
gh-781 If Security Enabled: Provide better User Experience when Starting the Shell

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowClientException.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/DataFlowClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,29 +16,41 @@
 
 package org.springframework.cloud.dataflow.rest.client;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.hateoas.VndErrors;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * A Java exception that wraps the serialized {@link VndErrors} object.
  *
  * @author Eric Bottard
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
-@SuppressWarnings("serial")
 public class DataFlowClientException extends RuntimeException {
 
-	private VndErrors vndErrors;
+	private static final long serialVersionUID = 1L;
+	private final VndErrors vndErrors;
 
-	public DataFlowClientException(VndErrors error) {
-		this.vndErrors = error;
+	/**
+	 * Initializes a {@link DataFlowClientException} with the provided (mandatory error).
+	 *
+	 * @param error Must not be null
+	 */
+	public DataFlowClientException(VndErrors vndErrors) {
+		Assert.notNull(vndErrors, "The provided vndErrors parameter must not be null.");
+		this.vndErrors = vndErrors;
 	}
 
 	@Override
 	public String getMessage() {
-		StringBuilder builder = new StringBuilder();
+		final List<String> errorMessages = new ArrayList<>(0);
 		for (VndErrors.VndError e : vndErrors) {
-			builder.append(e.getMessage()).append('\n');
+			errorMessages.add(e.getMessage());
 		}
-		return builder.toString();
+		return StringUtils.collectionToDelimitedString(errorMessages, "\n");
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/VndErrorResponseErrorHandler.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/VndErrorResponseErrorHandler.java
@@ -24,6 +24,7 @@ import org.springframework.hateoas.VndErrors.VndError;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpMessageConverterExtractor;
 import org.springframework.web.client.ResponseExtractor;
@@ -60,6 +61,18 @@ public class VndErrorResponseErrorHandler extends DefaultResponseErrorHandler {
 		catch (Exception e) {
 			super.handleError(response);
 		}
-		throw new DataFlowClientException(vndErrors);
+		if (vndErrors != null) {
+			throw new DataFlowClientException(vndErrors);
+		}
+		else {
+			//FIXME Basic Authentication Exceptions do not return a VndError
+			final String message = StringUtils.hasText(response.getStatusText())
+					? response.getStatusText()
+					: String.valueOf(response.getStatusCode());
+
+			throw new DataFlowClientException(
+				new VndErrors(String.valueOf(response.getStatusCode()), message));
+		}
+
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/VndErrorResponseErrorHandler.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/VndErrorResponseErrorHandler.java
@@ -65,7 +65,7 @@ public class VndErrorResponseErrorHandler extends DefaultResponseErrorHandler {
 			throw new DataFlowClientException(vndErrors);
 		}
 		else {
-			//FIXME Basic Authentication Exceptions do not return a VndError
+			//see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2898
 			final String message = StringUtils.hasText(response.getStatusText())
 					? response.getStatusText()
 					: String.valueOf(response.getStatusCode());

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowClientExceptionTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowClientExceptionTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.rest.client;
+
+import org.junit.Test;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.VndErrors;
+import org.springframework.hateoas.VndErrors.VndError;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class DataflowClientExceptionTests {
+
+	@Test
+	public void testCreationOfDataflowClientExceptionWithNullError() {
+
+		try {
+			new DataFlowClientException(null);
+		}
+		catch (IllegalArgumentException e) {
+			assertEquals("The provided vndErrors parameter must not be null.", e.getMessage());
+			return;
+		}
+
+		fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void testCreationOfDataflowClientExceptionWithSingleError() {
+		final VndErrors errors = new VndErrors("foo", "bar message", new Link("somewhere"));
+		final DataFlowClientException dataFlowClientException = new DataFlowClientException(errors);
+		assertEquals("bar message", dataFlowClientException.getMessage());
+	}
+
+	@Test
+	public void testCreationOfDataflowClientExceptionWithMultipleErrors() {
+		final VndError vndError1 = new VndError("foo logref", "foo message", new Link("foo link"));
+		final VndError vndError2 = new VndError("bar logref", "bar message", new Link("bar link"));
+
+		final VndErrors errors = new VndErrors(vndError1, vndError2);
+		final DataFlowClientException dataFlowClientException = new DataFlowClientException(errors);
+		assertEquals("foo message\nbar message", dataFlowClientException.getMessage());
+	}
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataflowJLineShellComponent.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataflowJLineShellComponent.java
@@ -46,12 +46,13 @@ public class DataflowJLineShellComponent extends JLineShellComponent {
 		final StringBuilder sb = new StringBuilder();
 		if (targetHolder.getTarget().getTargetException() != null &&
 			StringUtils.hasText(targetHolder.getTarget().getTargetResultMessage())) {
-			sb.append("WARNING - During targeting we encountered a problem:"
+			sb.append("WARNING - Problem connecting to the Spring Cloud Data Flow Server:"
 				+ System.lineSeparator())
 			.append("\"" + targetHolder.getTarget().getTargetResultMessage() + "\""
 				+ System.lineSeparator())
 			.append("Please double check your startup parameters and either restart the "
-				+ "Data Flow Shell or target the Data Flow Server using the "
+				+ "Data Flow Shell (with any missing configuration including security etc.) "
+				+ "or target the Data Flow Server using the "
 				+ "'dataflow config server' command."
 				+ System.lineSeparator()
 				+ System.lineSeparator());

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataflowJLineShellComponent.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/DataflowJLineShellComponent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.shell;
+
+import org.springframework.cloud.dataflow.shell.command.ConfigCommands;
+import org.springframework.shell.core.JLineShellComponent;
+import org.springframework.util.StringUtils;
+
+/**
+ * Extended version of {@link JLineShellComponent} that "targets" the Spring
+ * Cloud Data Flow server in {@link #getStartupNotifications()} before the shell
+ * is fully initialized (Any errors are printed to the console)
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public class DataflowJLineShellComponent extends JLineShellComponent {
+
+	private final ConfigCommands configCommands;
+	private final TargetHolder targetHolder;
+
+	public DataflowJLineShellComponent(ConfigCommands configCommands, TargetHolder targetHolder) {
+		this.configCommands = configCommands;
+		this.targetHolder = targetHolder;
+	}
+
+	@Override
+	public String getStartupNotifications() {
+		this.configCommands.triggerTarget();
+		super.setPromptPath(null);
+
+		final StringBuilder sb = new StringBuilder();
+		if (targetHolder.getTarget().getTargetException() != null &&
+			StringUtils.hasText(targetHolder.getTarget().getTargetResultMessage())) {
+			sb.append("WARNING - During targeting we encountered a problem:"
+				+ System.lineSeparator())
+			.append("\"" + targetHolder.getTarget().getTargetResultMessage() + "\""
+				+ System.lineSeparator())
+			.append("Please double check your startup parameters and either restart the "
+				+ "Data Flow Shell or target the Data Flow Server using the "
+				+ "'dataflow config server' command."
+				+ System.lineSeparator()
+				+ System.lineSeparator());
+		}
+		else if (StringUtils.hasText(targetHolder.getTarget().getTargetResultMessage())) {
+			sb.append(targetHolder.getTarget().getTargetResultMessage());
+		}
+		return sb.toString();
+	}
+
+}

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/autoconfigure/BaseShellAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.dataflow.shell.DataflowJLineShellComponent;
 import org.springframework.cloud.dataflow.shell.ShellCommandLineParser;
 import org.springframework.cloud.dataflow.shell.ShellProperties;
 import org.springframework.cloud.dataflow.shell.TargetHolder;
+import org.springframework.cloud.dataflow.shell.command.ConfigCommands;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -41,15 +42,13 @@ import org.springframework.shell.core.JLineShellComponent;
  * @author Josh Long
  * @author Mark Pollack
  * @author Eric Bottard
+ * @author Gunnar Hillert
  */
 @Configuration
 @ImportResource("classpath*:/META-INF/spring/spring-shell-plugin.xml")
 public class BaseShellAutoConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(BaseShellAutoConfiguration.class);
-
-	@Autowired
-	private CommandLine commandLine;
 
 	@Bean
 	public TargetHolder targetHolder() {
@@ -75,8 +74,8 @@ public class BaseShellAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(JLineShell.class)
-	public JLineShellComponent shell() {
-		return new JLineShellComponent();
+	public JLineShellComponent shell(ConfigCommands configCommands, TargetHolder targetHolder) {
+		return new DataflowJLineShellComponent(configCommands, targetHolder);
 	}
 
 	@Configuration

--- a/spring-cloud-dataflow-shell-core/src/main/resources/logback.xml
+++ b/spring-cloud-dataflow-shell-core/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
 			<pattern>%d{yyyy-MM-dd'T'HH:mm:ssZ} %level{5} %thread %c{2}:%L - %m%n</pattern>
 		</encoder>
 	</appender>
+	<logger name="org.springframework.cloud.dataflow.shell.DataflowJLineShellComponent" level="INFO"/>
 	<logger name="org.springframework.web.client.RestTemplate" level="ERROR"/>
 	<logger name="org.apache.hadoop.util.NativeCodeLoader" level="ERROR"/>
 	<logger name="org.springframework.shell.core.JLineShellComponent.exceptions" level="ERROR"/>

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -128,8 +128,6 @@ public class ConfigCommandTests {
 		value.add(new Link("http://localhost:9393/dashboard", "dashboard"));
 		when(restTemplate.getForObject(Mockito.any(URI.class), Mockito.eq(RootResource.class))).thenReturn(value);
 
-		configCommands.onApplicationEvent(null);
-
 		final String targetResult = configCommands.target("http://localhost:9393", null, null, null, false, null, null, null);
 		assertThat(targetResult, containsString("Incompatible version of Data Flow server detected"));
 	}


### PR DESCRIPTION
* With enabled security, shell users do not need to provide credentials as command-line arguments
  - The Shell will ask for username and/or password if needed
* Problems, e.g. wrong credentials will be printed to the console

resolves #781 