### PR TITLE
Polish shell output

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
@@ -265,7 +265,6 @@ public class ConfigCommands implements CommandMarker, InitializingBean, Applicat
 
 		}
 		catch (Exception e) {
-			e.printStackTrace();
 			this.targetHolder.getTarget().setTargetException(e);
 			this.shell.setDataFlowOperations(null);
 			handleTargetException(this.targetHolder.getTarget());


### PR DESCRIPTION
- Remove stacktrace print which for some reason were left in
  place during original boot 2.2.x upgrade work.
- Fixes #3428