### PR TITLE
Add feature to auto create task definitions if flag is set.

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -157,6 +157,20 @@ Created new task 'mytask'
 A listing of the current task definitions can be obtained through the RESTful API or the shell.
 To get the task definition list by using the shell, use the `task list` command.
 
+==== Automating the Creation of Task Definitions
+As of version 2.3.0, the Data Flow server can be configured to auto create task definitions by setting `spring.cloud.dataflow.task.autocreate-task-definitions` to `true`.
+This is not the default behavior but provided as a convenience.
+When this property is enabled, a task launch request can specify the registered task application name as the task name.
+If the task application is registered, the server will create a basic task definition that specifies only the app name, as required. This eliminates a manual step equivalent to something like:
+
+[source,bash,subs=attributes]
+----
+dataflow:>task create mytask --definition "mytask"
+----
+
+Command line arguments and deployment properties can still be specified for each task launch request.
+
+
 [[spring-cloud-dataflow-task-launch]]
 === Launching a Task
 An adhoc task can be launched through the RESTful API or the shell.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -97,6 +97,9 @@ public class TaskConfiguration {
 	@Value("${spring.cloud.dataflow.server.uri:}")
 	private String dataflowServerUri;
 
+	@Autowired
+	private TaskConfigurationProperties taskConfigurationProperties;
+
 	@Bean
 	public DeployerConfigurationMetadataResolver deployerConfigurationMetadataResolver(
 			TaskConfigurationProperties taskConfigurationProperties) {
@@ -181,12 +184,16 @@ public class TaskConfiguration {
 			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator,
 			TaskExplorer taskExplorer,
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
-		return new DefaultTaskExecutionService(
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			TaskSaveService taskSaveService) {
+
+		DefaultTaskExecutionService defaultTaskExecutionService = new DefaultTaskExecutionService(
 				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService,
 				taskAppDeploymentRequestCreator, taskExplorer, dataflowTaskExecutionDao,
-				dataflowTaskExecutionMetadataDao);
+				dataflowTaskExecutionMetadataDao, taskSaveService);
+		defaultTaskExecutionService.setAutoCreateTaskDefinitions(taskConfigurationProperties.isAutoCreateTaskDefinitions());
+		return defaultTaskExecutionService;
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -149,10 +149,11 @@ public class TaskExecutionController {
 	}
 
 	/**
-	 * Request the launching of an existing task definition. The name must be included in the
-	 * path.
+	 * Request the launching of an existing task definition. The task definition will be created from a registered task application
+	 * if `spring.cloud.dataflow.task.auto-create-task-definitions` is true.
+	 * The name must be included in the path.
 	 *
-	 * @param taskName the name of the existing task to be executed (required)
+	 * @param taskName the name of the task to be executed (required)
 	 * @param ctrname user specified name of a ctr app if different than the default.
 	 * @param properties the runtime properties for the task, as a comma-delimited list of
 	 *     key=value pairs
@@ -167,6 +168,7 @@ public class TaskExecutionController {
 			@RequestParam(required = false) String arguments) {
 		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parse(properties);
 		List<String> argumentsToUse = DeploymentPropertiesUtils.parseParamList(arguments, " ");
+
 		return this.taskExecutionService.executeTask(taskName, propertiesToUse, argumentsToUse, ctrname);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
@@ -127,6 +127,8 @@ public class DefaultTaskExecutionInfoService implements TaskExecutionInfoService
 
 		TaskDefinition originalTaskDefinition = taskDefinitionRepository.findById(taskName)
 				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskName));
+		//TODO: This normally called by JPA automatically but `AutoCreateTaskDefinitionTests` fails without this.
+		originalTaskDefinition.initialize();
 		TaskParser taskParser = new TaskParser(originalTaskDefinition.getName(), originalTaskDefinition.getDslText(),
 				true, true);
 		TaskNode taskNode = taskParser.parse();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -145,7 +145,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 * @param taskExecutionRepositoryService the service used to create the task execution
 	 * @param dataflowTaskExecutionMetadataDao repository used to manipulate task manifests
 	 */
-	//@formatter:off
 	public DefaultTaskExecutionService(LauncherRepository launcherRepository,
 			AuditRecordService auditRecordService,
 			TaskRepository taskRepository,
@@ -157,7 +156,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 			DataflowTaskExecutionDao dataflowTaskExecutionDao,
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
 			TaskSaveService taskSaveService) {
-		//@formatter:on
+
 		Assert.notNull(launcherRepository, "launcherRepository must not be null");
 		Assert.notNull(auditRecordService, "auditRecordService must not be null");
 		Assert.notNull(taskExecutionInfoService, "taskExecutionInfoService must not be null");

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -62,6 +62,12 @@ public class TaskConfigurationProperties {
 	private String taskLauncherPrefix = "tasklauncher";
 
 	/**
+	 * Whether the server should auto create task definitions if one does not exist for a launch request and
+	 * a registered task application with the same name does exist.
+	 */
+	private boolean autoCreateTaskDefinitions;
+
+	/**
 	 * The properties for showing deployer properties.
 	 */
 	private DeployerProperties deployerProperties = new DeployerProperties();
@@ -112,6 +118,14 @@ public class TaskConfigurationProperties {
 
 	public void setDeployerProperties(DeployerProperties deployerProperties) {
 		this.deployerProperties = deployerProperties;
+	}
+
+	public boolean isAutoCreateTaskDefinitions() {
+		return autoCreateTaskDefinitions;
+	}
+
+	public void setAutoCreateTaskDefinitions(boolean autoCreateTaskDefinitions) {
+		this.autoCreateTaskDefinitions = autoCreateTaskDefinitions;
 	}
 
 	public static class DeployerProperties {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -265,14 +265,15 @@ public class JobDependencies {
 			TaskExecutionCreationService taskExecutionRepositoryService,
 			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator,
 			TaskExplorer taskExplorer, DataflowTaskExecutionDao dataflowTaskExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			TaskSaveService taskSaveService) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, auditRecordService,
 				taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository,
 				taskExecutionRepositoryService, taskAppDeploymentRequestCreator,
 				taskExplorer, dataflowTaskExecutionDao,
-				dataflowTaskExecutionMetadataDao);
+				dataflowTaskExecutionMetadataDao, taskSaveService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -280,12 +280,15 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 			TaskExecutionCreationService taskExecutionRepositoryService,
 			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator,
 			TaskExplorer taskExplorer, DataflowTaskExecutionDao dataflowTaskExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
-		return new DefaultTaskExecutionService(
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			TaskSaveService taskSaveService) {
+		DefaultTaskExecutionService taskExecutionService =  new DefaultTaskExecutionService(
 				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository,
 				taskExecutionRepositoryService, taskAppDeploymentRequestCreator,
-				taskExplorer, dataflowTaskExecutionDao, dataflowTaskExecutionMetadataDao);
+				taskExplorer, dataflowTaskExecutionDao, dataflowTaskExecutionMetadataDao, taskSaveService);
+		taskExecutionService.setAutoCreateTaskDefinitions(taskConfigurationProperties.isAutoCreateTaskDefinitions());
+		return taskExecutionService;
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -168,6 +168,7 @@ import static org.mockito.Mockito.when;
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
  * @author Gunnar Hillert
+ * @author David Turanski
  */
 @Configuration
 @EnableSpringDataWebSupport
@@ -510,12 +511,13 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			TaskExecutionCreationService taskExecutionRepositoryService,
 			TaskAppDeploymentRequestCreator taskAppDeploymentRequestCreator,
 			TaskExplorer taskExplorer, DataflowTaskExecutionDao dataflowTaskExecutionDao,
-			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao) {
+			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
+			TaskSaveService taskSaveService) {
 		return new DefaultTaskExecutionService(
 				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository,
 				taskExecutionRepositoryService, taskAppDeploymentRequestCreator,
-				taskExplorer, dataflowTaskExecutionDao, dataflowTaskExecutionMetadataDao);
+				taskExplorer, dataflowTaskExecutionDao, dataflowTaskExecutionMetadataDao, taskSaveService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -152,9 +152,6 @@ public abstract class DefaultTaskExecutionServiceTests {
 	@Autowired
 	TaskDeleteService taskDeleteService;
 
-	//@Autowired
-	//TaskExecutionInfoService taskExecutionInfoService;
-
 	@Autowired
 	TaskExecutionService taskExecutionService;
 
@@ -730,6 +727,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			initializeSuccessfulRegistry(appRegistry);
 			when(this.taskLauncher.launch(any())).thenReturn("0");
 			taskExecutionService.executeTask("demo", new HashMap<>(), new LinkedList<>());
+			assertNotNull(taskDefinitionRepository.findByTaskName("demo"));
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
@@ -53,6 +53,7 @@ import org.springframework.cloud.dataflow.server.repository.TaskDeploymentReposi
 import org.springframework.cloud.dataflow.server.service.TaskExecutionCreationService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoService;
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -99,6 +100,9 @@ public class DefaultTaskExecutionServiceTransactionTests {
 	AppRegistryService appRegistry;
 
 	@Autowired
+	TaskSaveService taskSaveService;
+
+	@Autowired
 	TaskExecutionInfoService taskExecutionInfoService;
 
 	@Autowired
@@ -139,7 +143,7 @@ public class DefaultTaskExecutionServiceTransactionTests {
 				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, mock(TaskDeploymentRepository.class),
 				taskExecutionRepositoryService, taskAppDeploymentRequestCreator,
-				this.taskExplorer, this.dataflowTaskExecutionDao, this.dataflowTaskExecutionMetadataDao);
+				this.taskExplorer, this.dataflowTaskExecutionDao, this.dataflowTaskExecutionMetadataDao, this.taskSaveService);
 
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud-stream-app-starters/tasklauncher-dataflow/issues/24

Modify DefaultTaskExecutionService to auto create task definition from registered task app if property is set.  Currently requires a work-around to manually invoke `TaskDefinition.initialize()` in `DefaultTaskExecutionInfoService` still investigating root cause, but should work as is. 
