### PR TITLE
Restart failed job now uses task arg to get platform

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -261,9 +261,8 @@ public class JobExecutionsDocumentation extends BaseDocumentation {
 	}
 
 	private void createJobExecution(String name, BatchStatus status) {
-		TaskExecution taskExecution = this.dao.createTaskExecution(name, new Date(), new ArrayList<>(), null);
+		TaskExecution taskExecution = this.dao.createTaskExecution(name, new Date(), Collections.singletonList("--spring.cloud.data.flow.platformname=default"), null);
 		Map<String, JobParameter> jobParameterMap = new HashMap<>();
-		jobParameterMap.put("-spring.cloud.data.flow.platformname", new JobParameter("default"));
 		JobParameters jobParameters = new JobParameters(jobParameterMap);
 		JobExecution jobExecution = this.jobRepository.createJobExecution(this.jobRepository.createJobInstance(name, new JobParameters()), jobParameters, null);
 		this.taskBatchDao.saveRelationship(taskExecution, jobExecution);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -183,8 +183,7 @@ public class DefaultTaskJobService implements TaskJobService {
 		TaskExecution taskExecution = this.taskExplorer.getTaskExecution(taskJobExecution.getTaskId());
 		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskExecution.getTaskName())
 				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskExecution.getTaskName()));
-
-		String platformName = taskJobExecution.getJobExecution().getJobParameters().getString("-spring.cloud.data.flow.platformname");
+		String platformName = getPlatformFromTaskExecution(taskExecution.getArguments());
 		if (platformName != null) {
 			Map<String, String> deploymentProperties = new HashMap<>();
 			deploymentProperties.put(DefaultTaskExecutionService.TASK_PLATFORM_NAME, platformName);
@@ -196,6 +195,18 @@ public class DefaultTaskJobService implements TaskJobService {
 					taskExecution.getTaskName(),taskJobExecution.getTaskId()));
 		}
 
+	}
+
+	private String getPlatformFromTaskExecution(List<String> taskExecutionArgs) {
+		final String platformPrefix = "--spring.cloud.data.flow.platformname=";
+		String result = null;
+		for(String arg : taskExecutionArgs) {
+			if(arg.startsWith(platformPrefix)) {
+				result = arg.substring(platformPrefix.length());
+				break;
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -115,8 +115,8 @@ public class DefaultTaskJobServiceTests {
 			// not adding platform name as default as we want to check that this only one
 			// gets replaced
 			this.launcherRepository.save(new Launcher("fakeplatformname", "local", this.taskLauncher));
+			this.launcherRepository.save(new Launcher("demo", "local", this.taskLauncher));
 			Map<String, JobParameter> jobParameterMap = new HashMap<>();
-			jobParameterMap.put("-spring.cloud.data.flow.platformname", new JobParameter("demo"));
 			jobParameterMap.put("identifying.param", new JobParameter("testparam"));
 			this.jobParameters = new JobParameters(jobParameterMap);
 
@@ -135,6 +135,7 @@ public class DefaultTaskJobServiceTests {
 		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
+		appDeploymentRequest.getCommandlineArguments().contains("--spring.cloud.data.flow.platformname=demo");
 		assertTrue(appDeploymentRequest.getCommandlineArguments().contains("identifying.param(string)=testparam"));
 	}
 
@@ -149,7 +150,7 @@ public class DefaultTaskJobServiceTests {
 			TaskExecutionDao taskExecutionDao, String jobName,
 			int jobExecutionCount, BatchStatus status) {
 		JobInstance instance = jobRepository.createJobInstance(jobName, new JobParameters());
-		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), new ArrayList<>(), null);
+		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), Collections.singletonList("--spring.cloud.data.flow.platformname=demo"), null);
 		JobExecution jobExecution;
 
 		for (int i = 0; i < jobExecutionCount; i++) {


### PR DESCRIPTION
We were expecting  the platform name  to be in the job param but, since the value is non identifying, it is excluded from the job param.
resolves #4080