### PR TITLE
Running kubernetes non-root with RabbitMQ.

### DIFF
--- a/src/kubernetes/mysql/mysql-deployment.yaml
+++ b/src/kubernetes/mysql/mysql-deployment.yaml
@@ -11,6 +11,9 @@ spec:
       labels:
         app: mysql
     spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
       containers:
       - image: mysql:5.6
         name: mysql

--- a/src/kubernetes/rabbitmq/rabbitmq-deployment.yaml
+++ b/src/kubernetes/rabbitmq/rabbitmq-deployment.yaml
@@ -11,6 +11,9 @@ spec:
       labels:
         app: rabbitmq
     spec:
+      securityContext:
+        runAsUser: 999
+        fsGroup: 999
       containers:
       - image: rabbitmq:3.6.10
         name: rabbitmq

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -14,12 +14,15 @@ spec:
       labels:
         app: scdf-server
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       containers:
       - name: scdf-server
         image: springcloud/spring-cloud-dataflow-server:2.0.0.BUILD-SNAPSHOT
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         resources:
           limits:
             cpu: 1.0
@@ -33,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: "metadata.namespace"
         - name: SERVER_PORT
-          value: '80'
+          value: '8080'
         - name: SPRING_CLOUD_CONFIG_ENABLED
           value: 'false'
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
@@ -54,4 +57,8 @@ spec:
           # Add Maven repo for metadata artifact resolution for all stream apps
         - name: SPRING_APPLICATION_JSON
           value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
+        - name: JAVA_TOOL_OPTIONS
+          value: "-Duser.home=/tmp"
+        - name: MAVEN_CONFIG
+          value: "/tmp"
       serviceAccountName: scdf-sa

--- a/src/kubernetes/server/server-svc.yaml
+++ b/src/kubernetes/server/server-svc.yaml
@@ -8,7 +8,7 @@ spec:
   # If you are running k8s on a local dev box or using minikube, you can use type NodePort instead
   type: LoadBalancer
   ports:
-    - port: 80
+    - port: 8080
       name: scdf-server
   selector:
     app: scdf-server

--- a/src/kubernetes/skipper/skipper-deployment.yaml
+++ b/src/kubernetes/skipper/skipper-deployment.yaml
@@ -14,12 +14,15 @@ spec:
       labels:
         app: skipper
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       containers:
       - name: skipper
         image: springcloud/spring-cloud-skipper-server:2.0.0.BUILD-SNAPSHOT
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         resources:
           limits:
             cpu: 1.0


### PR DESCRIPTION
Includes changes to kubernetes manifest files to have the images run as non-root users. It also includes changes that are needed to be made as a consequence of using the non-root users(e.g., non-root users cannot bind on ports below 1024).

I did not create new users in the images but instead used the users that are already available in the images. However, most of those built-in users do not have home directories defined. The SCDF server uses the home directory of the user for some of its function (e.g. maven). I had to override it to use `/tmp` instead.

Resolves #2881