### PR TITLE
Fix deployment properties parsing

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -57,7 +57,7 @@ public final class DeploymentPropertiesUtils {
 			.compile("(\\s(?=" + "([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))");
 
 
-	private static final String[] DEPLOYMENT_PROPERTIES_PREFIX ={"deployer", "app", "version", "scheduler"};
+	private static final String[] DEPLOYMENT_PROPERTIES_PREFIX ={"deployer", "app", "version", "scheduler", "spring.cloud.dataflow.task"};
 
 	private DeploymentPropertiesUtils() {
 		// prevent instantiation

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/DeploymentPropertiesUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,14 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link DeploymentPropertiesUtils}.
  *
  * @author Janne Valkealahti
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 public class DeploymentPropertiesUtilsTests {
 
@@ -62,18 +64,18 @@ public class DeploymentPropertiesUtilsTests {
 		assertThat(props, hasEntry("deployer.other.cow", "meww"));
 		assertThat(props, hasEntry("scheduler.other.key", "baz"));
 
-		props = DeploymentPropertiesUtils.parse("f=v");
-		assertThat(props, hasEntry("f", "v"));
+		props = DeploymentPropertiesUtils.parse("app.f=v");
+		assertThat(props, hasEntry("app.f", "v"));
 
-		props = DeploymentPropertiesUtils.parse("foo1=bar1,app.foo2=bar2,foo3=bar3,xxx3");
-		assertThat(props, hasEntry("foo1", "bar1"));
+		props = DeploymentPropertiesUtils.parse("app.foo1=bar1,app.foo2=bar2,app.foo3=bar3,xxx3");
+		assertThat(props, hasEntry("app.foo1", "bar1"));
 		assertThat(props, hasEntry("app.foo2", "bar2"));
-		assertThat(props, hasEntry("foo3", "bar3,xxx3"));
+		assertThat(props, hasEntry("app.foo3", "bar3,xxx3"));
 
-		props = DeploymentPropertiesUtils.parse("foo1 = bar1 , app.foo2= bar2,  foo3  = bar3,xxx3");
-		assertThat(props, hasEntry("foo1", "bar1"));
+		props = DeploymentPropertiesUtils.parse("deployer.foo1 = bar1 , app.foo2= bar2,  deployer.foo3  = bar3,xxx3");
+		assertThat(props, hasEntry("deployer.foo1", "bar1"));
 		assertThat(props, hasEntry("app.foo2", "bar2"));
-		assertThat(props, hasEntry("foo3", "bar3,xxx3"));
+		assertThat(props, hasEntry("deployer.foo3", "bar3,xxx3"));
 
 		props = DeploymentPropertiesUtils.parse("app.*.count=1");
 		assertThat(props, hasEntry("app.*.count", "1"));
@@ -84,27 +86,29 @@ public class DeploymentPropertiesUtilsTests {
 		props = DeploymentPropertiesUtils.parse("app.transform.producer.partitionKeyExpression=fakeExpression('xxx')");
 		assertThat(props, hasEntry("app.transform.producer.partitionKeyExpression", "fakeExpression('xxx')"));
 
-		props = DeploymentPropertiesUtils.parse("invalidkeyvalue");
-		assertThat(props.size(), is(0));
+		try {
+			DeploymentPropertiesUtils.parse("invalidkeyvalue");
+			fail("Illegal Argument Exception expected.");
+		}
+		catch (Exception e) {
+			assertTrue(e.getMessage().equals("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed."));
+		}
 
-		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,invalidkeyvalue2");
-		assertThat(props.size(), is(0));
-
-		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,invalidkeyvalue2,foo=bar");
+		props = DeploymentPropertiesUtils.parse("deployer.foo=bar,invalidkeyvalue2");
 		assertThat(props.size(), is(1));
-		assertThat(props, hasEntry("foo", "bar"));
+		assertThat(props, hasEntry("deployer.foo", "bar,invalidkeyvalue2"));
 
-		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,foo=bar,invalidkeyvalue2");
-		assertThat(props.size(), is(1));
-		assertThat(props, hasEntry("foo", "bar,invalidkeyvalue2"));
+		props = DeploymentPropertiesUtils.parse("app.foo.bar1=jee1,jee2,jee3,deployer.foo.bar2=jee4,jee5,jee6");
+		assertThat(props, hasEntry("app.foo.bar1", "jee1,jee2,jee3"));
+		assertThat(props, hasEntry("deployer.foo.bar2", "jee4,jee5,jee6"));
 
-		props = DeploymentPropertiesUtils.parse("foo.bar1=jee1,jee2,jee3,foo.bar2=jee4,jee5,jee6");
-		assertThat(props, hasEntry("foo.bar1", "jee1,jee2,jee3"));
-		assertThat(props, hasEntry("foo.bar2", "jee4,jee5,jee6"));
+		props = DeploymentPropertiesUtils.parse("app.foo.bar1=xxx=1,app.foo.bar2=xxx=2");
+		assertThat(props, hasEntry("app.foo.bar1", "xxx=1"));
+		assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
 
-		props = DeploymentPropertiesUtils.parse("foo.bar1=xxx=1,foo.bar2=xxx=2");
-		assertThat(props, hasEntry("foo.bar1", "xxx=1"));
-		assertThat(props, hasEntry("foo.bar2", "xxx=2"));
+		props = DeploymentPropertiesUtils.parse("app.foo.bar1=xxx=1,test=value,app.foo.bar2=xxx=2");
+		assertThat(props, hasEntry("app.foo.bar1", "xxx=1,test=value"));
+		assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
 	}
 
 
@@ -117,16 +121,23 @@ public class DeploymentPropertiesUtilsTests {
 		assertTrue(props.contains(" app.other.key = value  "));
 		assertTrue(props.contains(" app.foo.wizz=v2  "));
 		assertTrue(props.contains(" deployer.foo.pot=fern"));
-		assertTrue(props.contains(" deployer.other.cow = meww"));
-		assertTrue(props.contains("special=koza=boza,more"));
+		assertTrue(props.contains(" deployer.other.cow = meww,special=koza=boza,more"));
 
-		props = DeploymentPropertiesUtils.parseParamList("a=b c=d", " ");
-		assertTrue(props.contains("a=b"));
+		try {
+			DeploymentPropertiesUtils.parseParamList("a=b", " ");
+			fail("Illegal Argument Exception expected.");
+		}
+		catch (Exception e) {
+			assertTrue(e.getMessage().equals("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed."));
+		}
+
+		props = DeploymentPropertiesUtils.parseArgumentList("a=b c=d", " ");
 		assertTrue(props.contains("c=d"));
+		assertTrue(props.contains("a=b"));
 
-		props = DeploymentPropertiesUtils.parseParamList("foo1=bar1 app.foo2=bar2 foo3=bar3 xxx3", " ");
+		props = DeploymentPropertiesUtils.parseArgumentList("foo1=bar1 foo2=bar2 foo3=bar3 xxx3", " ");
 		assertTrue(props.contains("foo1=bar1"));
-		assertTrue(props.contains("app.foo2=bar2"));
+		assertTrue(props.contains("foo2=bar2"));
 		assertTrue(props.contains("foo3=bar3 xxx3"));
 	}
 
@@ -195,14 +206,14 @@ public class DeploymentPropertiesUtilsTests {
 	@Test
 	public void testParseDeploymentProperties() throws IOException {
 		File file = Files.createTempFile(null, ".yaml").toFile();
-		FileCopyUtils.copy("foo1:\n  bar1: spam".getBytes(), file);
+		FileCopyUtils.copy("app.foo1:\n  bar1: spam".getBytes(), file);
 
-		Map<String, String> props = DeploymentPropertiesUtils.parseDeploymentProperties("foo2=bar2", file, 0);
+		Map<String, String> props = DeploymentPropertiesUtils.parseDeploymentProperties("app.foo2=bar2", file, 0);
 		assertThat(props.size(), is(1));
-		assertThat(props.get("foo2"), is("bar2"));
+		assertThat(props.get("app.foo2"), is("bar2"));
 
 		props = DeploymentPropertiesUtils.parseDeploymentProperties("foo2=bar2", file, 1);
 		assertThat(props.size(), is(1));
-		assertThat(props.get("foo1.bar1"), is("spam"));
+		assertThat(props.get("app.foo1.bar1"), is("spam"));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -167,7 +167,7 @@ public class TaskExecutionController {
 			@RequestParam(required = false) String properties,
 			@RequestParam(required = false) String arguments) {
 		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parse(properties);
-		List<String> argumentsToUse = DeploymentPropertiesUtils.parseParamList(arguments, " ");
+		List<String> argumentsToUse = DeploymentPropertiesUtils.parseArgumentList(arguments, " ");
 
 		return this.taskExecutionService.executeTask(taskName, propertiesToUse, argumentsToUse, ctrname);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerController.java
@@ -150,7 +150,7 @@ public class TaskSchedulerController {
 			@RequestParam String properties,
 			@RequestParam(required = false) String arguments) {
 		Map<String, String> propertiesToUse = DeploymentPropertiesUtils.parse(properties);
-		List<String> argumentsToUse = DeploymentPropertiesUtils.parseParamList(arguments, " ");
+		List<String> argumentsToUse = DeploymentPropertiesUtils.parseArgumentList(arguments, " ");
 		this.schedulerService.schedule(StringUtils.trim(scheduleName), taskDefinitionName, propertiesToUse, argumentsToUse);
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskSchedulerCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskSchedulerCommands.java
@@ -83,7 +83,7 @@ public class TaskSchedulerCommands implements CommandMarker {
 			@CliOption(key = {
 					"arguments" }, help = "command line args (space separated string eg.: --arguments 'a b c d'") String arguments) {
 		Map<String, String> params = DeploymentPropertiesUtils.parse(properties);
-		List<String> args = DeploymentPropertiesUtils.parseParamList(arguments, " ");
+		List<String> args = DeploymentPropertiesUtils.parseArgumentList(arguments, " ");
 		params.put("scheduler.cron.expression", expression);
 
 		scheduleOperations().schedule(name, definitionName, params, args);


### PR DESCRIPTION
 - Restrict prefix validation on deployment properties
 - Make sure the properties are folded into the existing properties appropriately
    - For instance, if a deployment property has multiple `=` sign then it will be folded into the previously parsed key
 - Use different util method for parsing task arguments
    - This allows to parse the arguments different from the deployment properties
 - Update tests

Resolves #3831