### PR TITLE
Resolve metadata from the Docker Image Config

### DIFF
--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -25,9 +25,11 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.audit.service.DefaultAuditRecordService;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.DefaultContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.core.AppRegistration;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
@@ -56,7 +58,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { CompletionConfiguration.class,
 		BootVersionsCompletionProviderTests.Mocks.class }, properties = {
-				"spring.main.allow-bean-definition-overriding=true" })
+		"spring.main.allow-bean-definition-overriding=true" })
 @SuppressWarnings("unchecked")
 public class BootVersionsCompletionProviderTests {
 
@@ -151,10 +153,13 @@ public class BootVersionsCompletionProviderTests {
 			};
 		}
 
+		@MockBean
+		private DefaultContainerImageMetadataResolver containerImageMetadataResolver;
+
 		@Bean
 		public ApplicationConfigurationMetadataResolver metadataResolver() {
 			return new BootApplicationConfigurationMetadataResolver(
-					StreamCompletionProviderTests.class.getClassLoader());
+					StreamCompletionProviderTests.class.getClassLoader(), containerImageMetadataResolver);
 		}
 	}
 }

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.audit.service.DefaultAuditRecordService;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.DefaultContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.core.AppRegistration;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
@@ -109,9 +111,12 @@ public class CompletionTestsMocks {
 		};
 	}
 
+	@MockBean
+	DefaultContainerImageMetadataResolver containerImageMetadataResolver;
+
 	@Bean
 	public ApplicationConfigurationMetadataResolver metadataResolver() {
 		return new BootApplicationConfigurationMetadataResolver(
-				CompletionTestsMocks.class.getClassLoader());
+				CompletionTestsMocks.class.getClassLoader(), containerImageMetadataResolver);
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -9,8 +9,30 @@
 	<artifactId>spring-cloud-dataflow-configuration-metadata</artifactId>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<aws-java-sdk-ecr.version>1.11.731</aws-java-sdk-ecr.version>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-ecr</artifactId>
+			<version>${aws-java-sdk-ecr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -10,8 +10,14 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<aws-java-sdk-ecr.version>1.11.731</aws-java-sdk-ecr.version>
+		<commons-text.version>1.8</commons-text.version>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>${commons-text.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -13,6 +13,11 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-ecr</artifactId>
 			<version>${aws-java-sdk-ecr.version}</version>

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/AppMetadataResolutionException.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/AppMetadataResolutionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AppMetadataResolutionException extends RuntimeException {
+	public AppMetadataResolutionException(String message) {
+		super(message);
+	}
+
+	public AppMetadataResolutionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.cloud.dataflow.configuration.metadata.container.Conta
 import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageParser;
 import org.springframework.cloud.dataflow.configuration.metadata.container.DefaultContainerImageMetadataResolver;
-import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
 import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.AwsEcrAuthorizer;
 import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.BasicAuthRegistryAuthorizer;
 import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.DockerHubRegistryAuthorizer;
@@ -65,15 +64,7 @@ public class ApplicationConfigurationMetadataResolverAutoConfiguration {
 	@Bean
 	@Validated
 	public ContainerImageMetadataProperties containerImageMetadataProperties() {
-		ContainerImageMetadataProperties properties = new ContainerImageMetadataProperties();
-
-		// Add the DockerHub registry configuration by default.
-		RegistryConfiguration dockerHubAuthConfig = new RegistryConfiguration();
-		dockerHubAuthConfig.setRegistryHost(ContainerImageMetadataProperties.DOCKER_HUB_HOST);
-		dockerHubAuthConfig.setAuthorizationType(RegistryConfiguration.AuthorizationType.dockerhub);
-		properties.getRegistryConfigurations().add(dockerHubAuthConfig);
-
-		return properties;
+		return new ContainerImageMetadataProperties();
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
@@ -16,22 +16,77 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataProperties;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageParser;
+import org.springframework.cloud.dataflow.configuration.metadata.container.DefaultContainerImageMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
+import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.AwsEcrAuthorizer;
+import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.BasicAuthRegistryAuthorizer;
+import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.DockerHubRegistryAuthorizer;
+import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.RegistryAuthorizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 /**
- * Automatically exposes an {@link ApplicationConfigurationMetadataResolver} if none is
- * already registered.
+ * Automatically exposes an {@link ApplicationConfigurationMetadataResolver} if none is already registered.
  *
  * @author Eric Bottard
+ * @author Christian Tzolov
  */
 @Configuration
 public class ApplicationConfigurationMetadataResolverAutoConfiguration {
 
 	@Bean
+	public RegistryAuthorizer dockerHubRegistryAuthorizer() {
+		return new DockerHubRegistryAuthorizer();
+	}
+
+	@Bean
+	public RegistryAuthorizer artifactoryRegistryAuthorizer() {
+		return new BasicAuthRegistryAuthorizer();
+	}
+
+	@Bean
+	public RegistryAuthorizer awsRegistryAuthorizer() {
+		return new AwsEcrAuthorizer();
+	}
+
+	@Bean
+	public ContainerImageParser containerImageParser(ContainerImageMetadataProperties properties) {
+		return new ContainerImageParser(properties.getDefaultRegistryHost(),
+				properties.getDefaultRepositoryTag(), properties.getOfficialRepositoryNamespace());
+	}
+
+	@Bean
+	@Validated
+	public ContainerImageMetadataProperties containerImageMetadataProperties() {
+		ContainerImageMetadataProperties properties = new ContainerImageMetadataProperties();
+
+		// Add the DockerHub registry configuration by default.
+		RegistryConfiguration dockerHubAuthConfig = new RegistryConfiguration();
+		dockerHubAuthConfig.setRegistryHost(ContainerImageMetadataProperties.DOCKER_HUB_HOST);
+		dockerHubAuthConfig.setAuthorizationType(RegistryConfiguration.AuthorizationType.dockerhub);
+		properties.getRegistryConfigurations().add(dockerHubAuthConfig);
+
+		return properties;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(ContainerImageMetadataResolver.class)
+	public DefaultContainerImageMetadataResolver containerImageMetadataResolver(ContainerImageParser imageNameParser,
+			List<RegistryAuthorizer> registryAuthorizers, ContainerImageMetadataProperties properties) {
+		return new DefaultContainerImageMetadataResolver(imageNameParser, registryAuthorizers, properties);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(ApplicationConfigurationMetadataResolver.class)
-	public ApplicationConfigurationMetadataResolver metadataResolver() {
-		return new BootApplicationConfigurationMetadataResolver();
+	public ApplicationConfigurationMetadataResolver metadataResolver(
+			DefaultContainerImageMetadataResolver containerImageMetadataResolver) {
+		return new BootApplicationConfigurationMetadataResolver(containerImageMetadataResolver);
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -32,6 +31,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.text.StringEscapeUtils;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataGroup;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
@@ -74,7 +75,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 
 	private static final String CONFIGURATION_PROPERTIES_NAMES = "configuration-properties.names";
 
-	private static final String CONTAINER_IMAGE_CONFIGURATION_METADATA_LABEL_NAME = "spring.configuration.metadata";
+	private static final String CONTAINER_IMAGE_CONFIGURATION_METADATA_LABEL_NAME = "org.springframework.cloud.dataflow.spring-configuration-metadata.json";
 
 	private final Set<String> globalWhiteListedProperties = new HashSet<>();
 
@@ -159,8 +160,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 		}
 
 		try {
-			String metadataJson = new String(Base64.getDecoder().decode(encodedMetadata.getBytes()));
-
+			String metadataJson = StringEscapeUtils.unescapeJson(encodedMetadata);
 			ConfigurationMetadataRepository configurationMetadataRepository =
 					ConfigurationMetadataRepositoryJsonBuilder.create().withJsonResource(
 							new ByteArrayInputStream(metadataJson.getBytes())).build();

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImage.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImage.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Domain class to represent the Container Image Name components.
+ *
+ * An image name is made up of slash-separated name components, prefixed by a registry hostname and optional port number.
+ * The name components define a namespace followed by a repository-name and a tag. The repository name needs to be
+ * unique in that namespace.
+ *
+ *   The container image has following structure:
+ *
+ *   registry-hostname : port / repo-namespace / repo-name : tag
+ *   |     REGISTRY-HOST      |          REPOSITORY        | TAG |
+ *
+ *   - The repository namespace is made up of zero or more slash-separated path components (eg. '/ns1/ns2/.../nsN/').
+ *   - The registry hostname (or IP) and the optional port parts together form the REGISTRY HOST. Later is used as a
+ *     unique identifier of the Container Registry hosting this container image. If not explicitly specified, a default
+ *     registry host value is used.
+ *   - The repository namespace together with the repository name form an unique REPOSITORY identifier, unique  within
+ *     the REGISTRY HOST.
+ *   - The TAG represents a particular REPOSITORY instance within the REGISTRY HOST.
+ *
+ * @author Christian Tzolov
+ */
+public class ContainerImage {
+
+	// https://dockr.ly/2T8cSH3
+	private static final Pattern NAMESPACE_COMPONENT_PATTERN = Pattern.compile("[a-z0-9]+(?:[._\\-][a-z0-9]+)*");
+	// The repository name needs to be unique in that namespace, can be two to 255 characters, and can only contain
+	// lowercase letters, numbers or - and _ (https://bit.ly/2Vz8kev)
+	private static final Pattern REPOSITORY_NAME_PATTERN = Pattern.compile("[a-z0-9\\-_]{2,255}");
+	// A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods
+	// and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+	// (https://dockr.ly/3chhQZF)
+	private static final Pattern TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9_][a-zA-Z0-9\\-_.]{0,127}$");
+	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
+	private static final Pattern IP_PATTERN = Pattern.compile("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+	private static final Pattern PORT_PATTERN = Pattern.compile("^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$");
+
+	/**
+	 * Registry hostname or IP address where the image is stored.
+	 */
+	private String hostname;
+
+	/**
+	 * Optional registry port
+	 */
+	private String port;
+
+	/**
+	 * Optional namespace. Zero or more path components.
+	 */
+	private String repositoryNamespace;
+
+	/**
+	 * Repository name
+	 */
+	private String repositoryName;
+
+	/**
+	 * Repository tag
+	 */
+	private String repositoryTag;
+
+
+	/**
+	 * Helper method that returns the full Registry host address (host:port)
+	 */
+	public String getRegistryHost() {
+		return this.hostname + (StringUtils.hasText(this.port) ? ":" + this.port : "");
+	}
+
+	/**
+	 * Helper method that returns the full Repository name (e.g. namespace/registryName) without the tag.
+	 */
+	public String getRepository() {
+		String ns = StringUtils.hasText(this.repositoryNamespace) ? this.repositoryNamespace + "/" : "";
+		return ns + this.repositoryName;
+	}
+
+	/**
+	 * @return hostname:port/repositoryNamespace/repositoryName:repositoryTag
+	 */
+	public String getCanonicalName() {
+		return getRegistryHost() + "/" + getRepository() + ":" + getRepositoryTag();
+	}
+
+	// Validated getters and setters
+
+	public String getHostname() {
+		return hostname;
+	}
+
+	public void setHostname(String hostname) {
+		Assert.isTrue(HOSTNAME_PATTERN.matcher(hostname).matches()
+				|| IP_PATTERN.matcher(hostname).matches(), "Invalid registry hostname: " + hostname);
+		this.hostname = hostname;
+	}
+
+	public String getPort() {
+		return port;
+	}
+
+	public void setPort(String port) {
+		Assert.isTrue(PORT_PATTERN.matcher(port).matches(), "Invalid registry port: " + port);
+		this.port = port;
+	}
+
+	public String getRepositoryNamespace() {
+		return repositoryNamespace;
+	}
+
+	public void setRepositoryNamespace(String repositoryNamespace) {
+		this.repositoryNamespace = repositoryNamespace;
+	}
+
+	public void setNamespaceComponents(String[] namespaceComponents) {
+		if (namespaceComponents != null && namespaceComponents.length > 0) {
+			Stream.of(namespaceComponents).forEach(
+					pathComponent -> Assert.isTrue(NAMESPACE_COMPONENT_PATTERN.matcher(pathComponent).matches(),
+							"Invalid namespace path component: " + pathComponent));
+			this.setRepositoryNamespace(String.join("/", namespaceComponents));
+		}
+	}
+
+	public String getRepositoryName() {
+		return repositoryName;
+	}
+
+	public void setRepositoryName(String repositoryName) {
+		Assert.isTrue(REPOSITORY_NAME_PATTERN.matcher(repositoryName).matches(),
+				"Invalid repository name: " + repositoryName);
+		this.repositoryName = repositoryName;
+	}
+
+	public String getRepositoryTag() {
+		return repositoryTag;
+	}
+
+	public void setRepositoryTag(String repositoryTag) {
+		Assert.isTrue(TAG_PATTERN.matcher(repositoryTag).matches(),
+				"Invalid repository tag: " + repositoryTag);
+		this.repositoryTag = repositoryTag;
+	}
+
+	@Override
+	public String toString() {
+		return "ContainerImage{ host='" + hostname + "', port='" + port + "', namespace='"
+				+ repositoryNamespace + "', name='" + repositoryName + "', tag='" + repositoryTag + "'}";
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataProperties.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Christian Tzolov
+ */
+@ConfigurationProperties(prefix = ContainerImageMetadataProperties.CONTAINER_IMAGE_METADATA_PREFIX)
+public class ContainerImageMetadataProperties {
+
+	public static final String CONTAINER_IMAGE_METADATA_PREFIX = "spring.cloud.dataflow.container.metadata";
+	public static final String OCI_IMAGE_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+	public static final String DOCKER_IMAGE_MANIFEST_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v2+json";
+	public static final String DOCKER_HUB_HOST = "registry-1.docker.io";
+	public static final String DEFAULT_TAG = "latest";
+	public static final String DEFAULT_OFFICIAL_REPO_NAMESPACE = "library";
+
+	/**
+	 * Default registry host to use when not provided in the image name.
+	 * Usually the privet registries provide the host as the part of the image name, while empty host defaults to
+	 * the DockerHub public registry.
+	 */
+	private String defaultRegistryHost = DOCKER_HUB_HOST;
+
+	/**
+	 * Default repository tag to be used if not provided through the image name.
+	 */
+	private String defaultRepositoryTag = DEFAULT_TAG;
+
+	/**
+	 * (applicable only for the default registry host) default namespace used if the image belongs to the default
+	 * registry but no namespace was specified.
+	 */
+	private String officialRepositoryNamespace = DEFAULT_OFFICIAL_REPO_NAMESPACE;
+
+	/**
+	 * Registry authentication configuration
+	 */
+	private List<RegistryConfiguration> registryConfigurations = new ArrayList<>();
+
+	public List<RegistryConfiguration> getRegistryConfigurations() {
+		return registryConfigurations;
+	}
+
+	public String getDefaultRegistryHost() {
+		return defaultRegistryHost;
+	}
+
+	public void setDefaultRegistryHost(String defaultRegistryHost) {
+		this.defaultRegistryHost = defaultRegistryHost;
+	}
+
+	public String getDefaultRepositoryTag() {
+		return defaultRepositoryTag;
+	}
+
+	public void setDefaultRepositoryTag(String defaultRepositoryTag) {
+		this.defaultRepositoryTag = defaultRepositoryTag;
+	}
+
+	public String getOfficialRepositoryNamespace() {
+		return officialRepositoryNamespace;
+	}
+
+	public void setOfficialRepositoryNamespace(String officialRepositoryNamespace) {
+		this.officialRepositoryNamespace = officialRepositoryNamespace;
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.Map;
+
+/**
+ * Retrieves the configuration metadata for Docker and OCI container images.
+ *
+ * @author Christian Tzolov
+ */
+public interface ContainerImageMetadataResolver {
+	/**
+	 * @param imageName container image name
+	 * @return Returns map of all image configuration labels.
+	 */
+	Map<String, String> getImageLabels(String imageName);
+
+	/**
+	 * @param imageName container image name
+	 * @return Returns image's configuration object structured as nested Maps.
+	 */
+	Map<String, Object> getImageConfig(String imageName);
+
+	/**
+	 * @param imageName container image name
+	 * @return Returns the image's manifest as JSON.
+	 */
+	String getImageManifest(String imageName);
+
+	/**
+	 * @param imageName container image name
+	 * @return Returns all image tags.
+	 */
+	String[] getImageTags(String imageName);
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageMetadataResolver.java
@@ -29,22 +29,4 @@ public interface ContainerImageMetadataResolver {
 	 * @return Returns map of all image configuration labels.
 	 */
 	Map<String, String> getImageLabels(String imageName);
-
-	/**
-	 * @param imageName container image name
-	 * @return Returns image's configuration object structured as nested Maps.
-	 */
-	Map<String, Object> getImageConfig(String imageName);
-
-	/**
-	 * @param imageName container image name
-	 * @return Returns the image's manifest as JSON.
-	 */
-	String getImageManifest(String imageName);
-
-	/**
-	 * @param imageName container image name
-	 * @return Returns all image tags.
-	 */
-	String[] getImageTags(String imageName);
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParser.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParser.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.Arrays;
+
+import org.springframework.util.Assert;
+
+/**
+ *  - https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+ *     An image name is made up of slash-separated name components, optionally prefixed by a registry hostname.
+ *
+ *     The hostname must comply with standard DNS rules, BUT MAY NOT CONTAIN UNDERSCORES. If a hostname is present,
+ *     it may optionally be followed by a port number in the format :8080. If not present, the command uses Docker’s
+ *     public registry located at registry-1.docker.io by default.
+ *
+ *     Name components may contain lowercase letters, digits and separators. A separator is defined as a period, one or
+ *     two underscores, or one or more dashes. A name component may not start or end with a separator.
+ *
+ *     A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods
+ *     and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+ *
+ *  - https://github.com/docker/docker.github.io/blob/master/docker-hub/repos.md#creating-repositories
+ *     The repository name needs to be unique in that namespace, can be two to 255 characters, and can only contain
+ *     lowercase letters, numbers or - and _
+ *
+ * - https://docs.docker.com/registry/spec/api/#overview
+ *   1. A repository name is broken up into path components. A component of a repository name must be at least one
+ *      lowercase, alpha-numeric characters, optionally separated by periods, dashes or underscores. More strictly,
+ *      it must match the regular expression [a-z0-9]+(?:[._-][a-z0-9]+)*.
+ *   2. If a repository name has two or more path components, they must be separated by a forward slash (“/”).
+ *   3. The total length of a repository name, including slashes, must be less than 256 characters.
+ *
+ * - Heuristic logic implemented by Docker to detect domain part in repository name:
+ *      https://github.com/docker/distribution/blob/master/reference/normalize.go#L91
+ *
+ * @author Christian Tzolov
+ */
+public class ContainerImageParser {
+
+	/**
+	 * Registry host (with optional port) to be used if the repository' image name has not specified one.
+	 */
+	private final String defaultRegistryHost;
+
+	/**
+	 * Repository image tag to be used when not specified by the image name.
+	 */
+	private final String defaultTag;
+
+	/**
+	 * Default namespace to be used if no namespace path component is provided by the Image Name.
+	 */
+	private final String officialRepositoryNamespace;
+
+	/**
+	 * Common registry hosts defaults.
+	 */
+	private static final String LOCALHOST_DOMAIN = "localhost";
+	private static final String LEGACY_DEFAULT_DOMAIN = "index.docker.io";
+	private static final String PLAIN_DOCKER_IO_DOMAIN = "docker.io";
+
+	/**
+	 * Characters used to split the image name in parts.
+	 */
+	private static final String SLASH_SEPARATOR = "/";
+	private static final String COLUMN_SEPARATOR = ":";
+	private static final String PERIOD_SEPARATOR = ".";
+
+	public ContainerImageParser() {
+		this(ContainerImageMetadataProperties.DOCKER_HUB_HOST,
+				ContainerImageMetadataProperties.DEFAULT_TAG,
+				ContainerImageMetadataProperties.DEFAULT_OFFICIAL_REPO_NAMESPACE);
+	}
+
+	public ContainerImageParser(String defaultRegistryHost, String defaultTag, String officialRepoName) {
+		this.defaultRegistryHost = defaultRegistryHost;
+		this.defaultTag = defaultTag;
+		this.officialRepositoryNamespace = officialRepoName;
+	}
+
+	/**
+	 * @param imageName  = [registry-host[:port]/] (namespace-path-component/)+ repository-name:tag
+	 * @return Returns {@link ContainerImage}
+	 */
+	public ContainerImage parse(String imageName) {
+		ContainerImage containerImageName = new ContainerImage();
+
+		String[] registryHostAndRemainderSplit = splitDockerRegistryHost(imageName);
+		String registryHost = registryHostAndRemainderSplit[0];
+		String remainder = registryHostAndRemainderSplit[1];
+
+		// Registry Host
+		String[] hostAndPortSplit = registryHost.split(COLUMN_SEPARATOR);
+		Assert.isTrue(hostAndPortSplit.length > 0 && hostAndPortSplit.length <= 2,
+				"Invalid registry host address: " + registryHost);
+		containerImageName.setHostname(hostAndPortSplit[0]);
+
+		if (hostAndPortSplit.length == 2) { // has a port section
+			containerImageName.setPort(hostAndPortSplit[1]);
+		}
+
+		String[] pathComponents = remainder.split(SLASH_SEPARATOR);
+
+		// Repository name and tag
+		String repositoryNameAndTag = pathComponents[pathComponents.length - 1];
+		String[] repositoryNameAndTagSplit = repositoryNameAndTag.split(COLUMN_SEPARATOR);
+		Assert.isTrue(repositoryNameAndTagSplit.length > 0 && repositoryNameAndTagSplit.length <= 2,
+				"Invalid repository name: " + repositoryNameAndTag);
+		containerImageName.setRepositoryName(repositoryNameAndTagSplit[0]);
+
+		String repositoryTag = (repositoryNameAndTagSplit.length == 2) ? repositoryNameAndTagSplit[1] : this.defaultTag;
+		containerImageName.setRepositoryTag(repositoryTag);
+
+		// Namespace components
+		if (pathComponents.length >= 2) {
+			String[] namespaceComponents = Arrays.copyOf(pathComponents, pathComponents.length - 1);
+			containerImageName.setNamespaceComponents(namespaceComponents);
+		}
+
+		return containerImageName;
+	}
+
+	/**
+	 * The Docker Image Name specification (https://github.com/docker/distribution/blob/master/reference/reference.go)
+	 * don't provide deterministic rules to distinct registry host (e.g. domain) component from the rest of the
+	 * repository name.
+	 *
+	 * Therefore here we re-implement the heuristic logic used by the Docker implementation itself:
+	 * https://github.com/docker/distribution/blob/master/reference/normalize.go#L91
+	 *
+	 * @param imageName the full repository name (including the optional registry host and port).
+	 * @return Returns two-element array, where the [0] part contains the registry host and the [1] part the repository
+	 * name remainder.
+	 */
+	private String[] splitDockerRegistryHost(String imageName) {
+		String registryHost;
+		String remainder;
+		int i = imageName.indexOf(SLASH_SEPARATOR);
+		if ((i == -1) || (!(imageName.substring(0, i).contains(PERIOD_SEPARATOR) || imageName.substring(0, i).contains(COLUMN_SEPARATOR))
+				&& !imageName.substring(0, i).equals(LOCALHOST_DOMAIN))) {
+			// No registry host detected use the default host!
+			registryHost = this.defaultRegistryHost;
+			remainder = imageName;
+		}
+		else { // registry host detected
+			registryHost = imageName.substring(0, i);
+			remainder = imageName.substring(i + 1);
+		}
+
+		// Note that 'docker.io' has to be replaced by the actual registry host ''
+		if (registryHost.equals(LEGACY_DEFAULT_DOMAIN) || registryHost.equals(PLAIN_DOCKER_IO_DOMAIN)) {
+			registryHost = this.defaultRegistryHost;
+		}
+
+		if (registryHost.equals(this.defaultRegistryHost) && !remainder.contains(SLASH_SEPARATOR)) {
+			remainder = this.officialRepositoryNamespace + SLASH_SEPARATOR + remainder;
+		}
+
+		return new String[] { registryHost, remainder };
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/RegistryConfiguration.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/RegistryConfiguration.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configurations specific for each target Container Registry provider/instance.
+ *
+ * The Docker Hub configuration is set by default. Additional registries can be configured through the
+ * {@link ContainerImageMetadataProperties#getRegistryConfigurations()} properties like this:
+ *
+ * <code>
+ *  Configure Arifactory/JFrog private container registry:
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[0].registry-host=springsource-docker-private-local.jfrog.io
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[0].authorization-type=basicauth
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[0].user=[artifactory user]
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[0].secret=[artifactory encryptedkey]
+ *
+ *  Configure Amazon ECR private registry:
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].registry-host=283191309520.dkr.ecr.us-west-1.amazonaws.com
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].authorization-type=awsecr
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].user=[your AWS accessKey]
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].secret=[your AWS secretKey]
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].extra[region]=us-west-1
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[1].extra[registryIds]=283191309520
+ *
+ *  Configure Azure private container registry
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[2].registry-host=tzolovazureregistry.azurecr.io
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[2].authorization-type=basicauth
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[2].user=[your Azure registry username]
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[2].secret=[your Azure registry access password]
+ *
+ *  Harbor Registry. Same as DockerHub but with different registryAuthUri
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[3].registry-host=demo.goharbor.io
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[3].authorization-type=dockerhub
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[3].user=admin
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[3].secret=Harbor12345
+ *    - spring.cloud.dataflow.container.metadata.registry-configurations[3].extra[registryAuthUri]=https://demo.goharbor.io/service/token?service=harbor-registry&scope=repository:{repository}:pull
+ * </code>
+ *
+ * @author Christian Tzolov
+ */
+public class RegistryConfiguration {
+
+	/**
+	 * Registry authorization types supported by SCDF.
+	 */
+	public enum AuthorizationType {
+
+		/**
+		 * Uses a basic authentication. Can be used with the
+		 * Azure Container Registry or the Artifactory/JFrog registries.
+		 */
+		basicauth,
+
+		/**
+		 * OAuth2 token based authorization.
+		 * Can be used the DockerHub or Harbor registries.
+		 */
+		dockerhub,
+
+		/**
+		 * AWS ECR authorization model.
+		 * Set the 'user' to your AWS accessKey as the 'secret' to the AWS secretKey.
+		 * You have to provided the AWS region via the extra[region]=your AWS region
+		 */
+		awsecr
+	}
+
+	/**
+	 * Container Registry Host (and optional port). Must me unique per registry.
+	 *
+	 * Used as a key to to map a container image to target registry where it is stored!
+	 */
+	private String registryHost;
+
+	/**
+	 * Credentials used by the registry specific {@link org.springframework.cloud.dataflow.configuration.metadata.container.authorization.RegistryAuthorizer}
+	 * (determined by the {@link #authorizationType}) to authorize the registry access.
+	 */
+	private String user;
+	private String secret;
+
+	/**
+	 * Authorization type supported by this Registry.
+	 */
+	private AuthorizationType authorizationType;
+
+	/**
+	 * Image Manifest media type. Docker and OCI are supported.
+	 */
+	private String manifestMediaType = ContainerImageMetadataProperties.DOCKER_IMAGE_MANIFEST_MEDIA_TYPE;
+
+	/**
+	 * Additional registry specific configuration properties.
+	 * Usually used inside the Registry authorizer implementations. For example check the AwsEcrAuthorizer implementation.
+	 */
+	private Map<String, String> extra = new HashMap<>();
+
+	public Map<String, String> getExtra() {
+		return extra;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	public String getSecret() {
+		return secret;
+	}
+
+	public void setSecret(String secret) {
+		this.secret = secret;
+	}
+
+	public String getRegistryHost() {
+		return registryHost;
+	}
+
+	public void setRegistryHost(String registryHost) {
+		this.registryHost = registryHost;
+	}
+
+	public AuthorizationType getAuthorizationType() {
+		return authorizationType;
+	}
+
+	public void setAuthorizationType(AuthorizationType authorizationType) {
+		this.authorizationType = authorizationType;
+	}
+
+	public String getManifestMediaType() {
+		return manifestMediaType;
+	}
+
+	public void setManifestMediaType(String manifestMediaType) {
+		this.manifestMediaType = manifestMediaType;
+	}
+
+	@Override
+	public String toString() {
+		return "RegistryConfiguration{" +
+				"registryHost='" + registryHost + '\'' +
+				", user='" + user + '\'' +
+				", secret='" + secret + '\'' +
+				", authorizationType=" + authorizationType +
+				", manifestMediaType='" + manifestMediaType + '\'' +
+				", extra=" + extra +
+				'}';
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/AwsEcrAuthorizer.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/AwsEcrAuthorizer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.configuration.metadata.container.authorization;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ecr.AmazonECR;
+import com.amazonaws.services.ecr.AmazonECRClientBuilder;
+import com.amazonaws.services.ecr.model.GetAuthorizationTokenRequest;
+import com.amazonaws.services.ecr.model.GetAuthorizationTokenResult;
+
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
+import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AwsEcrAuthorizer implements RegistryAuthorizer {
+
+	public static final String AWS_REGION = "region";
+	public static final String REGISTRY_IDS = "registryIds";
+
+	@Override
+	public RegistryConfiguration.AuthorizationType getType() {
+		return RegistryConfiguration.AuthorizationType.awsecr;
+	}
+
+	@Override
+	public HttpHeaders getAuthorizationHeaders(ContainerImage containerImage,
+			RegistryConfiguration registryConfiguration) {
+
+		Assert.isTrue(registryConfiguration.getAuthorizationType() == this.getType(),
+				"Incorrect type: " + registryConfiguration.getAuthorizationType());
+
+		AmazonECRClientBuilder ecrBuilder = AmazonECRClientBuilder.standard();
+		if (registryConfiguration.getExtra().containsKey(AWS_REGION)) {
+			ecrBuilder.withRegion(registryConfiguration.getExtra().get(AWS_REGION));
+		}
+		if (StringUtils.hasText(registryConfiguration.getUser()) && StringUtils.hasText(registryConfiguration.getSecret())) {
+			// Expects that the 'user' == 'Access Key ID' and 'secret' == 'Secret Access Key'
+			ecrBuilder.withCredentials(new AWSStaticCredentialsProvider(
+					new BasicAWSCredentials(registryConfiguration.getUser(), registryConfiguration.getSecret())));
+		}
+
+		AmazonECR client = ecrBuilder.build();
+
+		GetAuthorizationTokenRequest request = new GetAuthorizationTokenRequest();
+		if (registryConfiguration.getExtra().containsKey(REGISTRY_IDS)) {
+			request.withRegistryIds(registryConfiguration.getExtra().get(REGISTRY_IDS).split(","));
+		}
+		GetAuthorizationTokenResult response = client.getAuthorizationToken(request);
+		String token = response.getAuthorizationData().iterator().next().getAuthorizationToken();
+		final HttpHeaders headers = new HttpHeaders();
+		headers.setBasicAuth(token);
+		return headers;
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/BasicAuthRegistryAuthorizer.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/BasicAuthRegistryAuthorizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container.authorization;
+
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
+import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ */
+public class BasicAuthRegistryAuthorizer implements RegistryAuthorizer {
+
+	@Override
+	public RegistryConfiguration.AuthorizationType getType() {
+		return RegistryConfiguration.AuthorizationType.basicauth;
+	}
+
+	@Override
+	public HttpHeaders getAuthorizationHeaders(ContainerImage containerImage,
+			RegistryConfiguration registryConfiguration) {
+
+		Assert.isTrue(registryConfiguration.getAuthorizationType() == this.getType(),
+				"Incorrect type: " + registryConfiguration.getAuthorizationType());
+
+		final HttpHeaders headers = new HttpHeaders();
+		headers.setBasicAuth(registryConfiguration.getUser(), registryConfiguration.getSecret());
+		return headers;
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/DockerHubRegistryAuthorizer.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/DockerHubRegistryAuthorizer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container.authorization;
+
+import java.util.Map;
+
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
+import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Docker Hub requires authorization per Repository (e.g. springcloudstream/rabbit-sink-rabbit).
+ *
+ * @author Christian Tzolov
+ */
+public class DockerHubRegistryAuthorizer implements RegistryAuthorizer {
+
+	public static final String DEFAULT_DOCKER_REGISTRY_AUTH_URI = "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:pull&offline_token=1&client_id=shell";
+
+	public static final String TOKEN_KEY = "token";
+	public static final String DOCKER_REGISTRY_AUTH_URI_KEY = "registryAuthUri";
+
+	@Override
+	public RegistryConfiguration.AuthorizationType getType() {
+		return RegistryConfiguration.AuthorizationType.dockerhub;
+	}
+
+	@Override
+	public HttpHeaders getAuthorizationHeaders(ContainerImage containerImage, RegistryConfiguration registryConfiguration) {
+
+		Assert.isTrue(registryConfiguration.getAuthorizationType() == this.getType(),
+				"Incorrect authorization type: " + registryConfiguration.getAuthorizationType());
+
+		Assert.notNull(containerImage, "Valid containerImageName is required!");
+		String imageRepository = containerImage.getRepository();
+		Assert.hasText(imageRepository, "Valid repository name (e.g. namespace/repository-name without the tag)" +
+				" is required for the authorization");
+
+		final HttpHeaders requestHttpHeaders = new HttpHeaders();
+		if (StringUtils.hasText(registryConfiguration.getUser()) && StringUtils.hasText(registryConfiguration.getSecret())) {
+			// Use basic authentication to obtain the authorization token.
+			// Usually the public docker hub authorization service doesn't require authentication for image pull requests.
+			requestHttpHeaders.setBasicAuth(registryConfiguration.getUser(), registryConfiguration.getSecret());
+		}
+
+		String registryAuthUri = registryConfiguration.getExtra().containsKey(DOCKER_REGISTRY_AUTH_URI_KEY) ?
+				registryConfiguration.getExtra().get(DOCKER_REGISTRY_AUTH_URI_KEY) : DEFAULT_DOCKER_REGISTRY_AUTH_URI;
+
+		final HttpEntity<String> entity = new HttpEntity<>(requestHttpHeaders);
+		ResponseEntity<Map> authorization = new RestTemplate().exchange(registryAuthUri, HttpMethod.GET,
+				entity, Map.class, imageRepository);
+		Map<String, String> authorizationBody = (Map<String, String>) authorization.getBody();
+
+		final HttpHeaders responseHttpHeaders = new HttpHeaders();
+		responseHttpHeaders.setBearerAuth(authorizationBody.get(TOKEN_KEY));
+		return responseHttpHeaders;
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/RegistryAuthorizer.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/RegistryAuthorizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container.authorization;
+
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
+import org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * Different Container Registry providers may enforce different mechanisms and policies to access the registries.
+ * Specific implementations of {@link RegistryAuthorizer} would allow to obtain the right credentials for each supported
+ * registry provider. One {@link RegistryAuthorizer} is provided per
+ * {@link org.springframework.cloud.dataflow.configuration.metadata.container.RegistryConfiguration.AuthorizationType}
+ *
+ * @author Christian Tzolov
+ */
+public interface RegistryAuthorizer {
+
+	/**
+	 * @return Returns the type of Registry servers that this authorizer supports.
+	 */
+	RegistryConfiguration.AuthorizationType getType();
+
+	/**
+	 * @param containerImage Container Image for which authorization is required.
+	 * @param registryConfiguration configuration such as credentials and additional information required to obtain the
+	 *                              authorized headers.
+	 * @return Returns HTTP headers, configured with authorization credentials or tokens that would allow access
+	 * the target Registry.
+	 */
+	HttpHeaders getAuthorizationHeaders(ContainerImage containerImage, RegistryConfiguration registryConfiguration);
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +33,6 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
 import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.util.Base64Utils;
 import org.springframework.util.StreamUtils;
 
 import static org.hamcrest.Matchers.hasItem;
@@ -74,7 +74,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		byte[] bytes = StreamUtils.copyToByteArray(new ClassPathResource(
 				"apps/no-whitelist/META-INF/spring-configuration-metadata.json", getClass()).getInputStream());
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest"))
-				.thenReturn(Collections.singletonMap("spring.configuration.metadata", Base64Utils.encodeToString(bytes)));
+				.thenReturn(Collections.singletonMap("org.springframework.cloud.dataflow.spring-configuration-metadata.json", StringEscapeUtils.escapeJson(new String(bytes))));
 		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new DockerResource("test/test:latest"));
 		assertThat(properties.size(), is(3));
 	}
@@ -82,7 +82,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 	@Test(expected = AppMetadataResolutionException.class)
 	public void appDockerResourceBrokenFormat() {
 		byte[] bytes = "Invalid metadata json content1".getBytes();
-		Map<String, String> result = Collections.singletonMap("spring.configuration.metadata", Base64Utils.encodeToString(bytes));
+		Map<String, String> result = Collections.singletonMap("org.springframework.cloud.dataflow.spring-configuration-metadata.json", StringEscapeUtils.escapeJson(new String(bytes)));
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(result);
 		resolver.listProperties(new DockerResource("test/test:latest"));
 	}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,76 @@
 
 package org.springframework.cloud.dataflow.configuration.metadata;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.Base64Utils;
+import org.springframework.util.StreamUtils;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link ApplicationConfigurationMetadataResolver}.
  *
  * @author Eric Bottard
+ * @author Christian Tzolov
  */
 public class BootApplicationConfigurationMetadataResolverTests {
 
-	private ApplicationConfigurationMetadataResolver resolver = new BootApplicationConfigurationMetadataResolver();
+	@Mock
+	private ContainerImageMetadataResolver containerImageMetadataResolver;
+
+	private ApplicationConfigurationMetadataResolver resolver;
+
+	@Before
+	public void init() {
+		MockitoAnnotations.initMocks(this);
+		resolver = new BootApplicationConfigurationMetadataResolver(containerImageMetadataResolver);
+	}
+
+	@Test
+	public void appDockerResourceEmptyLabels() {
+		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(new HashMap<>());
+		List<ConfigurationMetadataProperty> properties = resolver
+				.listProperties(new DockerResource("test/test:latest"));
+		assertThat(properties.size(), is(0));
+	}
+
+	@Test
+	public void appDockerResource() throws IOException {
+		byte[] bytes = StreamUtils.copyToByteArray(new ClassPathResource(
+				"apps/no-whitelist/META-INF/spring-configuration-metadata.json", getClass()).getInputStream());
+		when(containerImageMetadataResolver.getImageLabels("test/test:latest"))
+				.thenReturn(Collections.singletonMap("spring.configuration.metadata", Base64Utils.encodeToString(bytes)));
+		List<ConfigurationMetadataProperty> properties = resolver.listProperties(new DockerResource("test/test:latest"));
+		assertThat(properties.size(), is(3));
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void appDockerResourceBrokenFormat() {
+		byte[] bytes = "Invalid metadata json content1".getBytes();
+		Map<String, String> result = Collections.singletonMap("spring.configuration.metadata", Base64Utils.encodeToString(bytes));
+		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(result);
+		resolver.listProperties(new DockerResource("test/test:latest"));
+	}
 
 	@Test
 	public void appSpecificWhitelistedPropsShouldBeVisible() {

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParserTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParserTests.java
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.dataflow.configuration.metadata.container.parser;
+package org.springframework.cloud.dataflow.configuration.metadata.container;
 
 import org.junit.Test;
-
-import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
-import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageParser;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolverTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolverTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.cloud.dataflow.configuration.metadata.AppMetadataResolutionException;
+import org.springframework.cloud.dataflow.configuration.metadata.container.authorization.RegistryAuthorizer;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christian Tzolov
+ */
+public class DefaultContainerImageMetadataResolverTest {
+
+	@Mock
+	private RestTemplate mockRestTemplate;
+
+	@Mock
+	private RegistryAuthorizer registryAuthorizer;
+
+	private ContainerImageMetadataProperties containerImageMetadataProperties;
+
+	@Before
+	public void init() {
+		MockitoAnnotations.initMocks(this);
+
+		containerImageMetadataProperties = new ContainerImageMetadataProperties();
+
+		// DockerHub registry configuration by default.
+		RegistryConfiguration dockerHubAuthConfig = new RegistryConfiguration();
+		dockerHubAuthConfig.setRegistryHost(ContainerImageMetadataProperties.DOCKER_HUB_HOST);
+		dockerHubAuthConfig.setAuthorizationType(RegistryConfiguration.AuthorizationType.dockerhub);
+
+		containerImageMetadataProperties.getRegistryConfigurations().add(dockerHubAuthConfig);
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsInvalidImageName() {
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+		resolver.getImageLabels(null);
+	}
+
+	@Test
+	public void getImageLabels() {
+
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(new HttpHeaders());
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+
+		Map<String, Object> manifestResponse = Collections.singletonMap("config", Collections.singletonMap("digest", "123"));
+		mockManifestRestTemplateCall(manifestResponse, "test/image", "latest");
+
+		mockBlogRestTemplateCall("{\"config\": { \"Labels\": { \"boza\": \"koza\"} } }",
+				"test/image", "123");
+
+		Map<String, String> labels = resolver.getImageLabels("test/image:latest");
+		assertThat(labels.size(), is(1));
+		assertThat(labels.get("boza"), is("koza"));
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsMissingRegistryConfiguration() {
+
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(new HttpHeaders());
+
+		ContainerImageMetadataProperties propertiesWithoutRegistryConfiguration = new ContainerImageMetadataProperties();
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), propertiesWithoutRegistryConfiguration);
+
+		resolver.getImageLabels("test/image:latest");
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsMissingRegistryAuthorizer() {
+
+		List<RegistryAuthorizer> emptyAuthorizerList = Collections.emptyList();
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), emptyAuthorizerList, containerImageMetadataProperties);
+
+		resolver.getImageLabels("test/image:latest");
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsMissingAuthorizationHeader() {
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(null);
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+
+		resolver.getImageLabels("test/image:latest");
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsInvalidManifestResponse() {
+
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(new HttpHeaders());
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+
+		Map<String, Object> manifestResponseWithoutConfig = Collections.emptyMap();
+		mockManifestRestTemplateCall(manifestResponseWithoutConfig, "test/image", "latest");
+
+		resolver.getImageLabels("test/image:latest");
+	}
+
+	@Test(expected = AppMetadataResolutionException.class)
+	public void getImageLabelsInvalidDigest() {
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(new HttpHeaders());
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+
+		String emptyDigest = "";
+		Map<String, Object> manifestResponse = Collections.singletonMap("config", Collections.singletonMap("digest", emptyDigest));
+		mockManifestRestTemplateCall(manifestResponse, "test/image", "latest");
+
+		resolver.getImageLabels("test/image:latest");
+	}
+
+	@Test
+	public void getImageLabelsWithInvalidLabels() {
+
+		when(registryAuthorizer.getType()).thenReturn(RegistryConfiguration.AuthorizationType.dockerhub);
+		when(registryAuthorizer.getAuthorizationHeaders(any(), any())).thenReturn(new HttpHeaders());
+
+		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+				new ContainerImageParser(), Arrays.asList(registryAuthorizer), containerImageMetadataProperties);
+
+		Map<String, Object> manifestResponse = Collections.singletonMap("config", Collections.singletonMap("digest", "123"));
+		mockManifestRestTemplateCall(manifestResponse, "test/image", "latest");
+
+		mockBlogRestTemplateCall("{\"config\": { } }",
+				"test/image", "123");
+
+		Map<String, String> labels = resolver.getImageLabels("test/image:latest");
+		assertThat(labels.size(), is(0));
+	}
+
+	private void mockManifestRestTemplateCall(Map<String, Object> mapToReturn, String repository, String tag) {
+		when(mockRestTemplate.exchange(
+				eq("https://{registryHost}/v2/{repository}/manifests/{tag}"),
+				eq(HttpMethod.GET),
+				any(HttpEntity.class),
+				eq(Map.class),
+				any(String.class),
+				eq(repository),
+				eq(tag))).thenReturn(
+				new ResponseEntity<>(mapToReturn, HttpStatus.OK));
+	}
+
+	private void mockBlogRestTemplateCall(String jsonResponse, String repository, String digest) {
+		when(mockRestTemplate.exchange(
+				eq("https://{registryHost}/v2/{repository}/blobs/{digest}"),
+				eq(HttpMethod.GET),
+				any(HttpEntity.class),
+				eq(String.class),
+				any(String.class),
+				eq(repository),
+				eq(digest)))
+				.thenReturn(new ResponseEntity<>(jsonResponse, HttpStatus.OK));
+	}
+
+	private class MockedDefaultContainerImageMetadataResolver extends DefaultContainerImageMetadataResolver {
+		public MockedDefaultContainerImageMetadataResolver(ContainerImageParser containerImageParser,
+				List<RegistryAuthorizer> registryAuthorizes, ContainerImageMetadataProperties registryProperties) {
+			super(containerImageParser, registryAuthorizes, registryProperties);
+		}
+
+		@Override
+		protected RestTemplate getRestTemplate() {
+			return mockRestTemplate;
+		}
+	}
+}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/parser/ContainerImageParserTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/parser/ContainerImageParserTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.configuration.metadata.container.parser;
+
+import org.junit.Test;
+
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImage;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageParser;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ContainerImageParserTests {
+
+	private ContainerImageParser containerImageNameParser =
+			new ContainerImageParser("test-domain.io", "tag654", "official-repo-name");
+
+	@Test
+	public void testParseWithoutDefaults() {
+		ContainerImage containerImageName =
+				containerImageNameParser.parse("springsource-docker-private-local.jfrog.io:80/scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173:123");
+
+		assertThat(containerImageName.getHostname(), is("springsource-docker-private-local.jfrog.io"));
+		assertThat(containerImageName.getPort(), is("80"));
+		assertThat(containerImageName.getRepositoryNamespace(), is("scdf/stream"));
+		assertThat(containerImageName.getRepositoryName(), is("spring-cloud-dataflow-acceptance-image-drivers173"));
+		assertThat(containerImageName.getRepositoryTag(), is("123"));
+
+		assertThat(containerImageName.getRegistryHost(), is("springsource-docker-private-local.jfrog.io:80"));
+		assertThat(containerImageName.getRepository(), is("scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173"));
+
+		assertThat(containerImageName.getCanonicalName(), is("springsource-docker-private-local.jfrog.io:80/scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173:123"));
+	}
+
+	@Test
+	public void testParseWithDefaults() {
+		ContainerImage containerImageName = containerImageNameParser.parse("simple-repo-name");
+
+		assertThat(containerImageName.getHostname(), is("test-domain.io"));
+		assertNull(containerImageName.getPort());
+		assertThat(containerImageName.getRepositoryNamespace(), is("official-repo-name"));
+		assertThat(containerImageName.getRepositoryName(), is("simple-repo-name"));
+		assertThat(containerImageName.getRepositoryTag(), is("tag654"));
+
+		assertThat(containerImageName.getRegistryHost(), is("test-domain.io"));
+		assertThat(containerImageName.getRepository(), is("official-repo-name/simple-repo-name"));
+		assertThat(containerImageName.getCanonicalName(), is("test-domain.io/official-repo-name/simple-repo-name:tag654"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidRegistryHostName() {
+		containerImageNameParser.parse("6666#.6:80/scdf/spring-image:123");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidRegistryPart() {
+		containerImageNameParser.parse("localhost:80bla/scdf/spring-image:123");
+	}
+}

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
@@ -261,9 +261,8 @@ public class AppResourceCommon {
 			return this.metadataResourceLoader.getResource(metadataUri.toString());
 		}
 		else {
-			Resource appResource = this.getResource(appUri.toString());
 			// If the metadata URI is not set, only the archive type app resource can serve as the metadata resource
-			return (appResource instanceof DockerResource) ? null : appResource;
+			return this.getResource(appUri.toString());
 		}
 	}
 

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -99,7 +99,7 @@ public class AppResourceCommonTests {
 	}
 
 	@Test
-	public void testMetadataUriHttpApp2() throws Exception {
+	public void testJarMetadataUriDockerApp() throws Exception {
 		String appUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
 		String metadataUri = "https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), new URI(metadataUri));
@@ -118,7 +118,8 @@ public class AppResourceCommonTests {
 	public void testMetadataUriDockerApp() throws Exception {
 		String appUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), null);
-		assertThat(metadataResource).isNull();
+		assertThat(metadataResource).isNotNull();
+		assertTrue(metadataResource instanceof DockerResource);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -196,4 +196,8 @@ spring:
             # Tools
 
             - POST   /tools/**                       => hasRole('ROLE_VIEW')
-
+      container:
+        metadata:
+          registry-configurations:
+            - registry-host: registry-1.docker.io
+              authorization-type: dockerhub

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
@@ -182,7 +182,7 @@ public class TabOnTapCompletionProviderTests {
 
 		@Bean
 		public ApplicationConfigurationMetadataResolver configurationMetadataResolver() {
-			return new BootApplicationConfigurationMetadataResolver(null);
+			return new BootApplicationConfigurationMetadataResolver(null, null);
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -45,6 +45,7 @@ import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.audit.service.DefaultAuditRecordService;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.dataflow.registry.repository.AppRegistrationRepository;
@@ -161,7 +162,7 @@ public class JobDependencies {
 
 	@Bean
 	public ApplicationConfigurationMetadataResolver metadataResolver() {
-		return new BootApplicationConfigurationMetadataResolver();
+		return new BootApplicationConfigurationMetadataResolver(mock(ContainerImageMetadataResolver.class));
 	}
 
 	@Bean
@@ -398,6 +399,7 @@ public class JobDependencies {
 		return new JdbcDataflowTaskExecutionMetadataDao(dataSource, incrementerFactory.getIncrementer(databaseType,
 				"task_execution_metadata_seq"));
 	}
+
 	@Bean
 	public SchedulerService schedulerService() {
 		return new SchedulerService() {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreatorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreatorTests.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.StreamAppDefinition;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
@@ -54,7 +55,7 @@ public class AppDeploymentRequestCreatorTests {
 	public void setupMock() {
 		this.appDeploymentRequestCreator = new AppDeploymentRequestCreator(mock(AppRegistryService.class),
 				mock(CommonApplicationProperties.class),
-				new BootApplicationConfigurationMetadataResolver());
+				new BootApplicationConfigurationMetadataResolver(mock(ContainerImageMetadataResolver.class)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceTests.java
@@ -35,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.AuditActionType;
 import org.springframework.cloud.dataflow.core.AuditOperationType;
@@ -105,7 +106,7 @@ public class DefaultStreamServiceTests {
 		this.auditRecordService = mock(AuditRecordService.class); // FIXME
 		this.appDeploymentRequestCreator = new AppDeploymentRequestCreator(this.appRegistryService,
 				mock(CommonApplicationProperties.class),
-				new BootApplicationConfigurationMetadataResolver());
+				new BootApplicationConfigurationMetadataResolver(mock(ContainerImageMetadataResolver.class)));
 		this.streamValidationService = mock(DefaultStreamValidationService.class);
 		this.defaultStreamService = new DefaultStreamService(streamDefinitionRepository,
 				this.skipperStreamDeployer, this.appDeploymentRequestCreator, this.streamValidationService,

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactory;
 import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactoryProperties;
 import org.springframework.cloud.dataflow.integration.test.util.ResourceExtractor;
@@ -65,6 +66,7 @@ import org.springframework.cloud.dataflow.rest.client.dsl.DeploymentPropertiesBu
 import org.springframework.cloud.dataflow.rest.client.dsl.Stream;
 import org.springframework.cloud.dataflow.rest.client.dsl.StreamApplication;
 import org.springframework.cloud.dataflow.rest.client.dsl.StreamDefinition;
+import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionStatus;
 import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -215,6 +217,49 @@ public class DataFlowIT {
 		logger.info(String.format("Selected platform: [name: %s, type: %s]", runtimeApps.getPlatformName(), runtimeApps.getPlatformType()));
 		logger.info("Wait until at least 60 apps are registered in SCDF");
 		Awaitility.await().until(() -> dataFlowOperations.appRegistryOperations().list().getMetadata().getTotalElements() >= 60L);
+	}
+
+	@Test
+	public void applicationMetadataTests() {
+		// Maven app with metadata
+		DetailedAppRegistrationResource mavenAppWithJarMetadata = dataFlowOperations.appRegistryOperations()
+				.info("file", ApplicationType.sink, false);
+		assertThat(mavenAppWithJarMetadata.getOptions()).hasSize(8);
+
+		// Maven app without metadata
+		dataFlowOperations.appRegistryOperations().register("maven-app-without-metadata", ApplicationType.sink,
+				"maven://org.springframework.cloud.stream.app:file-sink-kafka:2.1.1.RELEASE", null, true);
+		DetailedAppRegistrationResource mavenAppWithoutMetadata = dataFlowOperations.appRegistryOperations()
+				.info("maven-app-without-metadata", ApplicationType.sink, false);
+		assertThat(mavenAppWithoutMetadata.getOptions()).hasSize(8);
+
+		// Docker app with container image metadata
+		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.sink,
+				"docker:springcloudstream/rabbit-sink-rabbit:latest", null, true);
+		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
+				.info("docker-app-with-container-metadata", ApplicationType.sink, false);
+		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(19);
+
+		// Docker app without metadata
+		dataFlowOperations.appRegistryOperations().register("docker-app-without-metadata", ApplicationType.sink,
+				"docker:springcloudstream/file-sink-kafka:2.1.1.RELEASE", null, true);
+		DetailedAppRegistrationResource dockerAppWithoutMetadata = dataFlowOperations.appRegistryOperations()
+				.info("docker-app-without-metadata", ApplicationType.sink, false);
+		assertThat(dockerAppWithoutMetadata.getOptions()).hasSize(0);
+
+		// Docker app with jar metadata
+		dataFlowOperations.appRegistryOperations().register("docker-app-with-jar-metadata", ApplicationType.sink,
+				"docker:springcloudstream/file-sink-kafka:2.1.1.RELEASE",
+				"maven://org.springframework.cloud.stream.app:file-sink-kafka:jar:metadata:2.1.1.RELEASE", true);
+		DetailedAppRegistrationResource dockerAppWithJarMetadata = dataFlowOperations.appRegistryOperations()
+				.info("docker-app-with-jar-metadata", ApplicationType.sink, false);
+		assertThat(dockerAppWithJarMetadata.getOptions()).hasSize(8);
+
+		// unregister the test apps
+		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-container-metadata", ApplicationType.sink);
+		dataFlowOperations.appRegistryOperations().unregister("docker-app-without-metadata", ApplicationType.sink);
+		dataFlowOperations.appRegistryOperations().unregister("maven-app-without-metadata", ApplicationType.sink);
+		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-jar-metadata", ApplicationType.sink);
 	}
 
 	// -----------------------------------------------------------------------

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -235,10 +235,10 @@ public class DataFlowIT {
 
 		// Docker app with container image metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.sink,
-				"docker:springcloudstream/rabbit-sink-rabbit:latest", null, true);
+				"docker:springcloudstream/time-source-kafka:2.1.2.BUILD-SNAPSHOT", null, true);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-container-metadata", ApplicationType.sink, false);
-		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(19);
+		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(6);
 
 		// Docker app without metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-without-metadata", ApplicationType.sink,


### PR DESCRIPTION
- Extend the metadata service to interact with Docker Registry HTTP V2 API to retrieve the config objects for a given image and tag names
- Retrieves the config metadata from preconfigured image label
- Fix the tests.
Resolves #3784
Resolves #3785
Resolves #3792
