### PR TITLE
Update docker Kafka image to support partitions

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -11,21 +11,21 @@ services:
     expose:
       - 3306
 
-  kafka:
-    image: confluentinc/cp-kafka:5.2.1
+  kafka-broker:
+    image: confluentinc/cp-kafka:5.3.1
     container_name: dataflow-kafka
     expose:
       - "9092"
     environment:
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka-broker:9092
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_ADVERTISED_HOST_NAME=kafka
+      - KAFKA_ADVERTISED_HOST_NAME=kafka-broker
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     depends_on:
       - zookeeper
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.2.1
+    image: confluentinc/cp-zookeeper:5.3.1
     container_name: dataflow-kafka-zookeeper
     expose:
       - "2181"
@@ -38,8 +38,8 @@ services:
     ports:
       - "9393:9393"
     environment:
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.binder.brokers=PLAINTEXT://kafka:9092
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.streams.binder.brokers=PLAINTEXT://kafka:9092
+      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.binder.brokers=PLAINTEXT://kafka-broker:9092
+      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.streams.binder.brokers=PLAINTEXT://kafka-broker:9092
       - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.binder.zkNodes=zookeeper:2181
       - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.streams.binder.zkNodes=zookeeper:2181
       - spring.cloud.skipper.client.serverUri=http://skipper-server:7577/api
@@ -48,7 +48,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=rootpw
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
     depends_on:
-      - kafka
+      - kafka-broker
     entrypoint: "./wait-for-it.sh mysql:3306 -- java -jar /maven/spring-cloud-dataflow-server.jar"
 
   app-import:

--- a/src/kubernetes/kafka/kafka-deployment.yaml
+++ b/src/kubernetes/kafka/kafka-deployment.yaml
@@ -3,35 +3,33 @@ kind: Deployment
 metadata:
   name: kafka-broker
   labels:
-    app: kafka
+    app: kafka-broker
     component: kafka-broker
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: kafka
-        component: kafka-broker
+        app: kafka-broker
+        component: kafka-broker-c
     spec:
       containers:
-      - name: kafka
-        image: wurstmeister/kafka:2.11-0.11.0.3
+      - name: kafka-broker
+        image: confluentinc/cp-kafka:5.3.1
         ports:
         - containerPort: 9092
         env:
+          - name: KAFKA_ADVERTISED_LISTENERS
+            value: PLAINTEXT://kafka-broker:9092
           - name: ENABLE_AUTO_EXTEND
             value: "true"
           - name: KAFKA_RESERVED_BROKER_MAX_ID
             value: "999999999"
-          - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
-            value: "false"
-          - name: KAFKA_PORT
-            value: "9092"
-          - name: KAFKA_ADVERTISED_PORT
-            value: "9092"
           - name: KAFKA_ADVERTISED_HOST_NAME
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
           - name: KAFKA_ZOOKEEPER_CONNECT
             value: kafka-zk:2181
+          - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+            value: "1"

--- a/src/kubernetes/kafka/kafka-svc.yaml
+++ b/src/kubernetes/kafka/kafka-svc.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kafka
+  name: kafka-broker
   labels:
-    app: kafka
+    app: kafka-broker
     component: kafka-broker
 spec:
   ports:
   - port: 9092
-    name: kafka-port
+    name: kafka-broker-port
     targetPort: 9092
     protocol: TCP
   selector:
-    app: kafka
-    component: kafka-broker
+    app: kafka-broker
+    component: kafka-broker-c

--- a/src/kubernetes/kafka/kafka-zk-deployment.yaml
+++ b/src/kubernetes/kafka/kafka-zk-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: kafka-zk
   labels:
-    app: kafka
+    app: kafka-broker
     component: kafka-zk
 spec:
   replicas: 1
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kafka-zk
-        image: digitalwonderland/zookeeper
+        image: confluentinc/cp-zookeeper:5.3.1
         ports:
         - containerPort: 2181
         env:
@@ -23,3 +23,6 @@ spec:
           value: "1"
         - name: ZOOKEEPER_SERVER_1
           value: kafka-zk
+        - name: ZOOKEEPER_CLIENT_PORT
+          value: "2181"
+

--- a/src/kubernetes/kafka/kafka-zk-svc.yaml
+++ b/src/kubernetes/kafka/kafka-zk-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: kafka-zk
   labels:
-    app: kafka
+    app: kafka-broker
     component: kafka-zk
 spec:
   ports:

--- a/src/kubernetes/skipper/skipper-config-kafka.yaml
+++ b/src/kubernetes/skipper/skipper-config-kafka.yaml
@@ -14,7 +14,7 @@ data:
               kubernetes:
                 accounts:
                   default:
-                    environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${KAFKA_SERVICE_HOST}:${KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${KAFKA_ZK_SERVICE_HOST}:${KAFKA_ZK_SERVICE_PORT}'
+                    environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${KAFKA_BROKER_SERVICE_HOST}:${KAFKA_BROKER_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${KAFKA_ZK_SERVICE_HOST}:${KAFKA_ZK_SERVICE_PORT}'
                     limits:
                       memory: 1024Mi
                       cpu: 500m


### PR DESCRIPTION
 - update kafka image used for k8s installation from wurstmeister/kafka:2.11-0.11.0.3 to confluentinc/cp-kafka:5.3.1
 - update kafka zookeeper image used for k8s installation from digitalwonderland/zookeeper to confluentinc/cp-zookeeper:5.3.1
 - adjust related Kafka configuration parameters (remove deprecated host and port)
 - rename the k8s kafka service to kafka-broker due to the https://github.com/confluentinc/cp-docker-images/issues/388
 - update the skipper config map environmentVariables to reflect the new kafka broker name
 - align the docker-compose kafka/zookeer image versions to confluentinc/cp-kafka:5.3.1 and confluentinc/cp-zookeeper:5.3.1

 Resolves #3547