### PR TITLE
Fix restdocs generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.0</version>
+				<version>2.22.1</version>
 				<configuration>
 					<includes>
 						<include>**/*Tests.java</include>


### PR DESCRIPTION
- Cloud build is now using latest junit5 deps which caused
  mismatch with surefire plugin. At least internally it got
  NoSuchMethodError as surefire also depends on junit5.
- We use explicit surefire configuration and this commit
  changes it to same version as cloud build which seems
  to fix this junit5 issue and thus putting restdocs
  back to business.
- Fixes #3421