### PR TITLE
Move UI dep away from server core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
 		<module>spring-cloud-dataflow-platform-kubernetes</module>
 		<module>spring-cloud-dataflow-platform-cloudfoundry</module>
 		<module>spring-cloud-starter-dataflow-server</module>
+		<module>spring-cloud-starter-dataflow-ui</module>
 		<module>spring-cloud-dataflow-audit</module>
 		<module>spring-cloud-dataflow-composed-task-runner</module>
 	</modules>

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -91,6 +91,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-starter-dataflow-ui</artifactId>
+				<version>2.6.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-dataflow-server</artifactId>
 				<version>2.6.0.BUILD-SNAPSHOT</version>
 				<type>test-jar</type>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -77,10 +77,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dataflow-ui</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -25,6 +25,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-dataflow-ui</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-dataflow-server</artifactId>
 		</dependency>
 		<dependency>

--- a/spring-cloud-starter-dataflow-ui/pom.xml
+++ b/spring-cloud-starter-dataflow-ui/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-parent</artifactId>
+		<version>2.6.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-cloud-starter-dataflow-ui</artifactId>
+	<description>Data Flow UI Starter</description>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-ui</artifactId>
+		</dependency>
+	</dependencies>
+</project>
+


### PR DESCRIPTION
- Add spring-cloud-starter-dataflow-ui to ease for those doing
  custom builds.
- Essentially move UI from server core to module creating
  main fatjar.
- Custom builds then need to add starter or define their own
  UI dep without a need to start excluding deps.
- Fixes #3961