### PR TITLE
Add k8s template files for build automation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,38 @@
 	</reporting>
 	<profiles>
 		<profile>
+			<id>deploymentfiles</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-resources-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>replace-deployment-files</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<overwrite>true</overwrite>
+									<outputDirectory>${basedir}/src</outputDirectory>
+									<resources>
+										<resource>
+											<directory>${basedir}/src/templates</directory>
+											<includes>
+												<include>**/*</include>
+											</includes>
+											<filtering>true</filtering>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>spring</id>
 			<repositories>
 				<repository>

--- a/src/README.md
+++ b/src/README.md
@@ -3,9 +3,12 @@ This directory contains various build files and definitions for k8s deployment.
 
 ## Kubernetes deployment files
 
-IMPORTANT: Never ever directly modify files under kubernetes as
-           these are generated from templates/kubernetes during
+IMPORTANT: If you are planning to PR changes to deployment files, never ever
+           directly modify files under kubernetes as these
+           should get updated from templates/kubernetes during
            a maven build if profile `deploymentfiles` is enabled.
+           After maven build has done updates, resulting changes
+           can be PR'd.
 
 To generate kubernetes deployment files from templates run command:
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,23 @@
+# Service Files
+This directory contains various build files and definitions for k8s deployment.
+
+## Kubernetes deployment files
+
+IMPORTANT: Never ever directly modify files under kubernetes as
+           these are generated from templates/kubernetes during
+           a maven build if profile `deploymentfiles` is enabled.
+
+To generate kubernetes deployment files from templates run command:
+
+    ./mvnw process-resources -P deploymentfiles
+
+CI build will use this profile during a release build so that
+correct version are resolved from build properties and then
+updated files will automatically land into git under correct
+tag.
+
+However with bamboo release process when next development version
+is set these deployment files are kept on an older wrong version
+as that particular step happens outside of a maven build. It can
+either done manually after a release or get automated i.e. via
+GitHub actions.

--- a/src/templates/kubernetes/grafana/grafana-configmap.yaml
+++ b/src/templates/kubernetes/grafana/grafana-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+    - name: ScdfPrometheus
+      type: prometheus
+      access: proxy
+      org_id: 1
+      url: http://prometheus:9090
+      is_default: true
+      version: 5
+      editable: true
+      read_only: false

--- a/src/templates/kubernetes/grafana/grafana-deployment.yaml
+++ b/src/templates/kubernetes/grafana/grafana-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - image: springcloud/spring-cloud-dataflow-grafana-prometheus:@project.version@
+          name: grafana
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana
+                  key: admin-username
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana
+                  key: admin-password
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2500Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: config
+              mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
+              subPath: datasources.yaml
+      volumes:
+        - name: config
+          configMap:
+            name: grafana

--- a/src/templates/kubernetes/grafana/grafana-secret.yaml
+++ b/src/templates/kubernetes/grafana/grafana-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+data:
+  admin-username: YWRtaW4=
+  admin-password: cGFzc3dvcmQ=

--- a/src/templates/kubernetes/grafana/grafana-service.yaml
+++ b/src/templates/kubernetes/grafana/grafana-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+spec:
+  selector:
+    app: grafana
+  type: LoadBalancer
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/src/templates/kubernetes/kafka/kafka-deployment.yaml
+++ b/src/templates/kubernetes/kafka/kafka-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-broker
+  labels:
+    app: kafka
+    component: kafka-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+        component: kafka-broker
+    spec:
+      containers:
+      - name: kafka
+        image: wurstmeister/kafka:2.12-2.3.0
+        ports:
+        - containerPort: 9092
+        env:
+          - name: ENABLE_AUTO_EXTEND
+            value: "true"
+          - name: KAFKA_RESERVED_BROKER_MAX_ID
+            value: "999999999"
+          - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+            value: "false"
+          - name: KAFKA_PORT
+            value: "9092"
+          - name: KAFKA_ADVERTISED_PORT
+            value: "9092"
+          - name: KAFKA_ADVERTISED_HOST_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: KAFKA_ZOOKEEPER_CONNECT
+            value: kafka-zk:2181

--- a/src/templates/kubernetes/kafka/kafka-svc.yaml
+++ b/src/templates/kubernetes/kafka/kafka-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    app: kafka
+    component: kafka-broker
+spec:
+  ports:
+  - port: 9092
+    name: kafka-port
+    targetPort: 9092
+    protocol: TCP
+  selector:
+    app: kafka
+    component: kafka-broker

--- a/src/templates/kubernetes/kafka/kafka-zk-deployment.yaml
+++ b/src/templates/kubernetes/kafka/kafka-zk-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-zk
+  labels:
+    app: kafka
+    component: kafka-zk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-zk
+  template:
+    metadata:
+      labels:
+        app: kafka-zk
+        component: kafka-zk
+    spec:
+      containers:
+      - name: kafka-zk
+        image: digitalwonderland/zookeeper
+        ports:
+        - containerPort: 2181
+        env:
+        - name: ZOOKEEPER_ID
+          value: "1"
+        - name: ZOOKEEPER_SERVER_1
+          value: kafka-zk

--- a/src/templates/kubernetes/kafka/kafka-zk-svc.yaml
+++ b/src/templates/kubernetes/kafka/kafka-zk-svc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-zk
+  labels:
+    app: kafka
+    component: kafka-zk
+spec:
+  ports:
+  - name: client
+    port: 2181
+    protocol: TCP
+  - name: follower
+    port: 2888
+    protocol: TCP
+  - name: leader
+    port: 3888
+    protocol: TCP
+  selector:
+    app: kafka-zk
+    component: kafka-zk

--- a/src/templates/kubernetes/mysql/mysql-deployment.yaml
+++ b/src/templates/kubernetes/mysql/mysql-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.7.25
+        name: mysql
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: mysql-root-password
+                name: mysql
+        ports:
+          - containerPort: 3306
+            name: mysql
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/mysql
+        args:
+          - "--ignore-db-dir=lost+found"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: mysql

--- a/src/templates/kubernetes/mysql/mysql-pvc.yaml
+++ b/src/templates/kubernetes/mysql/mysql-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/src/templates/kubernetes/mysql/mysql-secrets.yaml
+++ b/src/templates/kubernetes/mysql/mysql-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+data:
+  mysql-root-password: eW91cnBhc3N3b3Jk

--- a/src/templates/kubernetes/mysql/mysql-svc.yaml
+++ b/src/templates/kubernetes/mysql/mysql-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-proxy
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+spec:
+#  replicas: 3
+  selector:
+    matchLabels:
+      app: prometheus-proxy
+  template:
+    metadata:
+      labels:
+        app: prometheus-proxy
+    spec:
+      serviceAccountName: prometheus-proxy
+      containers:
+        - name: prometheus-proxy
+          image: micrometermetrics/prometheus-rsocket-proxy:latest
+          imagePullPolicy: Always
+          ports:
+            - name: scrape
+              containerPort: 8080
+            - name: rsocket
+              containerPort: 7001
+          resources:
+            limits:
+              cpu: 1.0
+              memory: 2048Mi
+            requests:
+              cpu: 0.5
+              memory: 1024Mi
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-service.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+spec:
+  selector:
+    app: prometheus-proxy
+  ports:
+    - name: scrape
+      port: 8080
+      targetPort: 8080
+    - name: rsocket
+      port: 7001
+      targetPort: 7001
+  type: LoadBalancer

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-serviceaccount.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-proxy
+  labels:
+    app: prometheus-proxy
+  namespace: default

--- a/src/templates/kubernetes/prometheus/prometheus-clusterrolebinding.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default

--- a/src/templates/kubernetes/prometheus/prometheus-clusterroles.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-clusterroles.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+

--- a/src/templates/kubernetes/prometheus/prometheus-configmap.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 10s
+      scrape_timeout: 9s
+      evaluation_interval: 10s
+
+    scrape_configs:
+    - job_name: 'proxied-applications'
+      metrics_path: '/metrics/connected'
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - default
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex: prometheus-proxy
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          action: keep
+          regex: 8080
+    - job_name: 'proxies'
+      metrics_path: '/metrics/proxy'
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - default
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          action: keep
+          regex: prometheus-proxy
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          action: keep
+          regex: 8080
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name

--- a/src/templates/kubernetes/prometheus/prometheus-deployment.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.12.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+            - "--web.enable-lifecycle"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus
+        - name: prometheus-storage-volume
+          emptyDir: {}

--- a/src/templates/kubernetes/prometheus/prometheus-service.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+  annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path:   /
+      prometheus.io/port:   '9090'
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/src/templates/kubernetes/prometheus/prometheus-serviceaccount.yaml
+++ b/src/templates/kubernetes/prometheus/prometheus-serviceaccount.yaml
@@ -1,0 +1,7 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+  namespace: default

--- a/src/templates/kubernetes/rabbitmq/rabbitmq-deployment.yaml
+++ b/src/templates/kubernetes/rabbitmq/rabbitmq-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - image: rabbitmq:3.6.10
+        name: rabbitmq
+        ports:
+        - containerPort: 5672

--- a/src/templates/kubernetes/rabbitmq/rabbitmq-svc.yaml
+++ b/src/templates/kubernetes/rabbitmq/rabbitmq-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+spec:
+  ports:
+  - port: 5672
+  selector:
+    app: rabbitmq

--- a/src/templates/kubernetes/server/server-config.yaml
+++ b/src/templates/kubernetes/server/server-config.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scdf-server
+  labels:
+    app: scdf-server
+data:
+  application.yaml: |-
+    spring:
+      cloud:
+        dataflow:
+          applicationProperties:
+            stream:
+              management:
+                metrics:
+                  export:
+                    prometheus:
+                      enabled: true
+                      rsocket:
+                        enabled: true
+                        host: prometheus-proxy
+                        port: 7001
+            task:
+              management:
+                metrics:
+                  export:
+                    prometheus:
+                      enabled: true
+                      rsocket:
+                        enabled: true
+                        host: prometheus-proxy
+                        port: 7001
+          grafana-info:
+            url: 'https://grafana:3000'
+          task:
+            platform:
+              kubernetes:
+                accounts:
+                  default:
+                    limits:
+                      memory: 1024Mi
+      datasource:
+        url: jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/mysql
+        username: root
+        password: ${mysql-root-password}
+        driverClassName: org.mariadb.jdbc.Driver
+        testOnBorrow: true
+        validationQuery: "SELECT 1"
+

--- a/src/templates/kubernetes/server/server-deployment-debug.yaml
+++ b/src/templates/kubernetes/server/server-deployment-debug.yaml
@@ -1,0 +1,10 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: scdf-server
+        ports:
+        - containerPort: 5005
+        env:
+        - name: JAVA_TOOL_OPTIONS
+          value: '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'

--- a/src/templates/kubernetes/server/server-deployment.yaml
+++ b/src/templates/kubernetes/server/server-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scdf-server
+  labels:
+    app: scdf-server
+spec:
+  selector:
+    matchLabels:
+      app: scdf-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: scdf-server
+    spec:
+      containers:
+      - name: scdf-server
+        image: springcloud/spring-cloud-dataflow-server:@project.version@
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 1.0
+            memory: 2048Mi
+          requests:
+            cpu: 0.5
+            memory: 1024Mi
+        env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
+        - name: SERVER_PORT
+          value: '80'
+        - name: SPRING_CLOUD_CONFIG_ENABLED
+          value: 'false'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_TASK_SCHEDULER_TASK_LAUNCHER_URL
+          value: 'docker://springcloud/spring-cloud-dataflow-scheduler-task-launcher:@project.version@'
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
+          value: 'true'
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_NAME
+          value: mysql
+        - name: SPRING_CLOUD_KUBERNETES_CONFIG_NAME
+          value: scdf-server
+        - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
+          value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
+          # Provide the Skipper service location
+        - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
+          value: 'http://${SKIPPER_SERVICE_HOST}:${SKIPPER_SERVICE_PORT}/api'
+          # Add Maven repo for metadata artifact resolution for all stream apps
+        - name: SPRING_APPLICATION_JSON
+          value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
+      initContainers:
+      - name: init-mysql-wait
+        image: busybox
+        command: ['sh', '-c', 'until nc -w3 -z mysql 3306; do echo waiting for mysql; sleep 3; done;']
+      serviceAccountName: scdf-sa

--- a/src/templates/kubernetes/server/server-rolebinding.yaml
+++ b/src/templates/kubernetes/server/server-rolebinding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: scdf-rb
+subjects:
+- kind: ServiceAccount
+  name: scdf-sa
+roleRef:
+  kind: Role
+  name: scdf-role
+  apiGroup: rbac.authorization.k8s.io

--- a/src/templates/kubernetes/server/server-roles.yaml
+++ b/src/templates/kubernetes/server/server-roles.yaml
@@ -1,0 +1,20 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scdf-role
+rules:
+  - apiGroups: [""]
+    resources: ["services", "pods", "replicationcontrollers", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]

--- a/src/templates/kubernetes/server/server-svc-debug.yaml
+++ b/src/templates/kubernetes/server/server-svc-debug.yaml
@@ -1,0 +1,4 @@
+spec:
+  ports:
+    - port: 5005
+      name: scdf-server-jdwp

--- a/src/templates/kubernetes/server/server-svc.yaml
+++ b/src/templates/kubernetes/server/server-svc.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: scdf-server
+  labels:
+    app: scdf-server
+    spring-deployment-id: scdf
+spec:
+  # If you are running k8s on a local dev box or using minikube, you can use type NodePort instead
+  type: LoadBalancer
+  ports:
+    - port: 80
+      name: scdf-server
+  selector:
+    app: scdf-server

--- a/src/templates/kubernetes/server/service-account.yaml
+++ b/src/templates/kubernetes/server/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scdf-sa

--- a/src/templates/kubernetes/skipper/skipper-config-kafka.yaml
+++ b/src/templates/kubernetes/skipper/skipper-config-kafka.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skipper
+  labels:
+    app: skipper
+data:
+  application.yaml: |-
+    spring:
+      cloud:
+        skipper:
+          server:
+            platform:
+              kubernetes:
+                accounts:
+                  default:
+                    environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${KAFKA_SERVICE_HOST}:${KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${KAFKA_ZK_SERVICE_HOST}:${KAFKA_ZK_SERVICE_PORT}'
+                    limits:
+                      memory: 1024Mi
+                      cpu: 500m
+                    readinessProbeDelay: 120
+                    livenessProbeDelay: 90
+      datasource:
+        url: jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/skipper
+        username: root
+        password: ${mysql-root-password}
+        driverClassName: org.mariadb.jdbc.Driver
+        testOnBorrow: true
+        validationQuery: "SELECT 1"

--- a/src/templates/kubernetes/skipper/skipper-config-rabbit.yaml
+++ b/src/templates/kubernetes/skipper/skipper-config-rabbit.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skipper
+  labels:
+    app: skipper
+data:
+  application.yaml: |-
+    spring:
+      cloud:
+        skipper:
+          server:
+            platform:
+              kubernetes:
+                accounts:
+                  default:
+                    environmentVariables: 'SPRING_RABBITMQ_HOST=${RABBITMQ_SERVICE_HOST},SPRING_RABBITMQ_PORT=${RABBITMQ_SERVICE_PORT}'
+                    limits:
+                      memory: 1024Mi
+                      cpu: 500m
+                    readinessProbeDelay: 120
+                    livenessProbeDelay: 90
+      datasource:
+        url: jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/skipper
+        username: root
+        password: ${mysql-root-password}
+        driverClassName: org.mariadb.jdbc.Driver
+        testOnBorrow: true
+        validationQuery: "SELECT 1"

--- a/src/templates/kubernetes/skipper/skipper-deployment.yaml
+++ b/src/templates/kubernetes/skipper/skipper-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: skipper
-        image: springcloud/spring-cloud-skipper-server:2.3.0.BUILD-SNAPSHOT
+        image: springcloud/spring-cloud-skipper-server:@spring-cloud-skipper.version@
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/src/templates/kubernetes/skipper/skipper-svc.yaml
+++ b/src/templates/kubernetes/skipper/skipper-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skipper
+  labels:
+    app: skipper
+    spring-deployment-id: scdf
+spec:
+  # If you are running k8s on a local dev box, using minikube, or Kubernetes on docker desktop you can use type NodePort instead
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 7577
+  selector:
+    app: skipper


### PR DESCRIPTION
- Now autogenerating `src/kubernetes` from `src/templates/kubernetes`
  by replacing property placeholders in those templates files.
- Generation activated by `deploymentfiles` profile during a
  `copy-resources` phase.
- This commit changed skipper-deployment.yaml as version there didn't
  match one from pom when I ran `mvnw process-resources -P deploymentfiles`.
- Fixes #3752