### PR TITLE
Basic SCDF Server metrics collection support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
 		<findbugs.version>3.0.2</findbugs.version>
 		<aws-java-sdk-ecr.version>1.11.731</aws-java-sdk-ecr.version>
 		<commons-text.version>1.8</commons-text.version>
+		<prometheus-rsocket-spring.version>0.11.0</prometheus-rsocket-spring.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-configuration-metadata</module>
@@ -257,6 +258,12 @@
 				<artifactId>jsr305</artifactId>
 				<version>${findbugs.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.micrometer.prometheus</groupId>
+				<artifactId>prometheus-rsocket-spring</artifactId>
+				<version>${prometheus-rsocket-spring.version}</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 	<build>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -24,7 +24,6 @@
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-spring</artifactId>
-			<version>0.11.0</version>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -10,6 +10,24 @@
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-wavefront</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-influx</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer.prometheus</groupId>
+			<artifactId>prometheus-rsocket-spring</artifactId>
+			<version>0.11.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-common-flyway</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,5 +1,11 @@
 management:
   metrics:
+    web:
+      server:
+        request:
+          autotime:
+            enabled: true
+          metric-name: 'spring.cloud.dataflow.http.server.requests'
     export:
       influx:
         enabled: false

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,4 +1,12 @@
 management:
+  metrics:
+    export:
+      influx:
+        enabled: false
+      prometheus:
+        enabled: false
+      wavefront:
+        enabled: false
   endpoints:
     web:
       base-path: /management

--- a/spring-cloud-dataflow-server/docker-compose-wavefront.yml
+++ b/spring-cloud-dataflow-server/docker-compose-wavefront.yml
@@ -10,6 +10,13 @@ version: '3'
 services:
   dataflow-server:
     environment:
+      - management.metrics.web.server.request.autotime.enabled=true
+      - management.metrics.web.server.request.metric-name=spring.cloud.dataflow.http.server.requests
+      - management.metrics.export.wavefront.enabled=true
+      - management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - management.metrics.export.wavefront.source=${WAVEFRONT_SOURCE:-scdf-docker-compose}
+
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.enabled=true
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
       - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}

--- a/spring-cloud-dataflow-server/docker-compose-wavefront.yml
+++ b/spring-cloud-dataflow-server/docker-compose-wavefront.yml
@@ -10,8 +10,6 @@ version: '3'
 services:
   dataflow-server:
     environment:
-      - management.metrics.web.server.request.autotime.enabled=true
-      - management.metrics.web.server.request.metric-name=spring.cloud.dataflow.http.server.requests
       - management.metrics.export.wavefront.enabled=true
       - management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
       - management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}


### PR DESCRIPTION
  - Add influx, prometheus + rsocket-proxy-clinet and wavefront Micrometer meter registry dependencies to SCDF core.
  - Disable the meter registries by default in the dataflow-server-defaults.yml file.
  - Extend the docker-compose-wavefront to enable wavefront metrics collection for the SCDF server along with the Stream and Task apps.
  - Enable the `http.server.requests` metric by default.
   - Add the `spring.cloud.dataflow` prefix to the metric (e.g. metric-name: `spring.cloud.dataflow.http.server.requests`)

 Related to #3937,  Related to #4016, related to https://github.com/sunnylabs/integrations/pull/523

 Resolves #2740