### PR TITLE
Persist original Stream Definition

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
@@ -80,6 +80,7 @@ public class StreamDefinitionsDocumentation extends BaseDocumentation {
 				responseFields(
 						fieldWithPath("name").description("The name of the created stream definition"),
 						fieldWithPath("dslText").description("The DSL of the created stream definition"),
+						fieldWithPath("originalDslText").description("The original DSL of the created stream definition"),
 						fieldWithPath("status").description("The status of the created stream definition"),
 						fieldWithPath("description").description("The description of the stream definition"),
 						fieldWithPath("statusDescription")
@@ -125,6 +126,7 @@ public class StreamDefinitionsDocumentation extends BaseDocumentation {
 				responseFields(
 					fieldWithPath("name").description("The name of the stream definition"),
 					fieldWithPath("dslText").description("The DSL of the stream definition"),
+					fieldWithPath("originalDslText").description("The original DSL of the stream definition"),
 					fieldWithPath("status").description("The status of the stream definition"),
 					fieldWithPath("description").description("The description of the stream definition"),
 					fieldWithPath("statusDescription")

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinition.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamDefinition.java
@@ -65,6 +65,13 @@ public class StreamDefinition {
 	private String dslText;
 
 	/**
+	 * Original DSL definition for stream.
+	 */
+	@Column(name = "ORIGINAL_DEFINITION")
+	@Lob
+	private String originalDslText;
+
+	/**
 	 * Custom description of the stream definition. (Optional)
 	 */
 	@Column(name = "DESCRIPTION")
@@ -91,6 +98,7 @@ public class StreamDefinition {
 		Assert.hasText(dslText, "dslText is required");
 		this.name = name;
 		this.dslText = dslText;
+		this.originalDslText = dslText;
 		this.applicationDefinitions = getAppDefinitions(name, dslText);
 	}
 
@@ -99,10 +107,16 @@ public class StreamDefinition {
 	 *
 	 * @param name name of stream
 	 * @param dslText DSL definition for stream
-	 * @param description custom description of the stream definition (Optional)
+	 * @param originalDslText the original DSL definition for stream
 	 */
-	public StreamDefinition(String name, String dslText, String description) {
+	public StreamDefinition(String name, String dslText, String originalDslText) {
 		this(name, dslText);
+		this.originalDslText = originalDslText;
+	}
+
+	public StreamDefinition(String name, String dslText, String originalDslText, String description) {
+		this(name, dslText);
+		this.originalDslText = originalDslText;
 		this.description = description;
 	}
 
@@ -118,10 +132,19 @@ public class StreamDefinition {
 	/**
 	 * Return the DSL definition for this stream.
 	 *
-	 * @return stream definition DSL
+	 * @return the stream definition DSL
 	 */
 	public String getDslText() {
 		return dslText;
+	}
+
+	/**
+	 * Return the Original DSL definition for this stream.
+	 *
+	 * @return the original stream definition DSL
+	 */
+	public String getOriginalDslText() {
+		return this.originalDslText;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -122,7 +122,7 @@ public class StreamDslTests {
 	@Test
 	public void definitionWithDeploymentPropertiesBuilder() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"tick: time | log", "demo stream");
+				"tick: time | log", "time | log", "demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
@@ -145,7 +145,7 @@ public class StreamDslTests {
 	@Test
 	public void deployWithCreate() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"time | log", "demo stream");
+				"time | log", "time | log","demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
@@ -161,7 +161,7 @@ public class StreamDslTests {
 	@Test
 	public void deployWithDefinition() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"time | log", "demo stream");
+				"time | log", "time | log","demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
@@ -178,7 +178,7 @@ public class StreamDslTests {
 	@Test
 	public void getStatus() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"time | log", "demo stream");
+				"time | log", "time | log","demo stream");
 		resource.setStatus("unknown");
 		when(streamOperations.getStreamDefinition(eq("ticktock")))
 				.thenReturn(resource);
@@ -200,7 +200,7 @@ public class StreamDslTests {
 	@Test
 	public void createStream() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"time | log", "demo stream");
+				"time | log", "time | log","demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
@@ -232,7 +232,7 @@ public class StreamDslTests {
 	@Test
 	public void update() {
 		StreamDefinitionResource ticktockDefinition = new StreamDefinitionResource("ticktock", "time | log",
-				"demo stream");
+				"time | log", "demo stream");
 		ticktockDefinition.setStatus("deploying");
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
@@ -254,7 +254,7 @@ public class StreamDslTests {
 	@Test
 	public void rollback() {
 		StreamDefinitionResource ticktockDefinition = new StreamDefinitionResource("ticktock", "time | log",
-				"demo stream");
+				"time | log", "demo stream");
 		ticktockDefinition.setStatus("deploying");
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
@@ -274,7 +274,7 @@ public class StreamDslTests {
 	@Test
 	public void manifest() {
 		StreamDefinitionResource ticktockDefinition = new StreamDefinitionResource("ticktock", "time | log",
-				"demo stream");
+				"time | log", "demo stream");
 		ticktockDefinition.setStatus("deploying");
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
@@ -291,7 +291,7 @@ public class StreamDslTests {
 	@Test
 	public void history() {
 		StreamDefinitionResource ticktockDefinition = new StreamDefinitionResource("ticktock", "time | log",
-				"demo stream");
+				"time | log", "demo stream");
 		ticktockDefinition.setStatus("deploying");
 		when(streamOperations.createStream(anyString(), anyString(), anyString(), anyBoolean()))
 				.thenReturn(ticktockDefinition);
@@ -307,7 +307,8 @@ public class StreamDslTests {
 
 	@Test
 	public void undeploy() {
-		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock", "time | log", "demo stream");
+		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock", "time | log",
+				"time | log", "demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);
@@ -329,7 +330,7 @@ public class StreamDslTests {
 	@Test
 	public void destroy() {
 		StreamDefinitionResource resource = new StreamDefinitionResource("ticktock",
-				"time | log", "demo stream");
+				"time | log", "time | log", "demo stream");
 		resource.setStatus("deploying");
 		when(streamOperations.createStream(anyString(),
 				anyString(), anyString(), anyBoolean())).thenReturn(resource);

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDefinitionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDefinitionResource.java
@@ -43,6 +43,11 @@ public class StreamDefinitionResource extends RepresentationModel<StreamDefiniti
 	private String dslText;
 
 	/**
+	 * Original Stream definition DSL text.
+	 */
+	private String originalDslText;
+
+	/**
 	 * Stream status (i.e. deployed, undeployed, etc).
 	 */
 	private String status;
@@ -70,9 +75,10 @@ public class StreamDefinitionResource extends RepresentationModel<StreamDefiniti
 	 * @param dslText stream definition DSL text
 	 * @param description Description of the stream definition
 	 */
-	public StreamDefinitionResource(String name, String dslText, String description) {
+	public StreamDefinitionResource(String name, String dslText, String originalDslText, String description) {
 		this.name = name;
 		this.dslText = dslText;
+		this.originalDslText = originalDslText;
 		this.description = description;
 	}
 
@@ -92,6 +98,15 @@ public class StreamDefinitionResource extends RepresentationModel<StreamDefiniti
 	 */
 	public String getDslText() {
 		return this.dslText;
+	}
+
+	/**
+	 * Return the original DSL definition for this stream.
+	 *
+	 * @return the original stream definition DSL
+	 */
+	public String getOriginalDslText() {
+		return this.originalDslText;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ArgumentSanitizer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ArgumentSanitizer.java
@@ -156,6 +156,16 @@ public class ArgumentSanitizer {
 	}
 
 	/**
+	 * Redacts sensitive property values in a stream.
+	 *
+	 * @param streamDefinition the stream definition to sanitize
+	 * @return Stream definition with the original DSL text that has sensitive data redacted.
+	 */
+	public String sanitizeOriginalStreamDsl(StreamDefinition streamDefinition) {
+		return sanitizeStream(new StreamDefinition(streamDefinition.getName(), streamDefinition.getOriginalDslText()));
+	}
+
+	/**
 	 * Redacts sensitive property values in a task.
 	 *
 	 * @param taskDefinition the task definition to sanitize

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -207,7 +207,7 @@ public class StreamDefinitionController {
 		@Override
 		public StreamDefinitionResource instantiateModel(StreamDefinition stream) {
 			final StreamDefinitionResource resource = new StreamDefinitionResource(stream.getName(),
-					new ArgumentSanitizer().sanitizeStream(stream), stream.getDescription());
+					new ArgumentSanitizer().sanitizeStream(stream), stream.getOriginalDslText(), stream.getDescription());
 			DeploymentState deploymentState = streamDeploymentStates.get(stream);
 			if (deploymentState != null) {
 				final DeploymentStateResource deploymentStateResource = ControllerUtils

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/StreamDefinitionController.java
@@ -207,7 +207,7 @@ public class StreamDefinitionController {
 		@Override
 		public StreamDefinitionResource instantiateModel(StreamDefinition stream) {
 			final StreamDefinitionResource resource = new StreamDefinitionResource(stream.getName(),
-					new ArgumentSanitizer().sanitizeStream(stream), stream.getOriginalDslText(), stream.getDescription());
+					new ArgumentSanitizer().sanitizeStream(stream), new ArgumentSanitizer().sanitizeOriginalStreamDsl(stream), stream.getDescription());
 			DeploymentState deploymentState = streamDeploymentStates.get(stream);
 			if (deploymentState != null) {
 				final DeploymentStateResource deploymentStateResource = ControllerUtils

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
@@ -38,6 +38,8 @@ public class V2_Add_Descriptions_And_OriginalDefinition extends BaseJavaMigratio
 	public final static String ALTER_TASK_DEFINITION_TABLE =
 			"alter table task_definitions add description varchar(255)";
 
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
@@ -45,6 +47,8 @@ public class V2_Add_Descriptions_And_OriginalDefinition extends BaseJavaMigratio
 		runner.execute(context.getConnection(), Arrays.asList(
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
-				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
+				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE),
+				SqlCommand.from(UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF)));
+		;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration.mysql;
+package org.springframework.cloud.dataflow.server.db.migration.db2;
 
 import java.util.Arrays;
 
@@ -25,15 +25,17 @@ import org.springframework.cloud.dataflow.server.db.migration.SqlCommandsRunner;
 
 /**
  * This migration class adds description column to stream_definitions and task_definitions
- * tables.
+ * tables and original_definition column to stream_definitions.
  *
  * @author Daniel Serleg
+ * @author Ilayaperumal Gopinathan
  */
-public class V2__Add_Descriptions extends BaseJavaMigration {
+public class V2_Add_Descriptions_And_OriginalDefinition extends BaseJavaMigration {
 
-	public final static String ALTER_STREAM_DEFINITION_TABLE = "alter table stream_definitions add description varchar(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_DESC = "alter table stream_definitions add description varchar(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF = "alter table stream_definitions add original_definition clob(255)";
 
-	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
+	public final static String ALTER_TASK_DEFINITION_TABLE =
 			"alter table task_definitions add description varchar(255)";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
@@ -41,7 +43,8 @@ public class V2__Add_Descriptions extends BaseJavaMigration {
 	@Override
 	public void migrate(Context context) throws Exception {
 		runner.execute(context.getConnection(), Arrays.asList(
-				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
 				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/db2/V2_Add_Descriptions_And_OriginalDefinition.java
@@ -38,7 +38,7 @@ public class V2_Add_Descriptions_And_OriginalDefinition extends BaseJavaMigratio
 	public final static String ALTER_TASK_DEFINITION_TABLE =
 			"alter table task_definitions add description varchar(255)";
 
-	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update stream_definitions set original_definition=definition";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration.db2;
+package org.springframework.cloud.dataflow.server.db.migration.mysql;
 
 import java.util.Arrays;
 
@@ -25,13 +25,16 @@ import org.springframework.cloud.dataflow.server.db.migration.SqlCommandsRunner;
 
 /**
  * This migration class adds description column to stream_definitions and task_definitions
- * tables.
+ * tables and original_definition column to stream_definitions.
  *
  * @author Daniel Serleg
+ * @author Ilayaperumal Gopinathan
  */
-public class V2__Add_Descriptions extends BaseJavaMigration {
+public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigration {
 
-	public final static String ALTER_STREAM_DEFINITION_TABLE = "alter table stream_definitions add description varchar(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_DESC = "alter table stream_definitions add description varchar(255)";
+
+	public final static String ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF = "alter table stream_definitions add original_definition longtext";
 
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
@@ -41,7 +44,8 @@ public class V2__Add_Descriptions extends BaseJavaMigration {
 	@Override
 	public void migrate(Context context) throws Exception {
 		runner.execute(context.getConnection(), Arrays.asList(
-				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
 				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,7 +39,7 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
 
-	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update stream_definitions set original_definition=definition";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/mysql/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,6 +39,8 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
 
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
@@ -46,6 +48,7 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 		runner.execute(context.getConnection(), Arrays.asList(
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
-				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
+				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE),
+				SqlCommand.from(UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,6 +39,9 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar2(255)";
 
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+
+
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
@@ -46,6 +49,8 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 		runner.execute(context.getConnection(), Arrays.asList(
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
-				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
+				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE),
+				SqlCommand.from(UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF)));
+
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration.postgresql;
+package org.springframework.cloud.dataflow.server.db.migration.oracle;
 
 import java.util.Arrays;
 
@@ -25,23 +25,27 @@ import org.springframework.cloud.dataflow.server.db.migration.SqlCommandsRunner;
 
 /**
  * This migration class adds description column to stream_definitions and task_definitions
- * tables.
+ * tables and original_definition column to stream_definitions.
  *
  * @author Daniel Serleg
+ * @author Ilayaperumal Gopinathan
  */
-public class V2__Add_Descriptions extends BaseJavaMigration {
+public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigration {
 
-	public final static String ALTER_STREAM_DEFINITION_TABLE = "alter table stream_definitions add column description varchar(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_DESC = "alter table stream_definitions add description varchar2(255)";
+
+	public final static String ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF = "alter table stream_definitions add original_definition clob";
 
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
-			"alter table task_definitions add column description varchar(255)";
+			"alter table task_definitions add description varchar2(255)";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
 	public void migrate(Context context) throws Exception {
 		runner.execute(context.getConnection(), Arrays.asList(
-				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
 				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,7 +39,7 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar2(255)";
 
-	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update stream_definitions set original_definition=definition";
 
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration.oracle;
+package org.springframework.cloud.dataflow.server.db.migration.postgresql;
 
 import java.util.Arrays;
 
@@ -25,23 +25,27 @@ import org.springframework.cloud.dataflow.server.db.migration.SqlCommandsRunner;
 
 /**
  * This migration class adds description column to stream_definitions and task_definitions
- * tables.
+ * tables and original_definition column to stream_definitions.
  *
  * @author Daniel Serleg
+ * @author Ilayaperumal Gopinathan
  */
-public class V2__Add_Descriptions extends BaseJavaMigration {
+public class V2__Add_Descriptions_OriginalDefinition extends BaseJavaMigration {
 
-	public final static String ALTER_STREAM_DEFINITION_TABLE = "alter table stream_definitions add description varchar2(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_DESC = "alter table stream_definitions add column description varchar(255)";
+
+	public final static String ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF = "alter table stream_definitions add column original_definition text";
 
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
-			"alter table task_definitions add description varchar2(255)";
+			"alter table task_definitions add column description varchar(255)";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
 	public void migrate(Context context) throws Exception {
 		runner.execute(context.getConnection(), Arrays.asList(
-				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
 				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
@@ -39,6 +39,9 @@ public class V2__Add_Descriptions_OriginalDefinition extends BaseJavaMigration {
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add column description varchar(255)";
 
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+
+
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
@@ -46,6 +49,8 @@ public class V2__Add_Descriptions_OriginalDefinition extends BaseJavaMigration {
 		runner.execute(context.getConnection(), Arrays.asList(
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
-				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
+				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE),
+				SqlCommand.from(UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF)));
+
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/postgresql/V2__Add_Descriptions_OriginalDefinition.java
@@ -39,7 +39,7 @@ public class V2__Add_Descriptions_OriginalDefinition extends BaseJavaMigration {
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add column description varchar(255)";
 
-	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update stream_definitions set original_definition=definition";
 
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -25,13 +25,16 @@ import org.springframework.cloud.dataflow.server.db.migration.SqlCommandsRunner;
 
 /**
  * This migration class adds description column to stream_definitions and task_definitions
- * tables.
+ * tables and original_definition column to stream_definitions.
  *
  * @author Daniel Serleg
+ * @author Ilayaperumal Gopinathan
  */
-public class V2__Add_Descriptions extends BaseJavaMigration {
+public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigration {
 
-	public final static String ALTER_STREAM_DEFINITION_TABLE = "alter table stream_definitions add description varchar(255)";
+	public final static String ALTER_STREAM_DEFINITION_TABLE_DESC = "alter table stream_definitions add description varchar(255)";
+
+	public final static String ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF = "alter table stream_definitions add original_definition varchar(MAX)";
 
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
@@ -41,7 +44,8 @@ public class V2__Add_Descriptions extends BaseJavaMigration {
 	@Override
 	public void migrate(Context context) throws Exception {
 		runner.execute(context.getConnection(), Arrays.asList(
-				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
+				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
 				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,7 +39,7 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
 
-	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update stream_definitions set original_definition=definition";
 
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/sqlserver/V2__Add_Descriptions_And_OriginalDefinition.java
@@ -39,6 +39,9 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 	public final static String ALTER_TASK_DEFINITION_TABLE = "" +
 			"alter table task_definitions add description varchar(255)";
 
+	public final static String UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF = "update table set original_definition=definition";
+
+
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();
 
 	@Override
@@ -46,6 +49,8 @@ public class V2__Add_Descriptions_And_OriginalDefinition extends BaseJavaMigrati
 		runner.execute(context.getConnection(), Arrays.asList(
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_DESC),
 				SqlCommand.from(ALTER_STREAM_DEFINITION_TABLE_ORIG_DEF),
-				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE)));
+				SqlCommand.from(ALTER_TASK_DEFINITION_TABLE),
+				SqlCommand.from(UPDATE_STREAM_DEFINITION_TABLE_ORIG_DEF)));
+
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -203,9 +203,9 @@ public class DefaultStreamService implements StreamService {
 			updatedStreamAppDefinitions.addLast(appDefinitionBuilder.build(streamDefinition.getName()));
 		}
 
-		String dslText = new StreamDefinitionToDslConverter().toDsl(updatedStreamAppDefinitions);
+		String updatedDslText = new StreamDefinitionToDslConverter().toDsl(updatedStreamAppDefinitions);
 
-		StreamDefinition updatedStreamDefinition = new StreamDefinition(streamName, dslText);
+		StreamDefinition updatedStreamDefinition = new StreamDefinition(streamName, updatedDslText, streamDefinition.getOriginalDslText());
 		logger.debug("Updated StreamDefinition: " + updatedStreamDefinition);
 
 		// TODO consider adding an explicit UPDATE method to the streamDefRepository
@@ -396,7 +396,7 @@ public class DefaultStreamService implements StreamService {
 
 	public StreamDefinition createStreamDefinition(String streamName, String dsl, String description) {
 		try {
-			return new StreamDefinition(streamName, dsl, description);
+			return new StreamDefinition(streamName, dsl, dsl, description);
 		}
 		catch (ParseException ex) {
 			throw new InvalidStreamDefinitionException(ex.getMessage());

--- a/spring-cloud-dataflow-server-core/src/main/resources/org/springframework/cloud/dataflow/server/db/migration/h2/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-dataflow-server-core/src/main/resources/org/springframework/cloud/dataflow/server/db/migration/h2/V1__INITIAL_SETUP.sql
@@ -37,6 +37,7 @@ create table audit_records (
 create table stream_definitions (
   definition_name varchar(255) not null,
   definition clob,
+  original_definition clob,
   description varchar(255),
   primary key (definition_name)
 );

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,5 +167,11 @@ public class ArgumentSanitizerTest {
 						+ "--twitter.credentials.access-token-secret=deteegdssa4466 | filter --expression='#jsonPath(payload,''$.lang'')==''en''' | "
 						+ "twitter-sentiment --vocabulary=https://dl.bintray.com/test --model-fetch=output/test --model=https://dl.bintray.com/test | "
 						+ "field-value-counter --field-name=sentiment --name=sentiment")));
+	}
+
+	@Test
+	public void testStreamSanitizeOriginalDsl() {
+		StreamDefinition streamDefinition = new StreamDefinition("test", "time --password='******' | log --password='******'", "time --password='******' | log");
+		Assert.assertEquals("time --password='******' | log", sanitizer.sanitizeOriginalStreamDsl(streamDefinition));
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -273,8 +273,8 @@ public class StreamCommands implements CommandMarker {
 		final PagedModel<StreamDefinitionResource> streams = streamOperations().list();
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Stream Name");
-		headers.put("dslText", "Stream Definition");
 		headers.put("description", "Description");
+		headers.put("originalDslText", "Stream Definition");
 		headers.put("statusDescription", "Status");
 		BeanListTableModel<StreamDefinitionResource> model = new BeanListTableModel<>(streams, headers);
 		return DataFlowTables.applyStyle(new TableBuilder(model)).build();


### PR DESCRIPTION
 - Currently,the stream DSL is updated by Skipper after successful deploy/update and this
causes the original DSL text updated with the DSL that has all the deployment properties etc.,
To avoid this, added a new column `ORIGINAL_DEFINITION`  in `STREAM_DEFINITIONS` table
 - This new column value is retrieved for the stream definition list
 - Added database related changes including migration code
 - Updated documentation and tests
 - The stream deployment properties can still be retrieved using `stream manifest`

Resolves #3429