### PR TITLE
Fix CF task application log retrieval

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPlatformFactory.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPlatformFactory.java
@@ -18,8 +18,24 @@ package org.springframework.cloud.dataflow.core;
 
 /**
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  **/
 public interface TaskPlatformFactory {
+
+	String CLOUDFOUNDRY_PLATFORM_TYPE = "Cloud Foundry";
+
+	/**
+	 * Create the {@link TaskPlatform} instance with the launchers.
+	 *
+	 * @return the task platform
+	 */
 	TaskPlatform createTaskPlatform();
+
+	/**
+	 * Create the {@link Launcher} by the given name.
+	 *
+	 * @param account the name of the launcher
+	 * @return the launcher instance.
+	 */
 	Launcher createLauncher(String account);
 }

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
@@ -45,13 +45,13 @@ import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundryAppSched
 import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.cloud.scheduler.spi.core.Scheduler;
 
+import static org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService.CLOUDFOUNDRY_PLATFORM_TYPE;
+
 /**
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
  **/
 public class CloudFoundryTaskPlatformFactory extends AbstractTaskPlatformFactory<CloudFoundryPlatformProperties> {
-
-	private final static String PLATFORM_TYPE = "Cloud Foundry";
 
 	private final static Logger logger = LoggerFactory.getLogger(CloudFoundryTaskPlatformFactory.class);
 
@@ -70,7 +70,7 @@ public class CloudFoundryTaskPlatformFactory extends AbstractTaskPlatformFactory
 			CloudFoundryPlatformClientProvider cloudFoundryClientProvider,
 			Optional<CloudFoundrySchedulerClientProvider> cloudFoundrySchedulerClientProvider) {
 
-		super(cloudFoundryPlatformProperties, PLATFORM_TYPE);
+		super(cloudFoundryPlatformProperties, CLOUDFOUNDRY_PLATFORM_TYPE);
 		this.platformTokenProvider = platformTokenProvider;
 		this.connectionContextProvider = connectionContextProvider;
 		this.cloudFoundryClientProvider = cloudFoundryClientProvider;
@@ -88,7 +88,7 @@ public class CloudFoundryTaskPlatformFactory extends AbstractTaskPlatformFactory
 				deploymentProperties(account),
 				cloudFoundryOperations,
 				runtimeEnvironmentInfo(cloudFoundryClient, account));
-		Launcher launcher = new Launcher(account, PLATFORM_TYPE, taskLauncher,
+		Launcher launcher = new Launcher(account, CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher,
 				scheduler(account, taskLauncher, cloudFoundryOperations));
 		CloudFoundryConnectionProperties connectionProperties = connectionProperties(account);
 		launcher.setDescription(String.format("org = [%s], space = [%s], url = [%s]",

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
@@ -45,8 +45,6 @@ import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundryAppSched
 import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.cloud.scheduler.spi.core.Scheduler;
 
-import static org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService.CLOUDFOUNDRY_PLATFORM_TYPE;
-
 /**
  * @author David Turanski
  * @author Ilayaperumal Gopinathan

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.core.AuditOperationType;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.TaskDeployment;
+import org.springframework.cloud.dataflow.core.TaskPlatformFactory;
 import org.springframework.cloud.dataflow.rest.util.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
@@ -108,8 +109,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	public static final String COMMAND_LINE_ARGS = "commandLineArgs";
 
 	public static final String TASK_PLATFORM_NAME = "spring.cloud.dataflow.task.platformName";
-
-	public static final String CLOUDFOUNDRY_PLATFORM_TYPE = "Cloud Foundry";
 
 	/**
 	 * Initializes the {@link DefaultTaskExecutionService}.
@@ -212,7 +211,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 		Launcher launcher = this.launcherRepository.findByName(platformName);
 		// In case of Cloud Foundry, fetching logs by external execution Id isn't valid as the execution instance is destroyed.
 		// We need to use the task name instead.
-		if (launcher != null && launcher.getType().equals(CLOUDFOUNDRY_PLATFORM_TYPE)) {
+		if (launcher != null && launcher.getType().equals(TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE)) {
 			TaskDeployment taskDeployment = this.taskDeploymentRepository.findByTaskDeploymentId(taskId);
 			taskId = taskDeployment.getTaskDefinitionName();
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -109,8 +109,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 
 	public static final String TASK_PLATFORM_NAME = "spring.cloud.dataflow.task.platformName";
 
-
-
+	public static final String CLOUDFOUNDRY_PLATFORM_TYPE = "Cloud Foundry";
 
 	/**
 	 * Initializes the {@link DefaultTaskExecutionService}.
@@ -210,6 +209,13 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 
 	@Override
 	public String getLog(String platformName, String taskId) {
+		Launcher launcher = this.launcherRepository.findByName(platformName);
+		// In case of Cloud Foundry, fetching logs by external execution Id isn't valid as the execution instance is destroyed.
+		// We need to use the task name instead.
+		if (launcher != null && launcher.getType().equals(CLOUDFOUNDRY_PLATFORM_TYPE)) {
+			TaskDeployment taskDeployment = this.taskDeploymentRepository.findByTaskDeploymentId(taskId);
+			taskId = taskDeployment.getTaskDefinitionName();
+		}
 		return findTaskLauncher(platformName).getLog(taskId);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -231,6 +231,39 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 		@Test
 		@DirtiesContext
+		public void getTaskLog() {
+			String platformName = "test-platform";
+			String taskDefinitionName = "test";
+			String taskDeploymentId = "12345";
+			TaskDeployment taskDeployment = new TaskDeployment();
+			taskDeployment.setPlatformName(platformName);
+			taskDeployment.setTaskDefinitionName(taskDefinitionName);
+			taskDeployment.setTaskDeploymentId(taskDeploymentId);
+			this.launcherRepository.save(new Launcher(platformName, "local", taskLauncher));
+			when(taskLauncher.getLog(taskDeploymentId)).thenReturn("Logs");
+			assertEquals("Logs", this.taskExecutionService.getLog(taskDeployment.getPlatformName(), taskDeploymentId));
+		}
+
+		@Test
+		@DirtiesContext
+		public void getCFTaskLog() {
+			String platformName = "cf-test-platform";
+			String taskDefinitionName = "test";
+			String taskDeploymentId = "12345";
+			TaskDeployment taskDeployment = new TaskDeployment();
+			taskDeployment.setPlatformName(platformName);
+			taskDeployment.setTaskDefinitionName(taskDefinitionName);
+			taskDeployment.setTaskDeploymentId(taskDeploymentId);
+			this.taskDeploymentRepository.save(taskDeployment);
+			this.launcherRepository.save(new Launcher(platformName,
+					DefaultTaskExecutionService.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
+			when(taskLauncher.getLog(taskDefinitionName)).thenReturn("Logs");
+			assertEquals("Logs", this.taskExecutionService.getLog(taskDeployment.getPlatformName(), taskDeploymentId));
+		}
+
+
+		@Test
+		@DirtiesContext
 		public void executeSameTaskDefinitionOnMultiplePlatforms() {
 			initializeSuccessfulRegistry(appRegistry);
 			when(taskLauncher.launch(any())).thenReturn("0");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -44,6 +44,7 @@ import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.TaskDeployment;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
+import org.springframework.cloud.dataflow.core.TaskPlatformFactory;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
 import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
@@ -256,7 +257,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			taskDeployment.setTaskDeploymentId(taskDeploymentId);
 			this.taskDeploymentRepository.save(taskDeployment);
 			this.launcherRepository.save(new Launcher(platformName,
-					DefaultTaskExecutionService.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
+					TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
 			when(taskLauncher.getLog(taskDefinitionName)).thenReturn("Logs");
 			assertEquals("Logs", this.taskExecutionService.getLog(taskDeployment.getPlatformName(), taskDeploymentId));
 		}


### PR DESCRIPTION
  - Use task definition name instead of task external execution ID as the task instance is destroyed upon completion
  - Add tests

Resolves #3337