### PR TITLE
Uses previous execution to determine platform to restart job.

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
@@ -31,9 +31,14 @@ import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.item.database.support.DataFieldMaxValueIncrementerFactory;
+import org.springframework.batch.item.database.support.DefaultDataFieldMaxValueIncrementerFactory;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.core.TaskManifest;
+import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionMetadataDao;
+import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionMetadataDao;
 import org.springframework.cloud.task.batch.listener.TaskBatchDao;
 import org.springframework.cloud.task.batch.listener.support.JdbcTaskBatchDao;
 import org.springframework.cloud.task.repository.TaskExecution;
@@ -269,6 +274,15 @@ public class JobExecutionsDocumentation extends BaseDocumentation {
 		jobExecution.setStatus(status);
 		jobExecution.setStartTime(new Date());
 		this.jobRepository.update(jobExecution);
+		TaskManifest manifest = new TaskManifest();
+		manifest.setPlatformName("default");
+		DataFieldMaxValueIncrementerFactory incrementerFactory = new DefaultDataFieldMaxValueIncrementerFactory(dataSource);
+
+		DataflowTaskExecutionMetadataDao metadataDao = new JdbcDataflowTaskExecutionMetadataDao(
+				dataSource, incrementerFactory.getIncrementer("h2", "task_execution_metadata_seq"));
+		TaskManifest taskManifest = new TaskManifest();
+		taskManifest.setPlatformName("default");
+		metadataDao.save(taskExecution, taskManifest);
 	}
 
 }

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -122,6 +122,8 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 								fieldWithPath("resourceUrl").description("The resource URL that defines the task that was executed"),
 								subsectionWithPath("appProperties").description("The application properties of the task execution"),
 								subsectionWithPath("deploymentProperties").description("The deployment properties of the task exectuion"),
+								subsectionWithPath("deploymentProperties").description("The deployment properties of the task execution"),
+								subsectionWithPath("platformName").description("The platform selected for the task execution"),
 								subsectionWithPath("_links.self").description("Link to the task execution resource")
 						)
 				));

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResource.java
@@ -108,6 +108,11 @@ public class TaskExecutionResource extends RepresentationModel<TaskExecutionReso
 
 	private Map<String, String> deploymentProperties;
 
+	/**
+	 * The platform for which the task was executed.
+	 */
+	private String platformName;
+
 	public TaskExecutionResource() {
 		arguments = new ArrayList<>();
 	}
@@ -142,6 +147,9 @@ public class TaskExecutionResource extends RepresentationModel<TaskExecutionReso
 			this.resourceUrl = taskJobExecutionRel.getTaskManifest().getTaskDeploymentRequest().getResource().toString();
 			this.appProperties = taskJobExecutionRel.getTaskManifest().getTaskDeploymentRequest().getDefinition().getProperties();
 			this.deploymentProperties = taskJobExecutionRel.getTaskManifest().getTaskDeploymentRequest().getDeploymentProperties();
+		}
+		if(taskJobExecutionRel.getTaskManifest() != null) {
+			this.platformName = taskJobExecutionRel.getTaskManifest().getPlatformName();
 		}
 	}
 
@@ -246,6 +254,14 @@ public class TaskExecutionResource extends RepresentationModel<TaskExecutionReso
 
 	public Map<String, String> getDeploymentProperties() {
 		return deploymentProperties;
+	}
+
+	public String getPlatformName() {
+		return platformName;
+	}
+
+	public void setPlatformName(String platformName) {
+		this.platformName = platformName;
 	}
 
 	/**

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
@@ -16,11 +16,18 @@
 
 package org.springframework.cloud.dataflow.rest.resource;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 
 import org.junit.Test;
 
+import org.springframework.cloud.dataflow.core.TaskManifest;
+import org.springframework.cloud.dataflow.rest.job.TaskJobExecutionRel;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.core.io.UrlResource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -30,6 +37,7 @@ import static org.junit.Assert.assertNull;
  *
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Glenn Renfro
  */
 public class TaskExecutionResourceTests {
 
@@ -74,5 +82,25 @@ public class TaskExecutionResourceTests {
 		final TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskExecution);
 		assertEquals(TaskExecutionStatus.ERROR, taskExecutionResource.getTaskExecutionStatus());
 	}
+
+	@Test
+	public void testTaskExecutionForTaskExecutionRel() throws Exception{
+		final TaskExecution taskExecution = new TaskExecution();
+		taskExecution.setStartTime(new Date());
+		taskExecution.setEndTime(new Date());
+		taskExecution.setExitCode(0);
+		TaskManifest taskManifest = new TaskManifest();
+		taskManifest.setPlatformName("testplatform");
+		taskManifest.setTaskDeploymentRequest(new AppDeploymentRequest(new AppDefinition("testapp", Collections.emptyMap()), new UrlResource("http://foo")));
+		TaskJobExecutionRel taskJobExecutionRel = new TaskJobExecutionRel(taskExecution, new ArrayList<>(), taskManifest);
+		TaskExecutionResource taskExecutionResource = new TaskExecutionResource(taskJobExecutionRel);
+		assertEquals("testplatform", taskExecutionResource.getPlatformName());
+		assertEquals(TaskExecutionStatus.COMPLETE, taskExecutionResource.getTaskExecutionStatus());
+		taskJobExecutionRel = new TaskJobExecutionRel(taskExecution, new ArrayList<>());
+		taskExecutionResource = new TaskExecutionResource(taskJobExecutionRel);
+		assertNull(taskExecutionResource.getPlatformName());
+		assertEquals(TaskExecutionStatus.COMPLETE, taskExecutionResource.getTaskExecutionStatus());
+	}
+
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -36,6 +36,7 @@ import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.springframework.batch.core.launch.NoSuchJobInstanceException;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
+import org.springframework.cloud.dataflow.core.TaskManifest;
 import org.springframework.cloud.dataflow.rest.job.JobInstanceExecutions;
 import org.springframework.cloud.dataflow.rest.job.TaskJobExecution;
 import org.springframework.cloud.dataflow.rest.job.support.JobUtils;
@@ -181,9 +182,10 @@ public class DefaultTaskJobService implements TaskJobService {
 		}
 
 		TaskExecution taskExecution = this.taskExplorer.getTaskExecution(taskJobExecution.getTaskId());
+		TaskManifest taskManifest = this.taskExecutionService.findTaskManifestById(taskExecution.getExecutionId());
 		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskExecution.getTaskName())
 				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskExecution.getTaskName()));
-		String platformName = getPlatformFromTaskExecution(taskExecution.getArguments());
+		String platformName = taskManifest.getPlatformName();
 		if (platformName != null) {
 			Map<String, String> deploymentProperties = new HashMap<>();
 			deploymentProperties.put(DefaultTaskExecutionService.TASK_PLATFORM_NAME, platformName);
@@ -195,18 +197,6 @@ public class DefaultTaskJobService implements TaskJobService {
 					taskExecution.getTaskName(),taskJobExecution.getTaskId()));
 		}
 
-	}
-
-	private String getPlatformFromTaskExecution(List<String> taskExecutionArgs) {
-		final String platformPrefix = "--spring.cloud.data.flow.platformname=";
-		String result = null;
-		for(String arg : taskExecutionArgs) {
-			if(arg.startsWith(platformPrefix)) {
-				result = arg.substring(platformPrefix.length());
-				break;
-			}
-		}
-		return result;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -134,11 +134,8 @@ public class TaskAppDeploymentRequestCreator {
 	private List<String> updateCommandLineArgs(List<String> commandLineArgs, TaskExecution taskExecution, String platformName) {
 		List<String> results = new ArrayList();
 		commandLineArgs.stream()
-				.filter(arg -> !arg.startsWith(TASK_EXECUTION_KEY)
-						&& !arg.startsWith(PLATFORM_NAME_KEY))
+				.filter(arg -> !arg.startsWith(TASK_EXECUTION_KEY))
 				.forEach(results::add);
-
-		results.add(PLATFORM_NAME_KEY + platformName);
 		results.add(TASK_EXECUTION_KEY + taskExecution.getExecutionId());
 		return results;
 	}
@@ -146,11 +143,9 @@ public class TaskAppDeploymentRequestCreator {
 		List<String> results = new ArrayList();
 		commandLineArgs.stream()
 				.filter(arg -> !arg.startsWith(TASK_EXECUTION_KEY)
-						&& !arg.startsWith(PLATFORM_NAME_KEY)
 						&& !arg.startsWith(TASK_EXECUTION_APP_NAME))
 				.forEach(results::add);
 
-		results.add(PLATFORM_NAME_KEY + platformName);
 		results.add(TASK_EXECUTION_KEY + taskExecution.getExecutionId());
 		results.add(TASK_EXECUTION_APP_NAME + appName);
 		return results;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,7 +70,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
@@ -446,7 +446,7 @@ public class TaskControllerTests {
 		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
-		assertThat(request.getDefinition().getProperties(), hasEntry("common.prop2", "wizz"));
+		MatcherAssert.assertThat(request.getDefinition().getProperties(), hasEntry("common.prop2", "wizz"));
 		assertEquals("myTask2", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 	}
 
@@ -471,9 +471,9 @@ public class TaskControllerTests {
 		verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
 		AppDeploymentRequest request = argumentCaptor.getValue();
-		assertThat(request.getCommandlineArguments().size(), is(3 + 2)); // +2 for spring.cloud.task.executionid and spring.cloud.data.flow.platformname
+		assertEquals(4, request.getCommandlineArguments().size());
 		// don't assume order in a list
-		assertThat(request.getCommandlineArguments(), hasItems("--foobar=jee", "--foobar2=jee2,foo=bar", "--foobar3='jee3 jee3'"));
+		MatcherAssert.assertThat(request.getCommandlineArguments(), hasItems("--foobar=jee", "--foobar2=jee2,foo=bar", "--foobar3='jee3 jee3'"));
 		assertEquals("myTask3", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -532,12 +532,12 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 			 this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.singletonList("--foo=bar"));
 			 TaskManifest lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			 assertEquals(3, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
+			 assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
 			 assertEquals("--foo=bar", lastManifest.getTaskDeploymentRequest().getCommandlineArguments().get(0));
 
 			 this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.emptyList());
 			 lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			 assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
+			 assertEquals(1, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
 		 }
 
 		@Test
@@ -1146,7 +1146,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			AppDeploymentRequest request = argumentCaptor.getValue();
 			assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 			assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
-			assertEquals(request.getCommandlineArguments().get(2),"--spring.cloud.data.flow.taskappname=composed-task-runner");
+			assertEquals(request.getCommandlineArguments().get(1),"--spring.cloud.data.flow.taskappname=composed-task-runner");
 			assertEquals(
 					"app.seqTask-AAA.app.AAA.timestamp.format=YYYY, deployer.seqTask-AAA.deployer.AAA.memory=1240m",
 					request.getDefinition().getProperties().get("composed-task-properties"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -150,8 +150,11 @@ public class DefaultTaskJobServiceTests {
 			TaskExecutionDao taskExecutionDao, String jobName,
 			int jobExecutionCount, BatchStatus status) {
 		JobInstance instance = jobRepository.createJobInstance(jobName, new JobParameters());
-		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), Collections.singletonList("--spring.cloud.data.flow.platformname=demo"), null);
+		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), Collections.emptyList(), null);
 		JobExecution jobExecution;
+		JdbcTemplate template = new JdbcTemplate(this.dataSource);
+		template.execute("ALTER SEQUENCE task_execution_metadata_seq RESTART WITH 50");
+		template.execute("INSERT INTO task_execution_metadata (id, task_execution_id, task_execution_manifest) VALUES (1, 1, '{\"taskDeploymentRequest\":{\"definition\":{\"name\":\"bd0917a\",\"properties\":{\"spring.datasource.username\":\"root\",\"spring.cloud.task.name\":\"bd0917a\",\"spring.datasource.url\":\"jdbc:mariadb://localhost:3306/task\",\"spring.datasource.driverClassName\":\"org.mariadb.jdbc.Driver\",\"spring.datasource.password\":\"password\"}},\"resource\":\"file:/Users/glennrenfro/tmp/batchdemo-0.0.1-SNAPSHOT.jar\",\"deploymentProperties\":{},\"commandlineArguments\":[\"run.id_long=1\",\"--spring.cloud.task.executionid=201\"]},\"platformName\":\"demo\"}')");
 
 		for (int i = 0; i < jobExecutionCount; i++) {
 			jobExecution = jobRepository.createJobExecution(instance,


### PR DESCRIPTION
resolves #4119 

* Uses previous execution to determine what platform to use when restarting the job.
* Provides the platformName as a part of the reply for job execution detail, instead of having to retrieve the info from the command line.  The command line no longer contains the data.
* Updated tests.