### PR TITLE
Fix task deployment properties

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -31,8 +31,10 @@ import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.util.FileCopyUtils;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -140,6 +142,7 @@ public class DeploymentPropertiesUtilsTests {
 	@Test
 	public void testDeployerProperties() {
 		Map<String, String> props = new LinkedHashMap<>();
+		props.put("app.myapp.foo", "bar");
 		props.put("deployer.myapp.count", "2");
 		props.put("deployer.myapp.foo", "bar");
 		props.put("deployer.otherapp.count", "5");
@@ -150,6 +153,24 @@ public class DeploymentPropertiesUtilsTests {
 		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
 		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
 		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
+		assertThat(result, not(hasKey("app.myapp.foo")));
+	}
+
+	@Test
+	public void testDeployerPropertiesWithApp() {
+		Map<String, String> props = new LinkedHashMap<>();
+		props.put("app.myapp.foo", "bar");
+		props.put("deployer.myapp.count", "2");
+		props.put("deployer.myapp.foo", "bar");
+		props.put("deployer.otherapp.count", "5");
+		props.put("deployer.*.precedence", "wildcard");
+		props.put("deployer.myapp.precedence", "app");
+		Map<String, String> result = DeploymentPropertiesUtils.qualifyDeployerProperties(props, "myapp");
+
+		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
+		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
+		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
+		assertThat(result, hasKey("app.myapp.foo"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.controller.WhitelistProperties;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
@@ -97,7 +98,10 @@ public class TaskAppDeploymentRequestCreator {
 
 		// Need to keep all properties around, not just 'deployer.*'
 		// as those are a source to restore app specific props
-		Map<String, String> deployerDeploymentProperties = taskExecutionInformation.getTaskDeploymentProperties();
+		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
+			.qualifyDeployerProperties(taskExecutionInformation.getTaskDeploymentProperties(),
+					taskExecutionInformation.isComposed()? "composed-task-runner" : registeredAppName);
+
 		if (StringUtils.hasText(this.dataflowServerUri) && taskExecutionInformation.isComposed()) {
 			TaskServiceUtils.updateDataFlowUriIfNeeded(this.dataflowServerUri, appDeploymentProperties,
 					commandLineArgs);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -309,7 +309,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			assertEquals("file:src/test/resources/apps/foo-task", lastManifest.getTaskDeploymentRequest().getResource().getURL().toString());
 			assertEquals("default", lastManifest.getPlatformName());
 			assertEquals(1, lastManifest.getTaskDeploymentRequest().getDeploymentProperties().size());
-			assertEquals("100000GB", lastManifest.getTaskDeploymentRequest().getDeploymentProperties().get("deployer.demo.memory"));
+			assertEquals("100000GB", lastManifest.getTaskDeploymentRequest().getDeploymentProperties().get("spring.cloud.deployer.memory"));
 
 			verify(this.taskLauncher, never()).destroy(TASK_NAME_ORIG);
 		}
@@ -342,7 +342,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			assertEquals("file:src/test/resources/apps/foo-task", lastManifest.getTaskDeploymentRequest().getResource().getURL().toString());
 			assertEquals("default", lastManifest.getPlatformName());
 			assertEquals(1, lastManifest.getTaskDeploymentRequest().getDeploymentProperties().size());
-			assertEquals("10000GB", lastManifest.getTaskDeploymentRequest().getDeploymentProperties().get("deployer.demo.memory"));
+			assertEquals("10000GB", lastManifest.getTaskDeploymentRequest().getDeploymentProperties().get("spring.cloud.deployer.memory"));
 
 			verify(this.taskLauncher).destroy(TASK_NAME_ORIG);
 		}


### PR DESCRIPTION
- Add new qualifyDeployerProperties which also keep around
  app related deploy props.
- Problem with original PR adding deploy props reuse were that
  we never qualified those props so we're missing a proper
  prefix.
- For exaple if we set `deployer.timestamp.local.javaOpts` we
  now get `spring.cloud.deployer.local.javaOpts` to stored in
  a manifest which aligns how things are used and stored with
  streams.
- Fixes #3636