### PR TITLE
Polish database support

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
@@ -30,28 +30,21 @@ The REST `/about` endpoint provides information on the features that have been e
 === Database
 
 A relational database is used to store stream and task definitions as well as the state of executed tasks.
-Spring Cloud Data Flow provides schemas for H2, HSQLDB, MySQL, Oracle, Postgresql, DB2, and SqlServer. The schema is automatically created when the server starts.
+Spring Cloud Data Flow provides schemas for *H2*, *MySQL*, *Oracle*, *PostgreSQL*, *Db2*, and *SQL Server*. The schema is automatically created when the server starts.
 
+By default, Spring Cloud Data Flow offers an embedded instance of the *H2* database. The *H2* database is good
+for development purposes but is not recommended for production use.
 
-By default, Spring Cloud Data Flow offers an embedded instance of the H2 database.
-The H2 database is good for development purposes but is not recommended for production use.
+NOTE: *H2* database is not supported as an external mode.
 
-The JDBC drivers for *MySQL* (through the MariaDB driver), *HSQLDB*, *PostgreSQL*, and embedded *H2* are available without additional configuration.
+The JDBC drivers for *MySQL* (through the MariaDB driver), *PostgreSQL*, *SQL Server*, and embedded *H2* are available without additional configuration.
 If you are using any other database, then you need to put the corresponding JDBC driver jar on the classpath of the server.
 
 The database properties can be passed as environment variables or command-line arguments to the Data Flow Server.
 
-The following example shows how to define a database connection with environment variables:
+==== MySQL
 
-[source,bash]
-----
-export spring_datasource_url=jdbc:postgresql://localhost:5432/mydb
-export spring_datasource_username=myuser
-export spring_datasource_password=mypass
-export spring_datasource_driver_class_name="org.postgresql.Driver"
-----
-
-The following example shows how to define a MySQL database connection with command Line arguments
+The following example shows how to define a MySQL database connection using MariaDB driver.
 
 [source,bash,subs=attributes]
 ----
@@ -59,8 +52,24 @@ java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{proj
     --spring.datasource.url=jdbc:mysql://localhost:3306/mydb \
     --spring.datasource.username=<user> \
     --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver &
+    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 ----
+
+MySQL versions up to _5.7_ can be used with a MariaDB driver. Starting from version _8.0_ MySQL's own driver has to be used.
+
+[source,bash,subs=attributes]
+----
+java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{project-version}.jar \
+    --spring.datasource.url=jdbc:mysql://localhost:3306/mydb \
+    --spring.datasource.username=<user> \
+    --spring.datasource.password=<password> \
+    --spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+----
+
+NOTE: Due to licensing restrictions we're unable to bundle MySQL driver. You need to add it to
+      server's classpath yourself.
+
+==== MariaDB
 
 The following example shows how to define a MariaDB database connection with command Line arguments
 
@@ -70,12 +79,28 @@ java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{proj
     --spring.datasource.url=jdbc:mariadb://localhost:3306/mydb?useMysqlMetadata=true \
     --spring.datasource.username=<user> \
     --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver &
+    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 ----
 
-NOTE: Starting with MariaDB v2.4.1 connector release, it is required to also add `useMysqlMetadata=true`
-      to the JDBC URL. This is a required workaround until when MySQL and MariaDB entirely switch as two
-      different databases.
+Starting with MariaDB v2.4.1 connector release, it is required to also add `useMysqlMetadata=true`
+to the JDBC URL. This is a required workaround until when MySQL and MariaDB entirely switch as two
+different databases.
+
+MariaDB version _10.3_ introduced a support for real database sequences which is yet another breaking
+change while toolings around these databases fully support MySQL and MariaDB as a separate database
+types. Workaround is to use older hibernate dialect which doesn't try to use sequences.
+
+[source,bash,subs=attributes]
+----
+java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{project-version}.jar \
+    --spring.datasource.url=jdbc:mariadb://localhost:3306/mydb?useMysqlMetadata=true \
+    --spring.datasource.username=<user> \
+    --spring.datasource.password=<password> \
+    --spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB102Dialect \
+    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+----
+
+==== PostgreSQL
 
 The following example shows how to define a PostgreSQL database connection with command line arguments:
 
@@ -85,29 +110,53 @@ java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{proj
     --spring.datasource.url=jdbc:postgresql://localhost:5432/mydb \
     --spring.datasource.username=<user> \
     --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.postgresql.Driver &
+    --spring.datasource.driver-class-name=org.postgresql.Driver
 ----
 
-The following example shows how to define a HSQLDB database connection with command line arguments:
+==== SQL Server
+
+The following example shows how to define a SQL Server database connection with command line arguments:
 
 [source,bash,subs=attributes]
 ----
 java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:hsqldb://localhost:9001/mydb \
-    --spring.datasource.username=SA \
-    --spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver &
+    --spring.datasource.url='jdbc:sqlserver://localhost:1433;databaseName=mydb' \
+    --spring.datasource.username=<user> \
+    --spring.datasource.password=<password> \
+    --spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 ----
 
-NOTE: H2 database is not supported as an external mode.
+==== Db2
 
-==== Disabling database schema creation and migration strategies
+The following example shows how to define a Db2 database connection with command line arguments:
 
-You can control whether or not Data Flow bootstraps your database on startup. On most production environments chances are you will not have enough privileges to do so.
-If that's the case you can disable it by setting the property `spring.cloud.dataflow.rdbms.initialize.enable` to `false`.
-The scripts that the server uses to bootstrap the database can be found under `spring-cloud-dataflow-core/src/main/resources/` folder.
+[source,bash,subs=attributes]
+----
+java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{project-version}.jar \
+    --spring.datasource.url=jdbc:db2://localhost:50000/mydb \
+    --spring.datasource.username=<user> \
+    --spring.datasource.password=<password> \
+    --spring.datasource.driver-class-name=com.ibm.db2.jcc.DB2Driver
+----
 
-For new installations run the corresponding database script located under `/schemas` and `/migrations.1.x.x`, for upgrades from version `1.2.0` you only need to run the `/migrations.1.x.x` scripts.
+NOTE: Due to licensing restrictions we're unable to bundle Db2 driver. You need to add it to
+      server's classpath yourself.
 
+==== Oracle
+
+The following example shows how to define a Oracle database connection with command line arguments:
+
+[source,bash,subs=attributes]
+----
+java -jar spring-cloud-dataflow-server/target/spring-cloud-dataflow-server-{project-version}.jar \
+    --spring.datasource.url=jdbc:oracle:thin:@localhost:1521/MYDB \
+    --spring.datasource.username=<user> \
+    --spring.datasource.password=<password> \
+    --spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
+----
+
+NOTE: Due to licensing restrictions we're unable to bundle Oracle driver. You need to add it to
+      server's classpath yourself.
 
 ==== Adding a Custom JDBC Driver
 To add a custom driver for the database (for example, Oracle), you should rebuild the Data Flow Server and add the dependency to the Maven `pom.xml` file.

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -134,10 +134,6 @@
 			<artifactId>h2</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -82,12 +82,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<scope>test</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-batch</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
- Drop hsqldb from poms and docs as it's not supported anymore.
- Drop manual migration section from docs as things are handled by flyway.
- Polish db sections for local server and add notes about
  MySQL 8+ and MariaDB 10.3+.
- Testing work has been done in db acceptance tests.
- Fixes #3255
- Fixes #3256