### PR TITLE
Resolves problem with testTaskLaunch

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
@@ -76,7 +76,11 @@ public class TaskCommandTemplate {
 		// add the task name to the tasks list before assertion
 		tasks.add(taskName);
 		CommandResult cr = shell.executeCommand("task launch " + taskName);
-		assertTrue(cr.toString().contains("with execution id 1"));
+		CommandResult idResult = shell.executeCommand("task execution list --name " + taskName);
+		Table result = (Table) idResult.getResult();
+
+		long value = (long) result.getModel().getValue(1, 1);
+		assertTrue(cr.toString().contains("with execution id " + value));
 	}
 
 	/**


### PR DESCRIPTION
While running locally the task execution id was 1. But in CI we have pre-existing task launches.
To resolve this, the test was updated to retrieve a task execution list for a unique test name.  And then the execution id is extracted.
This extracted execution id is then used to determine success