### PR TITLE
Cf deployer issue 335

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,10 @@
 		<spring-cloud-deployer.version>2.3.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-deployer-local.version>2.3.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 
+
 		<spring-cloud-deployer-cloudfoundry.version>2.3.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<spring-cloud-deployer-kubernetes.version>2.3.0.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
+
 		<kubernetes-client.version>4.1.0</kubernetes-client.version>
 
 		<spring-cloud-skipper.version>2.4.0.BUILD-SNAPSHOT</spring-cloud-skipper.version>

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryAppDeployer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryPlatformSpecificInfo;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryTaskLauncher;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
@@ -156,17 +157,19 @@ public class CloudFoundryTaskPlatformFactory extends AbstractTaskPlatformFactory
 	}
 
 	private RuntimeEnvironmentInfo runtimeEnvironmentInfo(CloudFoundryClient cloudFoundryClient, String account) {
-		return new RuntimeEnvironmentInfo.Builder()
-				.implementationName(CloudFoundryAppDeployer.class.getSimpleName())
-				.spiClass(AppDeployer.class)
-				.implementationVersion(
+		return new CloudFoundryPlatformSpecificInfo(new RuntimeEnvironmentInfo.Builder())
+				.apiEndpoint(connectionProperties(account).getUrl().toString())
+				.org(connectionProperties(account).getOrg())
+				.space(connectionProperties(account).getSpace())
+				.builder()
+					.implementationName(CloudFoundryAppDeployer.class.getSimpleName())
+					.spiClass(AppDeployer.class)
+					.implementationVersion(
 						RuntimeVersionUtils.getVersion(CloudFoundryAppDeployer.class))
-				.platformType("Cloud Foundry")
-				.platformClientVersion(
+					.platformType("Cloud Foundry")
+					.platformClientVersion(
 						RuntimeVersionUtils.getVersion(cloudFoundryClient.getClass()))
-				.platformApiVersion(version(cloudFoundryClient, account).toString()).platformHostVersion("unknown")
-				.addPlatformSpecificInfo("API Endpoint",
-						connectionProperties(account).getUrl().toString())
+					.platformApiVersion(version(cloudFoundryClient, account).toString()).platformHostVersion("unknown")
 				.build();
 	}
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
@@ -16,11 +16,19 @@
 
 package org.springframework.cloud.dataflow.server.single;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.pivotal.scheduler.SchedulerClient;
 import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
+import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
+import org.cloudfoundry.client.v2.organizations.OrganizationResource;
+import org.cloudfoundry.client.v2.organizations.Organizations;
+import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,6 +49,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,6 +100,10 @@ public class CloudFoundrySchedulerTests {
 		public CloudFoundryPlatformClientProvider mockCloudFoundryClientProvider() {
 			when(cloudFoundryClient.info())
 				.thenReturn(getInfoRequest -> Mono.just(GetInfoResponse.builder().apiVersion("0.0.0").build()));
+			when(cloudFoundryClient.organizations()).thenReturn(mock(Organizations.class));
+			when(cloudFoundryClient.spaces()).thenReturn(mock(Spaces.class));
+			when(cloudFoundryClient.organizations().list(any())).thenReturn(listOrganizationsResponse());
+			when(cloudFoundryClient.spaces().list(any())).thenReturn(listSpacesResponse());
 			CloudFoundryPlatformClientProvider cloudFoundryClientProvider = mock(
 				CloudFoundryPlatformClientProvider.class);
 			when(cloudFoundryClientProvider.cloudFoundryClient(anyString())).thenAnswer(invocation -> {
@@ -98,6 +111,24 @@ public class CloudFoundrySchedulerTests {
 				return cloudFoundryClient;
 			});
 			return cloudFoundryClientProvider;
+		}
+
+		private Mono<ListOrganizationsResponse> listOrganizationsResponse() {
+			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+					.addAllResources(Collections.<OrganizationResource>singletonList(
+							OrganizationResource.builder()
+									.metadata(Metadata.builder().id("123").build()).build())
+					).build();
+			return Mono.just(response);
+		}
+
+		private Mono<ListSpacesResponse> listSpacesResponse() {
+			ListSpacesResponse response = ListSpacesResponse.builder()
+					.addAllResources(Collections.<SpaceResource>singletonList(
+							SpaceResource.builder()
+									.metadata(Metadata.builder().id("123").build()).build())
+					).build();
+			return Mono.just(response);
 		}
 
 		@Bean
@@ -120,5 +151,4 @@ public class CloudFoundrySchedulerTests {
 			return platformTokenProvider;
 		}
 	}
-
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
@@ -16,10 +16,18 @@
 
 package org.springframework.cloud.dataflow.server.single;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.cloudfoundry.client.CloudFoundryClient;
+import org.cloudfoundry.client.v2.Metadata;
 import org.cloudfoundry.client.v2.info.GetInfoResponse;
+import org.cloudfoundry.client.v2.organizations.ListOrganizationsResponse;
+import org.cloudfoundry.client.v2.organizations.OrganizationResource;
+import org.cloudfoundry.client.v2.organizations.Organizations;
+import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
+import org.cloudfoundry.client.v2.spaces.SpaceResource;
+import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +47,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -114,6 +123,10 @@ public class MultiplePlatformTypeTests {
 		public CloudFoundryPlatformClientProvider mockCloudFoundryClientProvider() {
 			when(cloudFoundryClient.info())
 					.thenReturn(getInfoRequest -> Mono.just(GetInfoResponse.builder().apiVersion("0.0.0").build()));
+			when(cloudFoundryClient.organizations()).thenReturn(mock(Organizations.class));
+			when(cloudFoundryClient.spaces()).thenReturn(mock(Spaces.class));
+			when(cloudFoundryClient.organizations().list(any())).thenReturn(listOrganizationsResponse());
+			when(cloudFoundryClient.spaces().list(any())).thenReturn(listSpacesResponse());
 			CloudFoundryPlatformClientProvider cloudFoundryClientProvider = mock(
 					CloudFoundryPlatformClientProvider.class);
 			when(cloudFoundryClientProvider.cloudFoundryClient(anyString())).thenAnswer(invocation -> {
@@ -121,6 +134,24 @@ public class MultiplePlatformTypeTests {
 				return cloudFoundryClient;
 			});
 			return cloudFoundryClientProvider;
+		}
+
+		private Mono<ListOrganizationsResponse> listOrganizationsResponse() {
+			ListOrganizationsResponse response = ListOrganizationsResponse.builder()
+					.addAllResources(Collections.<OrganizationResource>singletonList(
+							OrganizationResource.builder()
+									.metadata(Metadata.builder().id("123").build()).build())
+					).build();
+			return Mono.just(response);
+		}
+
+		private Mono<ListSpacesResponse> listSpacesResponse() {
+			ListSpacesResponse response = ListSpacesResponse.builder()
+					.addAllResources(Collections.<SpaceResource>singletonList(
+							SpaceResource.builder()
+									.metadata(Metadata.builder().id("123").build()).build())
+					).build();
+			return Mono.just(response);
 		}
 
 		@Bean


### PR DESCRIPTION
Depends on https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/pull/336 and Fixes https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/issues/335

Since SCDF configures the TaskPlatform, this fix requires changes to `CloudFoundryTaskPlatformFactory` and corresponding changes to tests for the CF task platform. 

It would be difficult to automate integration tests for this.  I verified the fix manually using one of our AT environments and an account that has access to multiple orgs and spaces.  I deployed this branch of dataflow server to two different orgs and launched tasks in one while monitoring `tasks/executions/current`  using `watch curl ...` on both dataflow servers.  The instance that launched the task shows 1 task running, while the instance in the other space/org, correctly,  continues to show 0 tasks running. See attached (the missing url error due to an extra space, but the command still worked) 
<img width="1078" alt="Screen Shot 2020-02-05 at 10 01 24 AM" src="https://user-images.githubusercontent.com/886859/73857489-038f9800-4805-11ea-90a9-15f06b788945.png">


