### PR TITLE
Trim schedule name before processing

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.dataflow.server.controller;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.springframework.cloud.dataflow.rest.resource.ScheduleInfoResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.server.repository.NoSuchScheduleException;
@@ -149,7 +151,7 @@ public class TaskSchedulerController {
 			@RequestParam(required = false) String arguments) {
 		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parse(properties);
 		List<String> argumentsToUse = DeploymentPropertiesUtils.parseParamList(arguments, " ");
-		schedulerService.schedule(scheduleName, taskDefinitionName, propertiesToUse, argumentsToUse);
+		this.schedulerService.schedule(StringUtils.trim(scheduleName), taskDefinitionName, propertiesToUse, argumentsToUse);
 	}
 
 	/**
@@ -164,7 +166,7 @@ public class TaskSchedulerController {
 	}
 
 	/**
-	 * {@link org.springframework.hateoas.server.ResourceAssembler} implementation that converts
+	 * {@link org.springframework.hateoas.server.RepresentationModelAssembler} implementation that converts
 	 * {@link ScheduleInfo}s to {@link ScheduleInfoResource}s.
 	 */
 	class Assembler extends RepresentationModelAssemblerSupport<ScheduleInfo, ScheduleInfoResource> {


### PR DESCRIPTION
 - The valid exception message is now propogated from the K8s deployer back to the SCDF server side
 - The only pending issue to be fixed is to address one of the concerns raised in this (trim the schedule name)

Resolves #3551