### PR TITLE
Fix SkipperClient api changes

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,8 +49,6 @@ import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.VersionInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.Link;
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -94,7 +91,7 @@ public abstract class BaseDocumentation {
 		about.getVersionInfo().getServer().setName("Test Server");
 		about.getVersionInfo().getServer().setVersion("Test Version");
 		when(springDataflowServer.getSkipperClient().info()).thenReturn(about);
-		when(springDataflowServer.getSkipperClient().listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+		when(springDataflowServer.getSkipperClient().listDeployers()).thenReturn(new ArrayList<>());
 
 		Info info = new Info();
 		info.setStatus(new Status());
@@ -102,9 +99,9 @@ public abstract class BaseDocumentation {
 		when(springDataflowServer.getSkipperClient().status(ArgumentMatchers.anyString())).thenReturn(info);
 
 		Deployer deployer = new Deployer("default", "local", mock(AppDeployer.class));
-		when(springDataflowServer.getSkipperClient().listDeployers()).thenReturn(new CollectionModel<>(Arrays.asList(deployer), new Link[0]));
+		when(springDataflowServer.getSkipperClient().listDeployers()).thenReturn(Arrays.asList(deployer));
 
-		when(springDataflowServer.getSkipperClient().search(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(new CollectionModel(Collections.EMPTY_LIST));
+		when(springDataflowServer.getSkipperClient().search(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(new ArrayList<>());
 
 		this.prepareDocumentationTests(springDataflowServer.getWebApplicationContext());
 	}

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
@@ -32,7 +32,6 @@ import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -178,7 +177,7 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 	@Test
 	public void history() throws Exception {
 		when(this.springDataflowServer.getSkipperClient().history(anyString()))
-				.thenReturn(new CollectionModel<>(Arrays.asList(new Release())));
+				.thenReturn(Arrays.asList(new Release()));
 
 		this.mockMvc.perform(
 				get("/streams/deployments/history/{name}", "timelog1")

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployer.java
@@ -84,7 +84,6 @@ import org.springframework.cloud.skipper.io.PackageWriter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -273,8 +272,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	private String determinePlatformName(final String platformName) {
-		CollectionModel<Deployer> deployerResources = skipperClient.listDeployers();
-		Collection<Deployer> deployers = deployerResources.getContent();
+		Collection<Deployer> deployers = skipperClient.listDeployers();
 		if (StringUtils.hasText(platformName)) {
 			List<Deployer> filteredDeployers = deployers.stream()
 					.filter(d -> d.getName().equals(platformName))
@@ -452,8 +450,8 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	public void undeployStream(String streamName) {
-		CollectionModel<PackageMetadata> packageMetadataResources = this.skipperClient.search(streamName, false);
-		if (!packageMetadataResources.getContent().isEmpty()) {
+		Collection<PackageMetadata> packageMetadataResources = this.skipperClient.search(streamName, false);
+		if (!packageMetadataResources.isEmpty()) {
 			try {
 				this.skipperClient.delete(streamName, true);
 			}
@@ -523,7 +521,7 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	@Override
 	public RuntimeEnvironmentInfo environmentInfo() {
 		AboutResource skipperInfo = skipperClient.info();
-		CollectionModel<Deployer> deployers = skipperClient.listDeployers();
+		Collection<Deployer> deployers = skipperClient.listDeployers();
 		RuntimeEnvironmentInfo.Builder builder = new RuntimeEnvironmentInfo.Builder()
 				.implementationName(skipperInfo.getVersionInfo().getServer().getName())
 				.implementationVersion(skipperInfo.getVersionInfo().getServer().getVersion())
@@ -624,10 +622,10 @@ public class SkipperStreamDeployer implements StreamDeployer {
 	}
 
 	public Collection<Release> history(String releaseName) {
-		return this.skipperClient.history(releaseName).getContent();
+		return this.skipperClient.history(releaseName);
 	}
 
 	public Collection<Deployer> platformList() {
-		return this.skipperClient.listDeployers().getContent();
+		return this.skipperClient.listDeployers();
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -150,7 +150,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.jdbc.support.MetaDataAccessException;
@@ -318,7 +317,7 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		// Handle Skipper List Deployers
 		List<Deployer> deployers = new ArrayList<>();
 		// deployers.add(new Deployer("", "", null));
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(deployers, new ArrayList<>()));
+		when(skipperClient.listDeployers()).thenReturn(deployers);
 
 		return skipperClient;
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -43,8 +43,6 @@ import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.Link;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -115,7 +113,7 @@ public class AuditRecordControllerTests {
 		when(skipperClient.status(ArgumentMatchers.anyString())).thenReturn(info);
 
 		when(skipperClient.search(ArgumentMatchers.anyString(), ArgumentMatchers.eq(false)))
-				.thenReturn(new CollectionModel(new ArrayList<PackageMetadata>(), new Link[0]));
+				.thenReturn(new ArrayList<PackageMetadata>());
 
 		startDate = ZonedDateTime.now();
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -65,8 +65,6 @@ import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationSp
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.Link;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -146,10 +144,9 @@ public class StreamControllerTests {
 		when(skipperClient.status(anyString())).thenReturn(streamStatusInfo);
 
 		Deployer deployer = new Deployer("default", "local", mock(AppDeployer.class));
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(Arrays.asList(deployer), new Link[0]));
+		when(skipperClient.listDeployers()).thenReturn(Arrays.asList(deployer));
 
-		when(skipperClient.search(anyString(), eq(false))).thenReturn(
-				new CollectionModel(new ArrayList<PackageMetadata>(), new Link[0]));
+		when(skipperClient.search(anyString(), eq(false))).thenReturn(new ArrayList<PackageMetadata>());
 	}
 
 	@After
@@ -964,8 +961,7 @@ public class StreamControllerTests {
 
 	@Test
 	public void testUndeployNonDeployedStream() throws Exception {
-		when(skipperClient.search(eq("myStream"), eq(false))).thenReturn(
-				new CollectionModel(Arrays.asList(new PackageMetadata()), new Link[0]));
+		when(skipperClient.search(eq("myStream"), eq(false))).thenReturn(Arrays.asList(new PackageMetadata()));
 
 		repository.save(new StreamDefinition("myStream", "time | log"));
 		mockMvc.perform(delete("/streams/deployments/myStream")
@@ -984,10 +980,8 @@ public class StreamControllerTests {
 
 	@Test
 	public void testUndeployAllNonDeployedStream() throws Exception {
-		when(skipperClient.search(eq("myStream1"), eq(false))).thenReturn(
-				new CollectionModel(Arrays.asList(new PackageMetadata()), new Link[0]));
-		when(skipperClient.search(eq("myStream2"), eq(false))).thenReturn(
-				new CollectionModel(Arrays.asList(new PackageMetadata()), new Link[0]));
+		when(skipperClient.search(eq("myStream1"), eq(false))).thenReturn(Arrays.asList(new PackageMetadata()));
+		when(skipperClient.search(eq("myStream2"), eq(false))).thenReturn(Arrays.asList(new PackageMetadata()));
 
 		repository.save(new StreamDefinition("myStream1", "time | log"));
 		repository.save(new StreamDefinition("myStream2", "time | log"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,7 +59,6 @@ import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -106,8 +105,7 @@ public class DefaultStreamServiceIntegrationTests {
 
 	@After
 	public void destroyStream() {
-		when(this.skipperClient.search(anyString(), anyBoolean()))
-				.thenReturn(new CollectionModel<>(Collections.singletonList(new PackageMetadata())));
+		when(this.skipperClient.search(anyString(), anyBoolean())).thenReturn(Arrays.asList(new PackageMetadata()));
 		streamService.undeployStream("ticktock");
 		streamDefinitionRepository.deleteAll();
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -53,14 +53,12 @@ import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.domain.VersionInfo;
 import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.util.StreamUtils;
 
 import static junit.framework.TestCase.fail;
@@ -210,7 +208,7 @@ public class SkipperStreamDeployerTests {
 				skipperDeployerProperties);
 
 		SkipperClient skipperClient = mock(SkipperClient.class);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+		when(skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				mock(StreamDefinitionRepository.class), mock(AppRegistryService.class), mock(ForkJoinPool.class));
@@ -497,8 +495,7 @@ public class SkipperStreamDeployerTests {
 
 		StreamDefinition streamDefinition = new StreamDefinition("foo", "foo|bar");
 
-		when(skipperClient.search(eq(streamDefinition.getName()), eq(false)))
-				.thenReturn(new CollectionModel(Collections.EMPTY_LIST));
+		when(skipperClient.search(eq(streamDefinition.getName()), eq(false))).thenReturn(new ArrayList<>());
 
 		skipperStreamDeployer.undeployStream(streamDefinition.getName());
 
@@ -518,7 +515,7 @@ public class SkipperStreamDeployerTests {
 		StreamDefinition streamDefinition = new StreamDefinition("foo", "foo|bar");
 
 		when(skipperClient.search(eq(streamDefinition.getName()), eq(false)))
-				.thenReturn(new CollectionModel(Collections.singleton(new PackageMetadata())));
+				.thenReturn(Arrays.asList(new PackageMetadata()));
 
 		skipperStreamDeployer.undeployStream(streamDefinition.getName());
 		verify(skipperClient, times(1)).delete(eq(streamDefinition.getName()), eq(true));
@@ -550,7 +547,7 @@ public class SkipperStreamDeployerTests {
 	@Test
 	public void testPlatformList() {
 		SkipperClient skipperClient = mock(SkipperClient.class);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+		when(skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				mock(StreamDefinitionRepository.class), mock(AppRegistryService.class), mock(ForkJoinPool.class));
 		skipperStreamDeployer.platformList();
@@ -560,7 +557,7 @@ public class SkipperStreamDeployerTests {
 	@Test
 	public void testHistory() {
 		SkipperClient skipperClient = mock(SkipperClient.class);
-		when(skipperClient.history(eq("release1"))).thenReturn(new CollectionModel<Release>(new ArrayList<>()));
+		when(skipperClient.history(eq("release1"))).thenReturn(new ArrayList<>());
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				mock(StreamDefinitionRepository.class), mock(AppRegistryService.class), mock(ForkJoinPool.class));
 		skipperStreamDeployer.history("release1");
@@ -606,7 +603,7 @@ public class SkipperStreamDeployerTests {
 		about.setVersionInfo(new VersionInfo());
 		about.getVersionInfo().setServer(new Dependency("d1", "v1", "check", "check2", "url"));
 		when(skipperClient.info()).thenReturn(about);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(Arrays.asList(new Deployer("d1", "t1", null))));
+		when(skipperClient.listDeployers()).thenReturn(Arrays.asList(new Deployer("d1", "t1", null)));
 
 		SkipperStreamDeployer skipperStreamDeployer = new SkipperStreamDeployer(skipperClient,
 				mock(StreamDefinitionRepository.class), mock(AppRegistryService.class), mock(ForkJoinPool.class));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/MockUtils.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/MockUtils.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.Deployer;
-import org.springframework.hateoas.CollectionModel;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -39,7 +38,7 @@ public class MockUtils {
 	public static SkipperClient configureMock(SkipperClient skipperClient) {
 		List<Deployer> deployers = new ArrayList<>();
 		deployers.add(createTestDeployer());
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(deployers, new ArrayList<>()));
+		when(skipperClient.listDeployers()).thenReturn(deployers);
 		return skipperClient;
 	}
 	/**

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
@@ -32,7 +32,6 @@ import org.springframework.cloud.skipper.domain.VersionInfo;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.hateoas.CollectionModel;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -83,7 +82,7 @@ public class TestConfig {
 		about.getVersionInfo().getServer().setName("Test Server");
 		about.getVersionInfo().getServer().setVersion("Test Version");
 		when(skipperClient.info()).thenReturn(about);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+		when(skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 		return skipperClient;
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
@@ -34,8 +34,6 @@ import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.Link;
 import org.springframework.shell.core.CommandResult;
 import org.springframework.shell.table.Table;
 
@@ -79,7 +77,7 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 		when(skipperClient.status(ArgumentMatchers.anyString())).thenReturn(info);
 		AppDeployer appDeployer = applicationContext.getBean(AppDeployer.class);
 		Deployer deployer = new Deployer("testDeployer", "testType", appDeployer);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(Arrays.asList(deployer), new Link[0]));
+		when(skipperClient.listDeployers()).thenReturn(Arrays.asList(deployer));
 		stream().create(streamName, "time | log");
 	}
 
@@ -96,7 +94,7 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 		when(skipperClient.status(ArgumentMatchers.anyString())).thenReturn(info);
 		AppDeployer appDeployer = applicationContext.getBean(AppDeployer.class);
 		Deployer deployer = new Deployer("testDeployer", "testType", appDeployer);
-		when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(Arrays.asList(deployer), new Link[0]));
+		when(skipperClient.listDeployers()).thenReturn(Arrays.asList(deployer));
 
 		//stream().create(streamName, "time | log");
 		stream().createDontDeploy(streamName, "time | log");

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
@@ -53,7 +53,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.SocketUtils;
@@ -221,7 +220,7 @@ public class LocalDataflowResource extends ExternalResource {
 		about.getVersionInfo().getServer().setName("Test Server");
 		about.getVersionInfo().getServer().setVersion("Test Version");
 		when(this.skipperClient.info()).thenReturn(about);
-		when(this.skipperClient.listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+		when(this.skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 	}
 
 	@EnableAutoConfiguration(
@@ -250,7 +249,7 @@ public class LocalDataflowResource extends ExternalResource {
 			about.getVersionInfo().getServer().setName("Test Server");
 			about.getVersionInfo().getServer().setVersion("Test Version");
 			when(skipperClient.info()).thenReturn(about);
-			when(skipperClient.listDeployers()).thenReturn(new CollectionModel<>(new ArrayList<>(), new ArrayList<>()));
+			when(skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 			return skipperClient;
 		}
 


### PR DESCRIPTION
NOTE: There is a companion PR on a skipper side for this https://github.com/spring-cloud/spring-cloud-skipper/pull/917

- As SkipperClient api signatures were changed because
  of a hateoas removal, do needed changes on a dataflow
  side. Most changes goes to test mocks as SkipperClient
  use has always been very narrow.