### PR TITLE
Add oauth client configs to DataFlowClient

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
@@ -56,6 +56,8 @@ public class DataFlowClientAutoConfiguration {
 
 	private static Log logger = LogFactory.getLog(DataFlowClientAutoConfiguration.class);
 
+	private static final String DEFAULT_REGISTRATION_ID = "default";
+
 	@Autowired
 	private DataFlowClientProperties properties;
 
@@ -80,7 +82,7 @@ public class DataFlowClientAutoConfiguration {
 			logger.debug("Configured OAuth2 Access Token for accessing the Data Flow Server");
 		}
 		else if (StringUtils.hasText(this.properties.getAuthentication().getClientId())) {
-			ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId("default");
+			ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId(DEFAULT_REGISTRATION_ID);
 			OAuth2ClientCredentialsGrantRequest grantRequest = new OAuth2ClientCredentialsGrantRequest(clientRegistration);
 			OAuth2AccessTokenResponse res = clientCredentialsTokenResponseClient.getTokenResponse(grantRequest);
 			String accessTokenValue = res.getAccessToken().getTokenValue();
@@ -112,7 +114,7 @@ public class DataFlowClientAutoConfiguration {
 		public InMemoryClientRegistrationRepository clientRegistrationRepository(
 			DataFlowClientProperties properties) {
 			ClientRegistration clientRegistration = ClientRegistration
-				.withRegistrationId("default")
+				.withRegistrationId(DEFAULT_REGISTRATION_ID)
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
 				.tokenUri(properties.getAuthentication().getTokenUri())
 				.clientId(properties.getAuthentication().getClientId())

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
@@ -22,8 +22,10 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.common.security.core.support.OAuth2AccessTokenProvidingClientHttpRequestInterceptor;
+import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
 import org.springframework.cloud.dataflow.rest.client.dsl.Stream;
@@ -31,6 +33,15 @@ import org.springframework.cloud.dataflow.rest.client.dsl.StreamBuilder;
 import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.client.endpoint.DefaultClientCredentialsTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
@@ -51,6 +62,12 @@ public class DataFlowClientAutoConfiguration {
 	@Autowired(required = false)
 	private RestTemplate restTemplate;
 
+	@Autowired
+	private @Nullable ClientRegistrationRepository clientRegistrations;
+
+	@Autowired
+	private @Nullable OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient;
+
 	@Bean
 	@ConditionalOnMissingBean(DataFlowOperations.class)
 	public DataFlowOperations dataFlowOperations() throws Exception{
@@ -61,6 +78,14 @@ public class DataFlowClientAutoConfiguration {
 		if (StringUtils.hasText(this.properties.getAuthentication().getAccessToken())) {
 			template.getInterceptors().add(new OAuth2AccessTokenProvidingClientHttpRequestInterceptor(this.properties.getAuthentication().getAccessToken()));
 			logger.debug("Configured OAuth2 Access Token for accessing the Data Flow Server");
+		}
+		else if (StringUtils.hasText(this.properties.getAuthentication().getClientId())) {
+			ClientRegistration clientRegistration = clientRegistrations.findByRegistrationId("default");
+			OAuth2ClientCredentialsGrantRequest grantRequest = new OAuth2ClientCredentialsGrantRequest(clientRegistration);
+			OAuth2AccessTokenResponse res = clientCredentialsTokenResponseClient.getTokenResponse(grantRequest);
+			String accessTokenValue = res.getAccessToken().getTokenValue();
+			template.getInterceptors().add(new OAuth2AccessTokenProvidingClientHttpRequestInterceptor(accessTokenValue));
+			logger.debug("Configured OAuth2 Client Credentials for accessing the Data Flow Server");
 		}
 		else if(!StringUtils.isEmpty(properties.getAuthentication().getBasic().getUsername()) &&
 				!StringUtils.isEmpty(properties.getAuthentication().getBasic().getPassword())){
@@ -79,4 +104,27 @@ public class DataFlowClientAutoConfiguration {
 		return Stream.builder(dataFlowOperations);
 	}
 
+	@ConditionalOnProperty(prefix = DataFlowPropertyKeys.PREFIX + "client.authentication", name = "client-id")
+	@Configuration
+	static class ClientCredentialsConfiguration {
+
+		@Bean
+		public InMemoryClientRegistrationRepository clientRegistrationRepository(
+			DataFlowClientProperties properties) {
+			ClientRegistration clientRegistration = ClientRegistration
+				.withRegistrationId("default")
+				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+				.tokenUri(properties.getAuthentication().getTokenUri())
+				.clientId(properties.getAuthentication().getClientId())
+				.clientSecret(properties.getAuthentication().getClientSecret())
+				.scope(properties.getAuthentication().getScope())
+				.build();
+			return new InMemoryClientRegistrationRepository(clientRegistration);
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient() {
+			return new DefaultClientCredentialsTokenResponseClient();
+		}
+	}
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientProperties.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.cloud.dataflow.rest.client.config;
+
+import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
@@ -86,12 +88,64 @@ public class DataFlowClientProperties {
 		 */
 		private String accessToken;
 
+		/**
+		 * OAuth2 Client Id.
+		 */
+		private String clientId;
+
+		/**
+		 * OAuth2 Client Secret.
+		 */
+		private String clientSecret;
+
+		/**
+		 * OAuth2 Token Uri.
+		 */
+		private String tokenUri;
+
+		/**
+		 * OAuth2 Scopes.
+		 */
+		private Set<String> scope;
+
 		public String getAccessToken() {
 			return accessToken;
 		}
 
 		public void setAccessToken(String accessToken) {
 			this.accessToken = accessToken;
+		}
+
+		public String getClientId() {
+			return clientId;
+		}
+
+		public void setClientId(String clientId) {
+			this.clientId = clientId;
+		}
+
+		public String getClientSecret() {
+			return clientSecret;
+		}
+
+		public void setClientSecret(String clientSecret) {
+			this.clientSecret = clientSecret;
+		}
+
+		public String getTokenUri() {
+			return tokenUri;
+		}
+
+		public void setTokenUri(String tokenUri) {
+			this.tokenUri = tokenUri;
+		}
+
+		public Set<String> getScope() {
+			return scope;
+		}
+
+		public void setScope(Set<String> scope) {
+			this.scope = scope;
 		}
 
 		public Basic getBasic() {

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/DataFlowClientAutoConfigurationAgaintstServerTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/DataFlowClientAutoConfigurationAgaintstServerTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.single.security;
 
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -47,6 +48,16 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(
 			"classpath:org/springframework/cloud/dataflow/server/single/security/oauthConfig.yml");
 
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void clean() {
+		if (context != null) {
+			context.close();
+		}
+		context = null;
+	}
+
 	@ClassRule
 	public static TestRule springDataflowAndOAuth2Server = RuleChain.outerRule(oAuth2ServerResource)
 			.around(localDataflowResource);
@@ -67,7 +78,7 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 
 		System.setProperty("accessTokenAsString", accessToken.getValue());
 
-		final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestApplication.class);
+		context = new AnnotationConfigApplicationContext(TestApplication.class);
 
 		final DataFlowOperations dataFlowOperations = context.getBean(DataFlowOperations.class);
 		final AboutResource about = dataFlowOperations.aboutOperation().get();
@@ -75,7 +86,6 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 		assertNotNull(about);
 		assertEquals("user", about.getSecurityInfo().getUsername());
 		assertEquals(7, about.getSecurityInfo().getRoles().size());
-		context.close();
 	}
 
 	@Test
@@ -94,7 +104,7 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 
 		System.setProperty("accessTokenAsString", accessToken.getValue());
 
-		final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestApplication.class);
+		context = new AnnotationConfigApplicationContext(TestApplication.class);
 
 		final DataFlowOperations dataFlowOperations = context.getBean(DataFlowOperations.class);
 		final AboutResource about = dataFlowOperations.aboutOperation().get();
@@ -102,13 +112,11 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 		assertNotNull(about);
 		assertEquals("bob", about.getSecurityInfo().getUsername());
 		assertEquals(1, about.getSecurityInfo().getRoles().size());
-		context.close();
 	}
 
 	@Test
-	public void usingUserWithViewRolesWithOauth() throws Exception {
-
-		final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+	public void usingUserWithViewRolesWithOauth() {
+		context = new AnnotationConfigApplicationContext();
 		TestPropertyValues.of(
 				"spring.cloud.dataflow.client.server-uri=" + "http://localhost:"
 						+ localDataflowResource.getDataflowPort(),
@@ -126,7 +134,6 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 		assertNotNull(about);
 		assertEquals("myclient", about.getSecurityInfo().getUsername());
 		assertEquals(1, about.getSecurityInfo().getRoles().size());
-		context.close();
 	}
 
 	@Import(DataFlowClientAutoConfiguration.class)


### PR DESCRIPTION
- New properties client-id, client-secret, token-uri and scope in
  DataFlowClientProperties
- Enabled if `access-token` is not defined and `client-id` is set.
- Basically idea copied from a tasklauncher sink.
- With this `spring-cloud-dataflow-scheduler-task-launcher` can just get launcher with props:
  spring.cloud.scheduler.task.launcher.task-name=task1
  spring.cloud.dataflow.client.authentication.client-id=dataflow
  spring.cloud.dataflow.client.authentication.client-secret=secret
  spring.cloud.dataflow.client.authentication.token-uri=http://localhost:8080/uaa/oauth/token
  spring.cloud.dataflow.client.authentication.scope=dataflow.view,dataflow.create,dataflow.manage
- Fixes #3617