### PR TITLE
Use stream/task descriptions in shell

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamOperations.java
@@ -55,10 +55,11 @@ public interface StreamOperations {
 	 *
 	 * @param name the name of the stream
 	 * @param definition the stream definition DSL
+	 * @param description the description of the stream
 	 * @param deploy whether to deploy the stream after creating its definition
 	 * @return the new stream definition
 	 */
-	StreamDefinitionResource createStream(String name, String definition, boolean deploy);
+	StreamDefinitionResource createStream(String name, String definition, String description, boolean deploy);
 
 	/**
 	 * Deploy an already created stream.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/StreamTemplate.java
@@ -112,10 +112,11 @@ public class StreamTemplate implements StreamOperations {
 	}
 
 	@Override
-	public StreamDefinitionResource createStream(String name, String definition, boolean deploy) {
+	public StreamDefinitionResource createStream(String name, String definition, String description, boolean deploy) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		values.add("name", name);
 		values.add("definition", definition);
+		values.add("description", description);
 		values.add("deploy", Boolean.toString(deploy));
 		StreamDefinitionResource stream = restTemplate.postForObject(definitionsLink.expand().getHref(), values,
 				StreamDefinitionResource.class);

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -55,9 +55,10 @@ public interface TaskOperations {
 	 *
 	 * @param name the name of the task
 	 * @param definition the task definition DSL
+	 * @param description the description of the task definition
 	 * @return the task definition
 	 */
-	TaskDefinitionResource create(String name, String definition);
+	TaskDefinitionResource create(String name, String definition, String description);
 
 	/**
 	 * Launch an already created task.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -149,13 +149,13 @@ public class TaskTemplate implements TaskOperations {
 	}
 
 	@Override
-	public TaskDefinitionResource create(String name, String definition) {
+	public TaskDefinitionResource create(String name, String definition, String description) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("name", name);
 		values.add("definition", definition);
-		TaskDefinitionResource task = restTemplate.postForObject(definitionsLink.expand().getHref(), values,
-				TaskDefinitionResource.class);
-		return task;
+		values.add("description", description);
+        return restTemplate.postForObject(definitionsLink.expand().getHref(), values,
+                TaskDefinitionResource.class);
 	}
 
 	@Override
@@ -244,6 +244,5 @@ public class TaskTemplate implements TaskOperations {
 		}
 		String uriTemplate = this.validationLink.expand(taskDefinitionName).getHref();
 		return restTemplate.getForObject(uriTemplate, TaskAppStatusResource.class);
-
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
@@ -58,14 +59,17 @@ public class Stream {
 
 	private String definition;
 
+	private String description;
+
 	private DataFlowOperations client;
 
-	Stream(String name, List<StreamApplication> applications, String definition,
+	Stream(String name, List<StreamApplication> applications, String definition, String description,
 			DataFlowOperations client) {
 		this.name = name;
 		this.applications = applications;
 		this.definition = definition;
 		this.client = client;
+		this.description = description;
 	}
 
 	/**
@@ -73,6 +77,10 @@ public class Stream {
 	 */
 	public String getName() {
 		return name;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 
 	/**
@@ -108,7 +116,6 @@ public class Stream {
 	 * @param propertiesToUse application properties to update.
 	 */
 	public void update(Map<String, String> propertiesToUse) {
-
 		PackageIdentifier packageIdentifier = new PackageIdentifier();
 		packageIdentifier.setPackageName(this.name);
 		this.client.streamOperations().updateStream(this.name, this.name, packageIdentifier, propertiesToUse, false, null);
@@ -151,7 +158,7 @@ public class Stream {
 	public Map<Integer, String> history() {
 		Collection<Release> history = this.client.streamOperations().history(this.name);
 		return history.stream().collect(Collectors.toMap(
-				r -> r.getVersion(),
+				Release::getVersion,
 				r -> r.getInfo().getStatus().getStatusCode().toString().toLowerCase()));
 	}
 
@@ -173,7 +180,7 @@ public class Stream {
 		return resource.getStatus();
 	}
 
-	public static class StreamNameBuilder {
+	public static class StreamNameBuilder extends PropertyBuilder{
 
 		private String name;
 
@@ -183,10 +190,87 @@ public class Stream {
 
 		private String definition;
 
+		private String description;
+
 		StreamNameBuilder(String name, DataFlowOperations client) {
 			this.client = client;
 			Assert.hasLength(name, "Stream name can't be empty");
 			this.name = name;
+		}
+
+		/**
+		 * Appends a {@link StreamApplication} as a source for this stream
+		 * @param source - The {@link StreamApplication} being added
+		 * @return a {@link SourceBuilder} to continue the building of the Stream
+		 */
+		public SourceBuilder source(StreamApplication source) {
+			Assert.notNull(source, "Source application can't be null");
+			return new SourceBuilder(
+					source.type(StreamApplication.ApplicationType.SOURCE), this);
+		}
+
+		/**
+		 * Creates a Stream bypassing the fluent API and just using the provided
+		 * definition
+		 * @param definition the Stream definition to use
+		 * @return A {@link Stream} object
+		 */
+		public StreamDefinitionBuilder definition(String definition) {
+			Assert.hasLength(name, "Stream definition can't be empty");
+			this.definition = definition;
+			return new StreamDefinitionBuilder(this.name, this.client, this.description, this.definition);
+		}
+
+		public StreamDescriptionBuilder description(String description) {
+			this.description = description;
+			return new StreamDescriptionBuilder(this.name, this.description, this.client);
+		}
+
+		/**
+		 * Creates the Stream. This method will invoke the remote server and create a stream
+		 * @return StreamDefinition to allow deploying operations on the created Stream
+		 */
+		protected StreamDefinition create() {
+			return new StreamDefinition(this.name, this.client, this.definition, this.description,
+					this.applications);
+		}
+
+		protected void addApplication(StreamApplication application) {
+			if (contains(application)) {
+				throw new IllegalStateException(
+						"There's already an application with the same definition in this stream");
+			}
+			this.applications.add(application);
+		}
+
+		private boolean contains(StreamApplication application) {
+			for (StreamApplication app : this.applications) {
+				if (app.getType().equals(application.getType())
+						&& app.getIdentity().equals(application.getIdentity())) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	public static class StreamDescriptionBuilder extends PropertyBuilder {
+
+		private String name;
+
+		private List<StreamApplication> applications = new LinkedList<>();
+
+		private DataFlowOperations client;
+
+		private String definition;
+
+		private String description;
+
+		StreamDescriptionBuilder(String name, String description, DataFlowOperations client) {
+			this.client = client;
+			Assert.hasLength(name, "Stream name can't be empty");
+			this.name = name;
+			this.description = description;
 		}
 
 		/**
@@ -209,19 +293,19 @@ public class Stream {
 		public StreamDefinitionBuilder definition(String definiton) {
 			Assert.hasLength(name, "Stream definition can't be empty");
 			this.definition = definiton;
-			return new StreamDefinitionBuilder(this.name, this.client, this.definition);
+			return new StreamDefinitionBuilder(this.name, this.client, this.description, this.definition);
 		}
 
 		/**
 		 * Creates the Stream. This method will invoke the remote server and create a stream
 		 * @return StreamDefinition to allow deploying operations on the created Stream
 		 */
-		private StreamDefinition create() {
-			return new StreamDefinition(this.name, this.client, this.definition,
+		protected StreamDefinition create() {
+			return new StreamDefinition(this.name, this.client, this.definition, this.description,
 					this.applications);
 		}
 
-		private void addApplication(StreamApplication application) {
+		protected void addApplication(StreamApplication application) {
 			if (contains(application)) {
 				throw new IllegalStateException(
 						"There's already an application with the same definition in this stream");
@@ -248,11 +332,14 @@ public class Stream {
 
 		private String definition;
 
-		private StreamDefinitionBuilder(String name, DataFlowOperations client,
+		private String description;
+
+		private StreamDefinitionBuilder(String name, DataFlowOperations client, String description,
 				String definition) {
 			this.name = name;
 			this.client = client;
 			this.definition = definition;
+			this.description = description;
 		}
 
 		/**
@@ -260,14 +347,14 @@ public class Stream {
 		 * @return StreamDefinition to allow deploying operations on the created Stream
 		 */
 		public StreamDefinition create() {
-			return new StreamDefinition(this.name, this.client, this.definition,
+			return new StreamDefinition(this.name, this.client, this.definition, description,
 					Collections.emptyList());
 		}
 	}
 
 	public static class SourceBuilder extends BaseBuilder {
 
-		private SourceBuilder(StreamApplication source, StreamNameBuilder parent) {
+		private SourceBuilder(StreamApplication source, PropertyBuilder parent) {
 			super(source, parent);
 		}
 
@@ -298,7 +385,7 @@ public class Stream {
 	public static class ProcessorBuilder extends BaseBuilder {
 
 		private ProcessorBuilder(StreamApplication application,
-				StreamNameBuilder parent) {
+				PropertyBuilder parent) {
 			super(application, parent);
 		}
 
@@ -329,7 +416,7 @@ public class Stream {
 
 	public static class SinkBuilder extends BaseBuilder {
 
-		private SinkBuilder(StreamApplication application, StreamNameBuilder parent) {
+		private SinkBuilder(StreamApplication application, PropertyBuilder parent) {
 			super(application, parent);
 		}
 
@@ -339,18 +426,22 @@ public class Stream {
 
 	}
 
+	static abstract class PropertyBuilder {
+		protected abstract StreamDefinition create();
+
+		protected abstract void addApplication(StreamApplication application);
+	}
+
 	static abstract class BaseBuilder {
 
 		protected StreamApplication application;
 
-		protected StreamNameBuilder parent;
+		protected PropertyBuilder parent;
 
-		public BaseBuilder(StreamApplication application, StreamNameBuilder parent) {
+		public BaseBuilder(StreamApplication application, PropertyBuilder parent) {
 			this.application = application;
 			this.parent = parent;
 			this.parent.addApplication(application);
 		}
-
 	}
-
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.resource.StreamDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource;
@@ -221,6 +220,11 @@ public class Stream {
 			return new StreamDefinitionBuilder(this.name, this.client, this.description, this.definition);
 		}
 
+		/**
+		 * Sets the description of the stream.
+		 * @param description the description text
+		 * @return A {@link StreamDescriptionBuilder} object
+		 */
 		public StreamDescriptionBuilder description(String description) {
 			this.description = description;
 			return new StreamDescriptionBuilder(this.name, this.description, this.client);

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/Stream.java
@@ -191,10 +191,11 @@ public class Stream {
 
 		private String description;
 
-		StreamNameBuilder(String name, DataFlowOperations client) {
+		StreamNameBuilder(String name, String description, DataFlowOperations client) {
 			this.client = client;
 			Assert.hasLength(name, "Stream name can't be empty");
 			this.name = name;
+			this.description = description;
 		}
 
 		/**
@@ -351,7 +352,7 @@ public class Stream {
 		 * @return StreamDefinition to allow deploying operations on the created Stream
 		 */
 		public StreamDefinition create() {
-			return new StreamDefinition(this.name, this.client, this.definition, description,
+			return new StreamDefinition(this.name, this.client, this.definition, this.description,
 					Collections.emptyList());
 		}
 	}

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
@@ -28,7 +28,8 @@ public class StreamBuilder {
 
 	/**
 	 * Construct a new StreamBuilder given a {@link DataFlowOperations} instance.
-	 * @param dataFlowOperations the dataflowOperations instance used to communicate to the Data Flow server
+	 * @param dataFlowOperations the dataflowOperations instance used to communicate to the
+	 *     Data Flow server
 	 */
 	public StreamBuilder(DataFlowOperations dataFlowOperations) {
 		this.dataFlowOperations = dataFlowOperations;
@@ -37,7 +38,8 @@ public class StreamBuilder {
 	/**
 	 * Fluent API method to set the name of the stream.
 	 * @param name - The unique identifier of a Stream with the server
-	 * @return A {@link Stream.StreamNameBuilder} that provides the next navigation step in the DSL.
+	 * @return A {@link Stream.StreamNameBuilder} that provides the next navigation step in
+	 * the DSL.
 	 */
 	public Stream.StreamNameBuilder name(String name) {
 		return new Stream.StreamNameBuilder(name, dataFlowOperations);

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamBuilder.java
@@ -42,7 +42,7 @@ public class StreamBuilder {
 	 * the DSL.
 	 */
 	public Stream.StreamNameBuilder name(String name) {
-		return new Stream.StreamNameBuilder(name, dataFlowOperations);
+		return new Stream.StreamNameBuilder(name, "", dataFlowOperations);
 	}
 
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDefinition.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDefinition.java
@@ -16,7 +16,6 @@
 package org.springframework.cloud.dataflow.rest.client.dsl;
 
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDefinition.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDefinition.java
@@ -44,18 +44,21 @@ public class StreamDefinition {
 
 	private String definition;
 
-	private List<StreamApplication> applications = new LinkedList<>();
+	private String description;
 
-	public StreamDefinition(String name, DataFlowOperations client, String definition,
+	private List<StreamApplication> applications;
+
+	public StreamDefinition(String name, DataFlowOperations client, String definition, String description,
 			List<StreamApplication> applications) {
 		this.name = name;
 		this.client = client;
 		this.definition = definition;
+		this.description = description;
 		this.applications = applications;
 		if (StringUtils.isEmpty(definition)) {
 			createStreamDefinition();
 		}
-		this.client.streamOperations().createStream(this.name, this.definition,
+		this.client.streamOperations().createStream(this.name, this.definition, this.description,
 				false);
 	}
 
@@ -76,7 +79,7 @@ public class StreamDefinition {
 		Map<String, String> resolvedProperties = resolveDeploymentProperties(
 				deploymentProperties);
 		client.streamOperations().deploy(this.name, resolvedProperties);
-		return new Stream(this.name, this.applications, this.definition, this.client);
+		return new Stream(this.name, this.applications, this.definition, this.description, this.client);
 	}
 
 	/**
@@ -88,7 +91,6 @@ public class StreamDefinition {
 	}
 
 	private void createStreamDefinition() {
-		StringBuilder buffer = new StringBuilder();
 		this.definition = StringUtils.collectionToDelimitedString(applications,
 				" | ");
 	}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -151,7 +151,7 @@ public class StreamDslTests {
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
 		StreamApplication time = new StreamApplication("time");
 		StreamApplication log = new StreamApplication("log");
-		Stream.builder(client).name("ticktock").source(time).sink(log).create().deploy();
+		Stream.builder(client).name("ticktock").description("demo stream").source(time).sink(log).create().deploy();
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));
 		verify(streamOperations, times(1)).deploy(eq("ticktock"),
@@ -166,7 +166,7 @@ public class StreamDslTests {
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
 
-		Stream.builder(client).name("ticktock").definition("time | log")
+		Stream.builder(client).name("ticktock").description("demo stream").definition("time | log")
 				.create().deploy(Collections.singletonMap("deployer.log.count", "2"));
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));
@@ -189,7 +189,7 @@ public class StreamDslTests {
 			return null;
 		}).when(streamOperations).deploy(eq("ticktock"), anyMap());
 
-		StreamDefinition streamDefinition = Stream.builder(client).name("ticktock")
+		StreamDefinition streamDefinition = Stream.builder(client).name("ticktock").description("demo stream")
 				.definition("time | log").create();
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));
@@ -206,7 +206,7 @@ public class StreamDslTests {
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
 		StreamApplication time = new StreamApplication("time");
 		StreamApplication log = new StreamApplication("log");
-		Stream.builder(client).name("ticktock").source(time).sink(log).create();
+		Stream.builder(client).name("ticktock").description("demo stream").source(time).sink(log).create();
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));
 	}
@@ -237,7 +237,8 @@ public class StreamDslTests {
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
 
-		Stream stream = Stream.builder(client).name("ticktock").definition(ticktockDefinition.getDslText()).create()
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.definition(ticktockDefinition.getDslText()).create()
 				.deploy();
 
 		when(streamOperations.info(eq("ticktock"))).thenReturn(new StreamDeploymentResource("ticktock", "time | log"));
@@ -258,7 +259,8 @@ public class StreamDslTests {
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
 
-		Stream stream = Stream.builder(client).name("ticktock").definition(ticktockDefinition.getDslText()).create()
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.definition(ticktockDefinition.getDslText()).create()
 				.deploy();
 
 		when(streamOperations.info(eq("ticktock"))).thenReturn(new StreamDeploymentResource("ticktock", "time | log"));
@@ -277,7 +279,8 @@ public class StreamDslTests {
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
 
-		Stream stream = Stream.builder(client).name("ticktock").definition(ticktockDefinition.getDslText()).create()
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.definition(ticktockDefinition.getDslText()).create()
 				.deploy();
 
 		stream.manifest(666);
@@ -293,7 +296,8 @@ public class StreamDslTests {
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
 
-		Stream stream = Stream.builder(client).name("ticktock").definition(ticktockDefinition.getDslText()).create()
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.definition(ticktockDefinition.getDslText()).create()
 				.deploy();
 
 		stream.history();
@@ -310,7 +314,8 @@ public class StreamDslTests {
 		StreamApplication time = new StreamApplication("time");
 		StreamApplication log = new StreamApplication("log");
 
-		Stream stream = Stream.builder(client).name("ticktock").source(time).sink(log)
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.source(time).sink(log)
 				.create().deploy();
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));
@@ -330,7 +335,8 @@ public class StreamDslTests {
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
 		StreamApplication time = new StreamApplication("time");
 		StreamApplication log = new StreamApplication("log");
-		Stream stream = Stream.builder(client).name("ticktock").source(time).sink(log)
+		Stream stream = Stream.builder(client).name("ticktock").description("demo stream")
+				.source(time).sink(log)
 				.create().deploy();
 		verify(streamOperations, times(1)).createStream(
 				eq("ticktock"), eq("time | log"), eq("demo stream"), eq(false));

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -34,7 +34,16 @@ import org.springframework.cloud.dataflow.rest.resource.StreamDeploymentResource
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDeploymentResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDeploymentResource.java
@@ -38,6 +38,11 @@ public class StreamDeploymentResource extends RepresentationModel<StreamDeployme
 	private String dslText;
 
 	/**
+	 * Stream description text.
+	 */
+	private String description;
+
+	/**
 	 * Stream status (i.e. deployed, undeployed, etc).
 	 */
 	private String status;
@@ -68,6 +73,11 @@ public class StreamDeploymentResource extends RepresentationModel<StreamDeployme
 		this.status = status;
 	}
 
+	public StreamDeploymentResource(String streamName, String dslText, String description, String deploymentProperties, String status) {
+		this(streamName, dslText, deploymentProperties, status);
+		this.description = description;
+	}
+
 	public String getStreamName() {
 		return streamName;
 	}
@@ -82,6 +92,10 @@ public class StreamDeploymentResource extends RepresentationModel<StreamDeployme
 
 	public String getStatus() {
 		return status;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 
 	public static class Page extends PagedModel<StreamDeploymentResource> {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
@@ -152,7 +152,7 @@ public class DockerComposeIT {
 				.build());
 
 		assertThat(stream.getStatus(), is(DEPLOYING));
-		Wait.on(stream).until(s -> s.getStatus().equals(DEPLOYING) == false); //E.g. blocks until in `deploying` state.
+		Wait.on(stream).until(s -> !s.getStatus().equals(DEPLOYING)); //E.g. blocks until in `deploying` state.
 
 		assertThat(stream.getStatus(), is(DEPLOYED));
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -68,11 +68,11 @@ import org.springframework.util.StringUtils;
 @Component
 public class StreamCommands implements CommandMarker {
 
-	protected static final String PROPERTIES_OPTION = "properties";
-	protected static final String PROPERTIES_FILE_OPTION = "propertiesFile";
+	private static final String PROPERTIES_OPTION = "properties";
+	private static final String PROPERTIES_FILE_OPTION = "propertiesFile";
 
 	protected DataFlowShell dataFlowShell;
-	protected UserInput userInput;
+	private UserInput userInput;
 
 	// Create Role
 
@@ -258,8 +258,9 @@ public class StreamCommands implements CommandMarker {
 			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the stream") String name,
 			@CliOption(mandatory = true, key = { "definition" }, help = "a stream definition, using the DSL (e.g. "
 					+ "\"http --port=9000 | hdfs\")", optionContext = "disable-string-converter completion-stream") String dsl,
+			@CliOption(mandatory = false, key = {"description"}, help = "a sort description about the stream", unspecifiedDefaultValue = "") String description,
 			@CliOption(key = "deploy", help = "whether to deploy the stream immediately", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean deploy) {
-		streamOperations().createStream(name, dsl, deploy);
+		streamOperations().createStream(name, dsl, description, deploy);
 		String message = String.format("Created new stream '%s'", name);
 		if (deploy) {
 			message += "\nDeployment request has been sent";

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -274,6 +274,7 @@ public class StreamCommands implements CommandMarker {
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Stream Name");
 		headers.put("dslText", "Stream Definition");
+		headers.put("description", "Description");
 		headers.put("statusDescription", "Status");
 		BeanListTableModel<StreamDefinitionResource> model = new BeanListTableModel<>(streams, headers);
 		return DataFlowTables.applyStyle(new TableBuilder(model)).build();
@@ -285,9 +286,10 @@ public class StreamCommands implements CommandMarker {
 		List<Object> result = new ArrayList<>();
 		final StreamDeploymentResource stream = streamOperations().info(name);
 		TableModelBuilder<Object> modelBuilder = new TableModelBuilder<>();
-		modelBuilder.addRow().addValue("Stream Name").addValue("Stream Definition").addValue("Status");
+		modelBuilder.addRow().addValue("Stream Name").addValue("Stream Definition").addValue("Description").addValue("Status");
 		modelBuilder.addRow().addValue(stream.getStreamName())
 				.addValue(stream.getDslText())
+				.addValue(stream.getDescription())
 				.addValue(stream.getStatus());
 		TableBuilder builder = DataFlowTables.applyStyle(new TableBuilder(modelBuilder.build()));
 		result.add(builder.build());

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -132,6 +132,7 @@ public class TaskCommands implements CommandMarker {
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Task Name");
 		headers.put("dslText", "Task Definition");
+		headers.put("description", "description");
 		headers.put("status", "Task Status");
 		final TableBuilder builder = new TableBuilder(new BeanListTableModel<>(tasks, headers));
 		return DataFlowTables.applyStyle(builder).build();

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -185,8 +185,9 @@ public class TaskCommands implements CommandMarker {
 	public String create(
 			@CliOption(mandatory = true, key = { "", "name" }, help = "the name to give to the task") String name,
 			@CliOption(mandatory = true, key = { "definition" }, help = "a task definition, using the DSL (e.g. "
-					+ "\"timestamp --format=YYYY\")", optionContext = "disable-string-converter completion-task") String dsl) {
-		this.taskOperations().create(name, dsl);
+					+ "\"timestamp --format=YYYY\")", optionContext = "disable-string-converter completion-task") String dsl,
+			@CliOption(mandatory = false, key = {"description"}, help = "a sort description about the task", unspecifiedDefaultValue = "") String description) {
+		this.taskOperations().create(name, dsl, description);
 		return String.format("Created new task '%s'", name);
 	}
 


### PR DESCRIPTION
This PR contains the CLI part of the stream and task definition description feature:

As stream creator, I should be able to provide a description for a stream & task definition.
This can make it easy for a new joiner to know what is the purpose of the stream and task.

Resolves: #3430 