### PR TITLE
Configure different prometheus-rsocket ports

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose-prometheus.yml
+++ b/spring-cloud-dataflow-server/docker-compose-prometheus.yml
@@ -27,18 +27,20 @@ services:
         }
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:0.11.0
+    image: micrometermetrics/prometheus-rsocket-proxy:1.0.0
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'
       - '7001'
-      - '8081'
+      - '8086'
     ports:
       - '9096:9096'
       - '7001:7001'
-      - '8081:8081'
+      - '8086:8086'
     environment:
       - server.port=9096
+      - micrometer.prometheus-proxy.websocket-port=8086
+      - micrometer.prometheus-proxy.tcp-port=7001
 
   grafana:
     image: springcloud/spring-cloud-dataflow-grafana-prometheus:${DATAFLOW_VERSION:?DATAFLOW_VERSION is not set! Use 'export DATAFLOW_VERSION=local-server-image-tag'}


### PR DESCRIPTION
 - Change the websocket port from 8081 to 8086
 - explicitly configure the tcp and websocket ports:
   - micrometer.prometheus-proxy.websocket-port=8086
   - micrometer.prometheus-proxy.tcp-port=7001

 Resolves #4082