### PR TITLE
Filter job executions on date range

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/support/TimeUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/support/TimeUtils.java
@@ -40,6 +40,8 @@ public final class TimeUtils {
 
 	public static final String DEFAULT_DATAFLOW_TIMEZONE_ID = "UTC";
 
+	public static final String DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss,SSS";
+
 	/**
 	 * Prevent instantiation.
 	 */

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
@@ -352,14 +352,15 @@ public interface JobService {
 			throws NoSuchJobException;
 
 	/**
-	 * List the {@link JobExecutionWithStepCount job executions} for a job in descending order
-	 * of creation (usually close to execution order).
+	 * List the {@link JobExecutionWithStepCount job executions} filtered by date range in
+	 * descending order of creation (usually close to execution order).
 	 *
 	 * @param fromDate the date which start date must be greater than.
-	 * @param toDate the date which start date must be less than.
-	 * @param start the start index of the first job execution
-	 * @param count the maximum number of executions to return
+	 * @param toDate   the date which start date must be less than.
+	 * @param start    the start index of the first job execution
+	 * @param count    the maximum number of executions to return
 	 * @return a collection of {@link JobExecutionWithStepCount}
 	 */
-	Collection<JobExecutionWithStepCount> listJobExecutionsForJobWithStepCount(Date fromDate, Date toDate, int start, int count);
+	Collection<JobExecutionWithStepCount> listJobExecutionsForJobWithStepCount(Date fromDate,
+			Date toDate, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.batch;
 
 import java.util.Collection;
+import java.util.Date;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -349,4 +350,16 @@ public interface JobService {
 	 */
 	Collection<JobExecution> listJobExecutionsForJob(String jobName, BatchStatus status, int pageOffset, int pageSize)
 			throws NoSuchJobException;
+
+	/**
+	 * List the {@link JobExecutionWithStepCount job executions} for a job in descending order
+	 * of creation (usually close to execution order).
+	 *
+	 * @param fromDate the date which start date must be greater than.
+	 * @param toDate the date which start date must be less than.
+	 * @param start the start index of the first job execution
+	 * @param count the maximum number of executions to return
+	 * @return a collection of {@link JobExecutionWithStepCount}
+	 */
+	Collection<JobExecutionWithStepCount> listJobExecutionsForJobWithStepCount(Date fromDate, Date toDate, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
@@ -136,7 +136,7 @@ public interface SearchableJobExecutionDao extends JobExecutionDao {
 	int countJobExecutions(String jobName, BatchStatus status);
 
 	/**
-	 * Get the {@link JobExecutionWithStepCount JobExecutions} for a specific job name in
+	 * Get the {@link JobExecutionWithStepCount JobExecutions} for a specific date range in
 	 * reverse order of creation (so normally of execution).
 	 *
 	 * @param fromDate the date which start date must be greater than.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.batch;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.batch.core.BatchStatus;
@@ -133,4 +134,16 @@ public interface SearchableJobExecutionDao extends JobExecutionDao {
 	 * this job
 	 */
 	int countJobExecutions(String jobName, BatchStatus status);
+
+	/**
+	 * Get the {@link JobExecutionWithStepCount JobExecutions} for a specific job name in
+	 * reverse order of creation (so normally of execution).
+	 *
+	 * @param fromDate the date which start date must be greater than.
+	 * @param toDate the date which start date must be less than.
+	 * @param start the start index of the instances
+	 * @param count the maximum number of instances to return
+	 * @return the {@link JobExecutionWithStepCount} instances requested
+	 */
+	List<JobExecutionWithStepCount> getJobExecutionsWithStepCount(Date fromDate, Date toDate, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
@@ -448,6 +448,12 @@ public class SimpleJobService implements JobService, DisposableBean {
 		return jobExecutions;
 	}
 
+	@Override
+	public Collection<JobExecutionWithStepCount> listJobExecutionsForJobWithStepCount(Date fromDate,
+			Date toDate, int start, int count) {
+			return jobExecutionDao.getJobExecutionsWithStepCount(fromDate, toDate, start, count);
+	}
+
 	private List<JobExecution> getJobExecutions(String jobName, BatchStatus status, int pageOffset, int pageSize) {
 		if (StringUtils.isEmpty(jobName)) {
 			if (status != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -33,6 +34,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
@@ -108,6 +110,29 @@ public class JobExecutionThinController {
 		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsForJobWithStepCount(pageable, jobName);
 		Page<TaskJobExecution> page = new PageImpl<>(jobExecutions, pageable,
 				taskJobService.countJobExecutionsForJob(jobName, null));
+		return assembler.toModel(page, jobAssembler);
+	}
+
+	/**
+	 * Retrieve all task job executions filtered with the date range specified
+	 *
+	 * @param fromDate the date which start date must be greater than.
+	 * @param toDate the date which start date must be less than.
+	 * @param pageable page-able collection of {@code TaskJobExecution}s.
+	 * @param assembler for the {@link TaskJobExecution}s
+	 * @return list task/job executions with the specified jobName.
+	 * @throws NoSuchJobException if the job with the given name does not exist.
+	 */
+	@RequestMapping(value = "", method = RequestMethod.GET, params = { "fromDate",
+			"toDate" }, produces = "application/json")
+	@ResponseStatus(HttpStatus.OK)
+	public PagedModel<JobExecutionThinResource> retrieveJobsByDateRange(
+			@RequestParam("fromDate") @DateTimeFormat(pattern = TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN) Date fromDate,
+			@RequestParam("toDate") @DateTimeFormat(pattern = TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN) Date toDate,
+			Pageable pageable, PagedResourcesAssembler<TaskJobExecution> assembler) throws NoSuchJobException {
+		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsForJobWithStepCount(pageable, fromDate,
+				toDate);
+		Page<TaskJobExecution> page = new PageImpl<>(jobExecutions, pageable, jobExecutions.size());
 		return assembler.toModel(page, jobAssembler);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.service;
 
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.batch.core.BatchStatus;
@@ -174,5 +175,18 @@ public interface TaskJobService {
 	 * @throws NoSuchJobException if the job with the given name does not exist.
 	 */
 	List<TaskJobExecution> listJobExecutionsForJob(Pageable pageable, String jobName, BatchStatus status)
+			throws NoSuchJobException;
+
+	/**
+	 * Retrieves Pageable list of {@link JobExecutionWithStepCount} from the JobRepository
+	 * filtered by the date range.
+	 *
+	 * @param pageable enumerates the data to be returned.
+	 * @param fromDate the date which start date must be greater than.
+	 * @param toDate the date which start date must be less than.
+	 * @return List containing {@link JobExecutionWithStepCount}s.
+	 * @throws NoSuchJobException if the job with the given name does not exist.
+	 */
+	List<TaskJobExecution> listJobExecutionsForJobWithStepCount(Pageable pageable, Date fromDate, Date toDate)
 			throws NoSuchJobException;
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,15 @@ public class DefaultTaskJobService implements TaskJobService {
 		Assert.notNull(pageable, "pageable must not be null");
 		return getTaskJobExecutionsForList(
 				jobService.listJobExecutionsForJob(jobName, status, getPageOffset(pageable), pageable.getPageSize()));
+	}
+
+	@Override
+	public List<TaskJobExecution> listJobExecutionsForJobWithStepCount(Pageable pageable,
+			Date fromDate, Date toDate) {
+		Assert.notNull(pageable, "pageable must not be null");
+		return getTaskJobExecutionsWithStepCountForList(
+				jobService.listJobExecutionsForJobWithStepCount(fromDate, toDate, getPageOffset(pageable),
+						pageable.getPageSize()));
 	}
 
 	@Override

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
@@ -112,12 +113,14 @@ public class JobExecutionThinControllerTests {
 	public void testGetExecutionsByDateRange() throws Exception {
 		final Date toDate = new Date();
 		final Date fromDate = DateUtils.addMinutes(toDate, -10);
-		mockMvc.perform(get("/jobs/thinexecutions/").param("fromDate",
-				new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
-						.format(fromDate)).param("toDate",
-				new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
-						.format(toDate)).accept(MediaType.APPLICATION_JSON)).andDo(print())
-				.andExpect(status().isOk())
+		mockMvc.perform(get("/jobs/thinexecutions/")
+				.param("fromDate",
+						new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
+								.format(fromDate))
+				.param("toDate",
+						new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
+								.format(toDate))
+				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
 				.andExpect(jsonPath("$.content[*].taskExecutionId", containsInAnyOrder(8, 7, 6, 5, 4, 3, 3, 2, 1)))
 				.andExpect(jsonPath("$.content[0].stepExecutionCount", is(1)))
 				.andExpect(jsonPath("$.content", hasSize(9)));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
@@ -28,6 +31,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.rest.job.support.TimeUtils;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.configuration.JobDependencies;
 import org.springframework.cloud.task.batch.listener.TaskBatchDao;
@@ -102,6 +106,21 @@ public class JobExecutionThinControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content[0].name", is(JobExecutionUtils.JOB_NAME_ORIG)))
 				.andExpect(jsonPath("$.content", hasSize(1)));
+	}
+
+	@Test
+	public void testGetExecutionsByDateRange() throws Exception {
+		final Date toDate = new Date();
+		final Date fromDate = DateUtils.addMinutes(toDate, -10);
+		mockMvc.perform(get("/jobs/thinexecutions/").param("fromDate",
+				new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
+						.format(fromDate)).param("toDate",
+				new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
+						.format(toDate)).accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content[*].taskExecutionId", containsInAnyOrder(8, 7, 6, 5, 4, 3, 3, 2, 1)))
+				.andExpect(jsonPath("$.content[0].stepExecutionCount", is(1)))
+				.andExpect(jsonPath("$.content", hasSize(9)));
 	}
 
 }


### PR DESCRIPTION
This PR adds a feature requested in issue #3866 

The following changes were made - 

- Added new API for passing date range to filter job executions
- Added new DAO method to search for job executions filtered by date range provided on the start time of execution.