### PR TITLE
Pre configure the DockerHub Auth URI

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -201,3 +201,5 @@ spring:
           default:
             registry-host: registry-1.docker.io
             authorization-type: dockeroauth2
+            extra:
+              "registryAuthUri": 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:pull&offline_token=1&client_id=shell'

--- a/src/kubernetes/server/server-config.yaml
+++ b/src/kubernetes/server/server-config.yaml
@@ -39,11 +39,6 @@ data:
                   default:
                     limits:
                       memory: 1024Mi
-          container:
-            registry-configurations:
-              default:
-                registry-host: registry-1.docker.io
-                authorization-type: dockeroauth2
       datasource:
         url: jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/mysql
         username: root

--- a/src/templates/kubernetes/server/server-config.yaml
+++ b/src/templates/kubernetes/server/server-config.yaml
@@ -39,11 +39,6 @@ data:
                   default:
                     limits:
                       memory: 1024Mi
-          container:
-            registry-configurations:
-              default:
-                registry-host: registry-1.docker.io
-                authorization-type: dockeroauth2
       datasource:
         url: jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/mysql
         username: root


### PR DESCRIPTION
- Set the Docker Hub token service uri within the `dataflow-server-defaults.yml`. E.g. 
```yaml
      container:
        registry-configurations:
          default:
            registry-host: registry-1.docker.io
            authorization-type: dockeroauth2
            extra:
              "registryAuthUri": 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:pull&offline_token=1&client_id=shell'
```

- Remove the redundant k8s yaml configs. 


  Resolves #3904