### PR TITLE
Uniquely identify the task elements within composed task

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -164,7 +164,7 @@ public class ComposedTaskProperties {
 	 * ComposedTaskRunner instance can only be executed once with a given set
 	 * of parameters, if true it can be re-executed.
 	 */
-	private boolean incrementInstanceEnabled = false;
+	private boolean incrementInstanceEnabled = true;
 
 	/**
 	 * The platform property that will be used for each task in the workflow when it is launched.

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskDefinitionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskDefinitionResource.java
@@ -41,6 +41,11 @@ public class TaskDefinitionResource extends RepresentationModel<TaskDefinitionRe
 	private boolean composed;
 
 	/**
+	 * Indicates whether this is a composed task element.
+	 */
+	private boolean composedTaskElement;
+
+	/**
 	 * The last execution of this task execution.
 	 */
 	private TaskExecutionResource lastTaskExecution;
@@ -86,6 +91,15 @@ public class TaskDefinitionResource extends RepresentationModel<TaskDefinitionRe
 	 */
 	public void setComposed(boolean composed) {
 		this.composed = composed;
+	}
+
+
+	public boolean isComposedTaskElement() {
+		return composedTaskElement;
+	}
+
+	public void setComposedTaskElement(boolean composedTaskElement) {
+		this.composedTaskElement = composedTaskElement;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
@@ -93,9 +93,9 @@ public class DefaultTaskSaveService implements TaskSaveService {
 						.map(argument -> String.format(" --%s=%s", argument.getKey(),
 								DefinitionUtils.autoQuotes(argument.getValue())))
 						.collect(Collectors.joining());
-				TaskDefinition composedTaskDefinition = new TaskDefinition(task.getExecutableDSLName(),
+				TaskDefinition composedTaskElementDefinition = new TaskDefinition(task.getExecutableDSLName(),
 						generatedTaskDSL);
-				saveStandardTaskDefinition(composedTaskDefinition);
+				saveStandardTaskDefinition(composedTaskElementDefinition);
 			});
 			taskDefinitionRepository.save(taskDefinition);
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -30,10 +30,12 @@ import org.springframework.validation.annotation.Validated;
  * @author David Turanski
  */
 @Validated
-@ConfigurationProperties(prefix = TaskConfigurationProperties.COMPOSED_TASK_PREFIX)
+@ConfigurationProperties(prefix = TaskConfigurationProperties.TASK_PREFIX)
 public class TaskConfigurationProperties {
 
-	public static final String COMPOSED_TASK_PREFIX = DataFlowPropertyKeys.PREFIX + "task";
+	public static final String TASK_PREFIX = DataFlowPropertyKeys.PREFIX + "task";
+
+	public static final String COMPOSED_TASK_ELEMENT = TASK_PREFIX + ".composed-task-element";
 
 	public static final String COMPOSED_TASK_RUNNER_NAME = "composed-task-runner";
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -369,6 +369,30 @@ public class TaskControllerTests {
 	}
 
 	@Test
+	public void testCTRElementUpdate() throws Exception {
+		repository.save(new TaskDefinition("a1", "t1: task && t2: task2"));
+		repository.save(new TaskDefinition("a2", "task"));
+		repository.save(new TaskDefinition("a1-t1", "task"));
+		repository.save(new TaskDefinition("a1-t2", "task"));
+
+		mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.content", hasSize(4)))
+				.andExpect(jsonPath("$.content[0].name", is("a1")))
+				.andExpect(jsonPath("$.content[0].composedTaskElement", is(false)))
+				.andExpect(jsonPath("$.content[1].name", is("a2")))
+				.andExpect(jsonPath("$.content[1].composedTaskElement", is(false)))
+				.andExpect(jsonPath("$.content[2].name", is("a1-t1")))
+				.andExpect(jsonPath("$.content[2].composedTaskElement", is(true)))
+				.andExpect(jsonPath("$.content[3].name", is("a1-t2")))
+				.andExpect(jsonPath("$.content[3].composedTaskElement", is(true)));
+
+		mockMvc.perform(get("/tasks/definitions/a1-t2").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.name", is("a1-t2")))
+				.andExpect(jsonPath("$.composedTaskElement", is(true)));
+	}
+
+
+	@Test
 	public void testMissingApplication() throws Exception {
 		repository.save(new TaskDefinition("myTask", "no-such-task-app"));
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1363,6 +1363,9 @@ public abstract class DefaultTaskExecutionServiceTests {
 			TaskDefinitionRepository taskDefinitionRepository) {
 		TaskDefinition taskDefinition = taskDefinitionRepository.findById(taskName).get();
 		assertThat(taskDefinition.getName(), is(equalTo(taskName)));
+		if (taskDefinition.getProperties().containsKey("spring.cloud.dataflow.task.composed-task-element")) {
+			dsl = dsl + " --spring.cloud.dataflow.task.composed-task-element=true";
+		}
 		assertThat(taskDefinition.getDslText(), is(equalTo(dsl)));
 	}
 


### PR DESCRIPTION
 - This is part of the changes required to fix #3930 to classify the task definitions that are part of a composed task definition.
 - Add a new property `spring.cloud.dataflow.task.composed-task-element` to identify the tasks within composed tasks
   - Set this property to `true` when creating the tasks of a CTR task
 - Set `increment-instance-enabled=true` for CTR to resolve #3933
 - Add test to verify the changes

Resolves #3930
Resolves #3933