### PR TITLE
Re-authorize jwt with every request

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/config/DataFlowClientAutoConfiguration.java
@@ -216,8 +216,8 @@ public class DataFlowClientAutoConfiguration {
 				.attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, password)
 				.build();
 
-		OAuth2AuthorizedClient authorizedClient = authorizedClientManager.authorize(authorizeRequest);
 		return (request, body, execution) -> {
+			OAuth2AuthorizedClient authorizedClient = authorizedClientManager.authorize(authorizeRequest);
 			request.getHeaders().setBearerAuth(authorizedClient.getAccessToken().getTokenValue());
 			return execution.execute(request, body);
 		};

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/ConfigCommands.java
@@ -543,8 +543,8 @@ public class ConfigCommands implements CommandMarker, InitializingBean, Applicat
 				.attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, password)
 				.build();
 
-		OAuth2AuthorizedClient authorizedClient = authorizedClientManager.authorize(authorizeRequest);
 		return (request, body, execution) -> {
+			OAuth2AuthorizedClient authorizedClient = authorizedClientManager.authorize(authorizeRequest);
 			request.getHeaders().setBearerAuth(authorizedClient.getAccessToken().getTokenValue());
 			return execution.execute(request, body);
 		};


### PR DESCRIPTION
- Instead of doing authorize request once, do it with
  every request which will handle use of refresh token
  if needed.
- Fixes #3882