### PR TITLE
Preserve stream description upon update

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -205,7 +205,8 @@ public class DefaultStreamService implements StreamService {
 
 		String updatedDslText = new StreamDefinitionToDslConverter().toDsl(updatedStreamAppDefinitions);
 
-		StreamDefinition updatedStreamDefinition = new StreamDefinition(streamName, updatedDslText, streamDefinition.getOriginalDslText());
+		StreamDefinition updatedStreamDefinition = new StreamDefinition(streamName, updatedDslText,
+				streamDefinition.getOriginalDslText(), streamDefinition.getDescription());
 		logger.debug("Updated StreamDefinition: " + updatedStreamDefinition);
 
 		// TODO consider adding an explicit UPDATE method to the streamDefRepository

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
@@ -208,7 +208,7 @@ public class DefaultStreamServiceIntegrationTests {
 
 		// Create stream
 		StreamDefinition streamDefinition = new StreamDefinition("ticktock",
-				"time --fixed-delay=100 | log --level=DEBUG");
+				"time --fixed-delay=100 | log --level=DEBUG", "time | log", "demo");
 		this.streamDefinitionRepository.deleteById(streamDefinition.getName());
 		this.streamDefinitionRepository.save(streamDefinition);
 
@@ -219,6 +219,7 @@ public class DefaultStreamServiceIntegrationTests {
 		StreamDefinition streamDefinitionBeforeDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionBeforeDeploy.getDslText())
 				.isEqualTo("time --fixed-delay=100 | log --level=DEBUG");
+		assertThat(streamDefinitionBeforeDeploy.getDescription()).isEqualTo("demo");
 
 		String expectedReleaseManifest = StreamUtils.copyToString(
 				TestResourceUtils.qualifiedResource(getClass(), "upgradeManifest.yml").getInputStream(),
@@ -237,6 +238,8 @@ public class DefaultStreamServiceIntegrationTests {
 		StreamDefinition streamDefinitionAfterDeploy = this.streamDefinitionRepository.findById("ticktock").get();
 		assertThat(streamDefinitionAfterDeploy.getDslText())
 				.isEqualTo("time --trigger.fixed-delay=200 | log --log.level=INFO");
+		assertThat(streamDefinitionAfterDeploy.getOriginalDslText()).isEqualTo("time | log");
+		assertThat(streamDefinitionAfterDeploy.getDescription()).isEqualTo("demo");
 	}
 
 	@Test


### PR DESCRIPTION
 - When the stream definition is updated after the successful update, the stream description needs to be updated as well.
 - Add test to check

Resolves #3486