### PR TITLE
Resolve maven co-ordinates

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 public class AppResourceCommon {
 
@@ -181,9 +182,20 @@ public class AppResourceCommon {
 		Assert.notNull(resource, "resource must not be null");
 		if (resource instanceof MavenResource) {
 			MavenResource mavenResource = (MavenResource) resource;
-			return String.format("maven://%s:%s",
+			StringBuilder mavenResourceStringBuilder = new StringBuilder();
+			mavenResourceStringBuilder.append(String.format("maven://%s:%s",
 					mavenResource.getGroupId(),
-					mavenResource.getArtifactId());
+					mavenResource.getArtifactId()));
+			if (StringUtils.hasText(mavenResource.getExtension())) {
+				mavenResourceStringBuilder.append(":" + mavenResource.getExtension());
+			}
+			else {
+				mavenResourceStringBuilder.append(":jar");
+			}
+			if (StringUtils.hasText(mavenResource.getClassifier())) {
+				mavenResourceStringBuilder.append(":" + mavenResource.getClassifier());
+			}
+			return mavenResourceStringBuilder.toString();
 		}
 		else if (resource instanceof DockerResource) {
 			DockerResource dockerResource = (DockerResource) resource;

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,6 +169,19 @@ public class AppResourceCommonTests {
 		assertThat(version).isEqualTo("1.2.0-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
+	}
+
+	@Test
+	public void testGetResourceWithoutVersion() {
+		assertThat(appResourceCommon.getResourceWithoutVersion(
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec:1.3.0.RELEASE")))
+				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec");
+		assertThat(appResourceCommon.getResourceWithoutVersion(
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit::exec:1.3.0.RELEASE")))
+				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar:exec");
+		assertThat(appResourceCommon.getResourceWithoutVersion(
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE")))
+				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -663,7 +663,7 @@ public class StreamControllerTests {
 		SpringCloudDeployerApplicationSpec filterSpec = parseSpec(filterPackage.getConfigValues().getRaw());
 
 		assertThat(filterSpec.getResource(),
-				is("maven://org.springframework.cloud.stream.app:filter-processor-rabbit"));
+				is("maven://org.springframework.cloud.stream.app:filter-processor-rabbit:jar"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
@@ -46,7 +46,7 @@ public class ResourceUtilsTests {
 				.version("1.0.0.RELEASE")
 				.build();
 		String resourceWithoutVersion = appResourceService.getResourceWithoutVersion(mavenResource);
-		assertThat(resourceWithoutVersion).isEqualTo("maven://org.springframework.cloud.task.app:timestamp-task");
+		assertThat(resourceWithoutVersion).isEqualTo("maven://org.springframework.cloud.task.app:timestamp-task:jar");
 		assertThat(appResourceService.getResourceVersion(mavenResource)).isEqualTo("1.0.0.RELEASE");
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-install.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-install.yml
@@ -1,7 +1,7 @@
 "metadata":
   "name": "log"
 "spec":
-  "resource": "maven://org.springframework.cloud.stream.app:log-sink-rabbit"
+  "resource": "maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar"
   "applicationProperties":
     "spring.metrics.export.triggers.application.includes": "integration**"
     "spring.cloud.dataflow.stream.app.label": "log"


### PR DESCRIPTION
 - When updating the Maven resource co-ordinates in the Skipper package,
all the supported co-ordinates (groupId, artifactId, extension and classifier) need to be updated.
 - Add tests

Resolves #2893