### PR TITLE
Retrieve log for latest task execution on CF

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -388,6 +388,27 @@ public abstract class DefaultTaskExecutionServiceTests {
 					this.taskExecutionService.getLog(platformName, taskDeploymentId));
 		}
 
+		@Test
+		@DirtiesContext
+		public void getCFTaskLogByTaskIdOtherThanLatest() {
+			String taskName = "test-task";
+			String platformName = "cf-test-platform";
+			String taskDeploymentId = "12345";
+			TaskDeployment taskDeployment = new TaskDeployment();
+			taskDeployment.setPlatformName(platformName);
+			taskDeployment.setTaskDeploymentId(taskDeploymentId);
+			taskDeployment.setTaskDefinitionName(taskName);
+			this.taskDeploymentRepository.save(taskDeployment);
+			TaskExecution taskExecution = new TaskExecution();
+			taskExecution.setStartTime(new Date());
+			taskExecution.setTaskName(taskName);
+			taskExecution.setExternalExecutionId("12346");
+			this.taskRepository.createTaskExecution(taskExecution);
+			this.launcherRepository.save(new Launcher(platformName,
+					TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
+			assertEquals("", this.taskExecutionService.getLog(platformName, taskDeploymentId));
+		}
+
 
 		@Test
 		@DirtiesContext


### PR DESCRIPTION
 - Since Cloud Foundry manages task executions by the given task name, the
log retrieval needs to be limited only to the latest acceptable task execution only.
 - Make sure to check the task execution is the latest when retrieving the logs in case of CF
 - Update tests

Resolves #3515