### PR TITLE
Remove second unescaping of Container Metadata

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -33,7 +33,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -215,10 +214,8 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 		}
 
 		try {
-			String metadataJson = StringEscapeUtils.unescapeJson(encodedMetadata);
 			ConfigurationMetadataRepository configurationMetadataRepository = ConfigurationMetadataRepositoryJsonBuilder
-					.create().withJsonResource(
-							new ByteArrayInputStream(metadataJson.getBytes()))
+					.create().withJsonResource(new ByteArrayInputStream(encodedMetadata.getBytes()))
 					.build();
 
 			List<ConfigurationMetadataProperty> result = configurationMetadataRepository.getAllProperties().entrySet()
@@ -279,7 +276,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 					}
 
 				} // Props in the root group have an id that looks prefixed itself. Handle
-					// here
+				// here
 				else if ("_ROOT_GROUP_".equals(group.getId())) {
 					for (ConfigurationMetadataProperty property : group.getProperties().values()) {
 						if (isVisible(property, visibleProperties)) {

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,7 +79,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest"))
 				.thenReturn(Collections.singletonMap(
 						"org.springframework.cloud.dataflow.spring-configuration-metadata.json",
-						StringEscapeUtils.escapeJson(new String(bytes))));
+						new String(bytes)));
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new DockerResource("test/test:latest"));
 		assertThat(properties.size(), is(3));
@@ -91,7 +90,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		byte[] bytes = "Invalid metadata json content1".getBytes();
 		Map<String, String> result = Collections.singletonMap(
 				"org.springframework.cloud.dataflow.spring-configuration-metadata.json",
-				StringEscapeUtils.escapeJson(new String(bytes)));
+				new String(bytes));
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(result);
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new DockerResource("test/test:latest"));

--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -149,14 +149,14 @@ To run the docker compose integration, enable the `-Pfailsafe` maven profile.
 ----
 
 With the help of the `TestProperties` properties one can change the docker-compose files used, the exact versions of the
-SCDF, Skipper servers installed or the versions Stream and Task apps:
+SCDF, Skipper servers installed, or the versions Stream and Task apps:
 
 ----
 ./mvnw clean test-compile failsafe:integration-test -pl spring-cloud-dataflow-server -Pfailsafe
    -Dtest.docker.compose.paths=docker-compose.yml,docker-compose-influxdb.yml,docker-compose-postgres.yml,docker-compose-rabbitmq.yml
    -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/rabbitmq-maven-latest
-   -Dtest.docker.compose.dataflow.version=2.4.0.BUILD-SNAPSHOT
-   -Dtest.docker.compose.skipper.version=2.3.0.BUILD-SNAPSHOT
+   -Dtest.docker.compose.dataflow.version=2.7.0-SNAPSHOT
+   -Dtest.docker.compose.skipper.version=2.6.0-SNAPSHOT
 ----
 The `test.docker.compose.paths` property accepts comma separated list of docker compose files names and supports `file:`, `classpath:` and `http:`/`https:` URI schemas. If the schema prefix is not explicitly set the file is treated as local one.
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -234,11 +234,19 @@ public class DataFlowIT {
 		assertThat(mavenAppWithoutMetadata.getOptions()).hasSize(8);
 
 		// Docker app with container image metadata
-		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.sink,
+		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.source,
 				"docker:springcloudstream/time-source-kafka:2.1.2.BUILD-SNAPSHOT", null, true);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
-				.info("docker-app-with-container-metadata", ApplicationType.sink, false);
+				.info("docker-app-with-container-metadata", ApplicationType.source, false);
 		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(6);
+
+
+		// Docker app with container image metadata with escape characters.
+		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata-escape-chars", ApplicationType.source,
+				"docker:springcloudstream/http-source-rabbit:2.1.3.RELEASE", null, true);
+		DetailedAppRegistrationResource dockerAppWithContainerMetadataWithEscapeChars = dataFlowOperations.appRegistryOperations()
+				.info("docker-app-with-container-metadata-escape-chars", ApplicationType.source, false);
+		assertThat(dockerAppWithContainerMetadataWithEscapeChars.getOptions()).hasSize(6);
 
 		// Docker app without metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-without-metadata", ApplicationType.sink,
@@ -256,7 +264,8 @@ public class DataFlowIT {
 		assertThat(dockerAppWithJarMetadata.getOptions()).hasSize(8);
 
 		// unregister the test apps
-		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-container-metadata", ApplicationType.sink);
+		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-container-metadata", ApplicationType.source);
+		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-container-metadata-escape-chars", ApplicationType.source);
 		dataFlowOperations.appRegistryOperations().unregister("docker-app-without-metadata", ApplicationType.sink);
 		dataFlowOperations.appRegistryOperations().unregister("maven-app-without-metadata", ApplicationType.sink);
 		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-jar-metadata", ApplicationType.sink);

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -50,12 +50,12 @@ public class DockerComposeFactory {
 	/**
 	 * Data Flow version to use for the tests.
 	 */
-	public static final String DEFAULT_DATAFLOW_VERSION = "2.6.0-SNAPSHOT";
+	public static final String DEFAULT_DATAFLOW_VERSION = "2.7.0-SNAPSHOT";
 
 	/**
 	 * Skipper version used for the tests.
 	 */
-	public static final String DEFAULT_SKIPPER_VERSION = "2.5.0-SNAPSHOT";
+	public static final String DEFAULT_SKIPPER_VERSION = "2.6.0-SNAPSHOT";
 
 	/**
 	 * Pre-registered Task apps used for testing.


### PR DESCRIPTION
  - Delegates the unescaping to the RestTemplate interacting with the container registries.
  - Add IT test.

  Resolves #4084