### PR TITLE
Add REST endpoint to delete task-executions from the Task repository

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.server.config;
 import javax.servlet.Filter;
 import javax.sql.DataSource;
 
+import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.completion.CompletionConfiguration;
@@ -30,6 +31,7 @@ import org.springframework.cloud.dataflow.server.repository.DataflowJobExecution
 import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.JdbcDataflowJobExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionDao;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -69,11 +71,12 @@ public class DataFlowServerConfiguration {
 	}
 
 	@Bean
-	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowTaskExecutionDao(dataSource);
+	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource, TaskProperties taskProperties) {
+		return new JdbcDataflowTaskExecutionDao(dataSource, taskProperties.getTablePrefix());
 	}
+
 	@Bean
 	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowJobExecutionDao(dataSource);
+		return new JdbcDataflowJobExecutionDao(dataSource, AbstractJdbcBatchMetadataDao.DEFAULT_TABLE_PREFIX);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.server.config;
 
 import javax.servlet.Filter;
+import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -25,6 +26,10 @@ import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationPr
 import org.springframework.cloud.dataflow.server.config.features.FeaturesConfiguration;
 import org.springframework.cloud.dataflow.server.config.web.WebConfiguration;
 import org.springframework.cloud.dataflow.server.db.migration.DataFlowFlywayConfigurationCustomizer;
+import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionDao;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -61,5 +66,14 @@ public class DataFlowServerConfiguration {
 	@Bean
 	public Filter forwardedHeaderFilter() {
 		return new ForwardedHeaderFilter();
+	}
+
+	@Bean
+	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowTaskExecutionDao(dataSource);
+	}
+	@Bean
+	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -37,6 +37,8 @@ import org.springframework.cloud.dataflow.server.batch.JobService;
 import org.springframework.cloud.dataflow.server.batch.SimpleJobServiceFactoryBean;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
+import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.LauncherInitializationService;
@@ -125,10 +127,14 @@ public class TaskConfiguration {
 	@Bean
 	public TaskDeleteService deleteTaskService(TaskExplorer taskExplorer, LauncherRepository launcherRepository,
 			TaskDefinitionRepository taskDefinitionRepository, TaskDeploymentRepository taskDeploymentRepository,
-			AuditRecordService auditRecordService) {
+			AuditRecordService auditRecordService,
+			DataflowTaskExecutionDao dataflowTaskExecutionDao,
+			DataflowJobExecutionDao dataflowJobExecutionDao) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
-				auditRecordService);
+				auditRecordService,
+				dataflowTaskExecutionDao,
+				dataflowJobExecutionDao);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.dataflow.server.batch.NoSuchStepExecutionExcept
 import org.springframework.cloud.dataflow.server.controller.support.InvalidDateRangeException;
 import org.springframework.cloud.dataflow.server.controller.support.InvalidStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.job.support.JobNotRestartableException;
+import org.springframework.cloud.dataflow.server.repository.CannotDeleteNonParentTaskExecutionException;
 import org.springframework.cloud.dataflow.server.repository.DuplicateStreamDefinitionException;
 import org.springframework.cloud.dataflow.server.repository.DuplicateTaskException;
 import org.springframework.cloud.dataflow.server.repository.NoSuchAuditRecordException;
@@ -175,7 +176,7 @@ public class RestControllerAdvice {
 	 */
 	@ExceptionHandler({ MissingServletRequestParameterException.class, HttpMessageNotReadableException.class,
 			UnsatisfiedServletRequestParameterException.class, MethodArgumentTypeMismatchException.class,
-			InvalidDateRangeException.class,
+			InvalidDateRangeException.class, CannotDeleteNonParentTaskExecutionException.class,
 			InvalidStreamDefinitionException.class, CreateScheduleException.class, OffsetOutOfBoundsException.class })
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ResponseBody

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,8 +184,35 @@ public class RestControllerAdvice {
 		if (logger.isTraceEnabled()) {
 			logTraceLevelStrackTrace(e);
 		}
-		String msg = getExceptionMessage(e);
-		return new VndErrors(logref, msg);
+
+		String message = null;
+		if (e instanceof MethodArgumentTypeMismatchException) {
+			final MethodArgumentTypeMismatchException methodArgumentTypeMismatchException = (MethodArgumentTypeMismatchException) e;
+			final Class<?> requiredType = methodArgumentTypeMismatchException.getRequiredType();
+
+			final Class<?> enumType;
+
+			if (requiredType.isEnum()) {
+				enumType = requiredType;
+			}
+			else if (requiredType.isArray() && requiredType.getComponentType().isEnum()) {
+				enumType = requiredType.getComponentType();
+			}
+			else {
+				enumType = null;
+			}
+
+			if (enumType != null) {
+				final String enumValues = StringUtils.arrayToDelimitedString(enumType.getEnumConstants(), ", ");
+				message = String.format("The parameter '%s' must contain one of the following values: '%s'.", methodArgumentTypeMismatchException.getName(), enumValues);
+			}
+		}
+
+		if (message == null) {
+			message = getExceptionMessage(e);
+		}
+
+		return new VndErrors(logref, message);
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -204,7 +204,9 @@ public class TaskExecutionController {
 	}
 
 	/**
-	 * Cleanup resources associated with one or more task executions, specified by id(s).
+	 * Cleanup resources associated with one or more task executions, specified by id(s). The
+	 * optional {@code actions} parameter can be used to not only clean up task execution resources,
+	 * but can also trigger the deletion of task execution and job data in the persistence store.
 	 *
 	 * @param ids The id of the {@link TaskExecution}s to clean up
 	 * @param actions Defaults to "CLEANUP" if not specified

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionControllerDeleteAction.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionControllerDeleteAction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller.support;
+
+/**
+ *
+ * @author Gunnar Hillert
+ *
+ */
+public enum TaskExecutionControllerDeleteAction {
+	CLEANUP,
+	REMOVE_DATA,
+	REMOVE_BATCH_DATA;
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionControllerDeleteAction.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/support/TaskExecutionControllerDeleteAction.java
@@ -15,13 +15,23 @@
  */
 package org.springframework.cloud.dataflow.server.controller.support;
 
+import org.springframework.cloud.dataflow.server.controller.TaskExecutionController;
+
 /**
+ * This enum is used by the {@link TaskExecutionController#cleanup(java.util.Set, TaskExecutionControllerDeleteAction[])}.
  *
  * @author Gunnar Hillert
  *
  */
 public enum TaskExecutionControllerDeleteAction {
+
+	/**
+	 * Cleanup resources associated with one or more task executions.
+	 */
 	CLEANUP,
-	REMOVE_DATA,
-	REMOVE_BATCH_DATA;
+
+	/**
+	 * Removed task execution and job execution data from the persistence store.
+	 */
+	REMOVE_DATA
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/CannotDeleteNonParentTaskExecutionException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/CannotDeleteNonParentTaskExecutionException.java
@@ -22,30 +22,31 @@ import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.util.StringUtils;
 
 /**
+ * Exception that allows to indicate that 1 or more {@link TaskExecution}s
+ * could not be deleted.
+ *
  * @author Gunnar Hillert
  */
 public class CannotDeleteNonParentTaskExecutionException extends RuntimeException {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 6186330473012259152L;
 
 	/**
-	 * Create a new exception.
+	 * Create a new exception for 1 {@link TaskExecution} id that could not be deleted.
 	 *
-	 * @param id the id of the {@link TaskExecution} that could not be found
+	 * @param taskExecutionId the id of the {@link TaskExecution} that could not be found
 	 */
-	public CannotDeleteNonParentTaskExecutionException(long id) {
-		super("Cannot delete non-parent TaskExecution with id " + id);
+	public CannotDeleteNonParentTaskExecutionException(Long taskExecutionId) {
+		super("Cannot delete non-parent TaskExecution with id " + taskExecutionId);
 	}
 
 	/**
-	 * Create a new exception.
+	 * Create a new exception for multiple {@link TaskExecution} ids
+	 * that could not be deleted.
 	 *
-	 * @param ids the ids of the {@link TaskExecution} that could not be found
+	 * @param taskExecutionIds the ids of the {@link TaskExecution} that could not be found
 	 */
-	public CannotDeleteNonParentTaskExecutionException(Set<Long> ids) {
-		super("Cannot delete non-parent TaskExecutions with the following ids: " + StringUtils.collectionToDelimitedString(ids, ", "));
+	public CannotDeleteNonParentTaskExecutionException(Set<Long> taskExecutionIds) {
+		super("Cannot delete non-parent TaskExecutions with the following ids: " + StringUtils.collectionToDelimitedString(taskExecutionIds, ", "));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/CannotDeleteNonParentTaskExecutionException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/CannotDeleteNonParentTaskExecutionException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository;
+
+import java.util.Set;
+
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class CannotDeleteNonParentTaskExecutionException extends RuntimeException {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Create a new exception.
+	 *
+	 * @param id the id of the {@link TaskExecution} that could not be found
+	 */
+	public CannotDeleteNonParentTaskExecutionException(long id) {
+		super("Cannot delete non-parent TaskExecution with id " + id);
+	}
+
+	/**
+	 * Create a new exception.
+	 *
+	 * @param ids the ids of the {@link TaskExecution} that could not be found
+	 */
+	public CannotDeleteNonParentTaskExecutionException(Set<Long> ids) {
+		super("Cannot delete non-parent TaskExecutions with the following ids: " + StringUtils.collectionToDelimitedString(ids, ", "));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
@@ -30,50 +30,52 @@ import org.springframework.batch.core.repository.dao.JobExecutionDao;
 public interface DataflowJobExecutionDao {
 
 	/**
+	 * Delete the batch job execution records from the persistence store for
+	 * the provided job execution ids.
 	 *
-	 * @return The number of affected records
-	 */
-	int deleteUnusedBatchJobInstances();
-
-	/**
-	 *
-	 * @param jobInstanceIds
-	 * @return The number of affected records
-	 */
-	int deleteBatchJobExecutionByJobInstanceIds(Set<Long> jobInstanceIds);
-
-	/**
-	 *
-	 * @param jobExecutionIds
+	 * @param jobExecutionIds Must contain at least 1 value
 	 * @return The number of affected records
 	 */
 	int deleteBatchJobExecutionByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
+	 * Delete the batch job execution context records from the persistence store for
+	 * the provided job execution ids.
 	 *
-	 * @param jobExecutionIds
-	 * @return The number of affected records
-	 */
-	int deleteBatchJobExecutionParamsByJobExecutionIds(Set<Long> jobExecutionIds);
-
-	/**
-	 *
-	 * @param jobExecutionIds
+	 * @param jobExecutionIds Must contain at least 1 value
 	 * @return The number of affected records
 	 */
 	int deleteBatchJobExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
+	 * Delete the batch job execution parameter records from the persistence store for
+	 * the provided job execution ids.
 	 *
-	 * @param jobExecutionIds
+	 * @param jobExecutionIds Must contain at least 1 value
+	 * @return The number of affected records
+	 */
+	int deleteBatchJobExecutionParamsByJobExecutionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 * Delete the batch step execution context records from the persistence store for
+	 * the provided job execution ids.
+	 *
+	 * @param jobExecutionIds Must contain at least 1 value
+	 * @return The number of affected records
+	 */
+	int deleteBatchStepExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds Must contain at least 1 value
 	 * @return The number of affected records
 	 */
 	int deleteBatchStepExecutionsByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
+	 * Will delete any unused job instance records from the persistence store.
 	 *
-	 * @param jobExecutionIds
 	 * @return The number of affected records
 	 */
-	int deleteBatchStepExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds);
+	int deleteUnusedBatchJobInstances();
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.repository;
+
+import java.util.Set;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.repository.dao.JobExecutionDao;
+
+/**
+ * Repository to access {@link JobExecution}s. Mirrors the {@link JobExecutionDao}
+ * but contains Spring Cloud Data Flow specific operations. This functionality might
+ * be migrated to Spring Batch itself eventually.
+ *
+ * @author Gunnar Hillert
+ */
+public interface DataflowJobExecutionDao {
+
+	/**
+	 *
+	 * @return
+	 */
+	int deleteUnusedBatchJobInstances();
+
+	/**
+	 *
+	 * @param jobInstanceIds
+	 * @return
+	 */
+	int deleteBatchJobExecutionByJobInstanceIds(Set<Long> jobInstanceIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds
+	 * @return
+	 */
+	int deleteBatchJobExecutionByJobExecitionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds
+	 * @return
+	 */
+	int deleteBatchJobExecutionParamsByJobExecitionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds
+	 * @return
+	 */
+	int deleteBatchJobExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds
+	 * @return
+	 */
+	int deleteBatchStepExecutionsByJobExecitionIds(Set<Long> jobExecutionIds);
+
+	/**
+	 *
+	 * @param jobExecutionIds
+	 * @return
+	 */
+	int deleteBatchStepExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds);
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowJobExecutionDao.java
@@ -31,49 +31,49 @@ public interface DataflowJobExecutionDao {
 
 	/**
 	 *
-	 * @return
+	 * @return The number of affected records
 	 */
 	int deleteUnusedBatchJobInstances();
 
 	/**
 	 *
 	 * @param jobInstanceIds
-	 * @return
+	 * @return The number of affected records
 	 */
 	int deleteBatchJobExecutionByJobInstanceIds(Set<Long> jobInstanceIds);
 
 	/**
 	 *
 	 * @param jobExecutionIds
-	 * @return
+	 * @return The number of affected records
 	 */
-	int deleteBatchJobExecutionByJobExecitionIds(Set<Long> jobExecutionIds);
+	int deleteBatchJobExecutionByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
 	 *
 	 * @param jobExecutionIds
-	 * @return
+	 * @return The number of affected records
 	 */
-	int deleteBatchJobExecutionParamsByJobExecitionIds(Set<Long> jobExecutionIds);
+	int deleteBatchJobExecutionParamsByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
 	 *
 	 * @param jobExecutionIds
-	 * @return
+	 * @return The number of affected records
 	 */
-	int deleteBatchJobExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds);
+	int deleteBatchJobExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
 	 *
 	 * @param jobExecutionIds
-	 * @return
+	 * @return The number of affected records
 	 */
-	int deleteBatchStepExecutionsByJobExecitionIds(Set<Long> jobExecutionIds);
+	int deleteBatchStepExecutionsByJobExecutionIds(Set<Long> jobExecutionIds);
 
 	/**
 	 *
 	 * @param jobExecutionIds
-	 * @return
+	 * @return The number of affected records
 	 */
-	int deleteBatchStepExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds);
+	int deleteBatchStepExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.repository;
+
+import java.util.Set;
+
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
+
+/**
+ * Repository to access {@link TaskExecution}s. Mirrors the {@link TaskExecutionDao}
+ * but contains Spring Cloud Data Flow specific operations. This functionality might
+ * be migrated to Spring Cloud Task itself.
+ *
+ * @author Gunnar Hillert
+ */
+public interface DataflowTaskExecutionDao {
+
+	/**
+	 * Deletes 1 or more Task Executions
+	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 */
+	int deleteTaskExecutionsByTaskExecitionIds(Set<Long> taskExecitionIds);
+
+	/**
+	 * Deletes 1 or more Task Executions
+	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 */
+	int deleteTaskExecutionParamsByTaskExecitionIds(Set<Long> taskExecitionIds);
+
+	/**
+	 * Deletes 1 or more Task Executions
+	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 */
+	int deleteTaskTaskBatchRelationshipsByTaskExecitionIds(Set<Long> taskExecitionIds);
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
@@ -30,27 +30,35 @@ import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 public interface DataflowTaskExecutionDao {
 
 	/**
-	 * Deletes 1 or more Task Executions
+	 * Deletes 1 or more task execution parameter records.
+	 *
 	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
-	 */
-	int deleteTaskExecutionsByTaskExecutionIds(Set<Long> taskExecutionIds);
-
-	/**
-	 * Deletes 1 or more Task Executions
-	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
+	 * @return The number of affected records
 	 */
 	int deleteTaskExecutionParamsByTaskExecutionIds(Set<Long> taskExecutionIds);
 
 	/**
-	 * Deletes 1 or more Task Executions
+	 * Deletes 1 or more task executions
+	 *
 	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
+	 * @return The number of affected records
+	 */
+	int deleteTaskExecutionsByTaskExecutionIds(Set<Long> taskExecutionIds);
+
+	/**
+	 * Deletes 1 or more task batch relationship records that links batch executions
+	 * to task executions.
+	 *
+	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
+	 * @return The number of affected records
 	 */
 	int deleteTaskTaskBatchRelationshipsByTaskExecutionIds(Set<Long> taskExecutionIds);
 
 	/**
+	 * Find all child task execution ids for the provided task execution ids.
 	 *
-	 * @param taskExecutionId
-	 * @return
+	 * @param taskExecutionId Must contain at least 1 taskExecutionId
+	 * @return A set of task execution or an empty collection, but never null
 	 */
 	Set<Long> findChildTaskExecutionIds(Set<Long> taskExecutionIds);
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowTaskExecutionDao.java
@@ -31,20 +31,27 @@ public interface DataflowTaskExecutionDao {
 
 	/**
 	 * Deletes 1 or more Task Executions
-	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
 	 */
-	int deleteTaskExecutionsByTaskExecitionIds(Set<Long> taskExecitionIds);
+	int deleteTaskExecutionsByTaskExecutionIds(Set<Long> taskExecutionIds);
 
 	/**
 	 * Deletes 1 or more Task Executions
-	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
 	 */
-	int deleteTaskExecutionParamsByTaskExecitionIds(Set<Long> taskExecitionIds);
+	int deleteTaskExecutionParamsByTaskExecutionIds(Set<Long> taskExecutionIds);
 
 	/**
 	 * Deletes 1 or more Task Executions
-	 * @param taskExecitionIds Must contain at least 1 taskExecitionId
+	 * @param taskExecutionIds Must contain at least 1 taskExecutionId
 	 */
-	int deleteTaskTaskBatchRelationshipsByTaskExecitionIds(Set<Long> taskExecitionIds);
+	int deleteTaskTaskBatchRelationshipsByTaskExecutionIds(Set<Long> taskExecutionIds);
+
+	/**
+	 *
+	 * @param taskExecutionId
+	 * @return
+	 */
+	Set<Long> findChildTaskExecutionIds(Set<Long> taskExecutionIds);
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowJobExecutionDao.java
@@ -112,7 +112,7 @@ public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
 	}
 
 	@Override
-	public int deleteBatchStepExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds) {
+	public int deleteBatchStepExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds) {
 		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
 				.addValue("jobExecutionIds", jobExecutionIds);
 		final String query = getQuery(SQL_DELETE_BATCH_STEP_EXECUTION_CONTEXT);
@@ -120,7 +120,7 @@ public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
 	}
 
 	@Override
-	public int deleteBatchStepExecutionsByJobExecitionIds(Set<Long> jobExecutionIds) {
+	public int deleteBatchStepExecutionsByJobExecutionIds(Set<Long> jobExecutionIds) {
 		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
 				.addValue("jobExecutionIds", jobExecutionIds);
 		final String query = getQuery(SQL_DELETE_BATCH_STEP_EXECUTION);
@@ -128,7 +128,7 @@ public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
 	}
 
 	@Override
-	public int deleteBatchJobExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds) {
+	public int deleteBatchJobExecutionContextByJobExecutionIds(Set<Long> jobExecutionIds) {
 		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
 				.addValue("jobExecutionIds", jobExecutionIds);
 		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION_CONTEXT);
@@ -136,7 +136,7 @@ public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
 	}
 
 	@Override
-	public int deleteBatchJobExecutionParamsByJobExecitionIds(Set<Long> jobExecutionIds) {
+	public int deleteBatchJobExecutionParamsByJobExecutionIds(Set<Long> jobExecutionIds) {
 		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
 				.addValue("jobExecutionIds", jobExecutionIds);
 		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION_PARAMS);
@@ -144,7 +144,7 @@ public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
 	}
 
 	@Override
-	public int deleteBatchJobExecutionByJobExecitionIds(Set<Long> jobExecutionIds) {
+	public int deleteBatchJobExecutionByJobExecutionIds(Set<Long> jobExecutionIds) {
 		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
 				.addValue("jobExecutionIds", jobExecutionIds);
 		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowJobExecutionDao.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository;
+
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.springframework.batch.core.repository.dao.JdbcJobExecutionDao;
+import org.springframework.cloud.task.configuration.TaskProperties;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Stores Task Execution Information to a JDBC DataSource. Mirrors the {@link JdbcJobExecutionDao}
+ * but contains Spring Cloud Data Flow specific operations. This functionality might
+ * be migrated to Spring Batch itself eventually.
+ *
+ * @author Gunnar Hillert
+ */
+public class JdbcDataflowJobExecutionDao implements DataflowJobExecutionDao {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	// private String tablePrefix = BatchProperties.DEFAULT_TABLE_PREFIX;
+	private String tablePrefix = "BATCH_";
+
+	/**
+	 * SQL statements for removing the Step Execution Context.
+	 */
+	private static final String  SQL_DELETE_BATCH_STEP_EXECUTION_CONTEXT =
+			"DELETE FROM %PREFIX%STEP_EXECUTION_CONTEXT " +
+			"WHERE STEP_EXECUTION_ID " +
+			"IN ( " +
+			"SELECT SEC.STEP_EXECUTION_ID " +
+			"FROM %PREFIX%STEP_EXECUTION_CONTEXT SEC " +
+			"JOIN %PREFIX%STEP_EXECUTION SE ON SE.STEP_EXECUTION_ID = SEC.STEP_EXECUTION_ID " +
+			"WHERE SE.JOB_EXECUTION_ID in (:jobExecutionIds))";
+
+	/**
+	 * SQL statements for removing the Step Executions.
+	 */
+	private static final String  SQL_DELETE_BATCH_STEP_EXECUTION =
+			"DELETE FROM %PREFIX%STEP_EXECUTION " +
+			"WHERE JOB_EXECUTION_ID " +
+			"IN (:jobExecutionIds)";
+
+	/**
+	 * SQL statements for removing the Job Execution Context.
+	 */
+	private static final String  SQL_DELETE_BATCH_JOB_EXECUTION_CONTEXT =
+			"DELETE FROM %PREFIX%JOB_EXECUTION_CONTEXT " +
+			"WHERE JOB_EXECUTION_ID IN (:jobExecutionIds)";
+
+	/**
+	 * SQL statements for removing the Job Execution Parameters.
+	 */
+	private static final String  SQL_DELETE_BATCH_JOB_EXECUTION_PARAMS =
+			"DELETE FROM %PREFIX%JOB_EXECUTION_PARAMS " +
+			"WHERE JOB_EXECUTION_ID IN (:jobExecutionIds)";
+
+	/**
+	 * SQL statements for removing the Job Executions.
+	 */
+	private static final String  SQL_DELETE_BATCH_JOB_EXECUTION =
+			"DELETE FROM %PREFIX%JOB_EXECUTION " +
+			"WHERE JOB_EXECUTION_ID IN (:jobExecutionIds)";
+
+	/**
+	 * SQL statements for removing Job Instances.
+	 */
+	private static final String  SQL_DELETE_BATCH_JOB_INSTANCE =
+			"DELETE FROM %PREFIX%JOB_INSTANCE BJI " +
+			"WHERE NOT EXISTS ( " +
+			"SELECT JOB_INSTANCE_ID FROM %PREFIX%JOB_EXECUTION BJE WHERE BJI.JOB_INSTANCE_ID = BJE.JOB_INSTANCE_ID)";
+
+	/**
+	 * Initializes the JdbcTaskExecutionDao.
+	 * @param dataSource used by the dao to execute queries and update the tables.
+	 * @param tablePrefix the table prefix to use for this dao.
+	 */
+	public JdbcDataflowJobExecutionDao(DataSource dataSource, String tablePrefix) {
+		this(dataSource);
+		Assert.hasText(tablePrefix, "tablePrefix must not be null nor empty");
+		this.tablePrefix = tablePrefix;
+	}
+
+	/**
+	 * Initializes the JdbTaskExecutionDao and defaults the table prefix to
+	 * {@link TaskProperties#DEFAULT_TABLE_PREFIX}.
+	 * @param dataSource used by the dao to execute queries and update the tables.
+	 */
+	public JdbcDataflowJobExecutionDao(DataSource dataSource) {
+		Assert.notNull(dataSource, "The dataSource must not be null.");
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public int deleteBatchStepExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobExecutionIds", jobExecutionIds);
+		final String query = getQuery(SQL_DELETE_BATCH_STEP_EXECUTION_CONTEXT);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteBatchStepExecutionsByJobExecitionIds(Set<Long> jobExecutionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobExecutionIds", jobExecutionIds);
+		final String query = getQuery(SQL_DELETE_BATCH_STEP_EXECUTION);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteBatchJobExecutionContextByJobExecitionIds(Set<Long> jobExecutionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobExecutionIds", jobExecutionIds);
+		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION_CONTEXT);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteBatchJobExecutionParamsByJobExecitionIds(Set<Long> jobExecutionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobExecutionIds", jobExecutionIds);
+		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION_PARAMS);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteBatchJobExecutionByJobExecitionIds(Set<Long> jobExecutionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobExecutionIds", jobExecutionIds);
+		final String query = getQuery(SQL_DELETE_BATCH_JOB_EXECUTION);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteBatchJobExecutionByJobInstanceIds(Set<Long> jobInstanceIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("jobInstanceIds", jobInstanceIds);
+		final String query = getQuery(SQL_DELETE_BATCH_JOB_INSTANCE);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteUnusedBatchJobInstances() {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource();
+		final String query = getQuery(SQL_DELETE_BATCH_JOB_INSTANCE);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	private String getQuery(String base) {
+		return StringUtils.replace(base, "%PREFIX%", this.tablePrefix);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
@@ -61,7 +61,7 @@ public class JdbcDataflowTaskExecutionDao implements DataflowTaskExecutionDao {
 
 	/**
 	 * Initializes the JdbcTaskExecutionDao.
-	 * @param dataSource used by the dao to execute queries and update the tables.
+	 * @param dataSource used by the dao to execute queries and updates the tables.
 	 * @param tablePrefix the table prefix to use for this dao.
 	 */
 	public JdbcDataflowTaskExecutionDao(DataSource dataSource, String tablePrefix) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository;
+
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.springframework.cloud.task.configuration.TaskProperties;
+import org.springframework.cloud.task.repository.dao.JdbcTaskExecutionDao;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Stores Task Execution Information to a JDBC DataSource. Mirrors the {@link JdbcTaskExecutionDao}
+ * but contains Spring Cloud Data Flow specific operations. This functionality might
+ * be migrated to Spring Cloud Task itself.
+ *
+ * @author Gunnar Hillert
+ */
+public class JdbcDataflowTaskExecutionDao implements DataflowTaskExecutionDao {
+
+	private static final String DELETE_TASK_EXECUTIONS = "DELETE FROM %PREFIX%EXECUTION "
+			+ "WHERE task_execution_id in (:taskExecutionIds)";
+
+	private static final String DELETE_TASK_EXECUTION_PARAMS = "DELETE FROM %PREFIX%EXECUTION_PARAMS "
+			+ "WHERE task_execution_id in (:taskExecutionIds)";
+
+	private static final String DELETE_TASK_TASK_BATCH = "DELETE FROM %PREFIX%TASK_BATCH "
+			+ "WHERE task_execution_id in (:taskExecutionIds)";
+
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	private String tablePrefix = TaskProperties.DEFAULT_TABLE_PREFIX;
+
+	/**
+	 * Initializes the JdbcTaskExecutionDao.
+	 * @param dataSource used by the dao to execute queries and update the tables.
+	 * @param tablePrefix the table prefix to use for this dao.
+	 */
+	public JdbcDataflowTaskExecutionDao(DataSource dataSource, String tablePrefix) {
+		this(dataSource);
+		Assert.hasText(tablePrefix, "tablePrefix must not be null nor empty");
+		this.tablePrefix = tablePrefix;
+	}
+
+	/**
+	 * Initializes the JdbTaskExecutionDao and defaults the table prefix to
+	 * {@link TaskProperties#DEFAULT_TABLE_PREFIX}.
+	 * @param dataSource used by the dao to execute queries and update the tables.
+	 */
+	public JdbcDataflowTaskExecutionDao(DataSource dataSource) {
+		Assert.notNull(dataSource, "The dataSource must not be null.");
+		this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+	}
+
+	@Override
+	public int deleteTaskExecutionsByTaskExecitionIds(Set<Long> taskExecitionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("taskExecutionIds", taskExecitionIds);
+		final String query = getQuery(DELETE_TASK_EXECUTIONS);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteTaskExecutionParamsByTaskExecitionIds(Set<Long> taskExecitionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("taskExecutionIds", taskExecitionIds);
+		final String query = getQuery(DELETE_TASK_EXECUTION_PARAMS);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	@Override
+	public int deleteTaskTaskBatchRelationshipsByTaskExecitionIds(Set<Long> taskExecitionIds) {
+		final MapSqlParameterSource queryParameters = new MapSqlParameterSource()
+				.addValue("taskExecutionIds", taskExecitionIds);
+		final String query = getQuery(DELETE_TASK_TASK_BATCH);
+		return this.jdbcTemplate.update(query, queryParameters);
+	}
+
+	private String getQuery(String base) {
+		return StringUtils.replace(base, "%PREFIX%", this.tablePrefix);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskExecutionException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskExecutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,21 @@
 
 package org.springframework.cloud.dataflow.server.repository;
 
+import java.util.Set;
+
 import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Glenn Renfro
+ * @author Gunnar Hillert
  */
 public class NoSuchTaskExecutionException extends RuntimeException {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Create a new exception.
@@ -30,5 +39,14 @@ public class NoSuchTaskExecutionException extends RuntimeException {
 	 */
 	public NoSuchTaskExecutionException(long id) {
 		super("Could not find TaskExecution with id " + id);
+	}
+
+	/**
+	 * Create a new exception.
+	 *
+	 * @param ids the ids of the {@link TaskExecution} that could not be found
+	 */
+	public NoSuchTaskExecutionException(Set<Long> ids) {
+		super("Could not find TaskExecutions with the following ids: " + StringUtils.collectionToDelimitedString(ids, ", "));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskExecutionException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/NoSuchTaskExecutionException.java
@@ -27,10 +27,7 @@ import org.springframework.util.StringUtils;
  */
 public class NoSuchTaskExecutionException extends RuntimeException {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = -303914974762305117L;
 
 	/**
 	 * Create a new exception.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.dataflow.server.service;
 
+import java.util.Set;
+
 /**
  * Provides task deletion services.
  *
  * @author Daniel Serleg
+ * @author Gunnar Hillert
  */
 public interface TaskDeleteService {
 	/**
@@ -28,6 +31,13 @@ public interface TaskDeleteService {
 	 * @param id the execution id
 	 */
 	void cleanupExecution(long id);
+
+	/**
+	 * Delete one or more Task executions.
+	 *
+	 * @param id the execution id
+	 */
+	void deleteOneOrMoreTaskExecutions(Set<Long> ids);
 
 	/**
 	 * Destroy the task definition. If it is a Composed Task then the task definitions

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.server.service;
 
 import java.util.Set;
 
+import org.springframework.cloud.dataflow.server.controller.support.TaskExecutionControllerDeleteAction;
+
 /**
  * Provides task deletion services.
  *
@@ -31,6 +33,13 @@ public interface TaskDeleteService {
 	 * @param id the execution id
 	 */
 	void cleanupExecution(long id);
+
+	/**
+	 *
+	 * @param actionsAsSet
+	 * @param ids
+	 */
+	void cleanupExecutions(Set<TaskExecutionControllerDeleteAction> actionsAsSet, Set<Long> ids);
 
 	/**
 	 * Delete one or more Task executions.
@@ -52,4 +61,5 @@ public interface TaskDeleteService {
 	 * required for a ComposedTaskRunner tasks are also destroyed.
 	 */
 	void deleteAll();
+
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
@@ -44,9 +44,9 @@ public interface TaskDeleteService {
 	/**
 	 * Delete one or more Task executions.
 	 *
-	 * @param id the execution id
+	 * @param ids Collection of task execution ids to delete. Must contain at least 1 id.
 	 */
-	void deleteOneOrMoreTaskExecutions(Set<Long> ids);
+	void deleteTaskExecutions(Set<Long> ids);
 
 	/**
 	 * Destroy the task definition. If it is a Composed Task then the task definitions

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
@@ -181,13 +181,13 @@ public class DefaultTaskDeleteService implements TaskDeleteService {
 		}
 
 		if (actionsAsSet.contains(TaskExecutionControllerDeleteAction.REMOVE_DATA)) {
-			this.deleteOneOrMoreTaskExecutions(ids);
+			this.deleteTaskExecutions(ids);
 		}
 	}
 
 	@Override
 	@Transactional
-	public void deleteOneOrMoreTaskExecutions(Set<Long> taskExecutionIds) {
+	public void deleteTaskExecutions(Set<Long> taskExecutionIds) {
 		Assert.notEmpty(taskExecutionIds, "You must provide at least 1 task execution id.");
 
 		final Set<Long> taskExecutionIdsWithChildren = new HashSet<>(taskExecutionIds);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
@@ -64,7 +64,6 @@ import static org.mockito.Mockito.mock;
  * @author Glenn Renfro
  * @author Ilayaperumal Gopinathan
  */
-@SuppressWarnings("unchecked")
 public class DataFlowServerConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
@@ -101,7 +100,7 @@ public class DataFlowServerConfigurationTests {
 	@Test
 	@Ignore
 	public void testStartEmbeddedH2Server() {
-		Map myMap = new HashMap();
+		Map<String, Object> myMap = new HashMap<>();
 		myMap.put("spring.datasource.url", "jdbc:h2:tcp://localhost:19092/mem:dataflow");
 		myMap.put("spring.dataflow.embedded.database.enabled", "true");
 		propertySources.addFirst(new MapPropertySource("EnvironmentTestPropsource", myMap));
@@ -120,7 +119,7 @@ public class DataFlowServerConfigurationTests {
 	@Test(expected = ConnectException.class)
 	public void testDoNotStartEmbeddedH2Server() throws Throwable {
 		Throwable exceptionResult = null;
-		Map myMap = new HashMap();
+		Map<String, Object> myMap = new HashMap<>();
 		myMap.put("spring.datasource.url", "jdbc:h2:tcp://localhost:19092/mem:dataflow");
 		myMap.put("spring.dataflow.embedded.database.enabled", "false");
 		myMap.put("spring.jpa.database", "H2");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -26,6 +26,7 @@ import org.springframework.batch.core.configuration.support.MapJobRegistry;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
+import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchDataSourceInitializer;
@@ -86,6 +87,7 @@ import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.batch.listener.TaskBatchDao;
 import org.springframework.cloud.task.batch.listener.support.JdbcTaskBatchDao;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
@@ -129,7 +131,7 @@ import static org.mockito.Mockito.mock;
 		"org.springframework.cloud.dataflow.audit.repository"
 })
 @EnableJpaAuditing
-@EnableConfigurationProperties({ DockerValidatorProperties.class, TaskConfigurationProperties.class })
+@EnableConfigurationProperties({ DockerValidatorProperties.class, TaskConfigurationProperties.class, TaskProperties.class })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 public class JobDependencies {
 
@@ -271,13 +273,13 @@ public class JobDependencies {
 	}
 
 	@Bean
-	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowTaskExecutionDao(dataSource);
+	public DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource, TaskProperties taskProperties) {
+		return new JdbcDataflowTaskExecutionDao(dataSource, taskProperties.getTablePrefix());
 	}
 
 	@Bean
-	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowJobExecutionDao(dataSource);
+	public DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource, AbstractJdbcBatchMetadataDao.DEFAULT_TABLE_PREFIX);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -60,6 +60,10 @@ import org.springframework.cloud.dataflow.server.controller.TaskExecutionControl
 import org.springframework.cloud.dataflow.server.controller.TaskLogsController;
 import org.springframework.cloud.dataflow.server.controller.TaskPlatformController;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
+import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.TaskDeleteService;
@@ -209,10 +213,13 @@ public class JobDependencies {
 	public TaskDeleteService deleteTaskService(TaskExplorer taskExplorer, LauncherRepository launcherRepository,
 			TaskDefinitionRepository taskDefinitionRepository,
 			TaskDeploymentRepository taskDeploymentRepository,
-			AuditRecordService auditRecordService) {
+			AuditRecordService auditRecordService,
+			DataflowTaskExecutionDao dataflowTaskExecutionDao,
+			DataflowJobExecutionDao dataflowJobExecutionDao) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
-				auditRecordService);
+				auditRecordService, dataflowTaskExecutionDao,
+				dataflowJobExecutionDao);
 	}
 
 	@Bean
@@ -261,6 +268,16 @@ public class JobDependencies {
 	@Bean
 	public TaskRepository taskRepository() {
 		return new SimpleTaskRepository(new TaskExecutionDaoFactoryBean());
+	}
+
+	@Bean
+	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowTaskExecutionDao(dataSource);
+	}
+
+	@Bean
+	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -41,6 +41,10 @@ import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
+import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
@@ -148,6 +152,16 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
+	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowTaskExecutionDao(dataSource);
+	}
+
+	@Bean
+	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource);
+	}
+
+	@Bean
 	public AuditRecordService auditRecordService() {
 		return mock(DefaultAuditRecordService.class);
 	}
@@ -198,10 +212,14 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	public TaskDeleteService deleteTaskService(TaskExplorer taskExplorer, LauncherRepository launcherRepository,
 			TaskDefinitionRepository taskDefinitionRepository,
 			TaskDeploymentRepository taskDeploymentRepository,
-			AuditRecordService auditRecordService) {
+			AuditRecordService auditRecordService,
+			DataflowTaskExecutionDao dataflowTaskExecutionDao,
+			DataflowJobExecutionDao dataflowJobExecutionDao) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
-				auditRecordService);
+				auditRecordService,
+				dataflowTaskExecutionDao,
+				dataflowJobExecutionDao);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -66,6 +67,7 @@ import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationP
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.scheduler.spi.core.Scheduler;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
@@ -106,6 +108,7 @@ import static org.mockito.Mockito.when;
 		VersionInfoProperties.class,
 		DockerValidatorProperties.class,
 		TaskConfigurationProperties.class,
+		TaskProperties.class,
 		DockerValidatorProperties.class })
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
@@ -152,13 +155,13 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowTaskExecutionDao(dataSource);
+	public DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource, TaskProperties taskProperties) {
+		return new JdbcDataflowTaskExecutionDao(dataSource, taskProperties.getTablePrefix());
 	}
 
 	@Bean
-	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowJobExecutionDao(dataSource);
+	public DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource, AbstractJdbcBatchMetadataDao.DEFAULT_TABLE_PREFIX);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -29,6 +29,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -128,6 +129,7 @@ import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Dependency;
 import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
@@ -170,6 +172,7 @@ import static org.mockito.Mockito.when;
 		VersionInfoProperties.class,
 		DockerValidatorProperties.class,
 		TaskConfigurationProperties.class,
+		TaskProperties.class,
 		DockerValidatorProperties.class,
 		GrafanaInfoProperties.class })
 @EntityScan({
@@ -415,13 +418,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowTaskExecutionDao(dataSource);
+	public DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource, TaskProperties taskProperties) {
+		return new JdbcDataflowTaskExecutionDao(dataSource, taskProperties.getTablePrefix());
 	}
 
 	@Bean
-	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
-		return new JdbcDataflowJobExecutionDao(dataSource);
+	public DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource, AbstractJdbcBatchMetadataDao.DEFAULT_TABLE_PREFIX);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -24,12 +24,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
+import javax.sql.DataSource;
+
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -83,6 +86,10 @@ import org.springframework.cloud.dataflow.server.controller.TaskSchedulerControl
 import org.springframework.cloud.dataflow.server.controller.ToolsController;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.registry.DataFlowAppRegistryPopulator;
+import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowJobExecutionDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
@@ -157,7 +164,7 @@ import static org.mockito.Mockito.when;
 @EnableSpringDataWebSupport
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 @Import(CompletionConfiguration.class)
-@ImportAutoConfiguration({ HibernateJpaAutoConfiguration.class, JacksonAutoConfiguration.class })
+@ImportAutoConfiguration({ HibernateJpaAutoConfiguration.class, JacksonAutoConfiguration.class, FlywayAutoConfiguration.class })
 @EnableWebMvc
 @EnableConfigurationProperties({ CommonApplicationProperties.class,
 		VersionInfoProperties.class,
@@ -403,8 +410,18 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public TaskRepository taskRepository() {
-		return new SimpleTaskRepository(new TaskExecutionDaoFactoryBean());
+	public TaskRepository taskRepository(DataSource dataSource) {
+		return new SimpleTaskRepository(new TaskExecutionDaoFactoryBean(dataSource));
+	}
+
+	@Bean
+	DataflowTaskExecutionDao dataflowTaskExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowTaskExecutionDao(dataSource);
+	}
+
+	@Bean
+	DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
+		return new JdbcDataflowJobExecutionDao(dataSource);
 	}
 
 	@Bean
@@ -436,10 +453,14 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	public TaskDeleteService deleteTaskService(TaskExplorer taskExplorer, LauncherRepository launcherRepository,
 			TaskDefinitionRepository taskDefinitionRepository,
 			TaskDeploymentRepository taskDeploymentRepository,
-			AuditRecordService auditRecordService) {
+			AuditRecordService auditRecordService,
+			DataflowTaskExecutionDao dataflowTaskExecutionDao,
+			DataflowJobExecutionDao dataflowJobExecutionDao) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
-				auditRecordService);
+				auditRecordService,
+				dataflowTaskExecutionDao,
+				dataflowJobExecutionDao);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -69,6 +69,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -276,8 +277,21 @@ public class TaskExecutionControllerTests {
 	@Test
 	public void testCleanup() throws Exception {
 		mockMvc.perform(delete("/tasks/executions/1")).andExpect(status().is(200));
-
 		verify(taskLauncher).cleanup("foobar");
+	}
+
+	@Test
+	public void testCleanupWithActionParam() throws Exception {
+		mockMvc.perform(delete("/tasks/executions/1").param("action", "CLEANUP")).andExpect(status().is(200));
+		verify(taskLauncher).cleanup("foobar");
+	}
+
+	@Test
+	public void testCleanupWithInvalidAction() throws Exception {
+		mockMvc.perform(delete("/tasks/executions/1").param("action", "does_not_exist").accept(MediaType.APPLICATION_JSON))
+		.andDo(print())
+		.andExpect(status().is(400))
+		.andExpect(jsonPath("$[0].message", is("The parameter 'action' must contain one of the following values: 'CLEANUP, REMOVE_DATA, REMOVE_BATCH_DATA'.")));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -78,6 +78,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Glenn Renfro
  * @author Ilayaperumal Gopinathan
  * @author David Turanski
+ * @author Gunnar Hillert
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class, PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
@@ -170,8 +171,10 @@ public class TaskExecutionControllerTests {
 			SAMPLE_CLEANSED_ARGUMENT_LIST.add("spring.datasource.password=******");
 
 			taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
-			dao.createTaskExecution(TASK_NAME_ORIG, new Date(), SAMPLE_ARGUMENT_LIST, "foobar");
-			dao.createTaskExecution(TASK_NAME_ORIG, new Date(), SAMPLE_ARGUMENT_LIST, null);
+			TaskExecution taskExecution1 =
+				dao.createTaskExecution(TASK_NAME_ORIG, new Date(), SAMPLE_ARGUMENT_LIST, "foobar");
+
+			dao.createTaskExecution(TASK_NAME_ORIG, new Date(), SAMPLE_ARGUMENT_LIST, "foobar", taskExecution1.getExecutionId());
 			dao.createTaskExecution(TASK_NAME_FOO, new Date(), SAMPLE_ARGUMENT_LIST, null);
 			TaskExecution taskExecution = dao.createTaskExecution(TASK_NAME_FOOBAR, new Date(), SAMPLE_ARGUMENT_LIST,
 					null);
@@ -291,13 +294,56 @@ public class TaskExecutionControllerTests {
 		mockMvc.perform(delete("/tasks/executions/1").param("action", "does_not_exist").accept(MediaType.APPLICATION_JSON))
 		.andDo(print())
 		.andExpect(status().is(400))
-		.andExpect(jsonPath("$[0].message", is("The parameter 'action' must contain one of the following values: 'CLEANUP, REMOVE_DATA, REMOVE_BATCH_DATA'.")));
+		.andExpect(jsonPath("$[0].message", is("The parameter 'action' must contain one of the following values: 'CLEANUP, REMOVE_DATA'.")));
 	}
 
 	@Test
 	public void testCleanupByIdNotFound() throws Exception {
 		mockMvc.perform(delete("/tasks/executions/10")).andExpect(status().is(404)).andReturn().getResponse()
 				.getContentAsString().contains("NoSuchTaskExecutionException");
+	}
+
+	@Test
+	public void testDeleteSingleTaskExecutionById() throws Exception {
+		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$.content[0].",
+			mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+					.andExpect(jsonPath("$.content[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
+					.andExpect(jsonPath("$.content", hasSize(4))));
+		mockMvc.perform(delete("/tasks/executions/1").param("action", "REMOVE_DATA"))
+			.andExpect(status().isOk());
+		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$.content[0].",
+				mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+						.andExpect(jsonPath("$.content[*].executionId", containsInAnyOrder(4, 3)))
+						.andExpect(jsonPath("$.content", hasSize(2))));
+	}
+
+	/**
+	 * This test will successfully delete 3 task executions. 2 task executions are specified in the arguments.
+	 * But since the task execution with id `1` is a parent task execution with 1 child, that child task
+	 * execution will be deleted as well.
+	 *
+	 */
+	@Test
+	public void testDeleteThreeTaskExecutionsById() throws Exception {
+		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$.content[0].",
+			mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+					.andExpect(jsonPath("$.content[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
+					.andExpect(jsonPath("$.content", hasSize(4))));
+		mockMvc.perform(delete("/tasks/executions/1,3").param("action", "REMOVE_DATA"))
+			.andExpect(status().isOk());
+		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$.content[0].",
+				mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+						.andExpect(jsonPath("$.content[*].executionId", containsInAnyOrder(4)))
+						.andExpect(jsonPath("$.content", hasSize(1))));
+	}
+
+	@Test
+	public void testDeleteNonParentTaskExecutionById() throws Exception {
+		mockMvc.perform(delete("/tasks/executions/2"))
+			.andDo(print())
+			.andExpect(status().is(400))
+			.andExpect(jsonPath("$[0].logref", is("CannotDeleteNonParentTaskExecutionException")))
+			.andExpect(jsonPath("$[0].message", is("Cannot delete non-parent TaskExecution with id 1")));
 	}
 
 	private ResultActions verifyTaskArgs(List<String> expectedArgs, String prefix, ResultActions ra) throws Exception {


### PR DESCRIPTION
* Add DataflowTaskExecutionDao
  - add support for deleting data in tables: `task_execution`, `task_task_batch`, `task_execution_params`
* Improvements to `TaskExecutionController#delete`:
  - Add `action` request parameter, supporting: `CLEANUP`, `REMOVE_DATA`
  - Relax `id` path-variable, allow to specify multiple ids, e.g.: `1,2,3?action=REMOVE_DATA`
* Add Tests
* Switch Task related tests (e.g. Task Execution Controller) from using the Map-based persistence store to JDBC (H2)
* Add better Enum-specific error message support for `MethodArgumentTypeMismatchException` in `RestControllerAdvice`
  - Provide a clearer error response and provide a list of allowed Enum values
* Add Support for Batch Job Execution Deletions
* Properly record audit records for Task/Job Execution Deletions

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/3279