### PR TITLE
Support Docker Stream&Task apps for docker-compose

### DIFF
--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -160,3 +160,20 @@ SCDF, Skipper servers installed, or the versions Stream and Task apps:
 ----
 The `test.docker.compose.paths` property accepts comma separated list of docker compose files names and supports `file:`, `classpath:` and `http:`/`https:` URI schemas. If the schema prefix is not explicitly set the file is treated as local one.
 
+
+----
+./mvnw clean test-compile failsafe:integration-test -pl spring-cloud-dataflow-server -Pfailsafe \
+   -Dtest.docker.compose.paths=docker-compose.yml,docker-compose-dood.yml,docker-compose-prometheus.yml \
+   -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/kafka-docker-latest \
+   -Dtest.docker.compose.task.apps.uri=https://dataflow.spring.io/task-docker-latest \
+   -Dtest.docker.compose.dataflow.version=2.7.0-SNAPSHOT \
+   -Dtest.docker.compose.skipper.version=2.6.0-SNAPSHOT \
+   -Dtest.docker.compose.apps.port.range=80 \
+   -Dtest.docker.compose.pullOnStartup=false
+----
+
+----
+./mvnw clean test-compile failsafe:integration-test -pl spring-cloud-dataflow-server -Pfailsafe \
+   -Dtest.docker.compose.dood=true \
+   -Dtest.docker.compose.pullOnStartup=false
+----

--- a/spring-cloud-dataflow-server/docker-compose-debug-dataflow.yml
+++ b/spring-cloud-dataflow-server/docker-compose-debug-dataflow.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "5005:5005"
     environment:
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005

--- a/spring-cloud-dataflow-server/docker-compose-debug-skipper.yml
+++ b/spring-cloud-dataflow-server/docker-compose-debug-skipper.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "6006:6006"
     environment:
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=6006
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:6006

--- a/spring-cloud-dataflow-server/docker-compose-dood.yml
+++ b/spring-cloud-dataflow-server/docker-compose-dood.yml
@@ -1,0 +1,71 @@
+version: '3'
+
+# Allows deploying docker (both Stream and Task) apps. The Docker-out-of-Docker (DooD) approach is used to allow Skipper
+# and DataFlow (running inside docker containers) to deploy stream and task docker apps in per-app docker containers.
+#
+# How to use:
+#   APPS_PORT_RANGE=80 \
+#   COMPOSE_PROJECT_NAME=scdf \
+#   STREAM_APPS_URI=https://dataflow.spring.io/kafka-docker-latest \
+#   TASK_APPS_URI=https://dataflow.spring.io/task-docker-latest \
+#   docker-compose -f ./docker-compose.yml -f ./docker-compose-dood.yml up
+#
+# - The docker-compose-dood.yml extends docker-compose.yml by installing the Docker CLI to the DataFlow and Skipper
+#   servers containers and mounting the server's docker sockets to the Host's socket. Therefore allowing the servers to
+#   use the Host's Docker daemon for deploying the apps. The DOCKER_NETWORK property is used to share the docker-compose
+#   network with the app's containers.
+#
+# - Set APPS_PORT_RANGE=80. In non DooD mode the stream apps are java processes running inside the Skipper container.
+#   The APPS_PORT_RANGE is used to let the Skipper's container expose the java's ports to the host. In DooD mode the
+#   apps are running in their own containers and exposing their ports directly. If APPS_PORT_RANGE is not overridden
+#   then both the apps' and Skipper's containers will try to use the same port ranges
+#   leading to conflicts.
+#
+# - COMPOSE_PROJECT_NAME sets the docker-compose project name. Later is used for naming the network passed to the apps
+#   containers (e.g. SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_DOCKER_NETWORK).
+#
+# - The STREAM_APPS_URI and TASK_APPS_URI are set to register docker based Stream and Task apps.
+#
+# TIPS:
+#  - If docker-compose exit before the data pipelines are stopped then the containers should be cleaned manually:
+#    docker stop $(docker ps -a -q);  docker rm $(docker ps -a -q)
+#  - Set the DOCKER_DELETE_CONTAINER_ON_EXIT=false to retain the stopped docker containers so you can check their logs:
+#    docker logs <container id>
+services:
+  dataflow-server:
+    environment:
+      - SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME must be set when DooD is enabled}_default
+      - SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_DOCKER_DELETE_CONTAINER_ON_EXIT=${DOCKER_DELETE_CONTAINER_ON_EXIT:-true}
+      - CHECK_IF_APPS_PORT_RANGE_IS_SET=${APPS_PORT_RANGE:?When DooD is enabled the APPS_PORT_RANGE must be set to 80}
+    entrypoint: >
+      bin/sh -c "
+         wget --no-check-certificate -P /tmp/ https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz &&
+         tar -xvf /tmp/docker-latest.tgz --directory /tmp/ &&
+         mv /tmp/docker/docker /usr/local/bin &&
+         ./wait-for-it.sh -t 180 skipper-server:7577 -- java -jar /maven/spring-cloud-dataflow-server.jar"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  skipper-server:
+    environment:
+      - SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME must be set when DooD is enabled}_default
+      - SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_DOCKER_DELETE_CONTAINER_ON_EXIT=${DOCKER_DELETE_CONTAINER_ON_EXIT:-true}
+    entrypoint: >
+      bin/sh -c "
+         wget --no-check-certificate -P /tmp/ https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz &&
+         tar -xvf /tmp/docker-latest.tgz --directory /tmp/ &&
+         mv /tmp/docker/docker /usr/local/bin &&
+         ./wait-for-it.sh mysql:3306 -- java -jar /maven/spring-cloud-skipper-server.jar"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  # Best effort to set default STREAM_APPS_URI and TASK_APPS_URI values. But because those can be overridden by other
+  # composition YAMLs, it is highly recommended to set the STREAM_APPS_URI and TASK_APPS_URI explicitly!
+  app-import:
+    command: >
+      /bin/sh -c "
+        ./wait-for-it.sh -t 360 dataflow-server:9393;
+        wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-latest&force=true}';
+        echo 'Docker Stream apps imported'
+        wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-latest&force=true}';
+        echo 'Docker Task apps imported'"

--- a/spring-cloud-dataflow-server/docker-compose-prometheus.yml
+++ b/spring-cloud-dataflow-server/docker-compose-prometheus.yml
@@ -35,11 +35,11 @@ services:
 
   skipper-server:
     environment:
-      - management.metrics.export.prometheus.enabled=true
-      - management.metrics.export.prometheus.rsocket.enabled=true
-      - management.metrics.export.prometheus.rsocket.host=prometheus-rsocket-proxy
-      - management.metrics.export.prometheus.rsocket.port=7001
-      - spring.jpa.properties.hibernate.generate_statistics=true
+      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
+      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_ENABLED=true
+      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_HOST=prometheus-rsocket-proxy
+      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_PORT=7001
+      - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
     image: micrometermetrics/prometheus-rsocket-proxy:1.0.0

--- a/spring-cloud-dataflow-server/docker-compose-rabbitmq.yml
+++ b/spring-cloud-dataflow-server/docker-compose-rabbitmq.yml
@@ -18,7 +18,7 @@ services:
 
   dataflow-server:
     environment:
-      - spring.cloud.dataflow.applicationProperties.stream.spring.rabbitmq.host=rabbitmq
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_RABBITMQ_HOST=rabbitmq
 
   app-import:
     command: >

--- a/spring-cloud-dataflow-server/docker-compose-wavefront.yml
+++ b/spring-cloud-dataflow-server/docker-compose-wavefront.yml
@@ -10,25 +10,25 @@ version: '3'
 services:
   dataflow-server:
     environment:
-      - management.metrics.export.wavefront.enabled=true
-      - management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - management.metrics.export.wavefront.source=${WAVEFRONT_SOURCE:-scdf-docker-compose}
-      - spring.jpa.properties.hibernate.generate_statistics=true
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_ENABLED=true
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
+      - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
-      - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.enabled=true
-      - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - spring.cloud.dataflow.applicationProperties.stream.management.metrics.export.wavefront.source=${WAVEFRONT_SOURCE:-scdf-docker-compose}
-      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.wavefront.enabled=true
-      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - spring.cloud.dataflow.applicationProperties.task.management.metrics.export.wavefront.source=${WAVEFRONT_SOURCE:-scdf-docker-compose}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_ENABLED=true
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_TASK_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_ENABLED=true
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_TASK_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_TASK_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_TASK_MANAGEMENT_METRICS_EXPORT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
 
   skipper-server:
     environment:
-      - management.metrics.export.wavefront.enabled=true
-      - management.metrics.export.wavefront.api-token=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - management.metrics.export.wavefront.uri=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - management.metrics.export.wavefront.source=${WAVEFRONT_SOURCE:-scdf-docker-compose}
-      - spring.jpa.properties.hibernate.generate_statistics=true
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_ENABLED=true
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - MANAGEMENT_METRICS_EXPORT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
+      - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}

--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -51,23 +51,25 @@ services:
     ports:
       - "9393:9393"
     environment:
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.binder.brokers=PLAINTEXT://kafka-broker:9092
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.streams.binder.brokers=PLAINTEXT://kafka-broker:9092
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.binder.zkNodes=zookeeper:2181
-      - spring.cloud.dataflow.applicationProperties.stream.spring.cloud.stream.kafka.streams.binder.zkNodes=zookeeper:2181
-      - spring.cloud.skipper.client.serverUri=http://skipper-server:7577/api
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=PLAINTEXT://kafka-broker:9092
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_STREAMS_BINDER_BROKERS=PLAINTEXT://kafka-broker:9092
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_BINDER_ZKNODES=zookeeper:2181
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_STREAMS_BINDER_ZKNODES=zookeeper:2181
+
+      - SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI=http://skipper-server:7577/api
+
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/dataflow
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=rootpw
       - SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.mariadb.jdbc.Driver
     depends_on:
       - kafka-broker
-    entrypoint: "./wait-for-it.sh mysql:3306 -- java -jar /maven/spring-cloud-dataflow-server.jar"
+    entrypoint: "./wait-for-it.sh -t 180 skipper-server:7577 -- java -jar /maven/spring-cloud-dataflow-server.jar"
     volumes:
       - ${HOST_MOUNT_PATH:-.}:${DOCKER_MOUNT_PATH:-/root/scdf}
 
   app-import:
-    image: springcloud/openjdk:11.0.8
+    image: springcloud/baseimage:1.0.0
     container_name: dataflow-app-import
     depends_on:
       - dataflow-server
@@ -75,16 +77,16 @@ services:
       /bin/sh -c "
         ./wait-for-it.sh -t 180 dataflow-server:9393;
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-latest&force=true}';
-        echo 'Stream apps imported'
+        echo 'Maven Stream apps imported'
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-latest&force=true}';
-        echo 'Task apps imported'"
+        echo 'Maven Task apps imported'"
 
   skipper-server:
     image: springcloud/spring-cloud-skipper-server:${SKIPPER_VERSION:?SKIPPER_VERSION is not set!}
     container_name: skipper
     ports:
       - "7577:7577"
-      - "20000-20105:20000-20105"
+      - ${APPS_PORT_RANGE:-20000-20105:20000-20105}
     environment:
       - SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_PORTRANGE_LOW=20000
       - SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_PORTRANGE_HIGH=20100

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -221,6 +221,7 @@ public class DataFlowIT {
 
 	@Test
 	public void applicationMetadataTests() {
+		logger.info("application-metadata-test");
 		// Maven app with metadata
 		DetailedAppRegistrationResource mavenAppWithJarMetadata = dataFlowOperations.appRegistryOperations()
 				.info("file", ApplicationType.sink, false);
@@ -239,7 +240,6 @@ public class DataFlowIT {
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-container-metadata", ApplicationType.source, false);
 		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(6);
-
 
 		// Docker app with container image metadata with escape characters.
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata-escape-chars", ApplicationType.source,

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
@@ -78,6 +78,21 @@ public class DockerComposeFactoryProperties {
 	 */
 	public static final String TEST_DOCKER_COMPOSE_STREAM_APPS_URI = PREFIX + "stream.apps.uri";
 
+	/**
+	 * Overrides the APPS_PORT_RANGE mapped by skipper.
+	 */
+	public static final String TEST_DOCKER_COMPOSE_APPS_PORT_RANGE = PREFIX + "apps.port.range";
+
+	/**
+	 * Shortcut that configures the DooD mode. Automatically sets the env. variables needed for the DooD mode.
+	 */
+	public static final String TEST_DOCKER_COMPOSE_DOOD = PREFIX + "dood";
+
+	/**
+	 * Set to false to keep the exited Docker containers (applicable only in DooD mode).
+	 */
+	public static final String TEST_DOCKER_COMPOSE_DOCKER_DELETE_CONTAINER_ON_EXIT = PREFIX + "docker.delete.container.on.exit";
+
 	public static boolean getBoolean(String propertyName, boolean defaultValue) {
 		String value = get(propertyName, "" + defaultValue);
 		return Boolean.valueOf(value);


### PR DESCRIPTION
 - Add docker-compose-dood.yml to provide Docker-out-of-Docker (DooD). It installs Docker CLI in the dataflow-server and skipper-server images and mounts their docker.socket's to the Host's docker.socket. This allow the docker stream and task apps to be run into the Host as standalone docker containers.
 - Streamline the DataFlowIT to allow easy activation of the DooD mode. The -Dtest.docker.compose.dood=true would add the docker-compose-dood.yml to the list of files, will set the APPS_PORT_RANGE to 80 and set the COMPOSE_PROJECT_NAME to scdf.
 - Use springcloud/baseimage:1.0.0 in docker-compose services.

 Resolves #3643