### PR TITLE
Fix docker-compose's grafana url prefix

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.prometheus.enabled=true
       - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.streamapp.security.enabled=false
       - spring.cloud.dataflow.applicationProperties.stream.management.endpoints.web.exposure.include=prometheus,info,health
-      - spring.cloud.dataflow.grafana-info.url=https://localhost:3000
+      - spring.cloud.dataflow.grafana-info.url=http://localhost:3000
     depends_on:
       - kafka
 


### PR DESCRIPTION
 - Revert https://localhost:3000 to http://localhost:3000 as grafana's container currently is not configured to accept https requests.
 Resolves #3111