### PR TITLE
Enhance local scheduler mock implementation

### DIFF
--- a/spring-cloud-dataflow-autoconfigure/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalSchedulerAutoConfiguration.java
+++ b/spring-cloud-dataflow-autoconfigure/src/main/java/org/springframework/cloud/dataflow/autoconfigure/local/LocalSchedulerAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.autoconfigure.local;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -40,22 +41,22 @@ public class LocalSchedulerAutoConfiguration {
 		return new Scheduler() {
 			@Override
 			public void schedule(ScheduleRequest scheduleRequest) {
-				throw new UnsupportedOperationException("Interface is not implemented for schedule method.");
+				throw new UnsupportedOperationException("Scheduling is not implemented for local platform.");
 			}
 
 			@Override
 			public void unschedule(String scheduleName) {
-				throw new UnsupportedOperationException("Interface is not implemented for unschedule method.");
+				throw new UnsupportedOperationException("Scheduling is not implemented for local platform.");
 			}
 
 			@Override
 			public List<ScheduleInfo> list(String taskDefinitionName) {
-				throw new UnsupportedOperationException("Interface is not implemented for list method.");
+				return Collections.emptyList();
 			}
 
 			@Override
 			public List<ScheduleInfo> list() {
-				throw new UnsupportedOperationException("Interface is not implemented for list method.");
+				return Collections.emptyList();
 			}
 		};
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactory.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncher;
+import org.springframework.cloud.scheduler.spi.core.Scheduler;
 import org.springframework.util.StringUtils;
 
 /**
@@ -31,9 +32,11 @@ import org.springframework.util.StringUtils;
 public class LocalTaskPlatformFactory extends AbstractTaskPlatformFactory<LocalPlatformProperties> {
 
 	private static final String PLATFORM_TYPE = "Local";
+	private final Scheduler localScheduler;
 
-	public LocalTaskPlatformFactory(LocalPlatformProperties platformProperties) {
+	public LocalTaskPlatformFactory(LocalPlatformProperties platformProperties, Scheduler localScheduler) {
 		super(platformProperties, PLATFORM_TYPE);
+		this.localScheduler = localScheduler;
 	}
 
 	@Override
@@ -57,7 +60,7 @@ public class LocalTaskPlatformFactory extends AbstractTaskPlatformFactory<LocalP
 
 	private Launcher doCreateLauncher(String account, LocalDeployerProperties deployerProperties) {
 		LocalTaskLauncher localTaskLauncher = new LocalTaskLauncher(deployerProperties);
-		Launcher launcher = new Launcher(account, PLATFORM_TYPE, localTaskLauncher);
+		Launcher launcher = new Launcher(account, PLATFORM_TYPE, localTaskLauncher, localScheduler);
 		launcher.setDescription(prettyPrintLocalDeployerProperties(deployerProperties));
 		return launcher;
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -54,6 +54,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobServ
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.scheduler.spi.core.Scheduler;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.context.annotation.Bean;
@@ -103,9 +104,9 @@ public class TaskConfiguration {
 	 */
 	@Profile({"local", "default"})
 	@Bean
-	public TaskPlatform localTaskPlatform(LocalPlatformProperties localPlatformProperties) {
+	public TaskPlatform localTaskPlatform(LocalPlatformProperties localPlatformProperties, Scheduler localScheduler) {
 		TaskPlatform taskPlatform = new
-			LocalTaskPlatformFactory(localPlatformProperties).createTaskPlatform();
+			LocalTaskPlatformFactory(localPlatformProperties, localScheduler).createTaskPlatform();
 		taskPlatform.setPrimary(true);
 		return taskPlatform;
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactoryTests.java
@@ -34,7 +34,7 @@ public class LocalTaskPlatformFactoryTests {
 	@Test
 	public void createsDefaultPlatform() {
 		LocalPlatformProperties platformProperties = new LocalPlatformProperties();
-		LocalTaskPlatformFactory taskPlatformFactory = new LocalTaskPlatformFactory(platformProperties);
+		LocalTaskPlatformFactory taskPlatformFactory = new LocalTaskPlatformFactory(platformProperties, null);
 		TaskPlatform taskPlatform = taskPlatformFactory.createTaskPlatform();
 		assertThat(taskPlatform.getLaunchers()).hasSize(1);
 		assertThat(taskPlatform.getName()).isEqualTo("Local");
@@ -48,7 +48,7 @@ public class LocalTaskPlatformFactoryTests {
 	public void createsConfiguredPlatform() {
 		LocalPlatformProperties platformProperties = new LocalPlatformProperties();
 		platformProperties.setAccounts(Collections.singletonMap("custom",new LocalDeployerProperties()));
-		LocalTaskPlatformFactory taskPlatformFactory = new LocalTaskPlatformFactory(platformProperties);
+		LocalTaskPlatformFactory taskPlatformFactory = new LocalTaskPlatformFactory(platformProperties, null);
 		TaskPlatform taskPlatform = taskPlatformFactory.createTaskPlatform();
 		assertThat(taskPlatform.getLaunchers()).hasSize(1);
 		assertThat(taskPlatform.getName()).isEqualTo("Local");

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,15 @@
 package org.springframework.cloud.dataflow.shell;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration;
 import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.cloud.scheduler.spi.core.ScheduleInfo;
+import org.springframework.cloud.scheduler.spi.core.ScheduleRequest;
+import org.springframework.cloud.scheduler.spi.core.Scheduler;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Dependency;
@@ -40,6 +45,33 @@ import static org.mockito.Mockito.when;
 @EnableDataFlowServer
 @Configuration
 public class TestConfig {
+
+	@Bean
+	public Scheduler localScheduler() {
+		// This is in auto-config package and we can depend on that, use same
+		// dummy no-op impl here.
+		return new Scheduler() {
+			@Override
+			public void schedule(ScheduleRequest scheduleRequest) {
+				throw new UnsupportedOperationException("Scheduling is not implemented for local platform.");
+			}
+
+			@Override
+			public void unschedule(String scheduleName) {
+				throw new UnsupportedOperationException("Scheduling is not implemented for local platform.");
+			}
+
+			@Override
+			public List<ScheduleInfo> list(String taskDefinitionName) {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<ScheduleInfo> list() {
+				return Collections.emptyList();
+			}
+		};
+	}
 
 	@Bean
 	@Primary


### PR DESCRIPTION
- Issue with current no-op local impl is that it
  throws error with UI just by going into a tasks and
  schedules page making UI side development more difficult.
  Error is java.lang.IllegalStateException: Could not find a default scheduler
  which is caused because existing `localScheduler` is not
  wired into a `Launcher`.
- Locally use `localScheduler` from `LocalSchedulerAutoConfiguration`
  so that we can delay UI errors to a point where actual
  scheduling would then throw an error. This allows UI
  to so some meaninfull errors instead of a cryptic messages.