### PR TITLE
gh-3328 Expose the parentTaskExecutionId for the TaskExecutionController

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,12 @@ public class TaskExecutionResource extends ResourceSupport {
 	 */
 	private String externalExecutionId;
 
+	/**
+	 * This Task Execution might be a child task as part of a composed
+	 * task and have a parent task execution id. This property can be null.
+	 */
+	private Long parentExecutionId;
+
 	public TaskExecutionResource() {
 		arguments = new ArrayList<>();
 	}
@@ -102,6 +108,7 @@ public class TaskExecutionResource extends ResourceSupport {
 	public TaskExecutionResource(TaskJobExecutionRel taskJobExecutionRel) {
 		Assert.notNull(taskJobExecutionRel, "taskJobExecutionDTO must not be null");
 		this.executionId = taskJobExecutionRel.getTaskExecution().getExecutionId();
+		this.parentExecutionId = taskJobExecutionRel.getTaskExecution().getParentExecutionId();
 		this.exitCode = taskJobExecutionRel.getTaskExecution().getExitCode();
 		this.taskName = taskJobExecutionRel.getTaskExecution().getTaskName();
 		this.exitMessage = taskJobExecutionRel.getTaskExecution().getExitMessage();
@@ -180,6 +187,10 @@ public class TaskExecutionResource extends ResourceSupport {
 
 	public String getExternalExecutionId() {
 		return externalExecutionId;
+	}
+
+	public Long getParentExecutionId() {
+		return parentExecutionId;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -65,6 +65,7 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -232,6 +233,16 @@ public class TaskExecutionControllerTests {
 		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "",
 				mockMvc.perform(get("/tasks/executions/1").accept(MediaType.APPLICATION_JSON))
 						.andExpect(status().isOk()).andExpect(content().json("{taskName: \"" + TASK_NAME_ORIG + "\"}"))
+						.andExpect(jsonPath("$.parentExecutionId", is(nullValue())))
+						.andExpect(jsonPath("jobExecutionIds", hasSize(0))));
+	}
+
+	@Test
+	public void testGetChildTaskExecution() throws Exception {
+		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "",
+				mockMvc.perform(get("/tasks/executions/2").accept(MediaType.APPLICATION_JSON))
+						.andExpect(status().isOk())
+						.andExpect(jsonPath("$.parentExecutionId", is(1)))
 						.andExpect(jsonPath("jobExecutionIds", hasSize(0))));
 	}
 
@@ -247,6 +258,7 @@ public class TaskExecutionControllerTests {
 		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$.content[0].",
 				mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 						.andExpect(jsonPath("$.content[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
+						.andExpect(jsonPath("$.content[*].parentExecutionId", containsInAnyOrder(null, null, null, 1)))
 						.andExpect(jsonPath("$.content", hasSize(4))));
 	}
 


### PR DESCRIPTION
- Add `parentTaskExecutionId` property to the `TaskExecutionResource`
- Update tests

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/3328