### PR TITLE
Add support for Container image digest reference

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
@@ -193,8 +193,8 @@ public class DefaultContainerImageMetadataResolver implements ContainerImageMeta
 				.scheme("https")
 				.host(containerImage.getHostname())
 				.port(StringUtils.hasText(containerImage.getPort()) ? containerImage.getPort() : null)
-				.path("v2/{repository}/manifests/{tag}")
-				.build().expand(containerImage.getRepository(), containerImage.getRepositoryTag());
+				.path("v2/{repository}/manifests/{reference}")
+				.build().expand(containerImage.getRepository(), containerImage.getRepositoryReference());
 
 		ResponseEntity<T> manifest = registryRequest.getRestTemplate().exchange(manifestUriComponents.toUri(),
 				HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParserTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImageParserTests.java
@@ -40,11 +40,32 @@ public class ContainerImageParserTests {
 		assertThat(containerImageName.getRepositoryNamespace(), is("scdf/stream"));
 		assertThat(containerImageName.getRepositoryName(), is("spring-cloud-dataflow-acceptance-image-drivers173"));
 		assertThat(containerImageName.getRepositoryTag(), is("123"));
+		assertThat(containerImageName.getRepositoryReference(), is("123"));
+		assertThat(containerImageName.getRepositoryReferenceType(), is(ContainerImage.RepositoryReferenceType.tag));
 
 		assertThat(containerImageName.getRegistryHost(), is("springsource-docker-private-local.jfrog.io:80"));
 		assertThat(containerImageName.getRepository(), is("scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173"));
 
 		assertThat(containerImageName.getCanonicalName(), is("springsource-docker-private-local.jfrog.io:80/scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173:123"));
+	}
+
+	@Test
+	public void testParseWithoutDigest() {
+		ContainerImage containerImageName =
+				containerImageNameParser.parse("springsource-docker-private-local.jfrog.io:80/scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173@sha256:d44e9ac4c4bf53fb0b5424c35c85230a28eb03f24a2ade5bb7f2cc1462846401");
+
+		assertThat(containerImageName.getHostname(), is("springsource-docker-private-local.jfrog.io"));
+		assertThat(containerImageName.getPort(), is("80"));
+		assertThat(containerImageName.getRepositoryNamespace(), is("scdf/stream"));
+		assertThat(containerImageName.getRepositoryName(), is("spring-cloud-dataflow-acceptance-image-drivers173"));
+		assertThat(containerImageName.getRepositoryDigest(), is("sha256:d44e9ac4c4bf53fb0b5424c35c85230a28eb03f24a2ade5bb7f2cc1462846401"));
+		assertThat(containerImageName.getRepositoryReference(), is("sha256:d44e9ac4c4bf53fb0b5424c35c85230a28eb03f24a2ade5bb7f2cc1462846401"));
+		assertThat(containerImageName.getRepositoryReferenceType(), is(ContainerImage.RepositoryReferenceType.digest));
+
+		assertThat(containerImageName.getRegistryHost(), is("springsource-docker-private-local.jfrog.io:80"));
+		assertThat(containerImageName.getRepository(), is("scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173"));
+
+		assertThat(containerImageName.getCanonicalName(), is("springsource-docker-private-local.jfrog.io:80/scdf/stream/spring-cloud-dataflow-acceptance-image-drivers173@sha256:d44e9ac4c4bf53fb0b5424c35c85230a28eb03f24a2ade5bb7f2cc1462846401"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolverTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolverTest.java
@@ -209,14 +209,14 @@ public class DefaultContainerImageMetadataResolverTest {
 	}
 
 	private void mockManifestRestTemplateCall(Map<String, Object> mapToReturn, String registryHost,
-			String registryPort, String repository, String tag) {
+			String registryPort, String repository, String tagOrDigest) {
 
 		UriComponents manifestUriComponents = UriComponentsBuilder.newInstance()
 				.scheme("https")
 				.host(registryHost)
 				.port(StringUtils.hasText(registryPort) ? registryPort : null)
-				.path("v2/{repository}/manifests/{tag}")
-				.build().expand(repository, tag);
+				.path("v2/{repository}/manifests/{reference}")
+				.build().expand(repository, tagOrDigest);
 
 
 		when(mockRestTemplate.exchange(


### PR DESCRIPTION
 - Extend the ContainerImage and ContainerImageParser to allow image digest along with existing image tags.

 Resolves #4169