### PR TITLE
gh-3502 Add `/favicon.ico` to `permit-all-paths`

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientProperties.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientProperties.java
@@ -81,6 +81,9 @@ public class DataFlowClientProperties {
 
 		private Basic basic = new Basic();
 
+		/**
+		 * OAuth2 Access Token.
+		 */
 		private String accessToken;
 
 		public String getAccessToken() {

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -70,7 +70,7 @@ spring:
         authorization:
           enabled: true
           loginUrl: "/"
-          permit-all-paths: "/authenticate,/security/info,/assets/**,/dashboard/logout-success-oauth.html"
+          permit-all-paths: "/authenticate,/security/info,/assets/**,/dashboard/logout-success-oauth.html,/favicon.ico"
           rules:
             # About
 


### PR DESCRIPTION
- Add `/favicon.ico` to `permit-all-paths` in the Data Flow default security settings
- Also polish comment on DataFlowClientProperties

resolves https://github.com/spring-cloud/spring-cloud-dataflow/issues/3502