### PR TITLE
Updated doc to fix version replacement in shell download command

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
@@ -426,6 +426,7 @@ wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/s
 . Download the Spring Cloud Data Flow Shell application by using the following command:
 +
 ====
+[source,bash,subs=attributes]
 ----
 wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{project-version}/spring-cloud-dataflow-shell-{project-version}.jar
 ----


### PR DESCRIPTION
A missing tag was preventing the substitution of the repository name and
version of SCDF in the command for downloading the shell.  This commit
fixes that.