### PR TITLE
Update the new Skipper image entrypoint

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose-postgres.yml
+++ b/spring-cloud-dataflow-server/docker-compose-postgres.yml
@@ -34,5 +34,5 @@ services:
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=rootpw
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver
-    entrypoint: "./wait-for-it.sh -t 240 postgres:5432 -- java -Djava.security.egd=file:/dev/./urandom -jar /spring-cloud-skipper-server.jar"
+    entrypoint: "./wait-for-it.sh -t 240 postgres:5432 -- java -jar /maven/spring-cloud-skipper-server.jar"
 

--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -92,6 +92,6 @@ services:
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=rootpw
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
-    entrypoint: "./wait-for-it.sh mysql:3306 -- java -Djava.security.egd=file:/dev/./urandom -jar /spring-cloud-skipper-server.jar"
+    entrypoint: "./wait-for-it.sh mysql:3306 -- java -jar /maven/spring-cloud-skipper-server.jar"
     volumes:
       - ${HOST_MOUNT_PATH:-.}:${DOCKER_MOUNT_PATH:-/root/scdf}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -50,12 +50,12 @@ public class DockerComposeFactory {
 	/**
 	 * Data Flow version to use for the tests.
 	 */
-	public static final String DEFAULT_DATAFLOW_VERSION = "2.5.0.BUILD-SNAPSHOT";
+	public static final String DEFAULT_DATAFLOW_VERSION = "2.6.0.BUILD-SNAPSHOT";
 
 	/**
 	 * Skipper version used for the tests.
 	 */
-	public static final String DEFAULT_SKIPPER_VERSION = "2.4.0.BUILD-SNAPSHOT";
+	public static final String DEFAULT_SKIPPER_VERSION = "2.5.0.BUILD-SNAPSHOT";
 
 	/**
 	 * Pre-registered Task apps used for testing.


### PR DESCRIPTION
  - update the docker-compose files to use skipper image entrypoint pointing to /maven/spring-cloud-skipper-server.jar instead of /spring-cloud-skipper-server.jar
  - Update the SCDF (2.6.0.BS) and SKIPPER (2.5.0.BS) docker images versions used for IT