### PR TITLE
Remove Codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,3 @@ jdk:
 install: true
 script:
   - './mvnw package -Pfull -U -Dmaven.test.redirectTestOutputToFile=true'
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@
     <img src="https://spring.io/badges/spring-cloud-dataflow/snapshot.svg"
          alt="Latest Snapshot Version" />
   </a>
-  <a href="https://codecov.io/gh/spring-cloud/spring-cloud-dataflow/branch/master">
-    <img src="https://codecov.io/gh/spring-cloud/spring-cloud-dataflow/branch/master/graph/badge.svg"
-         alt="Codecov" />
-  </a>
   <br>
   <a href="https://build.spring.io/browse/SCD-BMASTER">
     <img src="https://build.spring.io/plugins/servlet/wittified/build-status/SCD-BMASTER"


### PR DESCRIPTION
Based on the research [via: [3004#issuecomment-479540265](https://github.com/spring-cloud/spring-cloud-dataflow/issues/3004#issuecomment-479540265)] and after discussing with @markpollack, we have decided to remove Codecov integration from SCDF. 

False alarms is one thing; more than that, we don't appear to be using this tool effectively for each of the PRs, so it'd be good to reduce the noise. We will switch to Sonar or something else to add a test-coverage badge in the README eventually.

Resolves #3004 
