### PR TITLE
Update the prometheus proxy server version

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose-prometheus.yml
+++ b/spring-cloud-dataflow-server/docker-compose-prometheus.yml
@@ -27,7 +27,7 @@ services:
         }
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:0.9.0
+    image: micrometermetrics/prometheus-rsocket-proxy:0.11.0
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-proxy
       containers:
         - name: prometheus-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:latest
+          image: micrometermetrics/prometheus-rsocket-proxy:0.11.0
           imagePullPolicy: Always
           ports:
             - name: scrape

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-proxy
       containers:
         - name: prometheus-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:latest
+          image: micrometermetrics/prometheus-rsocket-proxy:0.11.0
           imagePullPolicy: Always
           ports:
             - name: scrape


### PR DESCRIPTION
 - Update to prometheus proxy server version based on rsocket-RC7compatible.
 - Ensures compatibility with the Spring Boot 2.3.0.RC1+ (also based on RC7).
 - Compatible with the older apps based on the prometheus proxy 0.9.0 client.
 - Fix the 0.11.0 version in the k8s deployment configuration.

 Resolves #3929