### PR TITLE
Update OOTB application coordinates

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/applications.adoc
@@ -14,139 +14,115 @@ A selection of pre-built link:https://cloud.spring.io/spring-cloud-stream-app-st
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-source[sftp]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-processor[tcp-client]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-sink[mqtt]
-|spark-yarn ~(deprecated)~
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_task[timestamp]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jms-source[jms]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-scriptable-transform[scriptable-transform]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-log-sink[log]
-|spark-cluster ~(deprecated)~
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-source[ftp]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-clound-stream-modules-transform-processor[transform]
-|task-launcher-yarn ~(deprecated)~
-|spark-client ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput]
+|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-time-source[time]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-header-enricher-processor[header-enricher]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-throughput-sink[throughput]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_task[timestamp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb]
+|
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-load-generator-source[load-generator]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-http-processor[python-http]
-|task-launcher-local ~(deprecated)~
-|jdbchdfs-local ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp]
+|
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-syslog-source[syslog]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitter-sentiment-processor[twitter-sentiment]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-sink[mongodb]
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_composed_task_runner[composed-task-runner]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc]
+|
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-source[s3]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-splitter[splitter]
-|hdfs-dataset ~(deprecated)~
-|link:https://docs.spring.io/spring-cloud-task-app-starters/docs/current/reference/htmlsingle/#_timestamp_batch_task[timestamp-batch]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra]
+|
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-loggregator-source[loggregator]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-image-recognition-processor[image-recognition]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-ftp-sink[ftp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[triggertask]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-bridge-processor[bridge]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-sink[jdbc]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-twitterstream-source[twitterstream]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pmml-processor[pmml]
-|aggregate-counter ~(deprecated)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mongodb-source[mongodb]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-python-jython-processor[python-jython]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-cassandra-sink[cassandra] ~(only:2.1.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-cq-source[gemfire-cq]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-transform-processor[groovy-transform]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-router-sink[router]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-http-source[http]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-httpclient-processor[httpclient]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-redis-sink[redis-pubsub]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-source[rabbit]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-filter-processor[filter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-sink[file]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-source[tcp]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pose-estimation-processor[pose-estimation]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-websocket-sink[websocket]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-trigger-source[trigger]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-grpc-processor[grpc]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aws-s3-sink[s3]
+|link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mqtt-source[mqtt]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-groovy-filter-processor[groovy-filter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-rabbit-sink[rabbit]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-client-source[tcp-client]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-aggregator-processor[aggregator]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-sink[counter]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-task-launcher-dataflow-sink[tasklauncher-dataflow]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-mail-source[mail]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-counter-processor[counter]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-pgcopy-sink[pgcopy]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-jdbc-source[jdbc]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tensorflow-processor[tensorflow]
-|link:https://github.com/spring-cloud-stream-app-starters/gpfdist[gpfdist] ~(1.3.x)~
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-source[gemfire]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tasklaunchrequest-transform[tasklaunchrequest-transform]
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-sink[sftp]
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire]
 |
 
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-file-source[file]
 |link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-object-detection-processor[object-detection]
-|field-value-counter ~(deprecated)~
+|
 |
 
+|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-sftp-dataflow-source[sftp-dataflow]
 |
 |
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-task-launcher-dataflow-sink[tasklauncher-dataflow]
-|
-
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-hdfs-sink[hdfs]
-|
-
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-tcp-sink[tcp]
-|
-
-|
-|
-|link:{scs-app-starters-docs-htmlsingle}/#spring-cloud-stream-modules-gemfire-sink[gemfire]
-|
-
-|
-|
-|task-launcher-cloudfoundry ~(deprecated)~
 |
 |======================
-
-NOTE: The above table includes Applications that are compatible with two versions of Spring Boot and Spring Cloud Stream
-releases. Darwin-release-train _(Spring Boot 2.0.x + Spring Cloud Stream 2.0.x)_ and Einstein-release-train
-_(Spring Boot 2.1.x + Spring Cloud Stream 2.1.x)_, respectively.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -347,55 +347,27 @@ list of desired application-URIs in a custom property file.
 
 ===== Spring Cloud Stream App Starters
 
-The following table includes the dataflow.spring.io links to the available Stream Application Starters based on Spring Cloud Stream 2.0.x
-and Spring Boot 2.0.x:
+The following table includes the dataflow.spring.io links to the available Stream Application Starters based on Spring Cloud Stream 2.1.x
+and Spring Boot 2.1.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |RabbitMQ + Maven
-|https://dataflow.spring.io/Darwin-SR3-stream-applications-rabbit-maven
-|https://dataflow.spring.io/Darwin-BUILD-SNAPSHOT-stream-applications-rabbit-maven
-
-|RabbitMQ + Docker
-|https://dataflow.spring.io/Darwin-SR3-stream-applications-rabbit-docker
-|https://dataflow.spring.io/Darwin-BUILD-SNAPSHOT-stream-applications-rabbit-docker
-
-|Apache Kafka + Maven
-|https://dataflow.spring.io/Darwin-SR3-stream-applications-kafka-maven
-|https://dataflow.spring.io/Darwin-BUILD-SNAPSHOT-stream-applications-kafka-maven
-
-|Apache Kafka + Docker
-|https://dataflow.spring.io/Darwin-SR3-stream-applications-kafka-docker
-|https://dataflow.spring.io/Darwin-BUILD-SNAPSHOT-stream-applications-kafka-docker
-|======================
-
-The following table includes the dataflow.spring.io links to the available Stream Application Starters based on Spring Cloud Stream 2.1.x
-and Spring Boot 2.1.x:
-
-[width="100%",frame="topbot",options="header"]
-|======================
-|Artifact Type |Latest Release|Stable Release |SNAPSHOT Release
-
-|RabbitMQ + Maven
 |https://dataflow.spring.io/rabbitmq-maven-latest
-|https://dataflow.spring.io/Einstein-SR3-stream-applications-rabbit-maven
 |https://dataflow.spring.io/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-maven
 
 |RabbitMQ + Docker
 |https://dataflow.spring.io/rabbitmq-docker-latest
-|https://dataflow.spring.io/Einstein-SR3-stream-applications-rabbit-docker
 |https://dataflow.spring.io/Einstein-BUILD-SNAPSHOT-stream-applications-rabbit-docker
 
 |Apache Kafka + Maven
 |https://dataflow.spring.io/kafka-maven-latest
-|https://dataflow.spring.io/Einstein-SR3-stream-applications-kafka-maven
 |https://dataflow.spring.io/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-maven
 
 |Apache Kafka + Docker
 |https://dataflow.spring.io/kafka-docker-latest
-|https://dataflow.spring.io/Einstein-SR3-stream-applications-kafka-docker
 |https://dataflow.spring.io/Einstein-BUILD-SNAPSHOT-stream-applications-kafka-docker
 |======================
 
@@ -413,35 +385,18 @@ Spring Cloud Data Flow"] blog to learn more about the developer and orchestratio
 
 ===== Spring Cloud Task App Starters
 
-The following table includes the available Task Application Starters based on Spring Cloud Task 2.0.x and Spring Boot 2.0.x:
+The following table includes the available Task Application Starters based on Spring Cloud Task 2.1.x and Spring Boot 2.1.x:
 
 [width="100%",frame="topbot",options="header"]
 |======================
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |Maven
-|https://dataflow.spring.io/Dearborn-SR1-task-applications-maven
-|https://dataflow.spring.io/Dearborn-BUILD-SNAPSHOT-task-applications-maven
-
-|Docker
-|https://dataflow.spring.io/Dearborn-SR1-task-applications-docker
-|https://dataflow.spring.io/Dearborn-BUILD-SNAPSHOT-task-applications-docker
-|======================
-
-The following table includes the available Task Application Starters based on Spring Cloud Task 2.1.x and Spring Boot 2.1.x:
-
-[width="100%",frame="topbot",options="header"]
-|======================
-|Artifact Type |Latest Release|Stable Release |SNAPSHOT Release
-
-|Maven
 |https://dataflow.spring.io/task-maven-latest
-|https://dataflow.spring.io/Elston-GA-task-applications-maven
 |https://dataflow.spring.io/Elston-BUILD-SNAPSHOT-task-applications-maven
 
 |Docker
 |https://dataflow.spring.io/task-docker-latest
-|https://dataflow.spring.io/Elston-GA-task-applications-docker
 |https://dataflow.spring.io/Elston-BUILD-SNAPSHOT-task-applications-docker
 |======================
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -109,24 +109,10 @@ Then you can use the `app import` command and provide the location of the proper
 app import --uri file:///tmp/task-apps.properties
 ```
 
-For convenience, we have the static files with application-URIs (for both maven and docker) available for all the out-of-the-box Task app-starters.
-You can point to this file and import all the application-URIs in bulk.
-Otherwise, as explained earlier in this chapter, you can register them individually or have your own custom property file with only the required application-URIs in it.
-It is recommended, however, to have a "`focused`" list of desired application-URIs in a custom property file.
-
-The following table lists the available static property files:
-
-[width="100%",frame="topbot",options="header"]
-|======================
-|Artifact Type |Stable Release |SNAPSHOT Release
-|Maven   | https://dataflow.spring.io/Dearborn-SR1-task-applications-maven | https://dataflow.spring.io/Dearborn-BUILD-SNAPSHOT-task-applications-maven
-|Docker  | https://dataflow.spring.io/Dearborn-SR1-task-applications-docker | https://dataflow.spring.io/Dearborn-BUILD-SNAPSHOT-task-applications-docker
-|======================
-
 For example, if you would like to register all out-of-the-box task applications in bulk, you can do so with the following command:
 
 ```
-dataflow:>app import --uri https://dataflow.spring.io/Dearborn-SR1-task-applications-maven
+dataflow:>app import --uri https://dataflow.spring.io/task-maven-latest
 ```
 
 You can also pass the `--local` option (which is `TRUE` by default) to indicate whether the properties file location should be resolved within the shell process itself.


### PR DESCRIPTION
- Update `Applications` list
- Remove stale and deprecated apps from the list 
- Remove App older release-train coordinates from the docs (i.e., Dearborn / Darwin)
- Remove explicit GA-link references; the `lates` URL going forward is sufficient