### PR TITLE
Fix default local with no scheduler

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -61,6 +61,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
+import org.springframework.lang.Nullable;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -97,16 +98,17 @@ public class TaskConfiguration {
 	}
 
 	/**
-	 * The default profile is active is no other profiles are active.  This is configured so that several tests
-	 * will pass without having to explicitly enable the local profile.
+	 * The default profile is active is no other profiles are active. This is configured so
+	 * that several tests will pass without having to explicitly enable the local profile.
 	 * @param localPlatformProperties
 	 * @return
 	 */
-	@Profile({"local", "default"})
+	@Profile({ "local", "default" })
 	@Bean
-	public TaskPlatform localTaskPlatform(LocalPlatformProperties localPlatformProperties, Scheduler localScheduler) {
-		TaskPlatform taskPlatform = new
-			LocalTaskPlatformFactory(localPlatformProperties, localScheduler).createTaskPlatform();
+	public TaskPlatform localTaskPlatform(LocalPlatformProperties localPlatformProperties,
+			@Nullable Scheduler localScheduler) {
+		TaskPlatform taskPlatform = new LocalTaskPlatformFactory(localPlatformProperties, localScheduler)
+				.createTaskPlatform();
 		taskPlatform.setPrimary(true);
 		return taskPlatform;
 	}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultLocalTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultLocalTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.single;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author David Turanski
+ **/
+@SpringBootTest(classes = {
+		DataFlowServerApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@RunWith(SpringRunner.class)
+public class DefaultLocalTests {
+
+	@Test
+	public void contextLoad() {
+	}
+}


### PR DESCRIPTION
Fix for local server not starting when `schedules-enabled=false`