### PR TITLE
Change com.puppycrawl.tools plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,19 +277,6 @@
 						</execution>
 					</executions>
 				</plugin>
-				<plugin>
-					<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match changes here -->
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
-					<dependencies>
-						<dependency>
-							<groupId>com.puppycrawl.tools</groupId>
-							<artifactId>checkstyle</artifactId>
-							<version>7.6.1</version>
-						</dependency>
-					</dependencies>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -189,22 +189,6 @@
 				</configuration>
 			</plugin>
 		</plugins>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
-					<dependencies>
-						<dependency>
-							<groupId>com.puppycrawl.tools</groupId>
-							<artifactId>checkstyle</artifactId>
-							<version>7.6.1</version>
-						</dependency>
-					</dependencies>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 
 	<reporting>


### PR DESCRIPTION
- Remove our explicit definitions to rely version(8.18) coming from
  a parent build. This handled CVE warning with a used version.