### PR TITLE
Document adding mysql driver to a server

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-local.adoc
@@ -196,6 +196,173 @@ spring:
     driver-class-name:org.postgresql.Driver
 ----
 
+[start=4]
+. Or build a custom server with your own build files. Here are examples of bundling MySQL driver using gradle and maven, which
+will result same jar as `2.1.2.RELEASE` with addition of a `mysql-connector-java-8.0.16.jar`:
+
+[source, groovy]
+.gradle
+----
+plugins {
+        id 'org.springframework.boot' version '2.1.3.RELEASE'
+        id 'java'
+}
+
+ext {
+        springCloudVersion = 'Greenwich.SR1'
+        springCloudDataflowVersion = '2.1.2.RELEASE'
+        springSecurityOauth2AutoconfigureVersion = '2.1.3.RELEASE'
+        springSecurityOauth2Version = '2.3.4.RELEASE'
+        kubernetesClientVersion = '4.0.4'
+        mysqlJdbcDriverVersion = '8.0.16'
+}
+
+apply plugin: 'io.spring.dependency-management'
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '1.8'
+
+repositories {
+        mavenCentral()
+        maven { url "https://repo.springsource.org/libs-snapshot" }
+}
+
+dependencyManagement {
+        imports {
+                mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+                mavenBom "org.springframework.cloud:spring-cloud-dataflow-dependencies:${springCloudDataflowVersion}"
+        }
+        dependencies {
+                dependency "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:${springSecurityOauth2AutoconfigureVersion}"
+                dependency "org.springframework.security.oauth:spring-security-oauth2:${springSecurityOauth2Version}"
+                dependency "io.fabric8:kubernetes-client:${kubernetesClientVersion}"
+                dependency("mysql:mysql-connector-java:${mysqlJdbcDriverVersion}") {
+                        exclude 'com.google.protobuf:protobuf-java'
+                }
+        }
+}
+
+dependencies {
+        implementation 'org.springframework.cloud:spring-cloud-starter-dataflow-server'
+        runtime 'mysql:mysql-connector-java'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+----
+
+
+[source, xml]
+.maven
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>2.1.3.RELEASE</version>
+                <relativePath/>
+        </parent>
+        <groupId>com.example</groupId>
+        <artifactId>custom-dataflow-server-maven</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <name>custom-dataflow-server</name>
+        <description>Demo project for Spring Boot</description>
+
+        <properties>
+                <java.version>1.8</java.version>
+                <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+                <spring-cloud-dataflow.version>2.1.2.RELEASE</spring-cloud-dataflow.version>
+                <spring-security-oauth2.version>2.3.4.RELEASE</spring-security-oauth2.version>
+                <mariadb.version>2.4.1</mariadb.version>
+                <spring-security-oauth2-autoconfigure.version>2.1.3.RELEASE</spring-security-oauth2-autoconfigure.version>
+                <kubernetes-client.version>4.0.4</kubernetes-client.version>
+                <mysql-jdbc-driver.version>8.0.16</mysql-jdbc-driver.version>
+        </properties>
+
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-dataflow-server</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security.oauth.boot</groupId>
+                        <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+                        <version>${spring-security-oauth2-autoconfigure.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security.oauth</groupId>
+                        <artifactId>spring-security-oauth2</artifactId>
+                        <version>${spring-security-oauth2.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-client</artifactId>
+                        <version>${kubernetes-client.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                </dependency>
+        </dependencies>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dependencies</artifactId>
+                                <version>${spring-cloud.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                        <dependency>
+                                <groupId>org.springframework.cloud</groupId>
+                                <artifactId>spring-cloud-dataflow-dependencies</artifactId>
+                                <version>${spring-cloud-dataflow.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                        <dependency>
+                                <groupId>mysql</groupId>
+                                <artifactId>mysql-connector-java</artifactId>
+                                <version>${mysql-jdbc-driver.version}</version>
+                                <exclusions>
+                                        <exclusion>
+                                                <groupId>com.google.protobuf</groupId>
+                                                <artifactId>protobuf-java</artifactId>
+                                        </exclusion>
+                                </exclusions>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
+
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
+        <repositories>
+                <repository>
+                        <id>spring-snapshots</id>
+                        <name>Spring Snapshots</name>
+                        <url>http://repo.spring.io/libs-snapshot</url>
+                        <snapshots>
+                                <enabled>true</enabled>
+                        </snapshots>
+                </repository>
+        </repositories>
+</project>
+----
+
 [[configuration-local-deployer]]
 === Deployer Properties
 You can use the following configuration properties of the https://github.com/spring-cloud/spring-cloud-deployer-local[Local deployer] to customize how Streams and Tasks are deployed.


### PR DESCRIPTION
- As an temporary fix for this documentation issue, provide
  gradle and maven samples how to build a custom dataflow server
  adding mysql driver. These custom build files examples will
  produce same fatjar as project itself with an addition of
  mysql-connector-java-8.0.16.jar.
- This lays groundwork to make dependency management more clear
  as there is a way too much manual configuration for dependencies
  and versions for custom gradle and maven builds.
- Fixes #2489