### PR TITLE
Fix app registration behaviour with version

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
@@ -40,6 +40,17 @@ public interface AppRegistryService {
 	AppRegistration getDefaultApp(String name, ApplicationType type);
 
 	/**
+	 * Validate given registration with given uri and version. Validation
+	 * will fail if given uri logically impossible to use with further
+	 * expected logic with using versions.
+	 *
+	 * @param registration app registration
+	 * @param uri uri of the registration
+	 * @param version version of the registration
+	 */
+	void validate(AppRegistration registration, String uri, String version);
+
+	/**
 	 * Set an application with name, type and version as the default for all name:type
 	 * applications. The previous default name:type application is set to non-default.
 	 * @param name application name

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -202,6 +202,36 @@ public class AppRegistryControllerTests {
 	}
 
 	@Test
+	public void testVersionWithMismatchBaseUri() throws Exception {
+		mockMvc.perform(post("/apps/processor/maven1").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/maven1").param("uri", "maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.1.RELEASE").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+		mockMvc.perform(post("/apps/processor/docker1").param("uri", "docker:prefix1/my-source:0.1.0").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/docker1").param("uri", "docker:prefix2/my-source:0.2.0").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+		mockMvc.perform(post("/apps/processor/http1").param("uri", "https://example.com/my-app1-1.1.1.RELEASE.jar").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/http1").param("uri", "https://example.com/my-app2-1.1.2.RELEASE.jar").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+
+		// in case you actually have version in part of an uri
+		mockMvc.perform(post("/apps/processor/maven2").param("uri", "maven://org.springframework.cloud.stream.app.1.2.0.RELEASE:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/maven2").param("uri", "maven://org.springframework.cloud.stream.app.1.2.0.RELEASE:time-source-rabbit:1.2.1.RELEASE").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+		mockMvc.perform(post("/apps/processor/docker2").param("uri", "docker:prefix1.0.1.0/my-source:0.1.0").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/docker2").param("uri", "docker:prefix2.0.1.0/my-source:0.2.0").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+		mockMvc.perform(post("/apps/processor/http2").param("uri", "https://1.1.1.example.com/my-app1-1.1.1.RELEASE.jar").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().isCreated());
+		mockMvc.perform(post("/apps/processor/http2").param("uri", "https://1.1.1.example.com/my-app2-1.1.2.RELEASE.jar").accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+	}
+
+	@Test
 	public void testRegisterAll() throws Exception {
 		mockMvc.perform(post("/apps").param("apps", "sink.foo=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());


### PR DESCRIPTION
- Previously you were able to register an app with different base uri
  while we're always assumed that versions works so that only version
  part can be different. i.e. docker:docker:prefix1/my-source:0.1.0
  vs docker:docker:prefix3/my-source:0.3.0. This would always fail with
  an actual upgrade and depending on which one is a default app also
  initial installation might fail.
- Fixing this on a registration time by denying user to use
  anything else than a changed version when registering an app
  with existing default app.
- Fixes #3241

```
dataflow:>app register --name test --uri docker:docker:prefix1/my-source:0.1.0 --type sink
Successfully registered application 'sink:test'
dataflow:>app register --name test --uri docker:docker:prefix1/my-source:0.2.0 --type sink
Successfully registered application 'sink:test'
dataflow:>app register --name test --uri docker:docker:prefix3/my-source:0.3.0 --type sink
Command failed org.springframework.cloud.dataflow.rest.client.DataFlowClientException: Existing default application [docker:docker:prefix1/my-source:0.1.0] can only differ by a version but is [docker:docker:prefix3/my-source:0.3.0]
```