### PR TITLE
Add Scheduling to CI/CD Task Effort

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
@@ -57,7 +56,6 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 	}
 
 	@Test
-	@Ignore
 	public void createSchedule() throws Exception {
 		this.mockMvc.perform(
 				post("/tasks/schedules")

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskDefinition.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskDefinition.java
@@ -220,7 +220,6 @@ public class TaskDefinition extends DataFlowAppDefinition {
 
 		private String taskName;
 
-
 		/**
 		 * Create a new builder that is initialized with properties of the given
 		 * definition. Useful for "mutating" a definition by building a slightly different

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/SchedulerOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/SchedulerOperations.java
@@ -35,10 +35,10 @@ public interface SchedulerOperations {
 	 * platform specific scheduler.  To setup the task with the scheduler set
 	 * the properties required to process the schedule within the taskProperties map.
 	 * Each scheduler property should be prefixed with
-	 * {@value org.springframework.cloud.scheduler.spi.core.SchedulerPropertyKeys#PREFIX}.
+	 * {@value org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys#PREFIX}.
 	 * The schedule expression (cron for example)
 	 * are specified within the task properties using the
-	 * {@value org.springframework.cloud.scheduler.spi.core.SchedulerPropertyKeys#CRON_EXPRESSION} as the key
+	 * {@value org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys#CRON_EXPRESSION} as the key
 	 * and the associated value would be the cron expression to be used.
 	 *
 	 * @param scheduleName A name to be associated with the schedule.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/SchedulerService.java
@@ -36,10 +36,10 @@ public interface SchedulerService {
 	 * platform specific scheduler.  To setup the task with the scheduler set
 	 * the properties required to process the schedule within the taskProperties map.
 	 * Each scheduler property should be prefixed with
-	 * {@value org.springframework.cloud.scheduler.spi.core.SchedulerPropertyKeys#PREFIX}.
+	 * {@value org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys#PREFIX}.
 	 * The schedule expression (cron for example)
 	 * are specified within the task properties using the
-	 * {@value org.springframework.cloud.scheduler.spi.core.SchedulerPropertyKeys#CRON_EXPRESSION} as the key
+	 * {@value org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys#CRON_EXPRESSION} as the key
 	 * and the associated value would be the cron expression to be used.
 	 *
 	 * @param scheduleName A name to be associated with the schedule.
@@ -57,6 +57,13 @@ public interface SchedulerService {
 	 * @param scheduleName the name of the schedule to be removed.
 	 */
 	void unschedule(String scheduleName);
+
+	/**
+	 *  Unschedule all schedules that have been created for this task definition name.
+	 *
+	 * @param taskDefinitionName the name of the task definition.
+	 */
+	void unscheduleForTaskDefinition(String taskDefinitionName);
 
 	/**
 	 * List all of the Schedules associated with the provided TaskDefinition.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -344,25 +344,13 @@ public class DefaultSchedulerService implements SchedulerService {
 	protected Resource getTaskLauncherResource() {
 		final URI url;
 		try {
-			url = new URI(getSchedulerTaskLauncherURL());
+			url = new URI(this.taskConfigurationProperties.getSchedulerTaskLauncherUrl());
 		} catch (URISyntaxException urise) {
 			throw new IllegalStateException(urise);
 		}
 
 		AppRegistration appRegistration = new AppRegistration(this.taskConfigurationProperties.getSchedulerTaskLauncherName(), ApplicationType.app, url);
 		return this.registry.getAppResource(appRegistration);
-	}
-
-	private String getSchedulerTaskLauncherURL() {
-		final String VERSION_TAG = "{version}";
-		String url = this.taskConfigurationProperties.getSchedulerTaskLauncherUrl();
-		if (!StringUtils.hasText(url)) {
-			throw new IllegalStateException("Scheduler Task Launcher URL must be specified");
-		}
-		if (url.contains(VERSION_TAG)) {
-			url = StringUtils.replace(url, VERSION_TAG, this.taskConfigurationProperties.getVersion());
-		}
-		return url;
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -344,13 +344,25 @@ public class DefaultSchedulerService implements SchedulerService {
 	protected Resource getTaskLauncherResource() {
 		final URI url;
 		try {
-			url = new URI(this.taskConfigurationProperties.getSchedulerTaskLauncherUrl());
+			url = new URI(getSchedulerTaskLauncherURL());
 		} catch (URISyntaxException urise) {
 			throw new IllegalStateException(urise);
 		}
 
 		AppRegistration appRegistration = new AppRegistration(this.taskConfigurationProperties.getSchedulerTaskLauncherName(), ApplicationType.app, url);
 		return this.registry.getAppResource(appRegistration);
+	}
+
+	private String getSchedulerTaskLauncherURL() {
+		final String VERSION_TAG = "{version}";
+		String url = this.taskConfigurationProperties.getSchedulerTaskLauncherUrl();
+		if (!StringUtils.hasText(url)) {
+			throw new IllegalStateException("Scheduler Task Launcher URL must be specified");
+		}
+		if (url.contains(VERSION_TAG)) {
+			url = StringUtils.replace(url, VERSION_TAG, this.taskConfigurationProperties.getVersion());
+		}
+		return url;
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -50,7 +50,7 @@ public class TaskConfigurationProperties {
 	/**
 	 * The URI of the resource to be used for launching apps via a schedule.
 	 */
-	private String schedulerTaskLauncherUrl = "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:2.3.0.BUILD-SNAPSHOT";
+	private String schedulerTaskLauncherUrl;
 	/**
 	 * The prefix to be applied to schedule names.
 	 */
@@ -60,6 +60,11 @@ public class TaskConfigurationProperties {
 	 * The prefix to attach to the application properties to be sent to the schedule task launcher.
 	 */
 	private String taskLauncherPrefix = "tasklauncher.";
+
+	/**
+	 * The Spring Cloud Data Flow version.
+	 */
+	private String version;
 
 	public String getComposedTaskRunnerName() {
 		return composedTaskRunnerName;
@@ -99,5 +104,13 @@ public class TaskConfigurationProperties {
 
 	public void setSchedulerTaskLauncherUrl(String schedulerTaskLauncherUrl) {
 		this.schedulerTaskLauncherUrl = schedulerTaskLauncherUrl;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -61,11 +61,6 @@ public class TaskConfigurationProperties {
 	 */
 	private String taskLauncherPrefix = "tasklauncher.";
 
-	/**
-	 * The Spring Cloud Data Flow version.
-	 */
-	private String version;
-
 	public String getComposedTaskRunnerName() {
 		return composedTaskRunnerName;
 	}
@@ -104,13 +99,5 @@ public class TaskConfigurationProperties {
 
 	public void setSchedulerTaskLauncherUrl(String schedulerTaskLauncherUrl) {
 		this.schedulerTaskLauncherUrl = schedulerTaskLauncherUrl;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -41,8 +41,25 @@ public class TaskConfigurationProperties {
 	@NotBlank
 	private String composedTaskRunnerName = "composed-task-runner";
 
+	/**
+	 * The schedule application name to be used for the scheduler task launcher.
+	 */
 	@NotBlank
 	private String schedulerTaskLauncherName = "scheduler-task-launcher";
+
+	/**
+	 * The URI of the resource to be used for launching apps via a schedule.
+	 */
+	private String schedulerTaskLauncherUrl = "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:2.3.0.BUILD-SNAPSHOT";
+	/**
+	 * The prefix to be applied to schedule names.
+	 */
+	private String scheduleNamePrefix = "scdf-";
+
+	/**
+	 * The prefix to attach to the application properties to be sent to the schedule task launcher.
+	 */
+	private String taskLauncherPrefix = "tasklauncher.";
 
 	public String getComposedTaskRunnerName() {
 		return composedTaskRunnerName;
@@ -58,5 +75,29 @@ public class TaskConfigurationProperties {
 
 	public void setSchedulerTaskLauncherName(String schedulerTaskLauncherName) {
 		this.schedulerTaskLauncherName = schedulerTaskLauncherName;
+	}
+
+	public String getScheduleNamePrefix() {
+		return scheduleNamePrefix;
+	}
+
+	public void setScheduleNamePrefix(String scheduleNamePrefix) {
+		this.scheduleNamePrefix = scheduleNamePrefix;
+	}
+
+	public String getTaskLauncherPrefix() {
+		return taskLauncherPrefix;
+	}
+
+	public void setTaskLauncherPrefix(String taskLauncherPrefix) {
+		this.taskLauncherPrefix = taskLauncherPrefix;
+	}
+
+	public String getSchedulerTaskLauncherUrl() {
+		return schedulerTaskLauncherUrl;
+	}
+
+	public void setSchedulerTaskLauncherUrl(String schedulerTaskLauncherUrl) {
+		this.schedulerTaskLauncherUrl = schedulerTaskLauncherUrl;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -125,9 +125,8 @@ public class TaskServiceUtils {
 			builder.setProperty("spring.datasource.password", dataSourceProperties.getPassword());
 		}
 		builder.setProperty("spring.datasource.driverClassName", dataSourceProperties.getDriverClassName());
-		builder.setDslText(taskDefinition.getDslText());
 		builder.setTaskName(taskDefinition.getTaskName());
-
+		builder.setDslText(taskDefinition.getDslText());
 		return builder.build();
 	}
 
@@ -139,7 +138,7 @@ public class TaskServiceUtils {
 	 */
 	public static Map<String, String> extractAppProperties(String name, Map<String, String> taskDeploymentProperties) {
 		Assert.hasText(name, "name must not be empty or null");
-		Assert.notNull(taskDeploymentProperties, "taskDeploymentProoperties must not be null");
+		Assert.notNull(taskDeploymentProperties, "taskDeploymentProperties must not be null");
 		return extractPropertiesByPrefix("app", name, taskDeploymentProperties);
 	}
 
@@ -168,10 +167,15 @@ public class TaskServiceUtils {
 
 	public static void updateDataFlowUriIfNeeded(String dataflowServerUri,
 			Map<String, String> appDeploymentProperties, List<String> commandLineArgs) {
+		updateDataFlowUriIfNeeded(DATAFLOW_SERVER_URI_KEY, dataflowServerUri, appDeploymentProperties, commandLineArgs);
+	}
+
+	public static void updateDataFlowUriIfNeeded(String dataFlowServerUriKey, String dataflowServerUri,
+			Map<String, String> appDeploymentProperties, List<String> commandLineArgs) {
 		Assert.notNull(appDeploymentProperties, "appDeploymentProperties must not be null");
 		Assert.notNull(commandLineArgs, "commandLineArgs must not be null");
 		if (!StringUtils.isEmpty(dataflowServerUri)) {
-			RelaxedNames relaxedNames = new RelaxedNames(DATAFLOW_SERVER_URI_KEY);
+			RelaxedNames relaxedNames = new RelaxedNames(dataFlowServerUriKey);
 			boolean isPutDataFlowServerUriKey = true;
 			for (String dataFlowUriKey : relaxedNames) {
 				if (appDeploymentProperties.containsKey(dataFlowUriKey)) {
@@ -185,7 +189,7 @@ public class TaskServiceUtils {
 				}
 			}
 			if(isPutDataFlowServerUriKey) {
-				appDeploymentProperties.put(DATAFLOW_SERVER_URI_KEY, dataflowServerUri);
+				appDeploymentProperties.put(dataFlowServerUriKey, dataflowServerUri);
 			}
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -67,8 +67,7 @@ spring:
             checksum-sha1-url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar.sha1"
             checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar.sha256"
       task:
-        version: "@project.version@"
-        scheduler-task-launcher-url: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:{version}"
+        scheduler-task-launcher-url: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:@project.version@"
       security:
         authorization:
           enabled: true

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -66,6 +66,9 @@ spring:
             url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar"
             checksum-sha1-url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar.sha1"
             checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar.sha256"
+      task:
+        version: "@project.version@"
+        scheduler-task-launcher-url: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:{version}"
       security:
         authorization:
           enabled: true

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -71,6 +72,7 @@ import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExec
 import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionMetadataDao;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
+import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.cloud.dataflow.server.service.TaskDeleteService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionCreationService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoService;
@@ -88,6 +90,7 @@ import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentR
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.batch.listener.TaskBatchDao;
 import org.springframework.cloud.task.batch.listener.support.JdbcTaskBatchDao;
@@ -103,6 +106,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
@@ -217,12 +222,15 @@ public class JobDependencies {
 			AuditRecordService auditRecordService,
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowJobExecutionDao dataflowJobExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			SchedulerService schedulerService) {
+
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
 				auditRecordService, dataflowTaskExecutionDao,
 				dataflowJobExecutionDao,
-				dataflowTaskExecutionMetadataDao);
+				dataflowTaskExecutionMetadataDao,
+				schedulerService);
 	}
 
 	@Bean
@@ -386,5 +394,49 @@ public class JobDependencies {
 		}
 		return new JdbcDataflowTaskExecutionMetadataDao(dataSource, incrementerFactory.getIncrementer(databaseType,
 				"task_execution_metadata_seq"), context);
+	}
+	@Bean
+	public SchedulerService schedulerService() {
+		return new SchedulerService() {
+			@Override
+			public void schedule(String scheduleName, String taskDefinitionName, Map<String, String> taskProperties, List<String> commandLineArgs) {
+
+			}
+
+			@Override
+			public void unschedule(String scheduleName) {
+
+			}
+
+			@Override
+			public void unscheduleForTaskDefinition(String taskDefinitionName) {
+
+			}
+
+			@Override
+			public List<ScheduleInfo> list(Pageable pageable, String taskDefinitionName) {
+				return null;
+			}
+
+			@Override
+			public Page<ScheduleInfo> list(Pageable pageable) {
+				return null;
+			}
+
+			@Override
+			public List<ScheduleInfo> list(String taskDefinitionName) {
+				return null;
+			}
+
+			@Override
+			public List<ScheduleInfo> list() {
+				return null;
+			}
+
+			@Override
+			public ScheduleInfo getSchedule(String scheduleName) {
+				return null;
+			}
+		};
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -299,14 +299,14 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	public SchedulerService schedulerService(CommonApplicationProperties commonApplicationProperties,
 											 TaskPlatform taskPlatform, TaskDefinitionRepository taskDefinitionRepository,
 											 AppRegistryService registry, ResourceLoader resourceLoader,
-											 DataSourceProperties dataSourceProperties,
 											 ApplicationConfigurationMetadataResolver metaDataResolver,
 											 SchedulerServiceProperties schedulerServiceProperties,
-											 AuditRecordService auditRecordService) {
+											 AuditRecordService auditRecordService,
+											 TaskConfigurationProperties taskConfigurationProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				taskPlatform, taskDefinitionRepository,
 				registry, resourceLoader,
-				new TaskConfigurationProperties(), null,
+				taskConfigurationProperties, null,
 				metaDataResolver, schedulerServiceProperties, auditRecordService);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.mockito.Mockito;
+
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.item.database.support.DataFieldMaxValueIncrementerFactory;
 import org.springframework.batch.item.database.support.DefaultDataFieldMaxValueIncrementerFactory;
@@ -159,6 +161,20 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
+	public DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao(DataSource dataSource, ApplicationContext context) {
+		DataFieldMaxValueIncrementerFactory incrementerFactory = new DefaultDataFieldMaxValueIncrementerFactory(dataSource);
+		String databaseType;
+		try {
+			databaseType = DatabaseType.fromMetaData(dataSource).name();
+		}
+		catch (MetaDataAccessException e) {
+			throw new IllegalStateException(e);
+		}
+		return new JdbcDataflowTaskExecutionMetadataDao(dataSource, incrementerFactory.getIncrementer(databaseType,
+				"task_execution_metadata_seq"), context);
+	}
+
+	@Bean
 	public DataflowJobExecutionDao dataflowJobExecutionDao(DataSource dataSource) {
 		return new JdbcDataflowJobExecutionDao(dataSource, AbstractJdbcBatchMetadataDao.DEFAULT_TABLE_PREFIX);
 	}
@@ -217,13 +233,16 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 			AuditRecordService auditRecordService,
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowJobExecutionDao dataflowJobExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			SchedulerService schedulerService) {
+
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
 				auditRecordService,
 				dataflowTaskExecutionDao,
 				dataflowJobExecutionDao,
-				dataflowTaskExecutionMetadataDao);
+				dataflowTaskExecutionMetadataDao,
+				schedulerService);
 	}
 
 	@Bean
@@ -287,36 +306,22 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				taskPlatform, taskDefinitionRepository,
 				registry, resourceLoader,
-				new TaskConfigurationProperties(),
-				dataSourceProperties, null,
+				new TaskConfigurationProperties(), null,
 				metaDataResolver, schedulerServiceProperties, auditRecordService);
 	}
 
 	@Bean
 	public TaskPlatform taskPlatform(Scheduler scheduler) {
-		Launcher launcher = new Launcher("default", "defaultType", null, scheduler);
+		Launcher launcher = new Launcher("default", "defaultType", Mockito.mock(TaskLauncher.class), scheduler);
 		List<Launcher> launchers = new ArrayList<>();
 		launchers.add(launcher);
 		TaskPlatform taskPlatform = new TaskPlatform("testTaskPlatform", launchers);
 		return taskPlatform;
 	}
 
+
 	@Bean
 	public Scheduler scheduler() {
 		return new SimpleTestScheduler();
-	}
-
-	@Bean
-	public DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao(DataSource dataSource, ApplicationContext context) {
-		DataFieldMaxValueIncrementerFactory incrementerFactory = new DefaultDataFieldMaxValueIncrementerFactory(dataSource);
-		String databaseType;
-		try {
-			databaseType = DatabaseType.fromMetaData(dataSource).name();
-		}
-		catch (MetaDataAccessException e) {
-			throw new IllegalStateException(e);
-		}
-		return new JdbcDataflowTaskExecutionMetadataDao(dataSource, incrementerFactory.getIncrementer(databaseType,
-				"task_execution_metadata_seq"), context);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -552,12 +552,12 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	public SchedulerService schedulerService(CommonApplicationProperties commonApplicationProperties,
 											 TaskPlatform taskPlatform, TaskDefinitionRepository taskDefinitionRepository,
 											 AppRegistryService registry, ResourceLoader resourceLoader,
-											 DataSourceProperties dataSourceProperties,
-											 ApplicationConfigurationMetadataResolver metaDataResolver, AuditRecordService auditRecordService) {
+											 ApplicationConfigurationMetadataResolver metaDataResolver, AuditRecordService auditRecordService,
+											 TaskConfigurationProperties taskConfigurationProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				taskPlatform, taskDefinitionRepository,
 				registry, resourceLoader,
-				new TaskConfigurationProperties(), null,
+				taskConfigurationProperties, null,
 				metaDataResolver, new SchedulerServiceProperties(), auditRecordService);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ForkJoinPool;
 import javax.sql.DataSource;
 
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.mockito.Mockito;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
@@ -466,13 +467,15 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			AuditRecordService auditRecordService,
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowJobExecutionDao dataflowJobExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			SchedulerService schedulerService) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
 				auditRecordService,
 				dataflowTaskExecutionDao,
 				dataflowJobExecutionDao,
-				dataflowTaskExecutionMetadataDao);
+				dataflowTaskExecutionMetadataDao,
+				schedulerService);
 	}
 
 	@Bean
@@ -554,14 +557,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		return new DefaultSchedulerService(commonApplicationProperties,
 				taskPlatform, taskDefinitionRepository,
 				registry, resourceLoader,
-				new TaskConfigurationProperties(),
-				dataSourceProperties, null,
+				new TaskConfigurationProperties(), null,
 				metaDataResolver, new SchedulerServiceProperties(), auditRecordService);
 	}
 
 	@Bean
 	public TaskPlatform taskPlatform(Scheduler scheduler) {
-		Launcher launcher = new Launcher("default", "defaultType", null, scheduler);
+		Launcher launcher = new Launcher("default", "defaultType", Mockito.mock(TaskLauncher.class), scheduler);
 		List<Launcher> launchers = new ArrayList<>();
 		launchers.add(launcher);
 		TaskPlatform taskPlatform = new TaskPlatform("testTaskPlatform", launchers);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -42,7 +42,6 @@ import org.springframework.cloud.dataflow.server.configuration.SimpleTestSchedul
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys;
 import org.springframework.data.domain.Page;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -42,12 +42,14 @@ import org.springframework.cloud.dataflow.server.configuration.SimpleTestSchedul
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -74,6 +76,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
+@TestPropertySource(properties = {"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test"})
 public class TaskSchedulerControllerTests {
 
 	@Autowired
@@ -162,7 +165,7 @@ public class TaskSchedulerControllerTests {
 
 	@Test
 	public void testCreateSchedule() throws Exception {
-		AppRegistration registration = this.registry.save("testApp", ApplicationType.task,
+		this.registry.save("testApp", ApplicationType.task,
 				"1.0.0", new URI("file:src/test/resources/apps/foo-task"), null);
 
 		repository.save(new TaskDefinition("testDefinition", "testApp"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -77,7 +77,8 @@ import static org.mockito.Mockito.when;
 		PropertyPlaceholderAutoConfiguration.class }, properties = {
 		"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
 		"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
-		"spring.main.allow-bean-definition-overriding=true"})
+		"spring.main.allow-bean-definition-overriding=true",
+		"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test"})
 @EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class, DockerValidatorProperties.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -303,7 +304,7 @@ public class DefaultSchedulerServiceTests {
 		assertEquals("Missing task name", "--spring.cloud.scheduler.task.launcher.taskName=myTaskDefinition",commandLineArguments.get(0));
 	}
 
-	private List<String> getCommandLineArguments(List<String> commandLineArguments) throws Exception {
+	private List<String> getCommandLineArguments(List<String> commandLineArguments) {
 		Scheduler mockScheduler = mock(SimpleTestScheduler.class);
 		TaskDefinitionRepository mockTaskDefinitionRepository = mock(TaskDefinitionRepository.class);
 		AppRegistryService mockAppRegistryService = mock(AppRegistryService.class);
@@ -314,7 +315,7 @@ public class DefaultSchedulerServiceTests {
 		TaskPlatform taskPlatform = new TaskPlatform("testTaskPlatform", launchers);
 		SchedulerService mockSchedulerService = new DefaultSchedulerService(mock(CommonApplicationProperties.class),
 				taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
-				new TaskConfigurationProperties(), "uri",
+				this.taskConfigurationProperties, "uri",
 				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
 				mock(AuditRecordService.class));
 

--- a/spring-cloud-dataflow-server/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server/src/main/resources/application.yml
@@ -37,9 +37,6 @@ info:
 #     config:
 #        discovery:
 #           enabled: true
-#     dataflow:
-#            task:
-#               schedulerTaskLauncherURL: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:2.3.0.BUILD-SNAPSHOT"
 #eureka:
 #  client:
 #    serviceUrl:

--- a/spring-cloud-dataflow-server/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server/src/main/resources/application.yml
@@ -37,6 +37,9 @@ info:
 #     config:
 #        discovery:
 #           enabled: true
+#     dataflow:
+#            task:
+#               schedulerTaskLauncherURL: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:2.3.0.BUILD-SNAPSHOT"
 #eureka:
 #  client:
 #    serviceUrl:

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           value: 'true'
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
           value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL
+          value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:latest'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
           value: 'true'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_NAME

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
           value: 'true'
         - name: SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL
-          value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:latest'
+          value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:2.3.0.BUILD-SNAPSHOT'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
           value: 'true'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_NAME


### PR DESCRIPTION
Note:
1) I will open a issus efor the UI and for core:
Currently if a user try to delete all schedules associated with a task definition it will fail to work.   This is because we no longer use just the app name.  It is now scdf-appname-schedulename
However if you delete the task definition it will delete all associated schedules (as it should).

2) You will see in the the application.yml and in TaskConfigurationProperties the maven URI for the scheduler-task-launcher is pointing to a snapshot.  Is there a way we can automate this value vs. having to do it via the release process?