### PR TITLE
Use a value from secret for MYSQL_ROOT_PASSWORD

### DIFF
--- a/src/kubernetes/mysql/mysql-deployment.yaml
+++ b/src/kubernetes/mysql/mysql-deployment.yaml
@@ -16,8 +16,10 @@ spec:
         name: mysql
         env:
           - name: MYSQL_ROOT_PASSWORD
-            # You can change this password - if you do change the base64 encoded value in the secrets file
-            value: yourpassword
+            valueFrom:
+              secretKeyRef:
+                key: mysql-root-password
+                name: mysql
         ports:
           - containerPort: 3306
             name: mysql


### PR DESCRIPTION
`MYSQL_ROOT_PASSWORD ` should be retrieved from Secret instead of a hardcoded value to make sure the same value is shared between mysql, server and skipper.