### PR TITLE
Fix incorrect application references

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -43,7 +43,7 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-dataset-sink[hdfs-dataset]
+|hdfs-dataset ~(deprecated)~
 |link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-loggregator-source[loggregator]
@@ -57,8 +57,8 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregate-counter-sink[aggregate-counter]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pmml-processor[pmml]
+|aggregate-counter ~(deprecated)~
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb]
@@ -97,17 +97,17 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-processor[counter]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow]
 |link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
 |
 
@@ -118,7 +118,12 @@ A selection of pre-built link:http://cloud.spring.io/spring-cloud-stream-app-sta
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-field-value-counter-sink[field-value-counter]
+|field-value-counter ~(deprecated)~
+|
+
+|
+|
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-task-launcher-dataflow-sink[tasklauncher-dataflow]
 |
 
 |

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-cloudfoundry.adoc
@@ -670,7 +670,7 @@ To run a simple task application, you can register all the out-of-the-box task a
 
 [source,bash,subs=attributes]
 ----
-dataflow:>app import --uri http://bit.ly/Dearborn-GA-task-applications-maven
+dataflow:>app import --uri http://bit.ly/Dearborn-SR1-task-applications-maven
 ----
 
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -432,11 +432,11 @@ The following table includes the available Task Application Starters based on Sp
 |Artifact Type |Milestone Release |SNAPSHOT Release
 
 |Maven
-|http://bit.ly/Elston-RC1-task-applications-maven
+|http://bit.ly/Elston-GA-task-applications-maven
 |http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-maven
 
 |Docker
-|http://bit.ly/Elston-RC1-task-applications-docker
+|http://bit.ly/Elston-GA-task-applications-docker
 |http://bit.ly/Elston-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
@@ -1592,7 +1592,7 @@ Attempting to create or deploy a stream that contains an unknown app throws an e
 [source,java,options="nowrap"]
 ----
 dataFlowOperations.appRegistryOperations().importFromResource(
-            "http://bit.ly/Darwin-GA-stream-applications-rabbit-maven", true);
+            "http://bit.ly/Darwin-SR3-stream-applications-rabbit-maven", true);
 ----
 
 The Stream applications can also be beans within your application that are injected in other classes to create Streams.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -118,8 +118,8 @@ The following table lists the available static property files:
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Stable Release |SNAPSHOT Release
-|Maven   | http://bit.ly/Dearborn-SR1-task-applications-maven | http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-maven
-|Docker  | http://bit.ly/Dearborn-SR1-task-applications-docker | http://bit.ly/Clark-BUILD-SNAPSHOT-task-applications-docker
+|Maven   | http://bit.ly/Dearborn-SR1-task-applications-maven | http://bit.ly/Dearborn-BUILD-SNAPSHOT-task-applications-maven
+|Docker  | http://bit.ly/Dearborn-SR1-task-applications-docker | http://bit.ly/Dearborn-BUILD-SNAPSHOT-task-applications-docker
 |======================
 
 For example, if you would like to register all out-of-the-box task applications in bulk, you can do so with the following command:


### PR DESCRIPTION
Following incorrect references were corrected.

1) Fix duplicate rows for "bridge" and "aggregator"
2) Add missing apps ("pmml", "counter", "tasklauncher-dataflow")
3) Add deprecations where applicable

There were a few references to Clark train and that's fixed now.

Finally, also, I flipped Elston from RC1 to GA albeit the release is not done yet. Elston is waiting on SCDF 2.0 (CTR 2.1 GA depends on SCDF 2.0 GA) -> 🐔 or 🥚? When we release SCDF 2.0, it'd be better not to have RC1 references.

