### PR TITLE
K8s configurations for Prometheus RSocket Proxy

### DIFF
--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+spec:
+#  replicas: 3
+  selector:
+    matchLabels:
+      app: prometheus-proxy
+  template:
+    metadata:
+      labels:
+        app: prometheus-proxy
+    spec:
+      serviceAccountName: prometheus-proxy
+      containers:
+        - name: prometheus-proxy
+          image: micrometermetrics/prometheus-rsocket-proxy:latest
+          imagePullPolicy: Always
+          ports:
+            - name: scrape
+              containerPort: 8080
+            - name: rsocket
+              containerPort: 7001
+          resources:
+            limits:
+              cpu: 1.0
+              memory: 2048Mi
+            requests:
+              cpu: 0.5
+              memory: 1024Mi
+#            requests:
+#              cpu: "2"
+#              memory: "1000Mi"
+#          args:
+#            - -cpus
+#            - "2"
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-service.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+spec:
+  selector:
+    app: prometheus-proxy
+  ports:
+    - name: scrape
+      port: 8080
+      targetPort: 8080
+    - name: rsocket
+      port: 7001
+      targetPort: 7001
+  type: LoadBalancer

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-serviceaccount.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+  namespace: default

--- a/src/kubernetes/prometheus/prometheus-configmap.yaml
+++ b/src/kubernetes/prometheus/prometheus-configmap.yaml
@@ -7,33 +7,41 @@ metadata:
 data:
   prometheus.yml: |-
     global:
-      scrape_interval: 15s
-      evaluation_interval: 15s
-    rule_files:
-      - /etc/prometheus/prometheus.rules
+      scrape_interval: 10s
+      scrape_timeout: 9s
+      evaluation_interval: 10s
+
     scrape_configs:
-      - job_name: 'kubernetes-pods'
-        kubernetes_sd_configs:
+    - job_name: 'proxied-applications'
+      metrics_path: '/metrics/connected'
+      kubernetes_sd_configs:
         - role: pod
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          namespaces:
+            names:
+              - default
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app]
           action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
+          regex: prometheus-proxy
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          action: keep
+          regex: 8080
+    - job_name: 'proxies'
+      metrics_path: '/metrics/proxy'
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - default
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex: prometheus-proxy
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          action: keep
+          regex: 8080
         - action: labelmap
           regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: kubernetes_pod_name
-

--- a/src/kubernetes/prometheus/prometheus-deployment.yaml
+++ b/src/kubernetes/prometheus/prometheus-deployment.yaml
@@ -15,12 +15,14 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.6.0
+          image: prom/prometheus:v2.12.0
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--web.enable-lifecycle"
           ports:
-            - containerPort: 9090
+            - name: prometheus
+              containerPort: 9090
           volumeMounts:
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/

--- a/src/kubernetes/server/server-config.yaml
+++ b/src/kubernetes/server/server-config.yaml
@@ -16,15 +16,20 @@ data:
                   export:
                     prometheus:
                       enabled: true
-                endpoints:
-                  web:
-                    exposure:
-                      include: 'prometheus,info,health'
-              spring:
-                cloud:
-                  streamapp:
-                    security:
-                      enabled: false
+                      rsocket:
+                        enabled: true
+                        host: prometheus-proxy
+                        port: 7001
+            task:
+              management:
+                metrics:
+                  export:
+                    prometheus:
+                      enabled: true
+                      rsocket:
+                        enabled: true
+                        host: prometheus-proxy
+                        port: 7001
           grafana-info:
             url: 'https://grafana:3000'
           task:


### PR DESCRIPTION
 - Add prometheus-proxy k8s configuration.
 - Update prometheus configuration to use the proxy as targets.
 - Update the server's app configuration to enable Stream/Task prometheus-rsocket metrics registry.

  Resolves #3449