### PR TITLE
commandline args must be prefixed

### DIFF
--- a/spring-cloud-dataflow-scheduler-task-launcher/src/test/java/org/springframework/cloud/dataflow/scheduler/launcher/SchedulerTaskLauncherTests.java
+++ b/spring-cloud-dataflow-scheduler-task-launcher/src/test/java/org/springframework/cloud/dataflow/scheduler/launcher/SchedulerTaskLauncherTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.scheduler.launcher;
 
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -129,6 +130,22 @@ public class SchedulerTaskLauncherTests {
 		verify(this.taskOperations, times(1)).launch(Mockito.any(), argument.capture(), Mockito.any(), Mockito.any());
 		Assert.assertTrue(argument.getValue().containsKey(propertyPrefix));
 		Assert.assertEquals("YYYY", argument.getValue().get(propertyPrefix));
+	}
+
+	@Test
+	public void testValidWithArgs() {
+		SchedulerTaskLauncherProperties schedulerTaskLauncherProperties = new SchedulerTaskLauncherProperties();
+		final String argPrefix = SchedulerTaskLauncher.COMMAND_ARGUMENT_PREFIX + "." +
+				schedulerTaskLauncherProperties.getTaskLauncherPropertyPrefix() + ".";
+		final String baseArg = "app.timestamp.timestamp=YYYY";
+		final String arg =  argPrefix + baseArg;
+		final ArgumentCaptor<List> argument = ArgumentCaptor.forClass(List.class);
+		MockEnvironment mockEnvironment = new MockEnvironment();
+		SchedulerTaskLauncher schedulerTaskLauncher = getSchedulerTaskLauncher(schedulerTaskLauncherProperties, mockEnvironment);
+
+		schedulerTaskLauncher.launchTask(arg);
+		verify(this.taskOperations, times(1)).launch(Mockito.any(), Mockito.any(), argument.capture(), Mockito.any());
+		Assert.assertTrue(argument.getValue().contains(baseArg));
 	}
 
 	private SchedulerTaskLauncher getSchedulerTaskLauncher(SchedulerTaskLauncherProperties schedulerTaskLauncherProperties,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -68,6 +68,7 @@ public class DefaultSchedulerService implements SchedulerService {
 
 	private final static String APP_PREFIX = "app.";
 	private final static String DEPLOYER_PREFIX = "deployer.";
+	private final static String COMMAND_ARGUMENT_PREFIX = "cmdarg.";
 	private final static String DATA_FLOW_URI_KEY = "spring.cloud.dataflow.client.serverUri";
 
 	private CommonApplicationProperties commonApplicationProperties;
@@ -199,7 +200,7 @@ public class DefaultSchedulerService implements SchedulerService {
 
 		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
 		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
-		List<String> revisedCommandLineArgs = new ArrayList<>(commandLineArgs);
+		List<String> revisedCommandLineArgs = tagCommandLineArgs(new ArrayList<>(commandLineArgs));
 		revisedCommandLineArgs.add("--spring.cloud.scheduler.task.launcher.taskName=" + taskDefinitionName);
 		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition, taskDeploymentProperties,
 				deployerDeploymentProperties, revisedCommandLineArgs, scheduleName, getTaskLauncherResource());
@@ -212,6 +213,23 @@ public class DefaultSchedulerService implements SchedulerService {
 		return taskDeploymentProperties.entrySet().stream()
 				.filter(kv -> kv.getKey().startsWith(prefix))
 				.collect(Collectors.toMap(kv -> kv.getKey().substring(prefix.length()), kv -> kv.getValue()));
+	}
+
+	private List<String> tagCommandLineArgs(List<String> args) {
+		List<String> taggedArgs = new ArrayList<>();
+
+		for(String arg : args) {
+			if(arg.contains("spring.cloud.task.name")) {
+				continue;
+			}
+			String updatedArg = arg;
+			if (!arg.startsWith(DATA_FLOW_URI_KEY) && !"--".concat(arg).startsWith(DATA_FLOW_URI_KEY)) {
+					updatedArg = COMMAND_ARGUMENT_PREFIX +
+							taskConfigurationProperties.getTaskLauncherPrefix() + arg;
+			}
+			taggedArgs.add(updatedArg);
+		}
+		return taggedArgs;
 	}
 
 	private Map<String, String> tagProperties(String appName, Map<String, String> appProperties, String prefix) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -197,7 +197,7 @@ public class TaskSchedulerControllerTests {
 		String auditData = createScheduleWithArguments("argument1=foo password=secret");
 
 		assertEquals(
-				"{\"commandlineArguments\":[\"argument1=foo\",\"password=******\",\"--spring.cloud.scheduler.task.launcher.taskName=testDefinition\"],\"taskDefinitionName\":\"mySchedule-scdf-testDefinition\","
+				"{\"commandlineArguments\":[\"cmdarg.tasklauncher.argument1=foo\",\"cmdarg.tasklauncher.password=******\",\"--spring.cloud.scheduler.task.launcher.taskName=testDefinition\"],\"taskDefinitionName\":\"mySchedule-scdf-testDefinition\","
 						+ "\"taskDefinitionProperties\":{\"tasklauncher.app.testApp.prop2.secret\":\"******\",\"tasklauncher.deployer.*.prop2.password\":\"******\",\"tasklauncher.app.testApp.prop1\":\"foo\",\"tasklauncher.deployer.*.prop1.secret\":\"******\"},"
 						+ "\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\",\"spring.cloud.deployer.prop2.password\":\"******\"}}",
 				auditData);
@@ -208,7 +208,7 @@ public class TaskSchedulerControllerTests {
 		String auditData = createScheduleWithArguments("argument1=foo spring.profiles.active=k8s,master argument3=bar");
 
 		assertEquals(
-				"{\"commandlineArguments\":[\"argument1=foo\",\"spring.profiles.active=k8s,master\",\"argument3=bar\",\"--spring.cloud.scheduler.task.launcher.taskName=testDefinition\"],\"taskDefinitionName\":\"mySchedule-scdf-testDefinition\","
+				"{\"commandlineArguments\":[\"cmdarg.tasklauncher.argument1=foo\",\"cmdarg.tasklauncher.spring.profiles.active=k8s,master\",\"cmdarg.tasklauncher.argument3=bar\",\"--spring.cloud.scheduler.task.launcher.taskName=testDefinition\"],\"taskDefinitionName\":\"mySchedule-scdf-testDefinition\","
 						+ "\"taskDefinitionProperties\":{\"tasklauncher.app.testApp.prop2.secret\":\"******\",\"tasklauncher.deployer.*.prop2.password\":\"******\",\"tasklauncher.app.testApp.prop1\":\"foo\",\"tasklauncher.deployer.*.prop1.secret\":\"******\"},"
 						+ "\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\",\"spring.cloud.deployer.prop2.password\":\"******\"}}",
 				auditData);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -291,8 +291,8 @@ public class DefaultSchedulerServiceTests {
 
 		assertNotNull("Command line arguments should not be null", commandLineArguments);
 		assertEquals("Invalid number of command line arguments", 3, commandLineArguments.size());
-		assertEquals("Invalid command line argument", "--myArg1", commandLineArguments.get(0));
-		assertEquals("Invalid command line argument", "--myArg2", commandLineArguments.get(1));
+		assertEquals("Invalid command line argument", "cmdarg.tasklauncher.--myArg1", commandLineArguments.get(0));
+		assertEquals("Invalid command line argument", "cmdarg.tasklauncher.--myArg2", commandLineArguments.get(1));
 		assertEquals("Missing task name", "--spring.cloud.scheduler.task.launcher.taskName=myTaskDefinition",commandLineArguments.get(2));
 	}
 


### PR DESCRIPTION
This is so that the args will not have an affect on the scheduler launcher.

resolves #3608