### PR TITLE
Add ability for user to set platform to use when stopping tasks

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -183,13 +183,16 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 						.param("arguments", "--server.port=8080 --foo=bar"))
 				.andExpect(status().isCreated());
 		this.mockMvc.perform(
-				post("/tasks/executions/{id}", 1))
+				post("/tasks/executions/{id}", 1)
+						.param("platform", "default"))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						pathParameters(
 								parameterWithName("id").description("The ids of an existing task execution (required)")
-						)));
+						),
+						requestParameters(parameterWithName("platform")
+								.description("The platform associated with the task execution(optional)"))));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -1769,6 +1769,7 @@ The following topics provide more details:
 
 * <<api-guide-resources-task-executions-stopping-request-structure>>
 * <<api-guide-resources-task-executions-stopping-path-parameters>>
+* <<api-guide-resources-task-executions-stopping-request-parameters>>
 * <<api-guide-resources-task-executions-stopping-example-request>>
 * <<api-guide-resources-task-executions-stopping-response-structure>>
 
@@ -1786,7 +1787,10 @@ include::{snippets}/task-executions-documentation/stop-task/http-request.adoc[]
 
 include::{snippets}/task-executions-documentation/stop-task/path-parameters.adoc[]
 
+[[api-guide-resources-task-executions-stopping-request-parameters]]
+===== Request Parameters
 
+include::{snippets}/task-executions-documentation/stop-task/request-parameters.adoc[]
 
 [[api-guide-resources-task-executions-stopping-example-request]]
 ===== Example Request

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -387,6 +387,18 @@ When stopping a task execution that has a running Spring Batch job, the job will
 Each of the supported platforms send a SIG-INT to the task application  when a stop is requested that allows Spring Cloud Task to capture the state of the app, however Spring Batch does not handle a SIG-INT and thus the job stops in the STARTED status. 
 ====
 
+==== Stopping a Task Execution that was started outside of Spring Cloud Data Flow
+
+You may wish to stop a task that has been launched outside of Spring Cloud Data Flow.  An example of this is the worker applications launched by a Remote Batch Partitioned application.
+In such cases the Remote Batch Partitioned Application stores the external-execution-id for each of the worker applications, however no platform information is stored.
+So when Spring Cloud Data Flow has to stop a Remote Batch Partitioned application and its worker applications, you will need to specify the platform name as shown below:
+
+[source,bash]
+----
+dataflow:>task execution stop --ids 1 --platform myplatform
+Request to stop the task execution with id(s): 1 for platform myplatform has been submitted
+----
+
 [[spring-cloud-dataflow-task-events]]
 == Subscribing to Task/Batch Events
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -78,6 +78,14 @@ public interface TaskOperations {
 	void stop(String ids);
 
 	/**
+	 * Request the stop of a group {@link org.springframework.cloud.task.repository.TaskExecution}s.
+	 *
+	 * @param ids comma delimited set of {@link org.springframework.cloud.task.repository.TaskExecution} ids to stop.
+	 * @param platform the platform name where the task is executing.
+	 */
+	void stop(String ids, String platform);
+
+	/**
 	 * Destroy an existing task.
 	 *
 	 * @param name the name of the task

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -176,6 +176,13 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	@Override
+	public void stop(String ids, String platform) {
+		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
+		values.add("platform", platform);
+		restTemplate.postForLocation(executionLink.expand(ids).getHref(),values);
+	}
+
+	@Override
 	public void destroy(String name) {
 		restTemplate.delete(definitionLink.expand(name).getHref(), Collections.singletonMap("name", name));
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -49,6 +49,7 @@ import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -231,8 +232,14 @@ public class TaskExecutionController {
 	 */
 	@RequestMapping(value = "/{id}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)
-	public void stop(@PathVariable("id") Set<Long> ids) {
-		this.taskExecutionService.stopTaskExecution(ids);
+	public void stop(@PathVariable("id") Set<Long> ids,
+	@RequestParam(defaultValue = "", name="platform") String platform) {
+		if(StringUtils.hasText(platform)) {
+			this.taskExecutionService.stopTaskExecution(ids, platform);
+		}
+		else {
+			this.taskExecutionService.stopTaskExecution(ids);
+		}
 	}
 
 	private Page<TaskJobExecutionRel> getPageableRelationships(Page<TaskExecution> taskExecutions, Pageable pageable) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskExecutionService.java
@@ -69,4 +69,12 @@ public interface TaskExecutionService {
 	 * @param ids a set of ids for the task executions to be stopped.
 	 */
 	void stopTaskExecution(Set<Long> ids);
+
+	/**
+	 * Request the platform to stop the task executions for the ids provided.
+	 *
+	 * @param ids a set of ids for the task executions to be stopped.
+	 * @param platform The name of the platform where the tasks are executing.
+	 */
+	void stopTaskExecution(Set<Long> ids, String platform);
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -179,6 +179,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 		@Before
 		public void setupMocks() {
 			this.launcherRepository.save(new Launcher("default", "local", taskLauncher));
+			this.launcherRepository.save(new Launcher("MyPlatform", "local", taskLauncher));
+
 			taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
 			taskDefinitionRepository.findAll();
 		}
@@ -232,7 +234,21 @@ public abstract class DefaultTaskExecutionServiceTests {
 			executionIds.add(1L);
 			taskExecutionService.stopTaskExecution(executionIds);
 			String logEntries = outputCapture.toString();
-			assertTrue(logEntries.contains("Task execution stop request for id 1 has been submitted"));
+			assertTrue(logEntries.contains("Task execution stop request for id 1 for platform default has been submitted"));
+		}
+
+		@Test
+		@DirtiesContext
+		public void executeStopForSpecificPlatformTaskTest() {
+			initializeSuccessfulRegistry(appRegistry);
+			when(taskLauncher.launch(any())).thenReturn("0");
+			assertEquals(1L, this.taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>()));
+
+			Set<Long> executionIds = new HashSet<>(1);
+			executionIds.add(1L);
+			taskExecutionService.stopTaskExecution(executionIds, "MyPlatform");
+			String logEntries = outputCapture.toString();
+			assertTrue(logEntries.contains("Task execution stop request for id 1 for platform MyPlatform has been submitted"));
 		}
 
 		@Test
@@ -466,6 +482,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 		@Before
 		public void setupMocks() {
 			this.launcherRepository.save(new Launcher("default", "local", taskLauncher));
+			this.launcherRepository.save(new Launcher("MyPlatform", "local", taskLauncher));
 		}
 
 		@Test

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -65,7 +65,7 @@ public class TaskCommands implements CommandMarker {
 	private static final String PROPERTIES_OPTION = "properties";
 	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
 	private static final String ARGUMENTS_OPTION = "arguments";
-	private static final String PLATFORM_OPTION = "platformName";
+	private static final String PLATFORM_OPTION = "platform";
 
 	// Create Role
 
@@ -225,9 +225,20 @@ public class TaskCommands implements CommandMarker {
 	}
 
 	@CliCommand(value = STOP, help = "Stop executing tasks")
-	public String stop(@CliOption(key = { "", "ids" }, help = "the task execution id", mandatory = true) String ids) {
-		taskOperations().stop(ids);
-		return String.format("Request to stop the task execution with id(s): %s has been submitted", ids);
+	public String stop(@CliOption(key = { "", "ids" }, help = "the task execution id", mandatory = true) String ids,
+			@CliOption(key = {
+					PLATFORM_OPTION }, help = "the name of the platform where the task is executing") String platform) {
+
+		String message = null;
+		if(StringUtils.hasText(platform)) {
+			taskOperations().stop(ids, platform);
+			message = String.format("Request to stop the task execution with id(s): %s for platform %s has been submitted", ids, platform);
+		}
+		else {
+			taskOperations().stop(ids);
+			message = String.format("Request to stop the task execution with id(s): %s has been submitted", ids);
+		}
+		return message;
 	}
 
 	@CliCommand(value = LOG, help = "Retrieve task execution log")

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
@@ -176,6 +176,17 @@ public class TaskCommandTemplate {
 		return cr;
 	}
 
+	/**
+	 * Stop a task execution.
+	 *
+	 * @param id the id of a {@link org.springframework.cloud.task.repository.TaskExecution}
+	 * @param platform the name of the platform where the task is executing.
+	 */
+	public CommandResult stopForPlatform(long id, String platform) {
+		CommandResult cr = shell.executeCommand(String.format("task execution stop --ids %s --platform %s", id, platform));
+		return cr;
+	}
+
 
 	/**
 	 * Executes a task execution list.

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -187,6 +187,17 @@ public class TaskCommandTests extends AbstractShellIntegrationTest {
 	}
 
 	@Test
+	public void testExecutionStopWithPlatform() {
+		logger.info("Launching instance of task");
+		String taskName = generateUniqueStreamOrTaskName();
+		task().create(taskName, "timestamp");
+		long id = task().launch(taskName);
+		CommandResult cr = task().stopForPlatform(id, "default");
+		assertTrue(cr.toString().contains(
+				String.format("Request to stop the task execution with id(s): %s for platform %s has been submitted", id, "default")));
+	}
+
+	@Test
 	public void testExecutionStopInvalid() {
 		boolean isException = false;
 		try {


### PR DESCRIPTION
This is for those cases where user executes a task with a Spring Cloud Deployer outside SCDF and populates the external-execution-id
resolves #3382