### PR TITLE
"pods/log" does not have create/delete/update

### DIFF
--- a/src/kubernetes/server/server-roles.yaml
+++ b/src/kubernetes/server/server-roles.yaml
@@ -4,10 +4,10 @@ metadata:
   name: scdf-role
 rules:
   - apiGroups: [""]
-    resources: ["services", "pods", "pods/log", "replicationcontrollers", "persistentvolumeclaims"]
+    resources: ["services", "pods", "replicationcontrollers", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets"]
+    resources: ["configmaps", "secrets", "pods/log"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["statefulsets", "deployments", "replicasets"]


### PR DESCRIPTION
In Kubernetes, the "pods/log" resource type do not have verbs for `"create", "delete", or "update"`. This PR moves "pods/logs" down to have the proper list of verbs.

Similar to what is noted in #3394:
> Kubernetes doesn't error out when attempting to apply server-roles.yaml as-is and when the operator is using the cluster-admin role. However when the operator does not have cluster-admin (for example in a multi-tenant kubernetes cluster where tenants have admin only in their namespace), this will error out. As such, this issue has likely gone unnoticed.

Attempt to apply this role before this PR:
```
Error from server (Forbidden): error when creating "STDIN": roles.rbac.authorization.k8s.io "scdf-role" is forbidden: user ... is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["pods/log"], Verbs:["create" "delete" "update"]}
```

Successful attempt after this PR:
```
role.rbac.authorization.k8s.io/scdf-role created
```
