### PR TITLE
Default to a single task platform

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -153,15 +153,23 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 		this.dataflowTaskExecutionDao = dataflowTaskExecutionDao;
 	}
 
-
-
 	@Override
-	public long executeTask(String taskName, Map<String, String> taskDeploymentProperties, List<String> commandLineArgs, String composedTaskRunnerName) {
+	public long executeTask(String taskName, Map<String, String> taskDeploymentProperties, List<String> commandLineArgs,
+			String composedTaskRunnerName) {
 
 		String platformName = taskDeploymentProperties.get(TASK_PLATFORM_NAME);
+
+		// If not given, use 'default'
 		if (!StringUtils.hasText(platformName)) {
 			platformName = "default";
 		}
+		// In case we have exactly one launcher, we override to that
+		List<String> launcherNames = StreamSupport.stream(launcherRepository.findAll().spliterator(), false)
+				.map(Launcher::getName).collect(Collectors.toList());
+		if (launcherNames.size() == 1) {
+			platformName = launcherNames.get(0);
+		}
+
 		// Remove since the key for task platform name will not pass validation for app, deployer, or scheduler prefix
 		if (taskDeploymentProperties.containsKey(TASK_PLATFORM_NAME)) {
 			taskDeploymentProperties.remove(TASK_PLATFORM_NAME);

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -92,7 +92,6 @@ public class TaskCommands implements CommandMarker {
 	private static final String TASK_EXECUTION_CURRENT = "task execution current";
 	private static final String TASK_EXECUTION_STATUS = "task execution status";
 	private static final String VALIDATE = "task validate";
-	private static final String PLATFORM_NAME = "platformName";
 	private static final String CTR_APP_NAME = "composedTaskRunnerName";
 
 
@@ -202,8 +201,7 @@ public class TaskCommands implements CommandMarker {
 			@CliOption(key = {
 					ARGUMENTS_OPTION }, help = "the commandline arguments for this launch") String arguments,
 			@CliOption(key = {
-					PLATFORM_NAME}, help = "the platform name to use for this launch",
-					unspecifiedDefaultValue = "default") String platformName,
+					PLATFORM_OPTION}, help = "the platform name to use for this launch") String platformName,
 			@CliOption(key = {
 					CTR_APP_NAME}, help = "Composed Task Runner app to use for this launch when not using default") String composedTaskRunnerApp)
 


### PR DESCRIPTION
- If user have only one task platform and that named platform is not
  given with properties, switch to that in a DefaultTaskExecutionService.
- We also log that a single platform was replaced.
- Other option would have been to forcefully register single platform as
  'default' as it's done in a skipper but looks like with tasks that
  might be more intrusive.
- Fixes #3367