### PR TITLE
Add deployment properties to LauncherRepository

### DIFF
--- a/spring-cloud-dataflow-core/pom.xml
+++ b/spring-cloud-dataflow-core/pom.xml
@@ -10,6 +10,17 @@
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-metadata</artifactId>
+			<exclusions>
+				<!-- We're only interested in the DTO classes, so exclude everything -->
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-core-dsl</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ConfigurationMetadataPropertyEntity.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/ConfigurationMetadataPropertyEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.core;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+
+/**
+ * This entity class is used to extend boot's {@link ConfigurationMetadataProperty} so that
+ * we can add our own constructor and not to explicitly import entity classes from boot.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class ConfigurationMetadataPropertyEntity extends ConfigurationMetadataProperty {
+
+	public ConfigurationMetadataPropertyEntity() {
+		super();
+	}
+
+	public ConfigurationMetadataPropertyEntity(ConfigurationMetadataProperty from) {
+		super();
+		setId(from.getId());
+		setName(from.getName());
+		setType(from.getType());
+		setDescription(from.getDescription());
+		setShortDescription(from.getShortDescription());
+		setDefaultValue(from.getDefaultValue());
+		getHints().getKeyHints().addAll(from.getHints().getKeyHints());
+		getHints().getKeyProviders().addAll(from.getHints().getKeyProviders());
+		getHints().getValueHints().addAll(from.getHints().getValueHints());
+		getHints().getValueProviders().addAll(from.getHints().getValueProviders());
+		setDeprecation(from.getDeprecation());
+	}
+}

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Launcher.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package org.springframework.cloud.dataflow.core;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -36,6 +39,8 @@ public class Launcher {
 	private String type;
 
 	private String description;
+
+	private List<ConfigurationMetadataPropertyEntity> options = new ArrayList<>();
 
 	@JsonIgnore
 	private TaskLauncher taskLauncher;
@@ -103,6 +108,14 @@ public class Launcher {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public List<ConfigurationMetadataPropertyEntity> getOptions() {
+		return options;
+	}
+
+	public void setOptions(List<ConfigurationMetadataPropertyEntity> options) {
+		this.options = options;
 	}
 
 	@Override

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/LauncherResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/LauncherResource.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.dataflow.rest.resource;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cloud.dataflow.core.ConfigurationMetadataPropertyEntity;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.RepresentationModel;
@@ -31,6 +35,8 @@ public class LauncherResource extends RepresentationModel<LauncherResource> {
 
 	private String description;
 
+	private List<ConfigurationMetadataPropertyEntity> options = new ArrayList<>();
+
 	@SuppressWarnings("unused")
 	private LauncherResource() {
 	}
@@ -39,6 +45,7 @@ public class LauncherResource extends RepresentationModel<LauncherResource> {
 		this.name = launcher.getName();
 		this.type = launcher.getType();
 		this.description = launcher.getDescription();
+		this.options = launcher.getOptions();
 	}
 
 	public String getName() {
@@ -59,6 +66,14 @@ public class LauncherResource extends RepresentationModel<LauncherResource> {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public List<ConfigurationMetadataPropertyEntity> getOptions() {
+		return options;
+	}
+
+	public void setOptions(List<ConfigurationMetadataPropertyEntity> options) {
+		this.options = options;
 	}
 
 	public static class Page extends PagedModel<LauncherResource> {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutio
 import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionMetadataDao;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
+import org.springframework.cloud.dataflow.server.service.DeployerConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.server.service.LauncherInitializationService;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.cloud.dataflow.server.service.TaskDeleteService;
@@ -100,10 +101,17 @@ public class TaskConfiguration {
 	private String dataflowServerUri;
 
 	@Bean
+	public DeployerConfigurationMetadataResolver deployerConfigurationMetadataResolver(
+			TaskConfigurationProperties taskConfigurationProperties) {
+		return new DeployerConfigurationMetadataResolver(taskConfigurationProperties.getDeployerProperties());
+	}
+
+	@Bean
 	public LauncherInitializationService launcherInitializationService(
 			LauncherRepository launcherRepository,
-			List<TaskPlatform> platforms) {
-		return new LauncherInitializationService(launcherRepository, platforms);
+			List<TaskPlatform> platforms,
+			DeployerConfigurationMetadataResolver resolver) {
+		return new LauncherInitializationService(launcherRepository, platforms, resolver);
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/DeployerConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/DeployerConfigurationMetadataResolver.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.springframework.beans.BeansException;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataGroup;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepositoryJsonBuilder;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties.DeployerProperties;
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.Resource;
+import org.springframework.util.ObjectUtils;
+
+public class DeployerConfigurationMetadataResolver implements ApplicationContextAware {
+
+	private static final String CONFIGURATION_METADATA_PATTERN = "classpath*:/META-INF/spring-configuration-metadata.json";
+	private static final String KEY_PREFIX = "spring.cloud.deployer.";
+	private ApplicationContext applicationContext;
+	private final DeployerProperties deployerProperties;
+
+	public DeployerConfigurationMetadataResolver(DeployerProperties deployerProperties) {
+		this.deployerProperties = deployerProperties;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * Resolve all configuration metadata properties prefixed with {@code spring.cloud.deployer.}
+	 *
+	 * @return the list
+	 */
+	public List<ConfigurationMetadataProperty> resolve() {
+		List<ConfigurationMetadataProperty> metadataProperties = new ArrayList<>();
+		ConfigurationMetadataRepositoryJsonBuilder builder = ConfigurationMetadataRepositoryJsonBuilder.create();
+		try {
+			Resource[] resources = applicationContext.getResources(CONFIGURATION_METADATA_PATTERN);
+			for (Resource resource : resources) {
+				builder.withJsonResource(resource.getInputStream());
+			}
+		}
+		catch (IOException e) {
+			throw new SkipperException("Unable to read configuration metadata", e);
+		}
+		ConfigurationMetadataRepository metadataRepository = builder.build();
+		Map<String, ConfigurationMetadataGroup> groups = metadataRepository.getAllGroups();
+		// 1. go through all groups and their properties
+		// 2. filter 'spring.cloud.deployer.' properties
+		// 3. pass in only group includes, empty passes through all
+		// 4. pass in group excludes
+		// 5. same logic for properties for includes and excludes
+		// 6. what's left is white/black listed props
+		groups.values().stream()
+			.filter(g -> g.getId().startsWith(KEY_PREFIX))
+			.filter(groupEmptyOrAnyMatch(deployerProperties.getGroupIncludes()))
+			.filter(groupNoneMatch(deployerProperties.getGroupExcludes()))
+			.forEach(g -> {
+				g.getProperties().values().stream()
+					.filter(propertyEmptyOrAnyMatch(deployerProperties.getPropertyIncludes()))
+					.filter(propertyNoneMatch(deployerProperties.getPropertyExcludes()))
+					.forEach(p -> {
+						metadataProperties.add(p);
+					});
+			});
+		return metadataProperties;
+	}
+
+	private Predicate<ConfigurationMetadataProperty> propertyEmptyOrAnyMatch(String[] matches) {
+		if (ObjectUtils.isEmpty(matches)) {
+			return p -> true;
+		}
+		return p -> Arrays.stream(matches).anyMatch(p.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataProperty> propertyNoneMatch(String[] matches) {
+		return p -> Arrays.stream(matches).noneMatch(p.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataGroup> groupEmptyOrAnyMatch(String[] matches) {
+		if (ObjectUtils.isEmpty(matches)) {
+			return g -> true;
+		}
+		return g -> Arrays.stream(matches).anyMatch(g.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataGroup> groupNoneMatch(String[] matches) {
+		return g -> Arrays.stream(matches).noneMatch(g.getId()::equals);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -61,6 +61,11 @@ public class TaskConfigurationProperties {
 	 */
 	private String taskLauncherPrefix = "tasklauncher.";
 
+	/**
+	 * The properties for showing deployer properties.
+	 */
+	private DeployerProperties deployerProperties = new DeployerProperties();
+
 	public String getComposedTaskRunnerName() {
 		return composedTaskRunnerName;
 	}
@@ -99,5 +104,53 @@ public class TaskConfigurationProperties {
 
 	public void setSchedulerTaskLauncherUrl(String schedulerTaskLauncherUrl) {
 		this.schedulerTaskLauncherUrl = schedulerTaskLauncherUrl;
+	}
+
+	public DeployerProperties getDeployerProperties() {
+		return deployerProperties;
+	}
+
+	public void setDeployerProperties(DeployerProperties deployerProperties) {
+		this.deployerProperties = deployerProperties;
+	}
+
+	public static class DeployerProperties {
+
+		private String[] propertyIncludes = new String[0];
+		private String[] groupIncludes = new String[0];
+		private String[] propertyExcludes = new String[0];
+		private String[] groupExcludes = new String[0];
+
+		public String[] getPropertyIncludes() {
+			return propertyIncludes;
+		}
+
+		public void setPropertyIncludes(String[] propertyIncludes) {
+			this.propertyIncludes = propertyIncludes;
+		}
+
+		public String[] getGroupIncludes() {
+			return groupIncludes;
+		}
+
+		public void setGroupIncludes(String[] groupIncludes) {
+			this.groupIncludes = groupIncludes;
+		}
+
+		public String[] getPropertyExcludes() {
+			return propertyExcludes;
+		}
+
+		public void setPropertyExcludes(String[] propertyExcludes) {
+			this.propertyExcludes = propertyExcludes;
+		}
+
+		public String[] getGroupExcludes() {
+			return groupExcludes;
+		}
+
+		public void setGroupExcludes(String[] groupExcludes) {
+			this.groupExcludes = groupExcludes;
+		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,7 +1,7 @@
 management:
   endpoints:
     web:
-      base-path: /management  
+      base-path: /management
   security:
     roles: MANAGE
 logging:
@@ -68,6 +68,19 @@ spring:
             checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-dataflow-shell/{version}/spring-cloud-dataflow-shell-{version}.jar.sha256"
       task:
         scheduler-task-launcher-url: "maven://org.springframework.cloud:spring-cloud-dataflow-scheduler-task-launcher:@project.version@"
+        deployer-properties:
+          group-excludes:
+            - spring.cloud.deployer.kubernetes.fabric8
+          property-excludes:
+            - spring.cloud.deployer.local.maximum-concurrent-tasks
+            - spring.cloud.deployer.kubernetes.maximum-concurrent-tasks
+            - spring.cloud.deployer.cloudfoundry.maximum-concurrent-tasks
+            - spring.cloud.deployer.cloudfoundry.org
+            - spring.cloud.deployer.cloudfoundry.space
+            - spring.cloud.deployer.cloudfoundry.url
+            - spring.cloud.deployer.cloudfoundry.username
+            - spring.cloud.deployer.cloudfoundry.password
+            - spring.cloud.deployer.cloudfoundry.skip-ssl-validation
       security:
         authorization:
           enabled: true


### PR DESCRIPTION
- This commit is basically same done for stream deployers where
  `/streams/deployments/platform/list` exposes deployers with possible
  deployment options. For this same dance is done for `/tasks/platforms`.
- Add options field to LauncherResource entity denoting possible
  deployment properties known to each deployer type.
- Read all known deployer related properties and update
  those to LauncherRepository during initialization phase.
- There's no actual user for these new fields for now but having
  those in place allows to start work to make task launch page UI
  to be more consistent with stream deploy UI.
- Has same black/white listing options under
 `spring.cloud.dataflow.task.deployer-properties` which are currently just
  copied from stream side. These would then get polished or redefined when
  actual UI side implementation starts.
- Fixes #3121

For example:
```
curl http://localhost:9393/tasks/platforms|jq
{
  "_embedded": {
    "launcherResourceList": [
      {
        "name": "default",
        "type": "Local",
        "description": "ShutdownTimeout = [30], EnvVarsToInherit = [TMP,LANG,LANGUAGE,LC_.*,PATH,SPRING_APPLICATION_JSON], JavaCmd = [/usr/lib/jvm/java-8-oracle/jre/bin/java], WorkingDirectoriesRoot = [/tmp], DeleteFilesOnExit = [true]",
        "options": [
          {
            "id": "spring.cloud.deployer.local.debug-suspend",
            "name": "debug-suspend",
            "type": "java.lang.String",
            "description": null,
            "shortDescription": null,
            "defaultValue": null,
            "hints": {
              "keyHints": [],
              "keyProviders": [],
              "valueHints": [
                {
                  "value": "y",
                  "description": null,
                  "shortDescription": null
                },
                {
                  "value": "n",
                  "description": null,
                  "shortDescription": null
                }
              ],
              "valueProviders": []
            },
            "deprecation": null,
            "deprecated": false
          },
```
