### PR TITLE
Allow deletion of all tasks definitions/executions/schedules when Authentication is enabled

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -183,6 +183,7 @@ spring:
 
             - POST   /tasks/definitions              => hasRole('ROLE_CREATE')
             - DELETE /tasks/definitions/*            => hasRole('ROLE_DESTROY')
+            - DELETE /tasks/definitions              => hasRole('ROLE_DESTROY')
             - GET    /tasks/definitions              => hasRole('ROLE_VIEW')
             - GET    /tasks/definitions/*            => hasRole('ROLE_VIEW')
 
@@ -193,6 +194,7 @@ spring:
             - POST   /tasks/executions               => hasRole('ROLE_DEPLOY')
             - POST   /tasks/executions/*             => hasRole('ROLE_DEPLOY')
             - DELETE /tasks/executions/*             => hasRole('ROLE_DESTROY')
+            - DELETE /tasks/executions               => hasRole('ROLE_DESTROY')
 
             # Task Schedules
 
@@ -202,6 +204,7 @@ spring:
             - GET    /tasks/schedules/instances/*    => hasRole('ROLE_VIEW')
             - POST   /tasks/schedules                => hasRole('ROLE_SCHEDULE')
             - DELETE /tasks/schedules/*              => hasRole('ROLE_SCHEDULE')
+            - DELETE /tasks/schedules                => hasRole('ROLE_SCHEDULE')
 
             # Task Platform Account List */
 


### PR DESCRIPTION
Fix the inability to destroy all Tasks at once from Shell (using task all destroy) when Authentication is enabled.
Applied same logic as for Streams to Task definitions, executions and schedules.