### PR TITLE
Application name validation

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -225,6 +225,7 @@ public class AppRegistryController {
 			@RequestParam("uri") String uri, @RequestParam(name = "metadata-uri", required = false) String metadataUri,
 			@RequestParam(value = "force", defaultValue = "false") boolean force) {
 
+		validateApplicationName(name);
 		appRegistryService.validate(appRegistryService.getDefaultApp(name, type), uri, version);
 		AppRegistration previous = appRegistryService.find(name, type, version);
 		if (!force && previous != null) {
@@ -435,6 +436,20 @@ public class AppRegistryController {
 				}
 			});
 		});
+	}
+
+	private void validateApplicationName(String name) {
+		char[] invalidWildCards = new char[]{':'};
+		StringBuilder invalidChars = new StringBuilder();
+		for (char invalidWildCard : invalidWildCards) {
+			if (name.contains(Character.toString(invalidWildCard))) {
+				invalidChars.append("'").append(invalidWildCard).append("'");
+			}
+		}
+
+		if (!invalidChars.toString().equals("")) {
+			throw new IllegalArgumentException("Application name: " + name + " cannot contain: " + invalidChars);
+		}
 	}
 
 	class Assembler extends RepresentationModelAssemblerSupport<AppRegistration, AppRegistrationResource> {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -133,6 +133,13 @@ public class AppRegistryControllerTests {
 	}
 
 	@Test
+	public void testRegisterAppWithInvalidName() throws Exception {
+		mockMvc.perform(post("/apps/sink/log:1")
+				.param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().is5xxServerError());
+	}
+
+	@Test
 	public void testRegisterApp() throws Exception {
 		mockMvc.perform(post("/apps/sink/log1").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());


### PR DESCRIPTION
Raising this PR to validate that the application name should not contain some specific wildcards. Currently, we are only checking for ':'.
This PR is against this [issue](https://github.com/spring-cloud/spring-cloud-dataflow/issues/4090).