### PR TITLE
Added env to the CF deployment properties table

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-cloudfoundry.adoc
@@ -89,7 +89,7 @@ These properties are also used when configuring the <<configuration-cloudfoundry
 |5000
 
 |useSpringApplicationJson
-|Flag to indicate whether application properties are fed into SPRING_APPLICATION_JSON or as environment variables.
+|Flag to indicate whether application properties are fed into `SPRING_APPLICATION_JSON` or as separate environment variables.
 |true
 
 |stagingTimeout
@@ -119,6 +119,11 @@ These properties are also used when configuring the <<configuration-cloudfoundry
 |autoDeleteMavenArtifacts
 |Whether to automatically delete Maven artifacts from the local repository when deployed.
 |true
+
+|env.<key>
+|Defines a top level environment variable. This is useful for customizing https://github.com/cloudfoundry/java-buildpack#configuration-and-extension[Java build pack configuration] which must be included as top level environment variables in the application manifest, as the Java build pack does not recognize `SPRING_APPLICATION_JSON`.
+
+|The deployer determines if the app has https://github.com/pivotal-cf/java-cfenv[Java CfEnv] in its classpath. If so, it applies the required https://github.com/pivotal-cf/java-cfenv#pushing-your-application-to-cloud-foundry[configuration].
 
 |===
 


### PR DESCRIPTION
This is related to https://github.com/spring-io/dataflow.spring.io/issues/259 .   Currently the description of all deployment properties are here. We should move them to the microsite at some point. 