### PR TITLE
Support reusing deployer props and command-line args in tasks

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
-import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
@@ -96,9 +95,9 @@ public class TaskAppDeploymentRequestCreator {
 						taskExecutionInformation.isComposed()? "composed-task-runner" : registeredAppName,
 						taskExecutionInformation.getTaskDeploymentProperties()));
 
-		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
-				.extractAndQualifyDeployerProperties(taskExecutionInformation.getTaskDeploymentProperties(),
-						taskExecutionInformation.isComposed()? "composed-task-runner" : registeredAppName);
+		// Need to keep all properties around, not just 'deployer.*'
+		// as those are a source to restore app specific props
+		Map<String, String> deployerDeploymentProperties = taskExecutionInformation.getTaskDeploymentProperties();
 		if (StringUtils.hasText(this.dataflowServerUri) && taskExecutionInformation.isComposed()) {
 			TaskServiceUtils.updateDataFlowUriIfNeeded(this.dataflowServerUri, appDeploymentProperties,
 					commandLineArgs);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiff.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiff.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.builder.Diff;
+import org.apache.commons.lang3.builder.DiffBuilder;
+import org.apache.commons.lang3.builder.DiffResult;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code PropertiesDiff} is an implementation to come up with a difference
+ * between two String based Maps. This difference gives answer to questions like
+ * what has been added, removed and changed between left and right hand properties.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public final class PropertiesDiff {
+
+	private Map<String, String> removed = new HashMap<>();
+	private Map<String, String> added = new HashMap<>();
+	private Map<String, String> common = new HashMap<>();
+	private Map<String, PropertyChange> changed = new HashMap<>();
+	private Map<String, String> deleted = new HashMap<>();
+
+	private PropertiesDiff(Map<String, String> removed, Map<String, String> added, Map<String, String> common,
+			Map<String, PropertyChange> changed, Map<String, String> deleted) {
+		this.removed = removed;
+		this.added = added;
+		this.common = common;
+		this.changed = changed;
+		this.deleted = deleted;
+	}
+
+	/**
+	 * Gets the removed properties.
+	 *
+	 * @return the removed
+	 */
+	public Map<String, String> getRemoved() {
+		return removed;
+	}
+
+	/**
+	 * Gets the added properties.
+	 *
+	 * @return the removed
+	 */
+	public Map<String, String> getAdded() {
+		return added;
+	}
+
+	/**
+	 * Gets the common properties.
+	 *
+	 * @return the removed
+	 */
+	public Map<String, String> getCommon() {
+		return common;
+	}
+
+	/**
+	 * Gets the changed properties.
+	 *
+	 * @return the removed
+	 */
+	public Map<String, PropertyChange> getChanged() {
+		return changed;
+	}
+
+	/**
+	 * Gets the deleted properties.
+	 *
+	 * @return the deleted
+	 */
+	public Map<String, String> getDeleted() {
+		return deleted;
+	}
+
+	/**
+	 * Check if given left and right hand side properties are equal.
+	 *
+	 * @return true, if successful
+	 */
+	public boolean areEqual() {
+		return removed.isEmpty() && added.isEmpty() && changed.isEmpty() && deleted.isEmpty();
+	}
+
+	@Override
+	public String toString() {
+		return "PropertiesDiff [added=" + added + ", removed=" + removed + ", changed=" + changed + ", common=" + common
+				+ ", disappeared=" + deleted + "]";
+	}
+
+	/**
+	 * Gets a {@link Builder} for {@code PropertiesDiff}.
+	 *
+	 * @return the builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Class representing a change in a property.
+	 */
+	public static class PropertyChange {
+
+		private final String original;
+		private final String replaced;
+
+		/**
+		 * Instantiates a new property change.
+		 *
+		 * @param original the original
+		 * @param replaced the replaced
+		 */
+		public PropertyChange(String original, String replaced) {
+			this.original = original;
+			this.replaced = replaced;
+		}
+
+		/**
+		 * Gets the original property value.
+		 *
+		 * @return the original property value
+		 */
+		public String getOriginal() {
+			return original;
+		}
+
+		/**
+		 * Gets the replaced property value.
+		 *
+		 * @return the replaced property value
+		 */
+		public String getReplaced() {
+			return replaced;
+		}
+
+		@Override
+		public String toString() {
+			return "original=" + original + ", replaced=" + replaced;
+		}
+	}
+
+	/**
+	 * {@code Builder} for {@link PropertiesDiff}.
+	 *
+	 */
+	public static class Builder {
+
+		private final Map<String, String> deleted = new HashMap<>();
+		private final Map<String, String> removed = new HashMap<>();
+		private final Map<String, String> added = new HashMap<>();
+		private final Map<String, String> common = new HashMap<>();
+		private final Map<String, PropertyChange> changed = new HashMap<>();
+		private final Map<String, String> leftMap = new HashMap<>();
+		private final Map<String, String> rightMap = new HashMap<>();
+
+		/**
+		 * Adds a left hand side map.
+		 *
+		 * @param leftMap the left map
+		 * @return the builder
+		 */
+		public Builder left(Map<String, String> leftMap) {
+			if (leftMap != null) {
+				this.leftMap.putAll(leftMap);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds a right hand side map.
+		 *
+		 * @param rightMap the right map
+		 * @return the builder
+		 */
+		public Builder right(Map<String, String> rightMap) {
+			if (rightMap != null) {
+				this.rightMap.putAll(rightMap);
+			}
+			return this;
+		}
+
+		/**
+		 * Builds the {@link PropertiesDiff}.
+		 *
+		 * @return the properties diff
+		 */
+		public PropertiesDiff build() {
+			DiffBuilder leftBuilder = new DiffBuilder(leftMap, rightMap, ToStringStyle.DEFAULT_STYLE);
+			DiffBuilder rightBuilder = new DiffBuilder(leftMap, rightMap, ToStringStyle.DEFAULT_STYLE);
+
+			List<String> leftMapRemove = new ArrayList<>();
+			for (Entry<String, String> entry : leftMap.entrySet()) {
+				if (!rightMap.containsKey(entry.getKey())) {
+					removed.put(entry.getKey(), entry.getValue());
+					leftMapRemove.add(entry.getKey());
+				}
+				else {
+					leftBuilder.append(entry.getKey(), entry.getValue(), rightMap.get(entry.getKey()));
+				}
+			}
+			for (String keyToRemove : leftMapRemove) {
+				leftMap.remove(keyToRemove);
+			}
+			for (Entry<String, String> entry : rightMap.entrySet()) {
+				rightBuilder.append(entry.getKey(), entry.getValue(), leftMap.get(entry.getKey()));
+			}
+
+			DiffResult leftResult = leftBuilder.build();
+			for (Diff<?> diff : leftResult) {
+				leftMap.remove(diff.getFieldName());
+				if (diff.getRight() == null) {
+					deleted.put(diff.getFieldName(), diff.getLeft().toString());
+				}
+				else if (!StringUtils.hasText(diff.getRight().toString())) {
+					deleted.put(diff.getFieldName(), diff.getLeft().toString());
+				}
+				else {
+					changed.put(diff.getFieldName(),
+							new PropertyChange(diff.getLeft().toString(), diff.getRight().toString()));
+				}
+			}
+
+			common.putAll(leftMap);
+
+			DiffResult rightResult = rightBuilder.build();
+			for (Diff<?> diff : rightResult) {
+				if (diff.getRight() == null) {
+					added.put(diff.getFieldName(), diff.getLeft().toString());
+				}
+			}
+
+			return new PropertiesDiff(removed, added, common, changed, deleted);
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalysisReport.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalysisReport.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.cloud.dataflow.server.service.impl.diff.PropertiesDiff.PropertyChange;
+
+/**
+ * Task analysis report contains differences for a task.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TaskAnalysisReport {
+
+	private TaskManifestDifference taskManifestDifference;
+
+	public TaskAnalysisReport(TaskManifestDifference taskManifestDifference) {
+		this.taskManifestDifference = taskManifestDifference;
+	}
+
+	public TaskManifestDifference getTaskManifestDifference() {
+		return taskManifestDifference;
+	}
+
+	public Map<String, String> getMergedDeploymentProperties() {
+		Map<String, String> props = new HashMap<>();
+		props.putAll(getTaskManifestDifference().getDeploymentPropertiesDifference().getCommon());
+		props.putAll(getTaskManifestDifference().getDeploymentPropertiesDifference().getAdded());
+		props.putAll(getTaskManifestDifference().getDeploymentPropertiesDifference().getRemoved());
+		for (Map.Entry<String, PropertyChange> entry : getTaskManifestDifference().getDeploymentPropertiesDifference()
+				.getChanged().entrySet()) {
+			props.put(entry.getKey(), entry.getValue().getReplaced());
+		}
+		return props;
+	}
+
+	public List<String> getMergedCommandLineArguments() {
+		ArrayList<String> args = new ArrayList<>();
+		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
+				.getCommon().entrySet()) {
+			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		}
+		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
+				.getAdded().entrySet()) {
+			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		}
+		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
+				.getRemoved().entrySet()) {
+			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		}
+		for (Map.Entry<String, PropertyChange> entry : getTaskManifestDifference()
+				.getCommandLineArgumentPropertiesDifference().getChanged().entrySet()) {
+			args.add("--" + entry.getKey() + "=" + entry.getValue().getReplaced());
+		}
+		return args;
+	}
+
+	@Override
+	public String toString() {
+		return "TaskAnalysisReport [taskManifestDifference=" + taskManifestDifference + "]";
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.core.TaskManifest;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+
+/**
+ * Analyze a task and create a {@link TaskAnalysisReport} which can be used
+ * resurrect needed properties and arguments to bring forward to new task launch.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TaskAnalyzer {
+
+	/**
+	 * Compares current and newly created manifest for their differences.
+	 *
+	 * @param existing the current manifest
+	 * @param replacing the new replacing manifest
+	 * @return the task analysis report
+	 */
+	public TaskAnalysisReport analyze(TaskManifest existing, TaskManifest replacing) {
+		Map<String, String> existingDeploymentProperties = null;
+		Map<String, String> existingCommandLineArgumentProperties = new HashMap<>();
+		if (existing != null) {
+			AppDeploymentRequest taskDeploymentRequest = existing.getTaskDeploymentRequest();
+			if (taskDeploymentRequest != null) {
+				existingDeploymentProperties = taskDeploymentRequest.getDeploymentProperties();
+
+				for (String arg : taskDeploymentRequest.getCommandlineArguments()) {
+					if (arg.startsWith("--")) {
+						String[] split = arg.substring(2).split("=", 2);
+						if (split.length == 2) {
+							existingCommandLineArgumentProperties.put(split[0], split[1]);
+						}
+					}
+				}
+			}
+		}
+
+		Map<String, String> replacingDeploymentProperties = null;
+		Map<String, String> replacingCommandLineArgumentProperties = new HashMap<>();
+		if (replacing != null) {
+			AppDeploymentRequest taskDeploymentRequest = replacing.getTaskDeploymentRequest();
+			if (taskDeploymentRequest != null) {
+				replacingDeploymentProperties = taskDeploymentRequest.getDeploymentProperties();
+
+				for (String arg : taskDeploymentRequest.getCommandlineArguments()) {
+					if (arg.startsWith("--")) {
+						String[] split = arg.substring(2).split("=", 2);
+						if (split.length == 2) {
+							replacingCommandLineArgumentProperties.put(split[0], split[1]);
+						}
+					}
+				}
+			}
+		}
+
+		PropertiesDiff deploymentPropertiesDifference = PropertiesDiff.builder().left(existingDeploymentProperties)
+				.right(replacingDeploymentProperties).build();
+
+		PropertiesDiff existingCommandLineArgumentPropertiesDifference = PropertiesDiff.builder()
+				.left(existingCommandLineArgumentProperties).right(replacingCommandLineArgumentProperties).build();
+
+		TaskManifestDifference taskManifestDifference = new TaskManifestDifference(deploymentPropertiesDifference,
+				existingCommandLineArgumentPropertiesDifference);
+		return new TaskAnalysisReport(taskManifestDifference);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskManifestDifference.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskManifestDifference.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+/**
+ * Contains difference for a task manifest properties.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class TaskManifestDifference {
+
+	private final PropertiesDiff deploymentPropertiesDifference;
+	private final PropertiesDiff commandLineArgumentPropertiesDifference;
+
+	public TaskManifestDifference(PropertiesDiff deploymentPropertiesDifference,
+			PropertiesDiff commandLineArgumentPropertiesDifference) {
+		this.deploymentPropertiesDifference = deploymentPropertiesDifference;
+		this.commandLineArgumentPropertiesDifference = commandLineArgumentPropertiesDifference;
+	}
+
+	public PropertiesDiff getDeploymentPropertiesDifference() {
+		return deploymentPropertiesDifference;
+	}
+
+	public PropertiesDiff getCommandLineArgumentPropertiesDifference() {
+		return commandLineArgumentPropertiesDifference;
+	}
+
+	@Override
+	public String toString() {
+		return "TaskManifestDifference [commandLineArgumentPropertiesDifference="
+				+ commandLineArgumentPropertiesDifference + ", deploymentPropertiesDifference="
+				+ deploymentPropertiesDifference + "]";
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -57,6 +57,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -389,9 +390,8 @@ public class TaskControllerTests {
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
 		assertThat(request.getCommandlineArguments().size(), is(3 + 2)); // +2 for spring.cloud.task.executionid and spring.cloud.data.flow.platformname
-		assertThat(request.getCommandlineArguments().get(0), is("--foobar=jee"));
-		assertThat(request.getCommandlineArguments().get(1), is("--foobar2=jee2,foo=bar"));
-		assertThat(request.getCommandlineArguments().get(2), is("--foobar3='jee3 jee3'"));
+		// don't assume order in a list
+		assertThat(request.getCommandlineArguments(), hasItems("--foobar=jee", "--foobar2=jee2,foo=bar", "--foobar3='jee3 jee3'"));
 		assertEquals("myTask3", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiffTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiffTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.server.service.impl.diff.PropertiesDiff.PropertyChange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PropertiesDiff}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class PropertiesDiffTests {
+
+	@Test
+	public void testEmptyMaps() {
+		Map<String, String> left = new HashMap<>();
+		Map<String, String> right = new HashMap<>();
+		PropertiesDiff diff = PropertiesDiff.builder().left(left).right(right).build();
+
+		assertThat(diff.areEqual()).isTrue();
+		assertThat(diff.getAdded()).hasSize(0);
+		assertThat(diff.getRemoved()).hasSize(0);
+		assertThat(diff.getChanged()).hasSize(0);
+		assertThat(diff.getCommon()).hasSize(0);
+		assertThat(diff.getDeleted()).hasSize(0);
+	}
+
+	@Test
+	public void testAddedRemovedChanging() {
+		Map<String, String> left = new HashMap<>();
+		left.put("key1", "value1");
+		left.put("key2", "value21");
+		left.put("key3", "value3");
+		Map<String, String> right = new HashMap<>();
+		right.put("key1", "value1");
+		right.put("key2", "value22");
+		right.put("key4", "value4");
+		PropertiesDiff diff = PropertiesDiff.builder().left(left).right(right).build();
+
+		assertThat(diff.areEqual()).isFalse();
+		assertThat(diff.getAdded()).hasSize(1);
+		assertThat(diff.getRemoved()).hasSize(1);
+		assertThat(diff.getChanged()).hasSize(1);
+		assertThat(diff.getCommon()).hasSize(1);
+		assertThat(diff.getDeleted()).hasSize(0);
+	}
+
+	@Test
+	public void testRemovedByEffectivelyNull() {
+		Map<String, String> left = new HashMap<>();
+		left.put("key1", "value1");
+		left.put("key2", "value2");
+		left.put("key3", "value3");
+		Map<String, String> right = new HashMap<>();
+		right.put("key1", "value1");
+		right.put("key2", "");
+		right.put("key3", null);
+		PropertiesDiff diff = PropertiesDiff.builder().left(left).right(right).build();
+
+		assertThat(diff.areEqual()).isFalse();
+		assertThat(diff.getAdded()).hasSize(0);
+		assertThat(diff.getRemoved()).hasSize(0);
+		assertThat(diff.getChanged()).hasSize(0);
+		assertThat(diff.getCommon()).hasSize(1);
+		assertThat(diff.getDeleted()).hasSize(2);
+	}
+
+	@Test
+	public void testChangedValues() {
+		Map<String, String> left = new HashMap<>();
+		left.put("key1", "value1");
+		Map<String, String> right = new HashMap<>();
+		right.put("key1", "value2");
+		PropertiesDiff diff = PropertiesDiff.builder().left(left).right(right).build();
+
+		assertThat(diff.getChanged()).hasSize(1);
+		PropertyChange propertyChange = diff.getChanged().get("key1");
+		assertThat(propertyChange).isNotNull();
+		assertThat(propertyChange.getOriginal()).isEqualTo("value1");
+		assertThat(propertyChange.getReplaced()).isEqualTo("value2");
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl.diff;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.core.TaskManifest;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class TaskAnalyzerTests {
+
+	private final TaskAnalyzer analyzer = new TaskAnalyzer();
+
+	@Test
+	public void testDeploymentProperties() {
+		AppDefinition leftAd = new AppDefinition("name1", new HashMap<>());
+		Resource leftResource = new ClassPathResource("path1");
+		Map<String, String> leftDeploymentProperties = new HashMap<>();
+		leftDeploymentProperties.put("key1", "value1");
+		List<String> leftCommandlineArguments = new ArrayList<>();
+		AppDeploymentRequest leftAdr = new AppDeploymentRequest(leftAd, leftResource, leftDeploymentProperties,
+				leftCommandlineArguments);
+		TaskManifest leftManifest = new TaskManifest();
+		leftManifest.setPlatformName("default");
+		leftManifest.setTaskDeploymentRequest(leftAdr);
+
+		AppDefinition rightAd = new AppDefinition("name2", new HashMap<>());
+		Resource rightResource = new ClassPathResource("path2");
+		Map<String, String> rightDeploymentProperties = new HashMap<>();
+		rightDeploymentProperties.put("key1", "value1");
+		List<String> rightCommandlineArguments = new ArrayList<>();
+		AppDeploymentRequest rightAdr = new AppDeploymentRequest(rightAd, rightResource, rightDeploymentProperties,
+				rightCommandlineArguments);
+		TaskManifest rightManifest = new TaskManifest();
+		rightManifest.setPlatformName("default");
+		rightManifest.setTaskDeploymentRequest(rightAdr);
+
+		TaskAnalysisReport report = analyzer.analyze(leftManifest, rightManifest);
+		TaskManifestDifference taskManifestDifference = report.getTaskManifestDifference();
+		PropertiesDiff deploymentPropertiesDifference = taskManifestDifference.getDeploymentPropertiesDifference();
+		assertThat(deploymentPropertiesDifference.areEqual()).isTrue();
+
+		rightDeploymentProperties.put("key1", "value2");
+
+		report = analyzer.analyze(leftManifest, rightManifest);
+		taskManifestDifference = report.getTaskManifestDifference();
+		deploymentPropertiesDifference = taskManifestDifference.getDeploymentPropertiesDifference();
+		assertThat(deploymentPropertiesDifference.areEqual()).isFalse();
+		assertThat(report.getMergedDeploymentProperties()).hasSize(1);
+		assertThat(report.getMergedDeploymentProperties()).contains(entry("key1", "value2"));
+	}
+
+	@Test
+	public void testCommandLineArguments() {
+		AppDefinition leftAd = new AppDefinition("name1", new HashMap<>());
+		Resource leftResource = new ClassPathResource("path1");
+		Map<String, String> leftDeploymentProperties = new HashMap<>();
+		List<String> leftCommandlineArguments = new ArrayList<>();
+		leftCommandlineArguments.add("--key1=value1");
+		AppDeploymentRequest leftAdr = new AppDeploymentRequest(leftAd, leftResource, leftDeploymentProperties,
+				leftCommandlineArguments);
+		TaskManifest leftManifest = new TaskManifest();
+		leftManifest.setPlatformName("default");
+		leftManifest.setTaskDeploymentRequest(leftAdr);
+
+		AppDefinition rightAd = new AppDefinition("name2", new HashMap<>());
+		Resource rightResource = new ClassPathResource("path2");
+		Map<String, String> rightDeploymentProperties = new HashMap<>();
+		List<String> rightCommandlineArguments = new ArrayList<>();
+		rightCommandlineArguments.add("--key1=value1");
+
+		AppDeploymentRequest rightAdr = new AppDeploymentRequest(rightAd, rightResource, rightDeploymentProperties,
+				rightCommandlineArguments);
+		TaskManifest rightManifest = new TaskManifest();
+		rightManifest.setPlatformName("default");
+		rightManifest.setTaskDeploymentRequest(rightAdr);
+
+		TaskAnalysisReport report = analyzer.analyze(leftManifest, rightManifest);
+		TaskManifestDifference taskManifestDifference = report.getTaskManifestDifference();
+		PropertiesDiff commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifference();
+		assertThat(commandLineArgumentPropertiesDifference.areEqual()).isTrue();
+
+		rightCommandlineArguments.add("--key1=value2");
+
+		report = analyzer.analyze(leftManifest, rightManifest);
+		taskManifestDifference = report.getTaskManifestDifference();
+
+		commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifference();
+		assertThat(commandLineArgumentPropertiesDifference.areEqual()).isFalse();
+		assertThat(report.getMergedCommandLineArguments()).hasSize(1);
+		assertThat(report.getMergedCommandLineArguments()).containsOnly("--key1=value2");
+	}
+
+}


### PR DESCRIPTION
- Bring over analyzer and diff utils from a skipper order
  to see what has been changed in a task launches.
- PropertiesDiff impl copied over from skipper has been enhanced
  to support understanding of a deletion of a property. This now
  means that we understand a common property(not changed), changed
  property, added property, removed(doesn't exist in a new set) and
  deleted property(value is effectively missing).
- Deleted property vs removed property has a distiction in a sense
  that we then know that if user explicitely deleted it should not
  get back while removed property should get back to a new launch.
- Change in TaskAppDeploymentRequestCreator to stash all deploy props
  so that we know what to resurrect when app specific props were passed
  in via deploy props.
- DefaultTaskExecutionService has been modified(mostly executeTask has
  been partially rewritten to reuse props and args).
- Fixes #3555

NOTE: This pr probably needs heavy scrutiny as things get complex as I've
      most likely missed something.

Generic way to test these manually is to play with parameters and arguments
respectively:

```
app.timestamp.format=yyyy
app.timestamp.format=yyyy-MM
app.timestamp.format=

--timestamp.format=yyyy
--timestamp.format=yyyy-MM
--timestamp.format=
```

These will show how `format` is still in place if you use launch with not arguments
or properties. You can see how these can be modified and if value is letf empty it
will essentially get removed and then default `format` value takes place. Then
see a latest log what gets printed there and also what gets into a `TaskManifest`.
