### PR TITLE
Remove H2 related task configs

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
@@ -83,12 +83,7 @@ java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{proj
     --spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver &
 ----
 
-NOTE: If you wish to use an external H2 database instance instead of the one
-embedded with Spring Cloud Data Flow, set the
-`spring.dataflow.embedded.database.enabled` property to false.  If
-`spring.dataflow.embedded.database.enabled` is set to false or a database
-other than h2 is specified as the datasource, the embedded database does not
-start.
+NOTE: H2 database is not supported as an external mode.
 
 ==== Disabling database schema creation and migration strategies
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -28,10 +28,6 @@ import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.batch.BatchDataSourceInitializer;
-import org.springframework.boot.autoconfigure.batch.BatchProperties;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
@@ -66,11 +62,9 @@ import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncher;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
-import org.springframework.cloud.task.repository.support.TaskRepositoryInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -217,61 +211,13 @@ public class TaskConfiguration {
 		return jobExplorerFactoryBean;
 	}
 
-	@Configuration
-	@ConditionalOnProperty(name = "spring.dataflow.embedded.database.enabled", havingValue = "true", matchIfMissing = true)
-	@ConditionalOnExpression("#{'${spring.datasource.url:}'.startsWith('jdbc:h2:tcp://localhost:')}")
-	public static class H2ServerConfiguration {
-
-		@Bean
-		public JobRepositoryFactoryBean jobRepositoryFactoryBeanForServer(DataSource dataSource,
-				PlatformTransactionManager dataSourceTransactionManager) {
-			JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
-			repositoryFactoryBean.setDataSource(dataSource);
-			repositoryFactoryBean.setTransactionManager(dataSourceTransactionManager);
-			return repositoryFactoryBean;
-		}
-
-		@Bean
-		public BatchDataSourceInitializer batchRepositoryInitializerForDefaultDBForServer(DataSource dataSource,
-				ResourceLoader resourceLoader, BatchProperties properties) {
-			return new BatchDataSourceInitializer(dataSource, resourceLoader, properties);
-		}
-
-		@Bean
-		public TaskRepositoryInitializer taskRepositoryInitializerForDefaultDB(DataSource dataSource) {
-			TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer();
-			taskRepositoryInitializer.setDataSource(dataSource);
-			return taskRepositoryInitializer;
-		}
-	}
-
-	@Configuration
-	@ConditionalOnExpression("#{!'${spring.datasource.url:}'.startsWith('jdbc:h2:tcp://localhost:') || "
-			+ "('${spring.datasource.url:}'.startsWith('jdbc:h2:tcp://localhost:') &&"
-			+ "'${spring.dataflow.embedded.database.enabled}'.equals('false'))}")
-	public static class NoH2ServerConfiguration {
-
-		@Bean
-		public JobRepositoryFactoryBean jobRepositoryFactoryBean(DataSource dataSource,
-				PlatformTransactionManager platformTransactionManager) {
-			JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
-			repositoryFactoryBean.setDataSource(dataSource);
-			repositoryFactoryBean.setTransactionManager(platformTransactionManager);
-			return repositoryFactoryBean;
-		}
-
-		@Bean
-		public BatchDataSourceInitializer batchRepositoryInitializerForDefaultDB(DataSource dataSource,
-				ResourceLoader resourceLoader, BatchProperties properties) {
-			return new BatchDataSourceInitializer(dataSource, resourceLoader, properties);
-		}
-
-		@Bean
-		public TaskRepositoryInitializer taskRepositoryInitializerForDB(DataSource dataSource) {
-			TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer();
-			taskRepositoryInitializer.setDataSource(dataSource);
-			return taskRepositoryInitializer;
-		}
+	@Bean
+	public JobRepositoryFactoryBean jobRepositoryFactoryBean(DataSource dataSource,
+			PlatformTransactionManager platformTransactionManager) {
+		JobRepositoryFactoryBean repositoryFactoryBean = new JobRepositoryFactoryBean();
+		repositoryFactoryBean.setDataSource(dataSource);
+		repositoryFactoryBean.setTransactionManager(platformTransactionManager);
+		return repositoryFactoryBean;
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/web/WebConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/web/WebConfiguration.java
@@ -71,9 +71,6 @@ public class WebConfiguration implements ServletContextInitializer, ApplicationL
 	@Value("${spring.datasource.url:#{null}}")
 	private String dataSourceUrl;
 
-	@Value("${spring.dataflow.embedded.database.enabled:false}")
-	private boolean embeddedDatabasedEnabled;
-
 	private Server server = null;
 
 	public Server initH2TCPServer() {
@@ -96,8 +93,7 @@ public class WebConfiguration implements ServletContextInitializer, ApplicationL
 
 	@Override
 	public void onStartup(ServletContext servletContext) {
-		if (this.embeddedDatabasedEnabled && StringUtils.hasText(dataSourceUrl)
-				&& dataSourceUrl.startsWith("jdbc:h2:tcp://localhost:")) {
+		if (StringUtils.hasText(dataSourceUrl) && dataSourceUrl.startsWith("jdbc:h2:tcp://localhost:")) {
 			logger.info("Start Embedded H2");
 			initH2TCPServer();
 		}

--- a/spring-cloud-starter-dataflow-server/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-starter-dataflow-server/src/main/resources/dataflow-server.yml
@@ -19,12 +19,7 @@ spring:
       uri: http://localhost:8888
 
   datasource:
-#    url: jdbc:h2:tcp://localhost:19092/mem:dataflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     url: jdbc:h2:tcp://localhost:19092/mem:dataflow
     username: sa
     password:
     driverClassName: org.h2.Driver
-  dataflow:
-    embedded:
-      database:
-        enabled: true


### PR DESCRIPTION
- Move JobRepositoryFactoryBean out from custom H2 configs
  as we don't no longer support H2 as non-embedded mode. This
  removes all tweaks and batch/task db initializers should not
  exist at all as db is managed by flyway.
- Remove spring.dataflow.embedded.database.enabled from dataflow-server.yml
  and WebConfiguration as setting itself is now pointless.
- We keep actual datasource config in dataflow-server.yml as that
  together with WebConfiguration starts H2 with tcp mode.
- Fixes #3019