### PR TITLE
Support importing multiple app versions

### DIFF
--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryServiceTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryServiceTests.java
@@ -278,6 +278,206 @@ public class DefaultAppRegistryServiceTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
+	public void testImportMixedVersions() {
+
+		final boolean overwrite = true;
+
+		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
+
+		appRegistryService.importAll(!overwrite,
+				new ClassPathResource("AppRegistryTests-importMixedVersions1.properties", getClass()));
+
+		ArgumentCaptor<AppRegistration> appRegistrationCaptor = ArgumentCaptor.forClass(AppRegistration.class);
+		verify(appRegistrationRepository, times(4)).save(appRegistrationCaptor.capture());
+
+		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
+
+		assertThat(registrations,
+				containsInAnyOrder(
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink)))));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testImportMixedVersionsMultiFile() {
+
+		final boolean overwrite = true;
+
+		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
+
+		appRegistryService.importAll(!overwrite,
+				new ClassPathResource("AppRegistryTests-importMixedVersions2.properties", getClass()),
+				new ClassPathResource("AppRegistryTests-importMixedVersions3.properties", getClass()));
+
+		ArgumentCaptor<AppRegistration> appRegistrationCaptor = ArgumentCaptor.forClass(AppRegistration.class);
+		verify(appRegistrationRepository, times(4)).save(appRegistrationCaptor.capture());
+
+		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
+
+		assertThat(registrations,
+				containsInAnyOrder(
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink)))));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testImportMixedVersionsWithSpaceAndComments() {
+
+		final boolean overwrite = true;
+
+		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
+
+		appRegistryService.importAll(!overwrite,
+				new ClassPathResource("AppRegistryTests-importMixedVersions4.properties", getClass()));
+
+		ArgumentCaptor<AppRegistration> appRegistrationCaptor = ArgumentCaptor.forClass(AppRegistration.class);
+		verify(appRegistrationRepository, times(4)).save(appRegistrationCaptor.capture());
+
+		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
+
+		assertThat(registrations,
+				containsInAnyOrder(
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink)))));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testImportMixedVersionsWithMixedOrder() {
+
+		final boolean overwrite = true;
+
+		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
+
+		appRegistryService.importAll(!overwrite,
+				new ClassPathResource("AppRegistryTests-importMixedVersions5.properties", getClass()));
+
+		ArgumentCaptor<AppRegistration> appRegistrationCaptor = ArgumentCaptor.forClass(AppRegistration.class);
+		verify(appRegistrationRepository, times(4)).save(appRegistrationCaptor.capture());
+
+		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
+
+		assertThat(registrations,
+				containsInAnyOrder(
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink)))));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testImportMixedVersionsWithMissingAndOnlyMetadata() {
+
+		final boolean overwrite = true;
+
+		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
+				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
+
+		appRegistryService.importAll(!overwrite,
+				new ClassPathResource("AppRegistryTests-importMixedVersions6.properties", getClass()));
+
+		ArgumentCaptor<AppRegistration> appRegistrationCaptor = ArgumentCaptor.forClass(AppRegistration.class);
+		verify(appRegistrationRepository, times(3)).save(appRegistrationCaptor.capture());
+
+		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
+
+		assertThat(registrations,
+				containsInAnyOrder(
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE"))),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("time")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE"))),
+								hasProperty("metadataUri", nullValue()),
+								hasProperty("type", is(ApplicationType.source))),
+						allOf(
+								hasProperty("name", is("log")),
+								hasProperty("uri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE"))),
+								hasProperty("metadataUri", is(URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE"))),
+								hasProperty("type", is(ApplicationType.sink)))));
+	}
+	@Test
 	public void testDelete() throws URISyntaxException {
 		AppRegistration fooSource = appRegistration("foo", ApplicationType.source, true);
 		appRegistryService.delete(fooSource.getName(), fooSource.getType(), fooSource.getVersion());

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions1.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions1.properties
@@ -1,0 +1,8 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions2.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions2.properties
@@ -1,0 +1,4 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions3.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions3.properties
@@ -1,0 +1,4 @@
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions4.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions4.properties
@@ -1,0 +1,13 @@
+ source.time = maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
+source.time.metadata  =maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
+source.time=  maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
+source.time.metadata =maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE
+ sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE
+# foobar
+
+#
+/
+//
+sink.log =maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE
+ sink.log.metadata= maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions5.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions5.properties
@@ -1,0 +1,8 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.1.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE

--- a/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions6.properties
+++ b/spring-cloud-dataflow-registry/src/test/resources/org/springframework/cloud/dataflow/registry/service/AppRegistryTests-importMixedVersions6.properties
@@ -1,0 +1,6 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.0.2.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.2.RELEASE
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:2.0.1.RELEASE

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -26,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.ForkJoinPool;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -59,7 +57,6 @@ import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -379,17 +376,15 @@ public class AppRegistryController {
 			Pageable pageable,
 			PagedResourcesAssembler<AppRegistration> pagedResourcesAssembler,
 			@RequestParam(value = "uri", required = false) String uri,
-			@RequestParam(value = "apps", required = false) Properties apps,
+			@RequestParam(value = "apps", required = false) String apps,
 			@RequestParam(value = "force", defaultValue = "false") boolean force) throws IOException {
 		List<AppRegistration> registrations = new ArrayList<>();
 
 		if (StringUtils.hasText(uri)) {
 			registrations.addAll(this.appRegistryService.importAll(force, this.resourceLoader.getResource(uri)));
 		}
-		else if (!CollectionUtils.isEmpty(apps)) {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			apps.store(baos, "");
-			ByteArrayResource bar = new ByteArrayResource(baos.toByteArray(), "Inline properties");
+		else if (!StringUtils.isEmpty(apps)) {
+			ByteArrayResource bar = new ByteArrayResource(apps.getBytes());
 			registrations.addAll(this.appRegistryService.importAll(force, bar));
 		}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -53,6 +53,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -176,32 +178,8 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content.*", hasSize(9)))
 
-				.andExpect(jsonPath("$.content[0].auditRecordId", is(4)))
-				.andExpect(jsonPath("$.content[0].correlationId", is("filter")))
-
-				.andExpect(jsonPath("$.content[1].auditRecordId", is(6)))
-				.andExpect(jsonPath("$.content[1].correlationId", is("log")))
-
-				.andExpect(jsonPath("$.content[2].auditRecordId", is(9)))
-				.andExpect(jsonPath("$.content[2].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[3].auditRecordId", is(12)))
-				.andExpect(jsonPath("$.content[3].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[4].auditRecordId", is(13)))
-				.andExpect(jsonPath("$.content[4].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[5].auditRecordId", is(10)))
-				.andExpect(jsonPath("$.content[5].correlationId", is("myStream1")))
-
-				.andExpect(jsonPath("$.content[6].auditRecordId", is(11)))
-				.andExpect(jsonPath("$.content[6].correlationId", is("myStream2")))
-
-				.andExpect(jsonPath("$.content[7].auditRecordId", is(2)))
-				.andExpect(jsonPath("$.content[7].correlationId", is("time")))
-
-				.andExpect(jsonPath("$.content[8].auditRecordId", is(8)))
-				.andExpect(jsonPath("$.content[8].correlationId", is("timestamp")));
+				.andExpect(jsonPath("$.content[*].correlationId", contains("filter", "log", "myStream",
+						"myStream", "myStream", "myStream1", "myStream2", "time", "timestamp")));
 	}
 
 	@Test
@@ -214,33 +192,8 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content.*", hasSize(9)))
 
-				.andExpect(jsonPath("$.content[0].auditRecordId", is(8)))
-				.andExpect(jsonPath("$.content[0].correlationId", is("timestamp")))
-
-				.andExpect(jsonPath("$.content[1].auditRecordId", is(2)))
-				.andExpect(jsonPath("$.content[1].correlationId", is("time")))
-
-				.andExpect(jsonPath("$.content[2].auditRecordId", is(11)))
-				.andExpect(jsonPath("$.content[2].correlationId", is("myStream2")))
-
-				.andExpect(jsonPath("$.content[3].auditRecordId", is(10)))
-				.andExpect(jsonPath("$.content[3].correlationId", is("myStream1")))
-
-				.andExpect(jsonPath("$.content[4].auditRecordId", is(13)))
-				.andExpect(jsonPath("$.content[4].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[5].auditRecordId", is(12)))
-				.andExpect(jsonPath("$.content[5].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[6].auditRecordId", is(9)))
-				.andExpect(jsonPath("$.content[6].correlationId", is("myStream")))
-
-				.andExpect(jsonPath("$.content[7].auditRecordId", is(6)))
-				.andExpect(jsonPath("$.content[7].correlationId", is("log")))
-
-				.andExpect(jsonPath("$.content[8].auditRecordId", is(4)))
-				.andExpect(jsonPath("$.content[8].correlationId", is("filter")));
-
+				.andExpect(jsonPath("$.content[*].correlationId", containsInAnyOrder("timestamp", "time", "filter",
+						"myStream2", "myStream1", "myStream", "myStream", "myStream", "log")));
 	}
 
 	@Test
@@ -368,17 +321,8 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content.*", hasSize(4)))
 
-				.andExpect(jsonPath("$.content[0].auditRecordId", is(2)))
-				.andExpect(jsonPath("$.content[0].correlationId", is("time")))
-
-				.andExpect(jsonPath("$.content[1].auditRecordId", is(4)))
-				.andExpect(jsonPath("$.content[1].correlationId", is("filter")))
-
-				.andExpect(jsonPath("$.content[2].auditRecordId", is(6)))
-				.andExpect(jsonPath("$.content[2].correlationId", is("log")))
-
-				.andExpect(jsonPath("$.content[3].auditRecordId", is(8)))
-				.andExpect(jsonPath("$.content[3].correlationId", is("timestamp")));
+				.andExpect(jsonPath("$.content[*].correlationId",
+						containsInAnyOrder("filter", "log", "time", "timestamp")));
 	}
 
 	@Test


### PR DESCRIPTION
- In DefaultAppRegistryService and AppRegistryController, move away
  from using jdk's Properties. Move to a custom app import parser
  which is able to understand that `source.time`, `sink.log` can have
  different versions defined in a same file.
- In AppRegistryController change incoming app string not to get
  converted into Properties as that causes all sort of issues
  how jdk handles escaping, etc. i.e. it adds header lines and
  escapes things from `maven:` into `maven\:`.
- Fix AuditRecordControllerTests as it used to assume an exact
  order of how things were inserted into a db where this order
  just magically happened to be a one what hashtable gave out from
  a Properties. Fixed 3 tests to just check that response has needed
  fields on order and not checking actual order in a json response.
- Few new tests to see that usual cases like, spaces, empty lines,
  comment lines, metadata before app, missing metadata and missing
  main app url, etc.
- Fixes #3287

Essentially with this we can do:
```
source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.1.RELEASE
source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.1.RELEASE
source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:2.0.0.RELEASE
source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:2.0.0.RELEASE
```
