### PR TITLE
Fix stream name length in tests

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,8 +184,12 @@ public abstract class AbstractShellIntegrationTest {
 	 * @param name name to use as part of stream/task name
 	 * @return unique random stream/task name
 	 */
-	protected String generateUniqueName(String name) {
-		return name + "-" + idGenerator.generateId();
+	protected String generateUniqueStreamOrTaskName(String name) {
+		// Return stream name of 20 characters of length
+		if (name.length() > 16) {
+			name = name.substring(0, 16);
+		}
+		return name + "-" + idGenerator.generateId().toString().substring(0, 4);
 	}
 
 	/**
@@ -193,8 +197,8 @@ public abstract class AbstractShellIntegrationTest {
 	 *
 	 * @return unique random stream/task name
 	 */
-	protected String generateUniqueName() {
-		return generateUniqueName(name.getMethodName().replace('[', '-').replace("]", ""));
+	protected String generateUniqueStreamOrTaskName() {
+		return generateUniqueStreamOrTaskName(name.getMethodName().replace('[', '-').replace("]", ""));
 	}
 
 	private static class DataFlowShell extends JLineShellComponent {

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,14 +69,14 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 	public void testStreamLifecycleForTickTock() throws InterruptedException {
 		logger.info("Starting Stream Test for TickTock");
 		Thread.sleep(2000);
-		String streamName = generateUniqueName();
+		String streamName = generateUniqueStreamOrTaskName();
 		stream().create(streamName, "time | log");
 	}
 
 	@Test
 	public void testValidate() throws InterruptedException {
 		Thread.sleep(2000);
-		String streamName = generateUniqueName();
+		String streamName = generateUniqueStreamOrTaskName();
 		Info info = new Info();
 		Status status = new Status();
 		status.setStatusCode(StatusCode.UNKNOWN);

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -114,7 +114,7 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void testTaskLaunch() {
 		logger.info("Launching instance of task");
-		String taskName = generateUniqueName();
+		String taskName = generateUniqueStreamOrTaskName();
 		task().create(taskName, "timestamp");
 		task().launch(taskName);
 	}
@@ -122,14 +122,14 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void testCreateTask() {
 		logger.info("Create Task Test");
-		String taskName = generateUniqueName();
+		String taskName = generateUniqueStreamOrTaskName();
 		task().create(taskName, "timestamp");
 	}
 
 	@Test
 	public void destroySpecificTask() {
 		logger.info("Create Task Test");
-		String taskName = generateUniqueName();
+		String taskName = generateUniqueStreamOrTaskName();
 		task().create(taskName, "timestamp");
 		logger.info("Destroy created task");
 		task().destroyTask(taskName);
@@ -138,9 +138,9 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void destroyAllTasks() {
 		logger.info("Create Task Test");
-		String taskName1 = generateUniqueName();
+		String taskName1 = generateUniqueStreamOrTaskName();
 		task().create(taskName1, "timestamp");
-		String taskName2 = generateUniqueName();
+		String taskName2 = generateUniqueStreamOrTaskName();
 		task().create(taskName2, "timestamp");
 		task().destroyAllTasks();
 	}
@@ -218,7 +218,7 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 
 	@Test
 	public void testValidate() {
-		String taskName = generateUniqueName();
+		String taskName = generateUniqueStreamOrTaskName();
 		task().create(taskName, "timestamp");
 
 		CommandResult cr = task().taskValidate(taskName);


### PR DESCRIPTION
 - Limit stream name length to be `20` to allow the resolved app name length inside the allowed limit of 58 chars.