### PR TITLE
Remove k8s "jobs" permissions from incorrect apigroup

### DIFF
--- a/src/kubernetes/server/server-roles.yaml
+++ b/src/kubernetes/server/server-roles.yaml
@@ -13,7 +13,7 @@ rules:
     resources: ["statefulsets", "deployments", "replicasets"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
   - apiGroups: ["extensions"]
-    resources: ["deployments", "replicasets", "jobs"]
+    resources: ["deployments", "replicasets"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
   - apiGroups: ["batch"]
     resources: ["cronjobs", "jobs"]


### PR DESCRIPTION
In Kubernetes, the `jobs` API resource is under the `batch` API Group, not `extensions`. This PR is a successor to #2956 which properly added jobs under the batch apigroup, but did not remove it from the extensions apigroup.

Kubernetes doesn't error out when attempting to apply `server-roles.yaml` as-is and when the operator is using the cluster-admin role. However when the operator does not have cluster-admin (for example in a multi-tenant kubernetes cluster where tenants have admin only in their namespace), this will error out. As such, this issue has likely gone unnoticed.

Evidence:
```
$ kubectl api-resources
NAME                               SHORTNAMES        APIGROUP                       NAMESPACED   KIND
cronjobs                           cj                batch                          true         CronJob
jobs                                                 batch                          true         Job
...
```

and notably the lack of `jobs` under `extensions`:
```
$ kubectl api-resources | grep extensions
customresourcedefinitions          crd,crds          apiextensions.k8s.io           false        CustomResourceDefinition
daemonsets                         ds                extensions                     true         DaemonSet
deployments                        deploy            extensions                     true         Deployment
ingresses                          ing               extensions                     true         Ingress
networkpolicies                    netpol            extensions                     true         NetworkPolicy
podsecuritypolicies                psp               extensions                     false        PodSecurityPolicy
replicasets                        rs                extensions                     true         ReplicaSet
```
