### PR TITLE
Add InfluxDB/Grafana charts for Task-run duration

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose-influxdb.yml
+++ b/spring-cloud-dataflow-server/docker-compose-influxdb.yml
@@ -35,8 +35,6 @@ services:
   dataflow-server:
     image: springcloud/spring-cloud-dataflow-server:${DATAFLOW_VERSION:?DATAFLOW_VERSION is not set!}
     container_name: dataflow-server
-    volumes:
-      - '/tmp/apps:/apps/'
     ports:
       - "9393:9393"
     environment:

--- a/spring-cloud-dataflow-server/docker-compose-influxdb.yml
+++ b/spring-cloud-dataflow-server/docker-compose-influxdb.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mysql:
-    image: mysql:5.7.25
+    image: mysql:5.7.26
     container_name: dataflow-mysql
     environment:
       MYSQL_DATABASE: dataflow
@@ -35,6 +35,8 @@ services:
   dataflow-server:
     image: springcloud/spring-cloud-dataflow-server:${DATAFLOW_VERSION:?DATAFLOW_VERSION is not set!}
     container_name: dataflow-server
+    volumes:
+      - '/tmp/apps:/apps/'
     ports:
       - "9393:9393"
     environment:
@@ -46,6 +48,9 @@ services:
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.influx.enabled=true
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.influx.db=myinfluxdb
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.influx.uri=http://influxdb:8086
+      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.influx.enabled=true
+      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.influx.db=myinfluxdb
+      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.influx.uri=http://influxdb:8086
       - spring.cloud.dataflow.grafana-info.url=http://localhost:3000
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/dataflow
       - SPRING_DATASOURCE_USERNAME=root
@@ -53,7 +58,7 @@ services:
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
     depends_on:
       - kafka
-    entrypoint: "./wait-for-it.sh mysql:3306 -- java -jar /maven/spring-cloud-dataflow-server.jar"
+    entrypoint: "./wait-for-it.sh -t 120 mysql:3306 -- java -jar /maven/spring-cloud-dataflow-server.jar"
 
   app-import:
     image: springcloud/openjdk:latest
@@ -82,10 +87,10 @@ services:
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=rootpw
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
-    entrypoint: "./wait-for-it.sh mysql:3306 -- java -Djava.security.egd=file:/dev/./urandom -jar /spring-cloud-skipper-server.jar"
+    entrypoint: "./wait-for-it.sh -t 120 mysql:3306 -- java -Djava.security.egd=file:/dev/./urandom -jar /spring-cloud-skipper-server.jar"
 
   influxdb:
-    image: influxdb:1.7.5
+    image: influxdb:1.7.7
     container_name: influxdb
     ports:
       - '8086:8086'

--- a/src/grafana/influxdb/docker/docker-compose.yml
+++ b/src/grafana/influxdb/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   # Grafana uses the InfluxDB datasource
   influxdb:
-    image: influxdb:1.7.5
+    image: influxdb:1.7.7
     container_name: 'influxdb'
     ports:
       - '8086:8086'

--- a/src/grafana/influxdb/docker/grafana/Dockerfile
+++ b/src/grafana/influxdb/docker/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.4.3
+FROM grafana/grafana:6.2.5
 ADD ./provisioning /etc/grafana/provisioning
 ADD ./config.ini /etc/grafana/config.ini
 ADD ./dashboards /var/lib/grafana/dashboards

--- a/src/grafana/influxdb/docker/grafana/dashboards/scdf-task-batch.json
+++ b/src/grafana/influxdb/docker/grafana/dashboards/scdf-task-batch.json
@@ -1,0 +1,430 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1562156612387,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": [],
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influx_auto_DataFlowMetricsCollector",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "alias": "$task_name  - $task_execution_id",
+          "groupBy": [
+            {
+              "params": [
+                "task_external_execution_id"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "task_name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "spring_cloud_task",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "upper"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "task_name",
+              "operator": "=~",
+              "value": "/^$task_name$/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Task Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influx_auto_DataFlowMetricsCollector",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "alias": "$job_name",
+          "groupBy": [
+            {
+              "params": [
+                "name"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "spring_batch_job",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT \"mean\" FROM \"autogen\".\"spring_batch_job\" WHERE $timeFilter",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "upper"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "name",
+              "operator": "=~",
+              "value": "/^$job_name$/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Job duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "influx_auto_DataFlowMetricsCollector",
+        "definition": "select distinct(\"name\") from (select  * from \"spring_batch_job\" WHERE time > now() -  6000s)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "job_name",
+        "multi": true,
+        "name": "job_name",
+        "options": [],
+        "query": "select distinct(\"name\") from (select  * from \"spring_batch_job\" WHERE time > now() -  6000s)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "isNone": true,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": "influx_auto_DataFlowMetricsCollector",
+        "definition": "show tag values with key=\"status\"  WHERE \"name\"='$job_name'",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job_status",
+        "multi": false,
+        "name": "job_status",
+        "options": [
+          {
+            "isNone": true,
+            "selected": true,
+            "text": "None",
+            "value": ""
+          }
+        ],
+        "query": "show tag values with key=\"status\"  WHERE \"name\"='$job_name'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "none",
+          "value": "none"
+        },
+        "datasource": "influx_auto_DataFlowMetricsCollector",
+        "definition": "select distinct(\"task_name\") from (select  * from \"spring_cloud_task\" WHERE time > now() -  160s)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "task_name",
+        "multi": true,
+        "name": "task_name",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          }
+        ],
+        "query": "select distinct(\"task_name\") from (select  * from \"spring_cloud_task\" WHERE time > now() -  160s)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "1",
+          "value": "1"
+        },
+        "datasource": "influx_auto_DataFlowMetricsCollector",
+        "definition": "show tag values with key=\"task_execution_id\"  WHERE \"task_name\"='$task_name'",
+        "hide": 0,
+        "includeAll": false,
+        "label": "task_execution_id",
+        "multi": false,
+        "name": "task_execution_id",
+        "options": [
+          {
+            "selected": true,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": false,
+            "text": "2",
+            "value": "2"
+          }
+        ],
+        "query": "show tag values with key=\"task_execution_id\"  WHERE \"task_name\"='$task_name'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Spring Cloud Task & Batch",
+  "uid": "Z8fhFe7Wk",
+  "version": 1
+}

--- a/src/grafana/prometheus/docker/grafana/Dockerfile
+++ b/src/grafana/prometheus/docker/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.4.3
+FROM grafana/grafana:6.2.5
 ADD ./provisioning /etc/grafana/provisioning
 ADD ./config.ini /etc/grafana/config.ini
 ADD ./dashboards /var/lib/grafana/dashboards

--- a/src/grafana/prometheus/docker/prometheus-local/Dockerfile
+++ b/src/grafana/prometheus/docker/prometheus-local/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:v2.8.0
+FROM prom/prometheus:v2.10.0
 COPY prometheus-local-file.yml /etc/prometheus-local-file.yml
 CMD  [ "--config.file=/etc/prometheus-local-file.yml", \
        "--storage.tsdb.path=/prometheus", \


### PR DESCRIPTION
 - augment the docker-compose-influx to enable task.management.metrics.xxx for influx.
 - add initial scdf-task-batch grafana dashboard to springcloud/spring-cloud-dataflow-grafana-influxdb image.
 - update prometheus, myslq, grafana and influx image versions.

 Depends on spring-cloud/spring-cloud-task/pull/612
 Depends on spring-cloud-task-app-starters/core/issues/14

 Resolves #3295