### PR TITLE
Allow empty string as a property value in stream definition

### DIFF
--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamApplicationDefinitionBuilder.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/StreamApplicationDefinitionBuilder.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.dataflow.core.dsl.SinkDestinationNode;
 import org.springframework.cloud.dataflow.core.dsl.SourceDestinationNode;
 import org.springframework.cloud.dataflow.core.dsl.StreamNode;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Builds a list of {@link StreamAppDefinition StreamAppDefinitions} out of a parsed
@@ -84,7 +85,8 @@ class StreamApplicationDefinitionBuilder {
 						builder.setProperty(BindingPropertyKeys.OUTPUT_CONTENT_TYPE, argument.getValue());
 					}
 					else {
-						builder.setProperty(argument.getName(), argument.getValue());
+						String value = StringUtils.hasText(argument.getValue()) ? argument.getValue() : "\\\"\\\"";
+						builder.setProperty(argument.getName(), value);
 					}
 				}
 			}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -386,7 +386,7 @@ public class DataFlowIT {
 		logger.info("stream-lifecycle-test: DEPLOY");
 		try (Stream stream = Stream.builder(dataFlowOperations)
 				.name("lifecycle-test")
-				.definition("time | log --log.expression='TICKTOCK - TIMESTAMP: '.concat(payload)")
+				.definition("time | log --log.name=\"\" --log.expression='TICKTOCK - TIMESTAMP: '.concat(payload)")
 				.create()
 				.deploy(testDeploymentProperties())) {
 


### PR DESCRIPTION
 - Fix stream definition builder to escape the empty string value of stream application property
 - Add test in Data Flow IT to check this working end-to-end

Resolves #3720