### PR TITLE
Support task arguments with single and no dash

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -346,7 +346,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 * @param previousManifest manifest from the last execution of the same task definition
 	 * @return an updated {@code AppDeploymentRequest}
 	 */
-	// private AppDeploymentRequest updateDeploymentProperties(List<String> commandLineArgs, String platformName, TaskExecutionInformation taskExecutionInformation, TaskExecution taskExecution, TaskManifest previousManifest) {
 	private AppDeploymentRequest updateDeploymentProperties(List<String> commandLineArgs, String platformName,
 			TaskExecutionInformation taskExecutionInformation, TaskExecution taskExecution,
 			Map<String, String> deploymentProperties) {
@@ -357,7 +356,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 		info.setComposed(taskExecutionInformation.isComposed());
 		info.setMetadataResource(taskExecutionInformation.getMetadataResource());
 		info.setOriginalTaskDefinition(taskExecutionInformation.getOriginalTaskDefinition());
-		// info.setTaskDeploymentProperties(previousManifest.getTaskDeploymentRequest().getDeploymentProperties());
 		info.setTaskDeploymentProperties(deploymentProperties);
 
 		appDeploymentRequest = this.taskAppDeploymentRequestCreator.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalysisReport.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalysisReport.java
@@ -55,21 +55,25 @@ public class TaskAnalysisReport {
 
 	public List<String> getMergedCommandLineArguments() {
 		ArrayList<String> args = new ArrayList<>();
-		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
-				.getCommon().entrySet()) {
-			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		args.addAll(buildArgsWithPrefix(getTaskManifestDifference().getCommandLineArgumentPropertiesDifferenceDoubleDash(), "--"));
+		args.addAll(buildArgsWithPrefix(getTaskManifestDifference().getCommandLineArgumentPropertiesDifferenceSingleDash(), "-"));
+		args.addAll(buildArgsWithPrefix(getTaskManifestDifference().getCommandLineArgumentPropertiesDifferenceNoDash(), ""));
+		return args;
+	}
+
+	private static List<String> buildArgsWithPrefix(PropertiesDiff diff, String prefix) {
+		ArrayList<String> args = new ArrayList<>();
+		for (Entry<String, String> entry : diff.getCommon().entrySet()) {
+			args.add(prefix + entry.getKey() + "=" + entry.getValue());
 		}
-		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
-				.getAdded().entrySet()) {
-			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		for (Entry<String, String> entry : diff.getAdded().entrySet()) {
+			args.add(prefix + entry.getKey() + "=" + entry.getValue());
 		}
-		for (Entry<String, String> entry : getTaskManifestDifference().getCommandLineArgumentPropertiesDifference()
-				.getRemoved().entrySet()) {
-			args.add("--" + entry.getKey() + "=" + entry.getValue());
+		for (Entry<String, String> entry : diff.getRemoved().entrySet()) {
+			args.add(prefix + entry.getKey() + "=" + entry.getValue());
 		}
-		for (Map.Entry<String, PropertyChange> entry : getTaskManifestDifference()
-				.getCommandLineArgumentPropertiesDifference().getChanged().entrySet()) {
-			args.add("--" + entry.getKey() + "=" + entry.getValue().getReplaced());
+		for (Map.Entry<String, PropertyChange> entry : diff.getChanged().entrySet()) {
+			args.add(prefix + entry.getKey() + "=" + entry.getValue().getReplaced());
 		}
 		return args;
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzer.java
@@ -39,7 +39,9 @@ public class TaskAnalyzer {
 	 */
 	public TaskAnalysisReport analyze(TaskManifest existing, TaskManifest replacing) {
 		Map<String, String> existingDeploymentProperties = null;
-		Map<String, String> existingCommandLineArgumentProperties = new HashMap<>();
+		Map<String, String> existingCommandLineArgumentPropertiesDoubleDash = new HashMap<>();
+		Map<String, String> existingCommandLineArgumentPropertiesSingleDash = new HashMap<>();
+		Map<String, String> existingCommandLineArgumentPropertiesNoDash = new HashMap<>();
 		if (existing != null) {
 			AppDeploymentRequest taskDeploymentRequest = existing.getTaskDeploymentRequest();
 			if (taskDeploymentRequest != null) {
@@ -49,7 +51,19 @@ public class TaskAnalyzer {
 					if (arg.startsWith("--")) {
 						String[] split = arg.substring(2).split("=", 2);
 						if (split.length == 2) {
-							existingCommandLineArgumentProperties.put(split[0], split[1]);
+							existingCommandLineArgumentPropertiesDoubleDash.put(split[0], split[1]);
+						}
+					}
+					else if (arg.startsWith("-")) {
+						String[] split = arg.substring(1).split("=", 2);
+						if (split.length == 2) {
+							existingCommandLineArgumentPropertiesSingleDash.put(split[0], split[1]);
+						}
+					}
+					else {
+						String[] split = arg.split("=", 2);
+						if (split.length == 2) {
+							existingCommandLineArgumentPropertiesNoDash.put(split[0], split[1]);
 						}
 					}
 				}
@@ -57,7 +71,9 @@ public class TaskAnalyzer {
 		}
 
 		Map<String, String> replacingDeploymentProperties = null;
-		Map<String, String> replacingCommandLineArgumentProperties = new HashMap<>();
+		Map<String, String> replacingCommandLineArgumentPropertiesDoubleDash = new HashMap<>();
+		Map<String, String> replacingCommandLineArgumentPropertiesSingleDash = new HashMap<>();
+		Map<String, String> replacingCommandLineArgumentPropertiesNoDash = new HashMap<>();
 		if (replacing != null) {
 			AppDeploymentRequest taskDeploymentRequest = replacing.getTaskDeploymentRequest();
 			if (taskDeploymentRequest != null) {
@@ -67,7 +83,19 @@ public class TaskAnalyzer {
 					if (arg.startsWith("--")) {
 						String[] split = arg.substring(2).split("=", 2);
 						if (split.length == 2) {
-							replacingCommandLineArgumentProperties.put(split[0], split[1]);
+							replacingCommandLineArgumentPropertiesDoubleDash.put(split[0], split[1]);
+						}
+					}
+					else if (arg.startsWith("-")) {
+						String[] split = arg.substring(1).split("=", 2);
+						if (split.length == 2) {
+							replacingCommandLineArgumentPropertiesSingleDash.put(split[0], split[1]);
+						}
+					}
+					else {
+						String[] split = arg.split("=", 2);
+						if (split.length == 2) {
+							replacingCommandLineArgumentPropertiesNoDash.put(split[0], split[1]);
 						}
 					}
 				}
@@ -77,11 +105,22 @@ public class TaskAnalyzer {
 		PropertiesDiff deploymentPropertiesDifference = PropertiesDiff.builder().left(existingDeploymentProperties)
 				.right(replacingDeploymentProperties).build();
 
-		PropertiesDiff existingCommandLineArgumentPropertiesDifference = PropertiesDiff.builder()
-				.left(existingCommandLineArgumentProperties).right(replacingCommandLineArgumentProperties).build();
+		PropertiesDiff existingCommandLineArgumentPropertiesDifferenceDoubleDash = PropertiesDiff.builder()
+				.left(existingCommandLineArgumentPropertiesDoubleDash)
+				.right(replacingCommandLineArgumentPropertiesDoubleDash).build();
+
+		PropertiesDiff existingCommandLineArgumentPropertiesDifferenceSingleDash = PropertiesDiff.builder()
+				.left(existingCommandLineArgumentPropertiesSingleDash)
+				.right(replacingCommandLineArgumentPropertiesSingleDash).build();
+
+		PropertiesDiff existingCommandLineArgumentPropertiesDifferenceNoDash = PropertiesDiff.builder()
+				.left(existingCommandLineArgumentPropertiesNoDash).right(replacingCommandLineArgumentPropertiesNoDash)
+				.build();
 
 		TaskManifestDifference taskManifestDifference = new TaskManifestDifference(deploymentPropertiesDifference,
-				existingCommandLineArgumentPropertiesDifference);
+				existingCommandLineArgumentPropertiesDifferenceDoubleDash,
+				existingCommandLineArgumentPropertiesDifferenceSingleDash,
+				existingCommandLineArgumentPropertiesDifferenceNoDash);
 		return new TaskAnalysisReport(taskManifestDifference);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskManifestDifference.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskManifestDifference.java
@@ -24,26 +24,42 @@ package org.springframework.cloud.dataflow.server.service.impl.diff;
 public class TaskManifestDifference {
 
 	private final PropertiesDiff deploymentPropertiesDifference;
-	private final PropertiesDiff commandLineArgumentPropertiesDifference;
+	private final PropertiesDiff commandLineArgumentPropertiesDifferenceDoubleDash;
+	private final PropertiesDiff commandLineArgumentPropertiesDifferenceSingleDash;
+	private final PropertiesDiff commandLineArgumentPropertiesDifferenceNoDash;
 
 	public TaskManifestDifference(PropertiesDiff deploymentPropertiesDifference,
-			PropertiesDiff commandLineArgumentPropertiesDifference) {
+			PropertiesDiff commandLineArgumentPropertiesDifferenceDoubleDash,
+			PropertiesDiff commandLineArgumentPropertiesDifferenceSingleDash,
+			PropertiesDiff commandLineArgumentPropertiesDifferenceNoDash) {
 		this.deploymentPropertiesDifference = deploymentPropertiesDifference;
-		this.commandLineArgumentPropertiesDifference = commandLineArgumentPropertiesDifference;
+		this.commandLineArgumentPropertiesDifferenceDoubleDash = commandLineArgumentPropertiesDifferenceDoubleDash;
+		this.commandLineArgumentPropertiesDifferenceSingleDash = commandLineArgumentPropertiesDifferenceSingleDash;
+		this.commandLineArgumentPropertiesDifferenceNoDash = commandLineArgumentPropertiesDifferenceNoDash;
 	}
 
 	public PropertiesDiff getDeploymentPropertiesDifference() {
 		return deploymentPropertiesDifference;
 	}
 
-	public PropertiesDiff getCommandLineArgumentPropertiesDifference() {
-		return commandLineArgumentPropertiesDifference;
+	public PropertiesDiff getCommandLineArgumentPropertiesDifferenceDoubleDash() {
+		return commandLineArgumentPropertiesDifferenceDoubleDash;
+	}
+
+	public PropertiesDiff getCommandLineArgumentPropertiesDifferenceSingleDash() {
+		return commandLineArgumentPropertiesDifferenceSingleDash;
+	}
+
+	public PropertiesDiff getCommandLineArgumentPropertiesDifferenceNoDash() {
+		return commandLineArgumentPropertiesDifferenceNoDash;
 	}
 
 	@Override
 	public String toString() {
-		return "TaskManifestDifference [commandLineArgumentPropertiesDifference="
-				+ commandLineArgumentPropertiesDifference + ", deploymentPropertiesDifference="
+		return "TaskManifestDifference [commandLineArgumentPropertiesDifferenceDoubleDash="
+				+ commandLineArgumentPropertiesDifferenceDoubleDash + ", commandLineArgumentPropertiesDifferenceNoDash="
+				+ commandLineArgumentPropertiesDifferenceNoDash + ", commandLineArgumentPropertiesDifferenceSingleDash="
+				+ commandLineArgumentPropertiesDifferenceSingleDash + ", deploymentPropertiesDifference="
 				+ deploymentPropertiesDifference + "]";
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
@@ -81,6 +81,8 @@ public class TaskAnalyzerTests {
 		Map<String, String> leftDeploymentProperties = new HashMap<>();
 		List<String> leftCommandlineArguments = new ArrayList<>();
 		leftCommandlineArguments.add("--key1=value1");
+		leftCommandlineArguments.add("-key2=value2");
+		leftCommandlineArguments.add("key3=value3");
 		AppDeploymentRequest leftAdr = new AppDeploymentRequest(leftAd, leftResource, leftDeploymentProperties,
 				leftCommandlineArguments);
 		TaskManifest leftManifest = new TaskManifest();
@@ -92,6 +94,8 @@ public class TaskAnalyzerTests {
 		Map<String, String> rightDeploymentProperties = new HashMap<>();
 		List<String> rightCommandlineArguments = new ArrayList<>();
 		rightCommandlineArguments.add("--key1=value1");
+		rightCommandlineArguments.add("-key2=value2");
+		rightCommandlineArguments.add("key3=value3");
 
 		AppDeploymentRequest rightAdr = new AppDeploymentRequest(rightAd, rightResource, rightDeploymentProperties,
 				rightCommandlineArguments);
@@ -101,18 +105,20 @@ public class TaskAnalyzerTests {
 
 		TaskAnalysisReport report = analyzer.analyze(leftManifest, rightManifest);
 		TaskManifestDifference taskManifestDifference = report.getTaskManifestDifference();
-		PropertiesDiff commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifference();
+		PropertiesDiff commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifferenceDoubleDash();
 		assertThat(commandLineArgumentPropertiesDifference.areEqual()).isTrue();
 
 		rightCommandlineArguments.add("--key1=value2");
+		rightCommandlineArguments.add("-key2=value3");
+		rightCommandlineArguments.add("key3=value4");
 
 		report = analyzer.analyze(leftManifest, rightManifest);
 		taskManifestDifference = report.getTaskManifestDifference();
 
-		commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifference();
+		commandLineArgumentPropertiesDifference = taskManifestDifference.getCommandLineArgumentPropertiesDifferenceDoubleDash();
 		assertThat(commandLineArgumentPropertiesDifference.areEqual()).isFalse();
-		assertThat(report.getMergedCommandLineArguments()).hasSize(1);
-		assertThat(report.getMergedCommandLineArguments()).containsOnly("--key1=value2");
+		assertThat(report.getMergedCommandLineArguments()).hasSize(3);
+		assertThat(report.getMergedCommandLineArguments()).containsOnly("--key1=value2", "-key2=value3", "key3=value4");
 	}
 
 }


### PR DESCRIPTION
- This commit adds support for processing task arguments
  which are passed as `-foo=bar` and `foo=bar` format.
- Relates to an issue PR'd with #3555 which broke
  tests as new tests for these pros were added after
  PR were issued.
- Polish DefaultTaskExecutionService