### PR TITLE
Move to spring-cloud-dataflow-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 			 release versions -->
 		<!-- Note: Also make sure the parent pom version in spring-cloud-dataflow-dependencies/pom.xml is in sync -->
 		<groupId>org.springframework.cloud</groupId>
-		<artifactId>spring-cloud-build</artifactId>
-		<version>2.2.0.RELEASE</version>
+		<artifactId>spring-cloud-dataflow-build</artifactId>
+		<version>2.4.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<licenses>


### PR DESCRIPTION
- Simple change to use spring-cloud-dataflow-build instead
  of spring-cloud-build.
- Relates spring-cloud/spring-cloud-dataflow#3670