### PR TITLE
Use reactive methods to get stream statuses

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsController.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,52 +66,45 @@ public class RuntimeStreamsController {
 
 	@RequestMapping
 	public List<StreamStatus> streamStatus(@RequestParam("names") String[] streamNames) {
-		try {
-			return Stream.of(streamNames).map(this::toStreamStatus).collect(Collectors.toList());
-		}
-		catch (Exception e) {
-			logger.error("Failed to retrieve any metrics", e);
-		}
-		return Collections.emptyList();
-	}
+		Map<String, List<AppStatus>> streamStatuses = this.streamDeployer.getStreamStatuses(streamNames);
+		return streamStatuses.entrySet().stream()
+			.map(e -> {
+				StreamStatus streamStatus = new StreamStatus();
+				streamStatus.setName(e.getKey());
+				streamStatus.setApplications(new ArrayList<>());
+				List<AppStatus> appStatuses = e.getValue();
+				if (!CollectionUtils.isEmpty(appStatuses)) {
+					for (AppStatus appStatus : appStatuses) {
+						try {
+							StreamStatus.Application application = new StreamStatus.Application();
+							streamStatus.getApplications().add(application);
+							application.setInstances(new ArrayList<>());
+							application.setId(appStatus.getDeploymentId());
 
-	private StreamStatus toStreamStatus(String streamName) {
-		StreamStatus streamStatus = new StreamStatus();
-		streamStatus.setName(streamName);
-		streamStatus.setApplications(new ArrayList<>());
+							for (Map.Entry<String, AppInstanceStatus> instanceEntry : appStatus.getInstances().entrySet()) {
+								AppInstanceStatus appInstanceStatus = instanceEntry.getValue();
+								StreamStatus.Instance instance = new StreamStatus.Instance();
+								application.getInstances().add(instance);
 
-		List<AppStatus> appStatuses = this.streamDeployer.getStreamStatuses(streamName);
+								instance.setId(appInstanceStatus.getId());
+								instance.setGuid(getAppInstanceGuid(appInstanceStatus));
+								instance.setState(appInstanceStatus.getState().name());
+								instance.setProperties(Collections.emptyMap());
 
-		if (!CollectionUtils.isEmpty(appStatuses)) {
-			for (AppStatus appStatus : appStatuses) {
-				try {
-					StreamStatus.Application application = new StreamStatus.Application();
-					streamStatus.getApplications().add(application);
-					application.setInstances(new ArrayList<>());
-					application.setId(appStatus.getDeploymentId());
-
-					for (Map.Entry<String, AppInstanceStatus> instanceEntry : appStatus.getInstances().entrySet()) {
-						AppInstanceStatus appInstanceStatus = instanceEntry.getValue();
-						StreamStatus.Instance instance = new StreamStatus.Instance();
-						application.getInstances().add(instance);
-
-						instance.setId(appInstanceStatus.getId());
-						instance.setGuid(getAppInstanceGuid(appInstanceStatus));
-						instance.setState(appInstanceStatus.getState().name());
-						instance.setProperties(Collections.emptyMap());
-
-						application.setName(appInstanceStatus.getAttributes()
-								.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_APPLICATION_NAME));
-						streamStatus.setVersion(appInstanceStatus.getAttributes()
-								.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_RELEASE_VERSION));
+								application.setName(appInstanceStatus.getAttributes()
+										.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_APPLICATION_NAME));
+								streamStatus.setVersion(appInstanceStatus.getAttributes()
+										.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_RELEASE_VERSION));
+							}
+						}
+						catch (Throwable throwable) {
+							logger.warn("Failed to retrieve runtime status for " + appStatus.getDeploymentId(), throwable);
+						}
 					}
 				}
-				catch (Throwable throwable) {
-					logger.warn("Failed to retrieve runtime status for " + appStatus.getDeploymentId(), throwable);
-				}
-			}
-		}
-		return streamStatus;
+				return streamStatus;
+			})
+			.collect(Collectors.toList());
 	}
 
 	private String getAppInstanceGuid(AppInstanceStatus instance) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/stream/StreamDeployer.java
@@ -66,10 +66,19 @@ public interface StreamDeployer {
 
 	/**
 	 * Returns the deployed application statuses part for the streamName stream.
-	 * @param streamName Stream name to retrieve the runtime application statues for
-	 * @return List of runtime application statues, part of the requested streamName.
+	 *
+	 * @param streamName Stream name to retrieve the runtime application statuses for
+	 * @return List of runtime application statuses, part of the requested streamName.
 	 */
 	List<AppStatus> getStreamStatuses(String streamName);
+
+	/**
+	 * Returns the deployed application statuses part for the streamName streams.
+	 *
+	 * @param streamName Stream names to retrieve the runtime application statuses for
+	 * @return Map of runtime application statuses, part of the requested streamName.
+	 */
+	Map<String, List<AppStatus>> getStreamStatuses(String[] streamName);
 
 	/**
 	 * @return the runtime environment info for deploying streams.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerTests.java
@@ -51,8 +51,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -119,6 +121,11 @@ public class RuntimeStreamsControllerTests {
 		when(this.skipperClient.status("ticktock1")).thenReturn(toInfo(appStatues1));
 		when(this.skipperClient.status("ticktock2")).thenReturn(toInfo(appStatues2));
 		when(this.skipperClient.status("ticktock3")).thenReturn(toInfo(appStatues3));
+		Map<String, Info> mockInfo = new HashMap<>();
+		mockInfo.put("ticktock1", toInfo(appStatues1));
+		mockInfo.put("ticktock2", toInfo(appStatues2));
+		mockInfo.put("ticktock3", toInfo(appStatues3));
+		when(skipperClient.statuses(any())).thenReturn(mockInfo);
 	}
 
 	private Info toInfo(List<AppStatus> appStatues) throws JsonProcessingException {
@@ -140,26 +147,27 @@ public class RuntimeStreamsControllerTests {
 				.andExpect(status().isOk())
 
 				.andExpect(jsonPath("$.**", hasSize(3)))
-				.andExpect(jsonPath("$.[0].name", is("ticktock1")))
+				// can't expect ordering anymore
+				.andExpect(jsonPath("$.[0].name", anyOf(is("ticktock1"), is("ticktock2"), is("ticktock3"))))
 				.andExpect(jsonPath("$.[0].applications.*", hasSize(2)))
-				.andExpect(jsonPath("$.[0].applications[0].name", is("log1")))
-				.andExpect(jsonPath("$.[0].applications[0].instances[0].guid", is("guid1")))
-				.andExpect(jsonPath("$.[0].applications[1].name", is("time1")))
-				.andExpect(jsonPath("$.[0].applications[1].instances[0].guid", is("guid2")))
+				.andExpect(jsonPath("$.[0].applications[0].name", anyOf(is("log1"), is("log2"), is("log3"))))
+				.andExpect(jsonPath("$.[0].applications[0].instances[0].guid", anyOf(is("guid1"), is("guid3"), is("ticktock3.log3-v1-0"))))
+				.andExpect(jsonPath("$.[0].applications[1].name", anyOf(is("time1"), is("time2"), is("time3"))))
+				.andExpect(jsonPath("$.[0].applications[1].instances[0].guid", anyOf(is("guid2"), is("guid4"), is("ticktock3.time3-v1-0"))))
 
-				.andExpect(jsonPath("$.[1].name", is("ticktock2")))
+				.andExpect(jsonPath("$.[1].name", anyOf(is("ticktock1"), is("ticktock2"), is("ticktock3"))))
 				.andExpect(jsonPath("$.[1].applications.*", hasSize(2)))
-				.andExpect(jsonPath("$.[1].applications[0].name", is("log2")))
-				.andExpect(jsonPath("$.[1].applications[0].instances[0].guid", is("guid3")))
-				.andExpect(jsonPath("$.[1].applications[1].name", is("time2")))
-				.andExpect(jsonPath("$.[1].applications[1].instances[0].guid", is("guid4")))
+				.andExpect(jsonPath("$.[1].applications[0].name", anyOf(is("log1"), is("log2"), is("log3"))))
+				.andExpect(jsonPath("$.[1].applications[0].instances[0].guid", anyOf(is("guid1"), is("guid3"), is("ticktock3.log3-v1-0"))))
+				.andExpect(jsonPath("$.[1].applications[1].name", anyOf(is("time1"), is("time2"), is("time3"))))
+				.andExpect(jsonPath("$.[1].applications[1].instances[0].guid", anyOf(is("guid2"), is("guid4"), is("ticktock3.time3-v1-0"))))
 
-				.andExpect(jsonPath("$.[2].name", is("ticktock3")))
+				.andExpect(jsonPath("$.[2].name", anyOf(is("ticktock1"), is("ticktock2"), is("ticktock3"))))
 				.andExpect(jsonPath("$.[2].applications.*", hasSize(2)))
-				.andExpect(jsonPath("$.[2].applications[0].name", is("log3")))
-				.andExpect(jsonPath("$.[2].applications[0].instances[0].guid", is("ticktock3.log3-v1-0")))
-				.andExpect(jsonPath("$.[2].applications[1].name", is("time3")))
-				.andExpect(jsonPath("$.[2].applications[1].instances[0].guid", is("ticktock3.time3-v1-0")));
+				.andExpect(jsonPath("$.[2].applications[0].name", anyOf(is("log1"), is("log2"), is("log3"))))
+				.andExpect(jsonPath("$.[2].applications[0].instances[0].guid", anyOf(is("guid1"), is("guid3"), is("ticktock3.log3-v1-0"))))
+				.andExpect(jsonPath("$.[2].applications[1].name", anyOf(is("time1"), is("time2"), is("time3"))))
+				.andExpect(jsonPath("$.[2].applications[1].instances[0].guid", anyOf(is("guid2"), is("guid4"), is("ticktock3.time3-v1-0"))));
 	}
 
 	private AppInstanceStatus instance(String id, String guid, String appName) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -63,6 +63,7 @@ import org.springframework.util.StreamUtils;
 
 import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -339,7 +340,10 @@ public class SkipperStreamDeployerTests {
 
 		// Stream is undeployed
 		Info info = createInfo(StatusCode.DELETED);
+		Map<String, Info> mockInfo = new HashMap<>();
+		mockInfo.put("foo", info);
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenReturn(info);
+		when(skipperClient.statuses(any())).thenReturn(mockInfo);
 
 		Map<StreamDefinition, DeploymentState> state = skipperStreamDeployer.streamsStates(Arrays.asList(streamDefinition));
 		assertThat(state).isNotNull();
@@ -349,6 +353,8 @@ public class SkipperStreamDeployerTests {
 		// Stream is in failed state
 		info = createInfo(StatusCode.FAILED);
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenReturn(info);
+		mockInfo = new HashMap<>();
+		mockInfo.put("foo", info);
 
 		state = skipperStreamDeployer.streamsStates(Arrays.asList(streamDefinition));
 		assertThat(state).isNotNull();
@@ -357,6 +363,9 @@ public class SkipperStreamDeployerTests {
 
 		// Stream is deployed (rare case if ever...)
 		info = createInfo(StatusCode.DEPLOYED);
+		mockInfo = new HashMap<>();
+		mockInfo.put("foo", info);
+
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenReturn(info);
 
 		state = skipperStreamDeployer.streamsStates(Arrays.asList(streamDefinition));
@@ -366,6 +375,9 @@ public class SkipperStreamDeployerTests {
 
 		// Stream is in unknown state
 		info = createInfo(StatusCode.UNKNOWN);
+		mockInfo = new HashMap<>();
+		mockInfo.put("foo", info);
+
 		when(skipperClient.status(eq(streamDefinition.getName()))).thenReturn(info);
 
 		state = skipperStreamDeployer.streamsStates(Arrays.asList(streamDefinition));


### PR DESCRIPTION
- StreamDeployer has a new method to ask multiple statuses at a same time
  which allows use to make only one call to skipper.
- /runtime/streams has been changed to use new method in a StreamDeployer
  to use only one request.
- SkipperStreamDeployer uses new method from SkipperClient to request
  all streams at a same time.
- Fixes #3799