### PR TITLE
Exclude jobExecution on client side

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/support/StepExecutionJacksonMixIn.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/support/StepExecutionJacksonMixIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.batch.core.StepExecution;
  * @author Gunnar Hillert
  * @since 1.0
  */
-@JsonIgnoreProperties({ "jobParameters", "jobExecutionId", "skipCount", "summary" })
+@JsonIgnoreProperties({ "jobExecution", "jobParameters", "jobExecutionId", "skipCount", "summary" })
 public abstract class StepExecutionJacksonMixIn {
 
 	@JsonCreator


### PR DESCRIPTION
- To overcome future errors in `JobCommandTests` exclude `jobExecution` if
  client side `StepExecutionJacksonMixIn` is used as what happens with those
  tests when hateoas 1.0.2 is brought in.
- Issue will happen with real server/shell but we can't do more clever
  things until shell is fully upgraded to boot 2.x.
- Fixes #3755