### PR TITLE
Applications list to include all the versions

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 public class AppRegistryDocumentation extends BaseDocumentation {
 
@@ -120,6 +121,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
             get("/apps")
                 .param("search", "")
                 .param("type", "source").accept(MediaType.APPLICATION_JSON)
+				.param("defaultVersion", "true")
 				.param("page", "0")
 				.param("size", "10")
 				.param("sort", "name,ASC")
@@ -130,6 +132,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
                     parameterWithName("search").description("The search string performed on the name (optional)"),
                     parameterWithName("type")
                         .description("Restrict the returned apps to the type of the app. One of " + Arrays.asList(ApplicationType.values())),
+					parameterWithName("defaultVersion").description("The boolean flag to set to retrieve only the apps of the default versions (optional)"),
 					parameterWithName("page").description("The zero-based page number (optional)"),
 					parameterWithName("sort").description("The sort on the list (optional)"),
 					parameterWithName("size").description("The requested page size (optional)")
@@ -168,6 +171,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 						fieldWithPath("type").description("The type of the application. One of " + Arrays.asList(ApplicationType.values())),
 						fieldWithPath("uri").description("The uri of the application"),
 						fieldWithPath("version").description("The version of the application"),
+						fieldWithPath("versions").description("All the registered versions of the application"),
 						fieldWithPath("defaultVersion").description("If true, the application is the default version"),
 						subsectionWithPath("options").description("The options of the application (Array)"),
 						fieldWithPath("shortDescription").description("The description of the application")

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/AppRegistration.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/AppRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package org.springframework.cloud.dataflow.core;
 
 import java.net.URI;
+import java.util.HashSet;
 
 import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import org.springframework.util.Assert;
 
@@ -69,6 +71,9 @@ public class AppRegistration extends AbstractEntity implements Comparable<AppReg
 	 * per (name, type) pair is allowed
 	 */
 	private Boolean defaultVersion = false;
+
+	@Transient
+	private HashSet<String> versions;
 
 	public AppRegistration() {
 	}
@@ -175,6 +180,14 @@ public class AppRegistration extends AbstractEntity implements Comparable<AppReg
 
 	public void setDefaultVersion(Boolean defaultVersion) {
 		this.defaultVersion = defaultVersion;
+	}
+
+	public HashSet<String> getVersions() {
+		return versions;
+	}
+
+	public void setVersions(HashSet<String> versions) {
+		this.versions = versions;
 	}
 
 	@Override

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepository.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,14 @@ public interface AppRegistrationRepository extends KeyValueRepository<AppRegistr
 	Page<AppRegistration> findAllByType(ApplicationType type, Pageable pageable);
 
 	Page<AppRegistration> findAllByNameContainingIgnoreCase(String name, Pageable pageable);
+
+	Page<AppRegistration> findAllByDefaultVersionIsTrue(Pageable pageable);
+
+	Page<AppRegistration> findAllByTypeAndNameContainingIgnoreCaseAndDefaultVersionIsTrue(ApplicationType type, String name, Pageable pageable);
+
+	Page<AppRegistration> findAllByTypeAndDefaultVersionIsTrue(ApplicationType type, Pageable pageable);
+
+	Page<AppRegistration> findAllByNameContainingIgnoreCaseAndDefaultVersionIsTrue(String name, Pageable pageable);
 
 	@Override
 	<S extends AppRegistration> S save(S s);

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/AppRegistryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 /**
  * @author Christian Tzolov
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 public interface AppRegistryService {
 
@@ -111,6 +112,16 @@ public interface AppRegistryService {
 	 * pagination.
 	 */
 	Page<AppRegistration> findAllByTypeAndNameIsLike(ApplicationType type, String name, Pageable pageable);
+
+
+	/**
+	 * @param type appliation type
+	 * @param name application name
+	 * @param pageable Pagination information
+	 * @return returns the {@link AppRegistration}s that have the default version set to `true` and matches the given name and type. Uses the
+	 * pagination.
+	 */
+	Page<AppRegistration> findAllByTypeAndNameIsLikeAndDefaultVersionIsTrue(ApplicationType type, String name, Pageable pageable);
 
 	/**
 	 * Checks if an application with such name and type exists and is set as default.

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppRegistrationResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/AppRegistrationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.dataflow.rest.resource;
 
+import java.util.HashSet;
+
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.RepresentationModel;
 
@@ -25,6 +27,7 @@ import org.springframework.hateoas.RepresentationModel;
  * @author Glenn Renfro
  * @author Mark Fisher
  * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
  */
 public class AppRegistrationResource extends RepresentationModel<AppRegistrationResource> {
 
@@ -53,6 +56,10 @@ public class AppRegistrationResource extends RepresentationModel<AppRegistration
 	 */
 	private Boolean defaultVersion;
 
+	/**
+	 * All the registered versions for this app.
+	 */
+	private HashSet<String> versions;
 
 	/**
 	 * Default constructor for serialization frameworks.
@@ -80,6 +87,26 @@ public class AppRegistrationResource extends RepresentationModel<AppRegistration
 		this.uri = uri;
 		this.defaultVersion = defaultVersion;
 	}
+
+	/**
+	 * Construct a {@code AppRegistrationResource}.
+	 *
+	 * @param name app name
+	 * @param type app type
+	 * @param version app version
+	 * @param uri uri for app resource
+	 * @param defaultVersion is this application selected to the be default version in DSL
+	 * @param versions all the registered versions of this application
+	 */
+	public AppRegistrationResource(String name, String type, String version, String uri, Boolean defaultVersion, HashSet<String> versions) {
+		this.name = name;
+		this.type = type;
+		this.version = version;
+		this.uri = uri;
+		this.defaultVersion = defaultVersion;
+		this.versions = versions;
+	}
+
 
 	/**
 	 * @return the name of the app
@@ -114,6 +141,13 @@ public class AppRegistrationResource extends RepresentationModel<AppRegistration
 	 */
 	public Boolean getDefaultVersion() {
 		return defaultVersion;
+	}
+
+	/**
+	 * @return all the available versions of the app
+	 */
+	public HashSet<String> getVersions() {
+		return this.versions;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,9 +132,12 @@ public class AppRegistryController {
 			Pageable pageable,
 			PagedResourcesAssembler<AppRegistration> pagedResourcesAssembler,
 			@RequestParam(value = "type", required = false) ApplicationType type,
-			@RequestParam(required = false) String search) {
+			@RequestParam(required = false) String search,
+			@RequestParam(required = false) boolean defaultVersion) {
 
-		Page<AppRegistration> pagedRegistrations = this.appRegistryService.findAllByTypeAndNameIsLike(type, search,
+		Page<AppRegistration> pagedRegistrations = (defaultVersion) ?
+				this.appRegistryService.findAllByTypeAndNameIsLikeAndDefaultVersionIsTrue(type, search, pageable)
+				: this.appRegistryService.findAllByTypeAndNameIsLike(type, search,
 				pageable);
 
 		return pagedResourcesAssembler.toModel(pagedRegistrations, this.assembler);
@@ -432,8 +435,11 @@ public class AppRegistryController {
 
 		@Override
 		protected AppRegistrationResource instantiateModel(AppRegistration registration) {
-			return new AppRegistrationResource(registration.getName(), registration.getType().name(),
-					registration.getVersion(), registration.getUri().toString(), registration.isDefaultVersion());
+			return (registration.getVersions() == null) ? new AppRegistrationResource(registration.getName(), registration.getType().name(),
+					registration.getVersion(), registration.getUri().toString(), registration.isDefaultVersion()) :
+					new AppRegistrationResource(registration.getName(), registration.getType().name(),
+					registration.getVersion(), registration.getUri().toString(), registration.isDefaultVersion(),
+					registration.getVersions());
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -281,6 +283,19 @@ public class AppRegistryControllerTests {
 	public void testListApplications() throws Exception {
 		mockMvc.perform(get("/apps").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
 				.andExpect(jsonPath("content", hasSize(4)));
+	}
+
+	@Test
+	public void testListAppsWithMultiVersions() throws Exception {
+		this.appRegistryService.importAll(false, new ClassPathResource("META-INF/test-apps-multi-versions.properties"));
+		mockMvc.perform(get("/apps").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(6)));
+		mockMvc.perform(get("/apps?defaultVersion=true").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("content", hasSize(4)))
+				.andExpect(jsonPath("$.content[*].versions", containsInAnyOrder(hasSize(1), hasSize(2), hasSize(2), hasSize(1))))
+				.andExpect(jsonPath("$.content[*].versions", containsInAnyOrder(contains("1.0.0.BUILD-SNAPSHOT"), containsInAnyOrder("1.0.0.RELEASE", "1.0.0.BUILD-SNAPSHOT"),
+						contains("1.0.0.BUILD-SNAPSHOT"), containsInAnyOrder("1.0.0.RELEASE","1.0.0.BUILD-SNAPSHOT"))))
+				.andExpect(jsonPath("$.content[*].defaultVersion", contains(true, true, true, true)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-multi-versions.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-multi-versions.properties
@@ -1,0 +1,2 @@
+source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.RELEASE
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.RELEASE


### PR DESCRIPTION
  - When the apps are retrieved, we need to have an ability to include all the versions associated with the app
  - Add a request parameter `defaultVersion=true` to retrieve only the apps that have default version set to true and along with the versions for that app
  - Update REST API documentation
  - Add/update tests

Resolves #2039