### PR TITLE
If the log retrieval throws an exception give the user a message

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -554,7 +554,15 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 				return "Log could not be retrieved as the task instance is not running by the ID: "+ taskId;
 			}
 		}
-		return findTaskLauncher(platformName).getLog(taskId);
+		String result;
+		try {
+			result = findTaskLauncher(platformName).getLog(taskId);
+		}
+		catch (Exception iae) {
+			logger.warn("Failed to retrieve the log, returning verification message. ", iae);
+			result = "Log could not be retrieved.  Verify that deployments are still available.";
+		}
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
vs just failing.   Also log the exception with a warning.

resolves #3523