### PR TITLE
Reference appropriate service account names in CRB's

### DIFF
--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     app: prometheus-proxy
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: prometheus-proxy
     namespace: default
 roleRef:
   kind: ClusterRole

--- a/src/kubernetes/prometheus/prometheus-clusterrolebinding.yaml
+++ b/src/kubernetes/prometheus/prometheus-clusterrolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: prometheus
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: prometheus
   namespace: default

--- a/src/kubernetes/prometheus/prometheus-deployment.yaml
+++ b/src/kubernetes/prometheus/prometheus-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: prometheus
       containers:
         - name: prometheus
           image: prom/prometheus:v2.12.0


### PR DESCRIPTION
Resolves #3618

Tested install and sample stream using guides:
* https://dataflow.spring.io/docs/2.3.0.SNAPSHOT/installation/kubernetes/kubectl/
* https://dataflow.spring.io/docs/feature-guides/streams/monitoring/

and was able to see metrics flowing