### PR TITLE
gh-2963 Fix Security: URI `/tasks/platforms` not covered

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -163,6 +163,10 @@ spring:
             - POST   /tasks/schedules                => hasRole('ROLE_SCHEDULE')
             - DELETE /tasks/schedules/*              => hasRole('ROLE_SCHEDULE')
 
+            # Task Platform Account List */
+
+            - GET    /tasks/platforms                => hasRole('ROLE_VIEW')
+
             # Task Validations
 
             - GET    /tasks/validation/               => hasRole('ROLE_VIEW')

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithUsersFileTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithUsersFileTests.java
@@ -473,6 +473,13 @@ public class LocalServerSecurityWithUsersFileTests {
 
 				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/platform/list", null, null },
 
+				/* TaskPlatformController */
+
+				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", manageOnlyUser, null },
+				{ HttpMethod.GET, HttpStatus.OK, "/tasks/platforms", viewOnlyUser, null },
+				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", createOnlyUser, null },
+				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/platforms", null, null },
+
 				/* TaskDefinitionController */
 
 				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,


### PR DESCRIPTION
* Add rule to `dataflow-server-defaults.yml`
* Add tests to `LocalServerSecurityWithUsersFileTests`

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/2963