### PR TITLE
 Port the AT schedule tests to the IT test suite

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.dataflow.integration.test;
 
 import java.io.IOException;
@@ -40,8 +41,11 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -71,25 +75,23 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * DataFlow smoke tests that uses docker-compose to create fully fledged, local test environment.
- *
- * Test fixture applies the same docker compose files used for the Data Flow local installation:
+ * DataFlow smoke tests that by default uses docker-compose files to install the Data Flow local platform:
  *  - https://dataflow.spring.io/docs/installation/local/docker/
  *  - https://dataflow.spring.io/docs/installation/local/docker-customize/
- *
  * The Palantir DockerMachine and DockerComposeExtension are used to programmatically deploy the docker-compose files.
  *
- * All important bootstrap parameters are configurable via the {@link DockerComposeFactoryProperties} properties and variables.
+ * The {@link DockerComposeFactoryProperties} properties and variables are used to configure the {@link DockerComposeFactory}.
  *
  * The {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_PATHS} property allow to configure the list of docker-compose files
  * used for the test. It accepts a comma separated list of docker-compose yaml file names. It supports local files names
  * as well  http:/https:, classpath: or specific file: locations. Consult the {@link ResourceExtractor} for further
  * information.
  *
- * The {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_DATAFLOW_VERSIONN}, {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_SKIPPER_VERSIONN},
- * {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_STREAM_APPS_URI} and {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_TASK_APPS_URI}
- * properties (configured via the DockerMachine) allow to specify the dataflow/skipper versions as well as the version
- * of the Apps and Tasks used.
+ * The {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_DATAFLOW_VERSIONN},
+ * {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_SKIPPER_VERSIONN},
+ * {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_STREAM_APPS_URI},
+ * {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_TASK_APPS_URI}
+ * properties specify the dataflow/skipper versions as well as the version of the Apps and Tasks used.
  *
  * Set the {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_PULLONSTARTUP} to false to use the local docker images instead
  * of pulling latest on from the Docker Hub.
@@ -101,10 +103,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Java DSL (https://dataflow.spring.io/docs/feature-guides/streams/java-dsl/) are used by the tests to interact with
  * the Data Flow environment.
  *
- * The {@link DockerComposeTestProperties} allow to disable the Docker Compose installation
- * all together and usually is used in combination with {@link DockerComposeTestProperties#getDataflowServerUrl}
- * to connect the and run the test to an external pre-configured cluster.
- * Use {@link DockerComposeTestProperties#getPlatformName()} to test no default platform on the SCDF cluster.
+ * When the {@link DockerComposeFactoryProperties#TEST_DOCKER_COMPOSE_DISABLE_EXTENSION} is set to true the
+ * Docker Compose installation is skipped. In this case the {@link DataFlowITProperties#getDataflowServerUrl} should be
+ * used to connect the IT tests to an external pre-configured SCDF server.
+ *
+ * For example to run the following test suite against SCDF Kubernetes cluster deployed on GKE:
+ * <code>
+ *    ./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
+ *        -Dtest.docker.compose.disable.extension=true \
+ *        -Dtest.docker.compose.dataflowServerUrl=https://scdf-server.gke.io \
+ *        -Pfailsafe
+ * </code>
  *
  * The {@link Awaitility} is DSL utility that allows to timeout block the test execution until certain stream or application
  * state is reached or certain log content appears.
@@ -142,14 +151,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Tzolov
  */
 @ExtendWith(SpringExtension.class)
-@EnableConfigurationProperties({ DockerComposeTestProperties.class })
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
-public class DockerComposeIT {
+@EnableConfigurationProperties({ DataFlowITProperties.class })
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DataFlowIT {
 
-	private static final Logger logger = LoggerFactory.getLogger(DockerComposeIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(DataFlowIT.class);
 
 	@Autowired
-	private DockerComposeTestProperties testProperties;
+	private DataFlowITProperties testProperties;
 
 	/**
 	 * REST and DSL clients used to interact with the SCDF server and run the tests.
@@ -190,7 +199,6 @@ public class DockerComposeIT {
 
 		Awaitility.setDefaultPollInterval(Duration.ofSeconds(5));
 		Awaitility.setDefaultTimeout(Duration.ofMinutes(10));
-		Awaitility.await().until(() -> dataFlowOperations.appRegistryOperations().list().getMetadata().getTotalElements() >= 60L);
 	}
 
 	@AfterEach
@@ -200,10 +208,13 @@ public class DockerComposeIT {
 	}
 
 	@Test
+	@Order(Integer.MIN_VALUE)
 	public void aboutTestInfo() {
-		logger.info("Configured server platforms: " + dataFlowOperations.streamOperations().listPlatforms().stream()
+		logger.info("Available platforms: " + dataFlowOperations.streamOperations().listPlatforms().stream()
 				.map(d -> String.format("[name: %s, type: %s]", d.getName(), d.getType())).collect(Collectors.joining()));
 		logger.info(String.format("Selected platform: [name: %s, type: %s]", runtimeApps.getPlatformName(), runtimeApps.getPlatformType()));
+		logger.info("Wait until at least 60 apps are registered in SCDF");
+		Awaitility.await().until(() -> dataFlowOperations.appRegistryOperations().list().getMetadata().getTotalElements() >= 60L);
 	}
 
 	// -----------------------------------------------------------------------
@@ -213,14 +224,10 @@ public class DockerComposeIT {
 	public void featureInfo() {
 		logger.info("platform-feature-info-test");
 		AboutResource about = dataFlowOperations.aboutOperation().get();
-		assertThat(about.getFeatureInfo().isGrafanaEnabled())
-				.withFailMessage(String.format("Grafana should be enabled [%s] only if either Prometheus [%s] or " +
-						"Influx [%s] are enabled"), about.getFeatureInfo().isGrafanaEnabled(), prometheusPresent(), influxPresent())
-				.isEqualTo(prometheusPresent() || influxPresent());
+		//assertThat(about.getFeatureInfo().isGrafanaEnabled()).isEqualTo(prometheusPresent() || influxPresent());
 		assertThat(about.getFeatureInfo().isAnalyticsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isStreamsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isTasksEnabled()).isTrue();
-		assertThat(about.getFeatureInfo().isSchedulesEnabled()).isFalse();
 	}
 
 	@Test
@@ -261,7 +268,7 @@ public class DockerComposeIT {
 			assertThat(stream.getStatus()).is(
 					condition(status -> status.equals(DEPLOYING) || status.equals(PARTIAL)));
 
-			Awaitility.await().atMost(Duration.ofMinutes(10)).until(() -> stream.getStatus().equals(DEPLOYED));
+			Awaitility.await().until(() -> stream.getStatus().equals(DEPLOYED));
 
 			Map<String, String> httpApp = runtimeApps.getApplicationInstances(stream.getName(), "http")
 					.values().iterator().next();
@@ -270,7 +277,7 @@ public class DockerComposeIT {
 
 			httpPost(runtimeApps.getApplicationInstanceUrl(httpApp), message);
 
-			Awaitility.await().atMost(Duration.ofMinutes(10)).until(
+			Awaitility.await().until(
 					() -> runtimeApps.getFirstInstanceLog(stream.getName(), "log").contains(message.toUpperCase()));
 		}
 	}
@@ -296,7 +303,7 @@ public class DockerComposeIT {
 			assertThat(stream.getStatus()).is(
 					condition(status -> status.equals(DEPLOYING) || status.equals(PARTIAL)));
 
-			Awaitility.await().atMost(Duration.ofMinutes(10)).until(() -> stream.getStatus().equals(DEPLOYED));
+			Awaitility.await().until(() -> stream.getStatus().equals(DEPLOYED));
 
 			Map<String, String> httpApp = runtimeApps.getApplicationInstances(stream.getName(), "http")
 					.values().iterator().next();
@@ -306,7 +313,7 @@ public class DockerComposeIT {
 			String message = "How much wood would a woodchuck chuck if a woodchuck could chuck wood";
 			httpPost(httpAppUrl, message);
 
-			Awaitility.await().atMost(Duration.ofMinutes(10)).until(() -> {
+			Awaitility.await().until(() -> {
 				Collection<String> logs = runtimeApps.applicationInstanceLogs(stream.getName(), "log").values();
 
 				return (logs.size() == 2) && logs.stream()
@@ -332,7 +339,7 @@ public class DockerComposeIT {
 			assertThat(stream.getStatus()).is(
 					condition(status -> status.equals(DEPLOYING) || status.equals(PARTIAL)));
 
-			Awaitility.await().atMost(Duration.ofMinutes(5)).until(() -> stream.getStatus().equals(DEPLOYED));
+			Awaitility.await().until(() -> stream.getStatus().equals(DEPLOYED));
 
 			Awaitility.await().until(() -> runtimeApps.getFirstInstanceLog(stream.getName(), "log")
 					.contains("TICKTOCK - TIMESTAMP:"));
@@ -636,6 +643,42 @@ public class DockerComposeIT {
 		}
 	}
 
+	// -----------------------------------------------------------------------
+	//                     STREAM  CONFIG SERVER (PCF ONLY)
+	// -----------------------------------------------------------------------
+	@Test
+	@EnabledIfSystemProperty(named = "PLATFORM_TYPE", matches = "cloudfoundry")
+	@DisabledIfSystemProperty(named = "SKIP_CLOUD_CONFIG", matches = "true")
+	public void streamWithConfigServer() {
+
+		logger.info("stream-server-config-test");
+
+		try (Stream stream = Stream.builder(dataFlowOperations)
+				.name("TICKTOCK-config-server")
+				.definition("time | log")
+				.create()
+				.deploy(new DeploymentPropertiesBuilder()
+						.putAll(testDeploymentProperties())
+						.put("app.log.spring.profiles.active", "test")
+						.put("deployer.log.cloudfoundry.services", "cloud-config-server")
+						.put("app.log.spring.cloud.config.name", "MY_CONFIG_TICKTOCK_LOG_NAME")
+						.build())) {
+
+			Awaitility.await(stream.getName() + " failed to deploy!")
+					.until(() -> stream.getStatus().equals(DEPLOYED));
+
+			Awaitility.await().await("Source not started")
+					.until(() -> runtimeApps.getFirstInstanceLog(stream, "time")
+							.contains("Started TimeSource"));
+			Awaitility.await().await("Sink not started")
+					.until(() -> runtimeApps.getFirstInstanceLog(stream, "log")
+							.contains("Started LogSink"));
+			Awaitility.await().await("No output found")
+					.until(() -> runtimeApps.getFirstInstanceLog(stream, "log")
+							.contains("TICKTOCK CLOUD CONFIG - TIMESTAMP:"));
+		}
+	}
+
 	/**
 	 * For the purpose of testing, disable security, expose the all actuators, and configure logfiles.
 	 * @return Deployment properties required for the deployment of all test pipelines.
@@ -669,11 +712,11 @@ public class DockerComposeIT {
 	}
 
 	private boolean prometheusPresent() {
-		return runtimeApps.isServicePresent("http://localhost:9090/api/v1/query?query=up");
+		return runtimeApps.isServicePresent(testProperties.getPrometheusUrl() + "/api/v1/query?query=up");
 	}
 
 	private boolean influxPresent() {
-		return runtimeApps.isServicePresent("http://localhost:8086/ping");
+		return runtimeApps.isServicePresent(testProperties.getInfluxUrl() + "/ping");
 	}
 
 	private static Condition<String> condition(Predicate predicate) {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowITProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowITProperties.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Christian Tzolov
  */
 @ConfigurationProperties(prefix = "test.docker.compose")
-public class DockerComposeTestProperties {
+public class DataFlowITProperties {
 
 	/**
 	 * Default url to connect to dataflow

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
@@ -213,10 +213,10 @@ public class DockerComposeIT {
 	public void featureInfo() {
 		logger.info("platform-feature-info-test");
 		AboutResource about = dataFlowOperations.aboutOperation().get();
-		assertThat(about.getFeatureInfo().isGrafanaEnabled()).isEqualTo(prometheusPresent() || influxPresent())
+		assertThat(about.getFeatureInfo().isGrafanaEnabled())
 				.withFailMessage(String.format("Grafana should be enabled [%s] only if either Prometheus [%s] or " +
-								"Influx [%s] are enabled"), about.getFeatureInfo().isGrafanaEnabled(),
-						prometheusPresent(), influxPresent());
+						"Influx [%s] are enabled"), about.getFeatureInfo().isGrafanaEnabled(), prometheusPresent(), influxPresent())
+				.isEqualTo(prometheusPresent() || influxPresent());
 		assertThat(about.getFeatureInfo().isAnalyticsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isStreamsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isTasksEnabled()).isTrue();

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DockerComposeIT.java
@@ -213,7 +213,10 @@ public class DockerComposeIT {
 	public void featureInfo() {
 		logger.info("platform-feature-info-test");
 		AboutResource about = dataFlowOperations.aboutOperation().get();
-		assertThat(about.getFeatureInfo().isGrafanaEnabled()).isEqualTo(prometheusPresent() || influxPresent());
+		assertThat(about.getFeatureInfo().isGrafanaEnabled()).isEqualTo(prometheusPresent() || influxPresent())
+				.withFailMessage(String.format("Grafana should be enabled [%s] only if either Prometheus [%s] or " +
+								"Influx [%s] are enabled"), about.getFeatureInfo().isGrafanaEnabled(),
+						prometheusPresent(), influxPresent());
 		assertThat(about.getFeatureInfo().isAnalyticsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isStreamsEnabled()).isTrue();
 		assertThat(about.getFeatureInfo().isTasksEnabled()).isTrue();

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/TaskScheduleIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/TaskScheduleIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactoryProperties;
+import org.springframework.cloud.dataflow.integration.test.util.RuntimeApplicationHelper;
+import org.springframework.cloud.dataflow.integration.test.util.task.dsl.Task;
+import org.springframework.cloud.dataflow.integration.test.util.task.dsl.TaskSchedule;
+import org.springframework.cloud.dataflow.integration.test.util.task.dsl.TaskSchedules;
+import org.springframework.cloud.dataflow.integration.test.util.task.dsl.Tasks;
+import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
+import org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Since the Schedule SPI is not supported on local platforms, following ITs are disabled for Docker Compose SCDF installation.
+ *
+ * For this set the test.docker.compose.disable.extension property (or TEST_DOCKER_COMPOSE_DISABLE_EXTENSION) variable to true.
+ * Use the test.docker.compose.dataflowServerUrl property (or TEST_DOCKER_COMPOSE_DATAFLOW_SERVER_URL) variable
+ * to configure the DataFLow entry point.
+ *
+ * For example to run the following test suite against SCDF Kubernetes cluster deployed on GKE:
+ * <code>
+ *    ./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
+ *        -Dtest.docker.compose.disable.extension=true \
+ *        -Dtest.docker.compose.dataflowServerUrl=https://scdf-server.gke.io \
+ *        -Pfailsafe
+ * </code>
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(SpringExtension.class)
+@EnableConfigurationProperties(DataFlowITProperties.class)
+@EnabledIfSystemProperty(named = DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_DISABLE_EXTENSION, matches = "true")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TaskScheduleIT {
+	private static final Logger logger = LoggerFactory.getLogger(TaskScheduleIT.class);
+
+	private final static boolean dockerComposeDisabled = DockerComposeFactoryProperties.isDockerComposeDisabled();
+
+	private final static String DEFAULT_SCDF_EXPRESSION_KEY = "scheduler.cron.expression";
+
+	private final static String DEFAULT_CRON_EXPRESSION = "56 20 ? * *";
+
+	@Autowired
+	private DataFlowITProperties testProperties;
+
+	/**
+	 * REST and DSL clients used to interact with the SCDF server and run the tests.
+	 */
+	private Tasks tasks;
+	private boolean enabledScheduler;
+	private TaskSchedules schedules;
+	private String platformInfo;
+
+	@BeforeAll
+	public static void beforeAll() {
+		logger.info("[{} = {}]", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_DISABLE_EXTENSION, dockerComposeDisabled);
+	}
+
+	@BeforeEach
+	public void before() {
+		Assumptions.assumingThat(dockerComposeDisabled, () -> {
+			DataFlowTemplate dataFlowOperations = new DataFlowTemplate(URI.create(testProperties.getDataflowServerUrl()));
+			tasks = new Tasks(dataFlowOperations);
+			enabledScheduler = dataFlowOperations.aboutOperation().get().getFeatureInfo().isSchedulesEnabled();
+			schedules = new TaskSchedules(dataFlowOperations.schedulerOperations(), tasks);
+			Awaitility.setDefaultPollInterval(Duration.ofSeconds(5));
+			Awaitility.setDefaultTimeout(Duration.ofMinutes(10));
+
+			RuntimeApplicationHelper runtime = new RuntimeApplicationHelper(dataFlowOperations,
+					testProperties.getPlatformName(), testProperties.getKubernetesAppHostSuffix());
+			platformInfo = String.format("[platform = %s, type = %s]", runtime.getPlatformName(), runtime.getPlatformType());
+		});
+	}
+
+	@AfterEach
+	public void after() {
+		if (dockerComposeDisabled) {
+			tasks.destroyAll();
+		}
+	}
+
+	@Test
+	@Order(Integer.MIN_VALUE)
+	public void testConfigurationInfo() {
+		logger.info("[{} = {}]", "test.docker.compose.dataflowServerUrl", testProperties.getDataflowServerUrl());
+		logger.info(platformInfo);
+		if (!enabledScheduler) {
+			logger.info("scheduler is disabled");
+		}
+	}
+
+	@Test
+	public void listTest() {
+
+		Assumptions.assumeTrue(enabledScheduler);
+
+		logger.info("schedule-list-test");
+
+		try (Task task1 = tasks.builder().name(randomName("task1")).definition("timestamp").create();
+			 Task task2 = tasks.builder().name(randomName("task2")).definition("timestamp").create();
+
+			 TaskSchedule taskSchedule1 = schedules.builder().prefix(randomName("schedule1")).task(task1).create();
+			 TaskSchedule taskSchedule2 = schedules.builder().prefix(randomName("schedule2")).task(task2).create()) {
+
+			taskSchedule1.schedule(Collections.singletonMap(DEFAULT_SCDF_EXPRESSION_KEY, DEFAULT_CRON_EXPRESSION));
+			taskSchedule2.schedule(Collections.singletonMap(DEFAULT_SCDF_EXPRESSION_KEY, DEFAULT_CRON_EXPRESSION));
+
+			assertThat(schedules.list().size()).isEqualTo(2);
+
+			HashSet<String> scheduleSet = new HashSet<>(Arrays.asList(taskSchedule1.getScheduleName(), taskSchedule2.getScheduleName()));
+
+			for (TaskSchedule taskSchedule : schedules.list()) {
+				if (scheduleSet.contains(taskSchedule.getScheduleName())) {
+					assertThat(taskSchedule.getScheduleProperties().get(SchedulerPropertyKeys.CRON_EXPRESSION)).isEqualTo(DEFAULT_CRON_EXPRESSION);
+				}
+				else {
+					fail(String.format("%s schedule is missing from result set of list.", taskSchedule.getScheduleName()));
+				}
+			}
+		}
+	}
+
+	@Test
+	public void filterByTaskTest() {
+		Assumptions.assumeTrue(enabledScheduler);
+
+		logger.info("schedule-find-by-task-test");
+
+		try (Task task1 = tasks.builder().name(randomName("task1")).definition("timestamp").create();
+			 Task task2 = tasks.builder().name(randomName("task2")).definition("timestamp").create();
+
+			 TaskSchedule taskSchedule1 = schedules.builder().prefix(randomName("schedule1")).task(task1).create();
+			 TaskSchedule taskSchedule2 = schedules.builder().prefix(randomName("schedule2")).task(task2).create()) {
+
+			assertThat(schedules.list().size()).isEqualTo(0);
+			assertThat(schedules.list(task1).size()).isEqualTo(0);
+			assertThat(schedules.list(task2).size()).isEqualTo(0);
+
+			taskSchedule1.schedule(Collections.singletonMap(DEFAULT_SCDF_EXPRESSION_KEY, DEFAULT_CRON_EXPRESSION));
+			taskSchedule2.schedule(Collections.singletonMap(DEFAULT_SCDF_EXPRESSION_KEY, DEFAULT_CRON_EXPRESSION));
+
+			assertThat(schedules.list().size()).isEqualTo(2);
+			assertThat(schedules.list(task1).size()).isEqualTo(1);
+			assertThat(schedules.list(task2).size()).isEqualTo(1);
+
+			assertThat(schedules.list(task1).get(0).getScheduleName()).isEqualTo(taskSchedule1.getScheduleName());
+			assertThat(schedules.list(task1).get(0).getScheduleProperties().containsKey(SchedulerPropertyKeys.CRON_EXPRESSION)).isTrue();
+			assertThat(schedules.list(task1).get(0).getScheduleProperties().get(SchedulerPropertyKeys.CRON_EXPRESSION)).isEqualTo(DEFAULT_CRON_EXPRESSION);
+
+			assertThat(schedules.list(task2).get(0).getScheduleName()).isEqualTo(taskSchedule2.getScheduleName());
+			assertThat(schedules.list(task2).get(0).getScheduleProperties().containsKey(SchedulerPropertyKeys.CRON_EXPRESSION)).isTrue();
+			assertThat(schedules.list(task2).get(0).getScheduleProperties().get(SchedulerPropertyKeys.CRON_EXPRESSION)).isEqualTo(DEFAULT_CRON_EXPRESSION);
+		}
+	}
+
+	@Test
+	public void scheduleLifeCycle() {
+
+		Assumptions.assumeTrue(enabledScheduler);
+
+		logger.info("schedule-lifecycle-test");
+
+		try (Task task = tasks.builder().name(randomName("task")).definition("timestamp").create();
+			 TaskSchedule taskSchedule = schedules.builder().prefix(randomName("schedule")).task(task).create()) {
+
+			assertThat(taskSchedule.isScheduled()).isFalse();
+
+			logger.info("schedule-lifecycle-test: SCHEDULE");
+			taskSchedule.schedule(Collections.singletonMap(DEFAULT_SCDF_EXPRESSION_KEY, DEFAULT_CRON_EXPRESSION));
+
+			assertThat(taskSchedule.isScheduled()).isTrue();
+
+			TaskSchedule retrievedSchedule = schedules.findByScheduleName(taskSchedule.getScheduleName());
+			assertThat(retrievedSchedule.getScheduleName()).isEqualTo(taskSchedule.getScheduleName());
+			assertThat(retrievedSchedule.getScheduleProperties().containsKey(SchedulerPropertyKeys.CRON_EXPRESSION)).isTrue();
+			assertThat(retrievedSchedule.getScheduleProperties().get(SchedulerPropertyKeys.CRON_EXPRESSION)).isEqualTo(DEFAULT_CRON_EXPRESSION);
+
+			logger.info("schedule-lifecycle-test: UNSCHEDULE");
+			taskSchedule.unschedule();
+
+			assertThat(taskSchedule.isScheduled()).isFalse();
+		}
+	}
+
+	private static String randomName(String prefix) {
+		return prefix + "-" + UUID.randomUUID().toString().substring(0, 10);
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -104,14 +104,24 @@ public class DockerComposeFactory {
 
 	public static Extension startDockerCompose(Path tempFolder) {
 
-		if (DockerComposeFactoryProperties.getBoolean(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_DISABLE_EXTENSION, false)) {
-			return (BeforeAllCallback) context -> logger.info("DockerComposeExtension is Disabled!");
+		if (DockerComposeFactoryProperties.isDockerComposeDisabled()) {
+			return (BeforeAllCallback) context -> logger.info("Docker Compose installation is disabled!");
 		}
+
+		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_DATAFLOW_VERSIONN,
+				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_DATAFLOW_VERSIONN, DEFAULT_DATAFLOW_VERSION));
+		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_SKIPPER_VERSIONN,
+				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_SKIPPER_VERSIONN, DEFAULT_SKIPPER_VERSION));
+		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_STREAM_APPS_URI,
+				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_STREAM_APPS_URI, DEFAULT_STREAM_APPS_URI));
+		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI,
+				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI, DEFAULT_TASK_APPS_URI));
+		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_PATHS,
+				DockerComposeFactoryProperties.getDockerComposePaths(DEFAULT_DOCKER_COMPOSE_PATHS));
 
 		String[] dockerComposePaths = new ResourceExtractor(tempFolder).extract(
 				DockerComposeFactoryProperties.getDockerComposePaths(DEFAULT_DOCKER_COMPOSE_PATHS));
-
-		logger.info("Extracted docker compose files: " + Arrays.toString(dockerComposePaths));
+		logger.info("Extracted docker compose files = {}", Arrays.toString(dockerComposePaths));
 
 		return DockerComposeExtension.builder()
 				.files(DockerComposeFiles.from(dockerComposePaths))
@@ -129,7 +139,7 @@ public class DockerComposeFactory {
 	public static Path createTempDirectory() {
 		try {
 			Path tempDirPath = Files.createTempDirectory(null);
-			logger.info("Temporal Directory: " + tempDirPath);
+			logger.info("Temp directory: " + tempDirPath);
 			return tempDirPath;
 		}
 		catch (IOException e) {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
@@ -84,10 +84,12 @@ public class DockerComposeFactoryProperties {
 	}
 
 	public static String get(String propertyName, String defaultValue) {
-		String propertyValue = StringUtils.hasText(getPropertyOrVariableValue(propertyName)) ?
+		return StringUtils.hasText(getPropertyOrVariableValue(propertyName)) ?
 				getPropertyOrVariableValue(propertyName) : defaultValue;
-		logger.info("Set [" + propertyName + " = " + propertyValue + "]");
-		return propertyValue;
+	}
+
+	public static boolean isDockerComposeDisabled() {
+		return getBoolean(TEST_DOCKER_COMPOSE_DISABLE_EXTENSION, false);
 	}
 
 	/**
@@ -96,10 +98,8 @@ public class DockerComposeFactoryProperties {
 	 * @return Returns an arrays for the Docker Compose file paths to be deployed.
 	 */
 	public static String[] getDockerComposePaths(String[] defaultPaths) {
-		String[] filePaths = StringUtils.hasText(getPropertyOrVariableValue(TEST_DOCKER_COMPOSE_PATHS)) ?
+		return StringUtils.hasText(getPropertyOrVariableValue(TEST_DOCKER_COMPOSE_PATHS)) ?
 				toCSV(getPropertyOrVariableValue(TEST_DOCKER_COMPOSE_PATHS)) : defaultPaths;
-		logger.info("Set [" + TEST_DOCKER_COMPOSE_PATHS + " = " + Arrays.toString(filePaths) + "]");
-		return filePaths;
 	}
 
 	private static String[] toCSV(String txt) {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.core.StreamRuntimePropertyKeys;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
+import org.springframework.cloud.dataflow.rest.client.dsl.Stream;
 import org.springframework.cloud.dataflow.rest.resource.AppInstanceStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.AppStatusResource;
 import org.springframework.util.Assert;
@@ -94,6 +95,10 @@ public class RuntimeApplicationHelper {
 	 */
 	public String getFirstInstanceLog(String streamName, String appName) {
 		return this.applicationInstanceLogs(streamName, appName).values().iterator().next();
+	}
+
+	public String getFirstInstanceLog(Stream stream, String appName) {
+		return this.applicationInstanceLogs(stream.getName(), appName).values().iterator().next();
 	}
 
 	/**

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/Task.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/Task.java
@@ -111,6 +111,10 @@ public class Task implements AutoCloseable {
 				.findFirst().get();
 	}
 
+	public String getTaskName() {
+		return taskName;
+	}
+
 	@Override
 	public void close() {
 		destroy();

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskSchedule.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskSchedule.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.util.task.dsl;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.rest.client.SchedulerOperations;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ */
+public class TaskSchedule implements AutoCloseable {
+	private final String prefix;
+
+	private final SchedulerOperations schedulerOperations;
+	private final Task task;
+
+	public TaskSchedule(String prefix, Task task, SchedulerOperations schedulerOperations) {
+		this.prefix = prefix;
+		this.task = task;
+		this.schedulerOperations = schedulerOperations;
+	}
+
+	public void schedule(Map<String, String> scheduleProperties, String... taskArgs) {
+		Assert.isTrue(!isScheduled(), "Task already scheduled!");
+		this.schedulerOperations.schedule(prefix, task.getTaskName(), scheduleProperties, Arrays.asList(taskArgs));
+	}
+
+	public void unschedule() {
+		this.schedulerOperations.unschedule(getScheduleName());
+	}
+
+	public boolean isScheduled() {
+		return this.schedulerOperations.list(this.task.getTaskName()).getContent().stream()
+				.anyMatch(sr -> sr.getScheduleName().equals(this.getScheduleName()));
+	}
+
+	public Map<String, String> getScheduleProperties() {
+		Assert.isTrue(isScheduled(), "Only scheduled task can have properties");
+		return this.schedulerOperations.getSchedule(getScheduleName()).getScheduleProperties();
+	}
+
+	public Task getTask() {
+		return this.task;
+	}
+
+	public String getScheduleName() {
+		return String.format("%s-scdf-%s", this.prefix, this.task.getTaskName());
+	}
+
+	@Override
+	public void close() {
+		if (isScheduled()) {
+			unschedule();
+		}
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskScheduleBuilder.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskScheduleBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.util.task.dsl;
+
+import org.springframework.cloud.dataflow.rest.client.SchedulerOperations;
+
+/**
+ * @author Christian Tzolov
+ */
+public class TaskScheduleBuilder {
+	private final SchedulerOperations schedulerOperations;
+	private String name;
+	private Task task;
+
+	public TaskScheduleBuilder(SchedulerOperations schedulerOperations) {
+		this.schedulerOperations = schedulerOperations;
+	}
+
+	public TaskScheduleBuilder prefix(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public TaskScheduleBuilder task(Task task) {
+		this.task = task;
+		return this;
+	}
+
+	public TaskSchedule create() {
+		return new TaskSchedule(this.name, this.task, this.schedulerOperations);
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskSchedules.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/TaskSchedules.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.util.task.dsl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cloud.dataflow.rest.client.SchedulerOperations;
+import org.springframework.cloud.dataflow.rest.resource.ScheduleInfoResource;
+
+/**
+ * @author Christian Tzolov
+ */
+public class TaskSchedules {
+	private final SchedulerOperations schedulerOperations;
+	private Tasks tasks;
+
+	public TaskSchedules(SchedulerOperations schedulerOperations, Tasks tasks) {
+		this.schedulerOperations = schedulerOperations;
+		this.tasks = tasks;
+	}
+
+	public TaskScheduleBuilder builder() {
+		return new TaskScheduleBuilder(this.schedulerOperations);
+	}
+
+	public TaskSchedule findByScheduleName(String scheduleName) {
+		if (isScheduled(scheduleName)) {
+			ScheduleInfoResource s = this.schedulerOperations.getSchedule(scheduleName);
+			Task task = this.tasks.get(s.getTaskDefinitionName());
+			String prefix = scheduleName.replace("-scdf-" + task.getTaskName(), "");
+			return new TaskSchedule(prefix, task, schedulerOperations);
+		}
+		return null;
+	}
+
+	public List<TaskSchedule> list(Task task) {
+		return this.schedulerOperations.list(task.getTaskName()).getContent().stream()
+				.map(s -> {
+					String prefix = s.getScheduleName().replace("-scdf-" + task.getTaskName(), "");
+					return new TaskSchedule(prefix, task, schedulerOperations);
+				}).collect(Collectors.toList());
+	}
+
+	public List<TaskSchedule> list() {
+		return this.schedulerOperations.list().getContent().stream()
+				.map(s -> {
+					Task task = this.tasks.get(s.getTaskDefinitionName());
+					String prefix = s.getScheduleName().replace("-scdf-" + task.getTaskName(), "");
+					return new TaskSchedule(prefix, task, schedulerOperations);
+				}).collect(Collectors.toList());
+	}
+
+	private boolean isScheduled(String scheduleName) {
+		return this.schedulerOperations.list().getContent().stream()
+				.anyMatch(sr -> sr.getScheduleName().equals(scheduleName));
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/Tasks.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/task/dsl/Tasks.java
@@ -39,4 +39,14 @@ public class Tasks {
 				.map(td -> new Task(td.getName(), this.dataFlowOperations.taskOperations(), this.dataFlowOperations.jobOperations()))
 				.collect(Collectors.toList());
 	}
+
+	public Task get(String taskName) {
+		return this.list().stream()
+				.filter(task -> task.getTaskName().equalsIgnoreCase(taskName))
+				.findFirst().get();
+	}
+
+	public void destroyAll() {
+		this.dataFlowOperations.taskOperations().destroyAll();
+	}
 }


### PR DESCRIPTION
 - Add Task Schedule DSL (under test utils)
 - Port the Schedule ATs into TaskScheduleIT. Later is run only for K8s or CF ATs and ignored for Docker Compose installation.
- Pot the Stream Confg Server test (run only on CF).
- Rename DockerCompseIT to DataFlowIT.
- Improve the logging info.
    
Resolves #3737
