### PR TITLE
Added check to make sure schedule name fits k8's spec

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPlatformFactory.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/TaskPlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,13 @@ package org.springframework.cloud.dataflow.core;
 /**
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
+ * @author Glenn Renfro
  **/
 public interface TaskPlatformFactory {
 
 	String CLOUDFOUNDRY_PLATFORM_TYPE = "Cloud Foundry";
+	String KUBERNETES_PLATFORM_TYPE = "Kubernetes";
+	String LOCAL_PLATFORM_TYPE = "Local";
 
 	/**
 	 * Create the {@link TaskPlatform} instance with the launchers.

--- a/spring-cloud-dataflow-platform-kubernetes/src/main/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/main/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,9 @@ import org.springframework.cloud.deployer.spi.scheduler.kubernetes.KubernetesSch
 
 /**
  * @author David Turanski
+ * @author Glenn Renfro
  **/
 public class KubernetesTaskPlatformFactory extends AbstractTaskPlatformFactory<KubernetesPlatformProperties> {
-
-	private final static String PLATFORM_TYPE = "Kubernetes";
 
 	private final Optional<KubernetesSchedulerProperties> schedulerProperties;
 
@@ -46,7 +45,7 @@ public class KubernetesTaskPlatformFactory extends AbstractTaskPlatformFactory<K
 			KubernetesPlatformProperties platformProperties,
 			Optional<KubernetesSchedulerProperties> schedulerProperties,
 			boolean schedulesEnabled) {
-		super(platformProperties, PLATFORM_TYPE);
+		super(platformProperties, KUBERNETES_PLATFORM_TYPE);
 		this.schedulerProperties = schedulerProperties;
 		this.schedulesEnabled = schedulesEnabled;
 	}
@@ -63,7 +62,7 @@ public class KubernetesTaskPlatformFactory extends AbstractTaskPlatformFactory<K
 				kubernetesProperties, kubernetesClient, containerFactory);
 
 		Scheduler scheduler = getScheduler(schedulerProperties, kubernetesClient);
-		Launcher launcher = new Launcher(account, PLATFORM_TYPE, kubernetesTaskLauncher, scheduler);
+		Launcher launcher = new Launcher(account, KUBERNETES_PLATFORM_TYPE, kubernetesTaskLauncher, scheduler);
 
 		launcher.setDescription(
 				String.format("master url = [%s], namespace = [%s], api version = [%s]",

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,14 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author David Turanski
+ * @author Glenn Renfro
  **/
 public class LocalTaskPlatformFactory extends AbstractTaskPlatformFactory<LocalPlatformProperties> {
 
-	private static final String PLATFORM_TYPE = "Local";
 	private final Scheduler localScheduler;
 
 	public LocalTaskPlatformFactory(LocalPlatformProperties platformProperties, Scheduler localScheduler) {
-		super(platformProperties, PLATFORM_TYPE);
+		super(platformProperties, LOCAL_PLATFORM_TYPE);
 		this.localScheduler = localScheduler;
 	}
 
@@ -60,7 +60,7 @@ public class LocalTaskPlatformFactory extends AbstractTaskPlatformFactory<LocalP
 
 	private Launcher doCreateLauncher(String account, LocalDeployerProperties deployerProperties) {
 		LocalTaskLauncher localTaskLauncher = new LocalTaskLauncher(deployerProperties);
-		Launcher launcher = new Launcher(account, PLATFORM_TYPE, localTaskLauncher, localScheduler);
+		Launcher launcher = new Launcher(account, LOCAL_PLATFORM_TYPE, localTaskLauncher, localScheduler);
 		launcher.setDescription(prettyPrintLocalDeployerProperties(deployerProperties));
 		return launcher;
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -167,22 +167,36 @@ public class DefaultSchedulerServiceTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
+		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
+				"12345677890123456", BASE_DEFINITION_NAME, this.testProperties,
+				this.commandLineArgs);
+	}
 
-		Launcher launcher = new Launcher("default", "kubernetes", Mockito.mock(TaskLauncher.class), scheduler);
+	@Test
+	public void testScheduleWithCapitalizeNameOnKuberenetesPlatform() {
+		SchedulerService testSchedulerService = getMockedKubernetesSchedulerService();
+		testSchedulerService.schedule(BASE_SCHEDULE_NAME + "AB", BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+		List<ScheduleInfo> scheduleInfos = testSchedulerService.list();
+		assertThat(scheduleInfos.size()).isEqualTo(1);
+		assertThat(scheduleInfos.get(0).getScheduleName()).isEqualTo("mytaskscheduleab-scdf-mytaskdefinition");
+	}
+
+	private SchedulerService getMockedKubernetesSchedulerService() {
+		Launcher launcher = new Launcher("default", "Kubernetes", Mockito.mock(TaskLauncher.class), scheduler);
 		List<Launcher> launchers = new ArrayList<>();
 		launchers.add(launcher);
 		TaskPlatform taskPlatform = new TaskPlatform("testTaskPlatform", launchers);
 
-		SchedulerService testSchedulerService = new DefaultSchedulerService(this.commonApplicationProperties,
+		return  new DefaultSchedulerService(this.commonApplicationProperties,
 				taskPlatform, this.taskDefinitionRepository,
 				this.appRegistry, this.resourceLoader,
 				this.taskConfigurationProperties, null,
 				this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService);
-		testSchedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456", BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 	}
 
 	public void testScheduleWithLongName(){
-		schedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456", BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+		schedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456",
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 


### PR DESCRIPTION
All other checks will be managed by the deployer.
This size check was required so that users could get a useful message when they exceed the 52 char limit
Since now we construct the schedule name

resolves #3704