### PR TITLE
Allow splits with a single entry for some composed task scenarios

### DIFF
--- a/spring-cloud-dataflow-core-dsl/src/main/java/org/springframework/cloud/dataflow/core/dsl/SplitNode.java
+++ b/spring-cloud-dataflow-core-dsl/src/main/java/org/springframework/cloud/dataflow/core/dsl/SplitNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,22 +45,17 @@ public class SplitNode extends LabelledTaskNode {
 
 	@Override
 	public String stringify(boolean includePositionInfo) {
-		if (parallelTaskApps.size() == 1) {
-			return parallelTaskApps.get(0).stringify(includePositionInfo);
-		}
-		else {
-			StringBuilder s = new StringBuilder();
-			s.append(TokenKind.LT.tokenChars);
-			for (int i = 0; i < parallelTaskApps.size(); i++) {
-				LabelledTaskNode jn = parallelTaskApps.get(i);
-				if (i > 0) {
-					s.append(" ").append(TokenKind.DOUBLEPIPE.tokenChars).append(" ");
-				}
-				s.append(jn.stringify(includePositionInfo));
+		StringBuilder s = new StringBuilder();
+		s.append(TokenKind.LT.tokenChars);
+		for (int i = 0; i < parallelTaskApps.size(); i++) {
+			LabelledTaskNode jn = parallelTaskApps.get(i);
+			if (i > 0) {
+				s.append(" ").append(TokenKind.DOUBLEPIPE.tokenChars).append(" ");
 			}
-			s.append(TokenKind.GT.tokenChars);
-			return s.toString();
+			s.append(jn.stringify(includePositionInfo));
 		}
+		s.append(TokenKind.GT.tokenChars);
+		return s.toString();
 	}
 
 	@Override

--- a/spring-cloud-dataflow-core-dsl/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
+++ b/spring-cloud-dataflow-core-dsl/src/main/java/org/springframework/cloud/dataflow/core/dsl/TaskValidatorVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,9 +81,9 @@ public class TaskValidatorVisitor extends TaskVisitor {
 
 	@Override
 	public boolean preVisit(SplitNode split) {
-		if (split.getSeriesLength() == 1) {
-			pushProblem(split.startPos, DSLMessage.TASK_VALIDATION_SPLIT_WITH_ONE_FLOW);
-		}
+		// This used to check there were multiple entries in the split otherwise it threw an error.
+		// It could conditionally still throw that error if there is one entry in the split
+		// and it has no transitions (since that is the only scenario that needs a single entry split)
 		if (split.hasLabel()) {
 			String labelString = split.getLabelString();
 			if (labelsDefined.contains(labelString)) {


### PR DESCRIPTION
With this change the DSL parser allows a single entry in a split - this
is so that you can have a task that uses transitions and rather than
those transitions jumping straight to the END after they are done, they
will jump to the task following the split. Effectively the split is
being used to create a nested flow. This is not a new usage of it, but
previously it only allowed nested flows involving multiple tasks to
run in parallel. Now you can use it for just a single task in a
nested flow.

The parser has been changed and the graph-to-text and text-to-graph
algorithms have been updated to support it.

Resolves #3263