### PR TITLE
Conditionally import SchedulerService

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.config.features;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -61,15 +59,12 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobServ
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
-import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
 import org.springframework.lang.Nullable;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -96,6 +91,9 @@ public class TaskConfiguration {
 
 	@Autowired
 	DataSourceProperties dataSourceProperties;
+
+	@Autowired(required = false)
+	SchedulerService schedulerService;
 
 	@Value("${spring.cloud.dataflow.server.uri:}")
 	private String dataflowServerUri;
@@ -130,55 +128,6 @@ public class TaskConfiguration {
 		return taskPlatform;
 	}
 
-	/**
-	 * The default profile is active when no other profiles are active. This is configured so
-	 * that several tests will pass without having to explicitly enable the local profile.
-	 * @return a no-op {@link SchedulerService}
-	 */
-	@Profile({ "local", "default" })
-	@Bean
-	public SchedulerService schedulerService() {
-		return new SchedulerService() {
-			@Override
-			public void schedule(String scheduleName, String taskDefinitionName, Map<String, String> taskProperties, List<String> commandLineArgs) {
-			}
-
-			@Override
-			public void unschedule(String scheduleName) {
-			}
-
-			@Override
-			public void unscheduleForTaskDefinition(String taskDefinitionName) {
-			}
-
-			@Override
-			public List<ScheduleInfo> list(Pageable pageable, String taskDefinitionName) {
-				return null;
-			}
-
-			@Override
-			public Page<ScheduleInfo> list(Pageable pageable) {
-				return null;
-			}
-
-			@Override
-			public List<ScheduleInfo> list(String taskDefinitionName) {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public List<ScheduleInfo> list() {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public ScheduleInfo getSchedule(String scheduleName) {
-				return null;
-			}
-		};
-	}
-
-
 	@Bean
 	public TaskExecutionInfoService taskDefinitionRetriever(AppRegistryService registry,
 			TaskExplorer taskExplorer, TaskDefinitionRepository taskDefinitionRepository,
@@ -194,15 +143,14 @@ public class TaskConfiguration {
 			AuditRecordService auditRecordService,
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowJobExecutionDao dataflowJobExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
-			SchedulerService schedulerService) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
 				auditRecordService,
 				dataflowTaskExecutionDao,
 				dataflowJobExecutionDao,
 				dataflowTaskExecutionMetadataDao,
-				schedulerService);
+				this.schedulerService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
@@ -114,7 +114,6 @@ public class DefaultTaskDeleteService implements TaskDeleteService {
 		Assert.notNull(dataflowTaskExecutionDao, "DataflowTaskExecutionDao must not be null");
 		Assert.notNull(dataflowJobExecutionDao, "DataflowJobExecutionDao must not be null");
 		Assert.notNull(dataflowTaskExecutionMetadataDao, "DataflowTaskExecutionMetadataDao must not be null");
-		Assert.notNull(schedulerService, "SchedulerService must not be null");
 		this.taskExplorer = taskExplorer;
 		this.launcherRepository = launcherRepository;
 		this.taskDefinitionRepository = taskDefinitionRepository;
@@ -324,7 +323,9 @@ public class DefaultTaskDeleteService implements TaskDeleteService {
 
 	private void deleteTaskDefinition(TaskDefinition taskDefinition) {
 		TaskParser taskParser = new TaskParser(taskDefinition.getName(), taskDefinition.getDslText(), true, true);
-		schedulerService.unscheduleForTaskDefinition(taskDefinition.getTaskName());
+		if (this.schedulerService != null) {
+			schedulerService.unscheduleForTaskDefinition(taskDefinition.getTaskName());
+		}
 		TaskNode taskNode = taskParser.parse();
 		// if composed-task-runner definition then destroy all child tasks associated with it.
 		if (taskNode.isComposed()) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -45,6 +45,7 @@ import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
 import org.springframework.cloud.dataflow.server.config.VersionInfoProperties;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.cloud.dataflow.server.config.features.SchedulerConfiguration;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.repository.DataflowJobExecutionDao;
 import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
@@ -82,6 +83,7 @@ import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
 import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
@@ -104,6 +106,7 @@ import static org.mockito.Mockito.when;
  * @author Glenn Renfro
  * @author David Turanski
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @EnableSpringDataWebSupport
@@ -234,7 +237,7 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowJobExecutionDao dataflowJobExecutionDao,
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
-			SchedulerService schedulerService) {
+			@Autowired(required = false) SchedulerService schedulerService) {
 
 		return new DefaultTaskDeleteService(taskExplorer, launcherRepository, taskDefinitionRepository,
 				taskDeploymentRepository,
@@ -296,6 +299,7 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
+	@Conditional({ SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
 	public SchedulerService schedulerService(CommonApplicationProperties commonApplicationProperties,
 											 TaskPlatform taskPlatform, TaskDefinitionRepository taskDefinitionRepository,
 											 AppRegistryService registry, ResourceLoader resourceLoader,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -78,7 +78,8 @@ import static org.mockito.Mockito.when;
 		"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
 		"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
 		"spring.main.allow-bean-definition-overriding=true",
-		"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test"})
+		"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
+		"spring.cloud.dataflow.features.schedules-enabled=true"})
 @EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class, DockerValidatorProperties.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)


### PR DESCRIPTION
 - The DefaultTaskDeleteService should import the scheduler service when the task and schedules are enabled.
   - Conditionally import the `SchedulerService` bean

 - Remove explicit `local` scheduler no-op which was used only for tests
 - Update documentation and scheduler service tests

Resolves #3546