### PR TITLE
Remove SCDF_HOST_IP from docker-compose

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-local.adoc
@@ -59,21 +59,18 @@ To get started, you need to start Docker Compose. To do so:
 ----
 $ export DATAFLOW_VERSION={local-server-image-tag}
 $ export SKIPPER_VERSION={skipper-version}
-$ export SCDF_HOST_IP=your-hsot-ip
 $ docker-compose up
 ----
 ====
 
-The `docker-compose.yml` file defines `DATAFLOW_VERSION`, `SKIPPER_VERSION` and `SCDF_HOST_IP` variables, so that those values can be easily changed. The preceding commands first set the `DATAFLOW_VERSION`, `SKIPPER_VERSION` and `SCDF_HOST_IP` to use in the environment. Then `docker-compose` is started.
+The `docker-compose.yml` file defines `DATAFLOW_VERSION` and `SKIPPER_VERSION` variables, so that those values can be easily changed. The preceding commands first set the `DATAFLOW_VERSION` and`SKIPPER_VERSION` to use in the environment. Then `docker-compose` is started.
 
-You can use the `ifconfig` (for linux/macos) or `ipconfig` (for Windows) command line toolkit to obtain the IP address to set in `SCDF_HOST_IP`. Note that `127.0.0.1` is not a valid option.
-
-You can also use a  shorthand version that exposes only the `DATAFLOW_VERSION`, `SKIPPER_VERSION` and `SCDF_HOST_IP` variables to the `docker-compose` process (rather than setting it in the environment), as follows:
+You can also use a  shorthand version that exposes only the `DATAFLOW_VERSION` and `SKIPPER_VERSION` variables to the `docker-compose` process (rather than setting it in the environment), as follows:
 
 ====
 [source,bash,subs=attributes]
 ----
-$ DATAFLOW_VERSION={local-server-image-tag} SKIPPER_VERSION={skipper-version} SCDF_HOST_IP=Your-Host-IP docker-compose up
+$ DATAFLOW_VERSION={local-server-image-tag} SKIPPER_VERSION={skipper-version} docker-compose up
 ----
 ====
 
@@ -84,7 +81,6 @@ If you use Windows, environment variables are defined by using the `set` command
 ----
 C:\ set DATAFLOW_VERSION={local-server-image-tag}
 C:\ set SKIPPER_VERSION={skipper-version}
-C:\ set SCDF_HOST_IP=Your-Host-IP
 C:\ docker-compose up
 ----
 ====
@@ -444,7 +440,6 @@ You can use InfluxDB rather than Prometheus for monitoring time-series database.
       - metrics.prometheus.target.refresh.cron=0/20 * * * * *
       - metrics.prometheus.target.discovery.url=http://localhost:9393/runtime/apps
       - metrics.prometheus.target.file.path=/tmp/targets.json
-      - 'SCDF_HOST_IP=${SCDF_HOST_IP:?SCDF_HOST_IP is not set! Use "export SCDF_HOST_IP=<SCDF Server IP>". Note: 127.0.0.1 is not a valid option!}'
     depends_on:
       - dataflow-server
 ----

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams-monitoring-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams-monitoring-local.adoc
@@ -43,11 +43,6 @@ You can use `ifconfig` to find out your IP address.
 ----
 export SCDF_HOST_IP=<YOUR locahost IP address>
 ----
-In many cases the provided `find_host_ip.sh` script will give you the IP address.
-[source,bash]
-----
-source ./find_host_ip.sh
-----
 
 Start Prometheus, Grafana + Service-Discovery using `docker-compose`.
 [source,bash]

--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -79,7 +79,7 @@ services:
   # The service-discovery container. Required for Prometheus setup only
   # Use `docker exec -it service-discovery /bin/sh` to logging the container
   service-discovery:
-    image: springcloud/spring-cloud-dataflow-prometheus-service-discovery:0.0.3.RELEASE
+    image: springcloud/spring-cloud-dataflow-prometheus-service-discovery:0.0.4.RELEASE
     container_name: 'service-discovery'
     volumes:
       - 'scdf-targets:/tmp/scdf-targets/'
@@ -90,12 +90,13 @@ services:
     environment:
       - metrics.prometheus.target.cron=0/20 * * * * *
       - metrics.prometheus.target.filePath=/tmp/scdf-targets/targets.json
+      - metrics.prometheus.target.discoveryUrl=http://dataflow-server:9393/runtime/apps
+      - metrics.prometheus.target.overrideIp=skipper-server
       - server.port=8181
-      - 'SCDF_HOST_IP=${SCDF_HOST_IP:?SCDF_HOST_IP is not set! Use "export SCDF_HOST_IP=<SCDF Server IP>". Note: 127.0.0.1 is not a valid option!}'
     depends_on:
       - dataflow-server
 
-  # Grafana SCDF Prometheus/InfluxDB pre-built image:
+  # Grafana SCDF Prometheus pre-built image:
   grafana:
     image: springcloud/spring-cloud-dataflow-grafana-prometheus:${DATAFLOW_VERSION:?DATAFLOW_VERSION is not set! Use 'export DATAFLOW_VERSION=local-server-image-tag'}
     container_name: 'grafana'

--- a/src/grafana/prometheus/docker/docker-compose.yml
+++ b/src/grafana/prometheus/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   # The service-discovery container.
   # Use `docker exec -it service-discovery /bin/sh` to logging the container
   service-discovery:
-    image: springcloud/spring-cloud-dataflow-prometheus-service-discovery:0.0.2
+    image: springcloud/spring-cloud-dataflow-prometheus-service-discovery:0.0.4.RELEASE
     container_name: 'service-discovery'
     volumes:
       - 'scdf-targets:/tmp/scdf-targets/'
@@ -30,8 +30,8 @@ services:
     ports:
       - '8181:8181'
     environment:
-      - 'SCDF_HOST_IP=${SCDF_HOST_IP:?SCDF_HOST_IP is not set!
-      Use "export SCDF_HOST_IP=<SCDF Server IP>". Note: 127.0.0.1 is not a valid option!}'
+      - metrics.prometheus.target.discoveryUrl=http://${SCDF_HOST_IP}r:9393/runtime/apps
+      - metrics.prometheus.target.overrideIp=${SCDF_HOST_IP}
 
 volumes:
   scdf-targets:

--- a/src/grafana/prometheus/docker/docker-compose.yml
+++ b/src/grafana/prometheus/docker/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - '8181:8181'
     environment:
-      - metrics.prometheus.target.discoveryUrl=http://${SCDF_HOST_IP}r:9393/runtime/apps
+      - metrics.prometheus.target.discoveryUrl=http://${SCDF_HOST_IP}:9393/runtime/apps
       - metrics.prometheus.target.overrideIp=${SCDF_HOST_IP}
 
 volumes:

--- a/src/grafana/prometheus/docker/find_host_ip.sh
+++ b/src/grafana/prometheus/docker/find_host_ip.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-export SCDF_HOST_IP=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-echo $SCDF_HOST_IP
-

--- a/src/grafana/prometheus/docker/grafana/provisioning/datasources/all.yml
+++ b/src/grafana/prometheus/docker/grafana/provisioning/datasources/all.yml
@@ -3,7 +3,7 @@ datasources:
     type: 'prometheus'
     access: 'proxy'
     org_id: 1
-    url: 'https://prometheus:9090'
+    url: 'http://prometheus:9090'
     is_default: true
     version: 5
     editable: true

--- a/src/kubernetes/grafana/grafana-configmap.yaml
+++ b/src/kubernetes/grafana/grafana-configmap.yaml
@@ -12,7 +12,7 @@ data:
       type: prometheus
       access: proxy
       org_id: 1
-      url: https://prometheus:9090
+      url: http://prometheus:9090
       is_default: true
       version: 5
       editable: true


### PR DESCRIPTION
  - For getting starter docker-compose replace the SCDF_HOST_IP by explicit dataflow-server and skipper-server container names.
  Resolves #3160