### PR TITLE
Clean build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 		<codearte-props2yml.version>0.5</codearte-props2yml.version>
 		<json-unit.version>2.11.1</json-unit.version>
 		<docker-compose-rule.version>1.4.2</docker-compose-rule.version>
+		<findbugs.version>3.0.2</findbugs.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-configuration-metadata</module>
@@ -245,6 +246,11 @@
 				<artifactId>docker-compose-junit-jupiter</artifactId>
 				<version>${docker-compose-rule.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>${findbugs.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<build>
@@ -285,7 +291,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<!-- Note: Change ./spring-cloud-dataflow-server-local/pom.xml to match changes here -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<executions>
@@ -294,7 +299,7 @@
 						<phase>validate</phase>
 						<configuration>
 							<encoding>UTF-8</encoding>
-							<!--<failsOnError>true</failsOnError>-->
+							<failsOnError>true</failsOnError>
 							<failOnViolation>true</failOnViolation>
 							<violationSeverity>warning</violationSeverity>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -333,22 +338,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>3.0.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
-					<executions>
-						<execution>
-							<id>attach-javadocs</id>
-							<goals>
-								<goal>jar</goal>
-							</goals>
-							<configuration>
-								<additionalparam>${javadoc.opts}</additionalparam>
-							</configuration>
-						</execution>
-					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/spring-cloud-dataflow-audit/src/main/java/org/springframework/cloud/dataflow/audit/service/AuditRecordService.java
+++ b/spring-cloud-dataflow-audit/src/main/java/org/springframework/cloud/dataflow/audit/service/AuditRecordService.java
@@ -49,6 +49,7 @@ public interface AuditRecordService {
 	 * @param auditActionType Must not be null
 	 * @param correlationId Id to identify the record
 	 * @param data The data as String to be audited
+	 * @param platformName the platform name
 	 *
 	 * @return newly created AuditRecord
 	 */
@@ -70,6 +71,7 @@ public interface AuditRecordService {
 	 * @param auditActionType Must not be null
 	 * @param correlationId Id to identify the record
 	 * @param data The data as a Map to be audited
+	 * @param platformName the platform name
 	 *
 	 * @return newly created AuditRecord
 	 */

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/security/support/CloudFoundrySecurityService.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/security/support/CloudFoundrySecurityService.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.common.security.core.support.OAuth2TokenUtilsService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -53,5 +53,10 @@
 			<artifactId>semver4j</artifactId>
 			<version>${semver.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDefinitionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/StreamDefinitionResource.java
@@ -73,6 +73,7 @@ public class StreamDefinitionResource extends RepresentationModel<StreamDefiniti
 	 *
 	 * @param name stream name
 	 * @param dslText stream definition DSL text
+	 * @param originalDslText original stream definition DSL text
 	 * @param description Description of the stream definition
 	 */
 	public StreamDefinitionResource(String name, String dslText, String originalDslText, String description) {

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -170,6 +170,11 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -118,8 +118,10 @@ public class TaskConfiguration {
 	/**
 	 * The default profile is active when no other profiles are active. This is configured so
 	 * that several tests will pass without having to explicitly enable the local profile.
-	 * @param localPlatformProperties
-	 * @return
+	 * @param localPlatformProperties the local platform properties
+	 * @param localScheduler the local scheduler
+	 *
+	 * @return the task platform
 	 */
 	@Profile({ "local", "default" })
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.dataflow.rest.resource.TaskToolsResource;
 import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
@@ -77,10 +78,10 @@ public class RootController {
 	}
 
 	/**
-	 * Return a {@link ResourceSupport} object containing the resources served by the Data
+	 * Return a {@link RepresentationModel} object containing the resources served by the Data
 	 * Flow server.
 	 *
-	 * @return {@code ResourceSupport} object containing the Data Flow server's resources
+	 * @return {@code RepresentationModel} object containing the Data Flow server's resources
 	 */
 	@RequestMapping("/")
 	public RootResource info() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerV2.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerV2.java
@@ -71,6 +71,10 @@ public class RuntimeStreamsControllerV2 {
 
 	/**
 	 * @param streamNames comma separated list of streams to retrieve the statuses for
+	 * @param pageable the page
+	 * @param assembler the resource assembler
+	 *
+	 * @return a paged model for stream statuses
 	 */
 	@RequestMapping(value = "/{streamNames}", method = RequestMethod.GET)
 	public PagedModel<StreamStatusResource> streamStatus(@PathVariable("streamNames") String[] streamNames, Pageable pageable,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -233,6 +233,7 @@ public class TaskExecutionController {
 	 * Stop a set of task executions.
 	 *
 	 * @param ids the ids of the {@link TaskExecution}s to stop
+	 * @param platform the platform name
 	 */
 	@RequestMapping(value = "/{id}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/SqlCommand.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/SqlCommand.java
@@ -110,6 +110,7 @@ public class SqlCommand {
 	 * Handle command in a given jdbc template.
 	 *
 	 * @param jdbcTemplate the jdbc template
+	 * @param connection the sql connection
 	 */
 	public void handle(JdbcTemplate jdbcTemplate, Connection connection) {
 		// expected to get handled in a sub-class

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskDeleteService.java
@@ -35,9 +35,11 @@ public interface TaskDeleteService {
 	void cleanupExecution(long id);
 
 	/**
+	 *  Cleanup the resources that resulted from running the task with the given execution
+	 *  ids and actions.
 	 *
-	 * @param actionsAsSet
-	 * @param ids
+	 * @param actionsAsSet the actions
+	 * @param ids the id's
 	 */
 	void cleanupExecutions(Set<TaskExecutionControllerDeleteAction> actionsAsSet, Set<Long> ids);
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
@@ -91,6 +91,8 @@ public class DefaultTaskExecutionInfoService implements TaskExecutionInfoService
 	 * @param taskDefinitionRepository the {@link TaskDefinitionRepository} this service will
 	 *     use for task CRUD operations.
 	 * @param taskConfigurationProperties the properties used to define the behavior of tasks
+	 * @param launcherRepository the launcher repository
+	 * @param taskPlatforms the task platforms
 	 */
 	public DefaultTaskExecutionInfoService(DataSourceProperties dataSourceProperties,
 			AppRegistryService appRegistryService,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -142,10 +142,16 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 * @param launcherRepository the repository of task launcher used to launch task apps.
 	 * @param auditRecordService the audit record service
 	 * @param taskRepository the repository to use for accessing and updating task executions
+	 * @param taskExecutionInfoService the task execution info service
 	 * @param taskDeploymentRepository the repository to track task deployment
 	 * @param taskExecutionInfoService the service used to setup a task execution
 	 * @param taskExecutionRepositoryService the service used to create the task execution
+	 * @param taskAppDeploymentRequestCreator the task app deployment request creator
+	 * @param taskExplorer the task explorer
+	 * @param dataflowTaskExecutionDao the dataflow task execution dao
 	 * @param dataflowTaskExecutionMetadataDao repository used to manipulate task manifests
+	 * @param oauth2TokenUtilsService the oauth2 token server
+	 * @param taskSaveService the task save service
 	 */
 	public DefaultTaskExecutionService(LauncherRepository launcherRepository,
 			AuditRecordService auditRecordService,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -81,6 +81,12 @@ public class TaskAppDeploymentRequestCreator {
 	/**
 	 * Create a {@link AppDeploymentRequest} from the provided
 	 * {@link TaskExecutionInformation}, {@link TaskExecution}.
+	 *
+	 * @param taskExecution the task execution
+	 * @param taskExecutionInformation the task execution info
+	 * @param commandLineArgs the command line args
+	 * @param platformName the platform name
+	 *
 	 * @return an instance of {@link AppDeploymentRequest}
 	 */
 	public AppDeploymentRequest createRequest(

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -103,10 +103,10 @@ public interface StreamDeployer {
 	/**
 	 * For a selected stream scales the number of appName instances to count.
 	 *
-	 * @param streamName
-	 * @param appName
-	 * @param count
-	 * @param properties
+	 * @param streamName the stream name
+	 * @param appName the app name
+	 * @param count the count
+	 * @param properties the properties
 	 */
 	void scale(String streamName, String appName, int count, Map<String, String> properties);
 }

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -96,17 +96,8 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>javadoc</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<phase>package</phase>
-					</execution>
-				</executions>
 				<configuration>
-					<quiet>true</quiet>
+					<detectOfflineLinks>false</detectOfflineLinks>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -118,26 +109,6 @@
 							<goal>jar</goal>
 						</goals>
 						<phase>package</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>checkstyle-validation</id>
-						<phase>validate</phase>
-						<configuration>
-							<encoding>UTF-8</encoding>
-							<consoleOutput>true</consoleOutput>
-							<failsOnError>true</failsOnError>
-							<includeTestSourceDirectory>true</includeTestSourceDirectory>
-							<configLocation>${checkstyle.config.location}</configLocation>
-						</configuration>
-						<goals>
-							<goal>check</goal>
-						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/spring-cloud-starter-dataflow-server/pom.xml
+++ b/spring-cloud-starter-dataflow-server/pom.xml
@@ -9,6 +9,9 @@
 	<artifactId>spring-cloud-starter-dataflow-server</artifactId>
 	<description>Data Flow Server Starter</description>
 	<packaging>jar</packaging>
+	<properties>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -84,23 +87,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>javadoc</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<phase>package</phase>
-					</execution>
-				</executions>
-				<configuration>
-					<quiet>true</quiet>
-					<sourcepath>${basedir}/src/test/java/org/springframework/cloud/dataflow/server/local/dataflowapp
-					</sourcepath>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- Refactor parts of a build files to remove
  errors and some warnings.
- For @NotNull warning we just import findbugs as
  provided dependency as that's currently what
  framework recommends.
- Polish javadocs so that we can at some point
  start failing build for incomplete javadocs, etc.
- Fixes #3739