### PR TITLE
Removed old link to the composed task runner app starter

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -527,7 +527,7 @@ You can create a composed task through the RESTful API, the Spring Cloud Data Fl
 
 === Configuring the Composed Task Runner
 
-Composed tasks are run through a task application called the https://github.com/spring-cloud-task-app-starters/composed-task-runner[Composed Task Runner].
+Composed tasks are run through a task application called the Composed Task Runner.
 
 ==== Registering the Composed Task Runner
 


### PR DESCRIPTION
The docs had been updated but noticed an old link that can be removed.

resolves #4069