### PR TITLE
Container Registry auth token URI auto-retrieval

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
@@ -29,6 +29,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -224,6 +226,8 @@ public class ApplicationConfigurationMetadataResolverAutoConfiguration {
 		List<MediaType> mediaTypeList = new ArrayList(octetToStringMessageConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
 		octetToStringMessageConverter.setSupportedMediaTypes(mediaTypeList);
+
+		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());
 
 		HttpComponentsClientHttpRequestFactory customRequestFactory =
 				new HttpComponentsClientHttpRequestFactory(

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,7 +169,11 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to retrieve properties for resource:" + app, e);
+			logger.warn("Failed to retrieve properties for resource {} because of {}",
+					app, ExceptionUtils.getRootCauseMessage(e));
+			if (logger.isDebugEnabled()) {
+				logger.debug("(Details) for failed to retrieve properties for resource:" + app, e);
+			}
 			return Collections.emptyList();
 		}
 
@@ -189,7 +194,11 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to retrieve properties for resource:" + app, e);
+			logger.warn("Failed to retrieve port names for resource {} because of {}",
+					app, ExceptionUtils.getRootCauseMessage(e));
+			if (logger.isDebugEnabled()) {
+				logger.debug("(Details) for failed to retrieve port names for resource:" + app, e);
+			}
 			return Collections.emptyMap();
 		}
 

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImage.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/ContainerImage.java
@@ -40,7 +40,8 @@ import org.springframework.util.StringUtils;
  *     registry host value is used.
  *   - The repository namespace together with the repository name form an unique REPOSITORY identifier, unique  within
  *     the REGISTRY HOST.
- *   - The TAG represents a particular REPOSITORY instance within the REGISTRY HOST. The DIGEST content-addressable identifier.
+ *   - The TAG or DIGEST can be used as image instance references. The TAG represents a particular REPOSITORY instance
+ *     within the REGISTRY HOST. The DIGEST content-addressable identifier.
  *
  * @author Christian Tzolov
  */
@@ -55,6 +56,7 @@ public class ContainerImage {
 	// and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
 	// (https://dockr.ly/3chhQZF)
 	private static final Pattern TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9_][a-zA-Z0-9\\-_.]{0,127}$");
+	// Digest format is defined inn the docker reference code (https://bit.ly/3l8HjYT) and (https://bit.ly/33nBcdk)
 	private static final Pattern DIGEST_PATTERN = Pattern.compile("^[A-Za-z][A-Za-z0-9]*(?:[\\-_+.][A-Za-z][A-Za-z0-9]*)*[:][[\\p{XDigit}]]{32,}$");
 	private static final Pattern HOSTNAME_PATTERN = Pattern.compile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
 	private static final Pattern IP_PATTERN = Pattern.compile("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
@@ -49,10 +49,10 @@ public class DefaultContainerImageMetadataResolver implements ContainerImageMeta
 					ContainerImageMetadataProperties.DOCKER_IMAGE_MANIFEST_MEDIA_TYPE));
 
 	private final RestTemplate containerRestTemplate;
-	private RestTemplate noSslVerificationContainerRestTemplate;
+	private final RestTemplate noSslVerificationContainerRestTemplate;
 	private final ContainerImageParser containerImageParser;
 	private final Map<RegistryConfiguration.AuthorizationType, RegistryAuthorizer> registryAuthorizerMap;
-	private Map<String, RegistryConfiguration> registryConfigurationMap;
+	private final Map<String, RegistryConfiguration> registryConfigurationMap;
 
 	public static class RegistryRequest {
 
@@ -157,6 +157,10 @@ public class DefaultContainerImageMetadataResolver implements ContainerImageMeta
 
 		// Find a registry configuration that matches the image's registry host
 		RegistryConfiguration registryConf = this.registryConfigurationMap.get(containerImage.getRegistryHost());
+		if (registryConf == null) {
+			throw new AppMetadataResolutionException(
+					"Could not find an Registry Configuration for: " + containerImage.getRegistryHost());
+		}
 
 		// Retrieve a registry authorizer that supports the configured authorization type.
 		RegistryAuthorizer registryAuthorizer = this.registryAuthorizerMap.get(registryConf.getAuthorizationType());

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/AnonymousRegistryAuthorizer.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/AnonymousRegistryAuthorizer.java
@@ -38,7 +38,6 @@ public class AnonymousRegistryAuthorizer implements RegistryAuthorizer {
 		Assert.isTrue(registryConfiguration.getAuthorizationType() == this.getType(),
 				"Incorrect type: " + registryConfiguration.getAuthorizationType());
 
-		final HttpHeaders headers = new HttpHeaders();
-		return headers;
+		return new HttpHeaders();
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
@@ -116,7 +116,7 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 
 		// Determine the OAuth2 token service entry point.
 		verify(noSslVerificationContainerRestTemplate)
-				.exchange(eq(new URI("https://demo.goharbor.io/v2/_catalog")), eq(HttpMethod.GET), any(), eq(Map.class));
+				.exchange(eq(new URI("https://demo.goharbor.io/v2/")), eq(HttpMethod.GET), any(), eq(Map.class));
 
 		// Get authorization token
 		verify(containerRestTemplate).exchange(
@@ -138,7 +138,7 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 
 		// Determine the OAuth2 token service entry point.
 		verify(noSslVerificationContainerRestTemplate)
-				.exchange(eq(new URI("https://demo.repository.io/v2/_catalog")), eq(HttpMethod.GET), any(), eq(Map.class));
+				.exchange(eq(new URI("https://demo.repository.io/v2/")), eq(HttpMethod.GET), any(), eq(Map.class));
 
 		// Get authorization token
 		verify(noSslVerificationContainerRestTemplate).exchange(
@@ -165,7 +165,7 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 			HttpClientErrorException httpClientErrorException =
 					HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "", authenticateHeader, new byte[0], null);
 
-			when(restTemplate.exchange(eq(new URI("https://demo.repository.io/v2/_catalog")),
+			when(restTemplate.exchange(eq(new URI("https://demo.repository.io/v2/")),
 					eq(HttpMethod.GET), any(), eq(Map.class))).thenThrow(httpClientErrorException);
 
 
@@ -193,7 +193,7 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 			HttpClientErrorException httpClientErrorException2 =
 					HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "", authenticateHeader2, new byte[0], null);
 
-			when(restTemplate.exchange(eq(new URI("https://demo.goharbor.io/v2/_catalog")),
+			when(restTemplate.exchange(eq(new URI("https://demo.goharbor.io/v2/")),
 					eq(HttpMethod.GET), any(), eq(Map.class))).thenThrow(httpClientErrorException2);
 
 			return restTemplate;

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/container/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
@@ -62,7 +62,7 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 	public void testConvertAnonymousRegistry() throws URISyntaxException {
 
 		when(mockRestTemplate.exchange(
-				eq(new URI("https://demo.repository.io/v2/_catalog")), eq(HttpMethod.GET), any(), eq(Map.class)))
+				eq(new URI("https://demo.repository.io/v2/")), eq(HttpMethod.GET), any(), eq(Map.class)))
 				.thenReturn(new ResponseEntity<>(new HashMap<>(), HttpStatus.OK));
 
 		String b = "{\"auths\":{\"demo.repository.io\":{}}}";
@@ -108,7 +108,7 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 		HttpClientErrorException httpClientErrorException =
 				HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "", authenticateHeader, new byte[0], null);
 
-		when(mockRestTemplate.exchange(eq(new URI("https://demo.repository.io/v2/_catalog")),
+		when(mockRestTemplate.exchange(eq(new URI("https://demo.repository.io/v2/")),
 				eq(HttpMethod.GET), any(), eq(Map.class))).thenThrow(httpClientErrorException);
 
 		String b = "{\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}";

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -25,6 +25,9 @@ spec:
           - name: database
             mountPath: /etc/secrets/database
             readOnly: true
+          - name: ctr-registry
+            mountPath: /workspace/runtime/secrets/ctr-registry
+            readOnly: true
         ports:
         - containerPort: 80
         livenessProbe:
@@ -64,7 +67,7 @@ spec:
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
           value: 'false'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
-          value: /etc/secrets
+          value: /etc/secrets,/workspace/runtime/secrets/ctr-registry
         - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
           value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
           # Provide the Skipper service location
@@ -88,3 +91,6 @@ spec:
         - name: database
           secret:
             secretName: mysql
+        - name: ctr-registry
+          secret:
+            secretName: scdf-metadata-regcred

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -15,82 +15,76 @@ spec:
         app: scdf-server
     spec:
       containers:
-      - name: scdf-server
-        image: springcloud/spring-cloud-dataflow-server:2.7.0-SNAPSHOT
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: config
-            mountPath: /config
-            readOnly: true
-          - name: database
-            mountPath: /etc/secrets/database
-            readOnly: true
-          - name: ctr-registry
-            mountPath: /workspace/runtime/secrets/ctr-registry
-            readOnly: true
-        ports:
-        - containerPort: 80
-        livenessProbe:
-          httpGet:
-            path: /management/health
-            port: 80
-          initialDelaySeconds: 45
-        readinessProbe:
-          httpGet:
-            path: /management/info
-            port: 80
-          initialDelaySeconds: 45
-        resources:
-          limits:
-            cpu: 1.0
-            memory: 2048Mi
-          requests:
-            cpu: 0.5
-            memory: 1024Mi
-        env:
-        - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: "metadata.namespace"
-        - name: SERVER_PORT
-          value: '80'
-        - name: SPRING_CLOUD_CONFIG_ENABLED
-          value: 'false'
-        - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
-          value: 'true'
-        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
-          value: 'true'
-        - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
-          value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.7.0-SNAPSHOT'
-        - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
-          value: 'false'
-        - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
-          value: 'false'
-        - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
-          value: /etc/secrets,/workspace/runtime/secrets/ctr-registry
-        - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
-          value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
-          # Provide the Skipper service location
-        - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
-          value: 'http://${SKIPPER_SERVICE_HOST}:${SKIPPER_SERVICE_PORT}/api'
-          # Add Maven repo for metadata artifact resolution for all stream apps
-        - name: SPRING_APPLICATION_JSON
-          value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
+        - name: scdf-server
+          image: springcloud/spring-cloud-dataflow-server:2.7.0-SNAPSHOT
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: database
+              mountPath: /etc/secrets/database
+              readOnly: true
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /management/health
+              port: 80
+            initialDelaySeconds: 45
+          readinessProbe:
+            httpGet:
+              path: /management/info
+              port: 80
+            initialDelaySeconds: 45
+          resources:
+            limits:
+              cpu: 1.0
+              memory: 2048Mi
+            requests:
+              cpu: 0.5
+              memory: 1024Mi
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.namespace"
+            - name: SERVER_PORT
+              value: '80'
+            - name: SPRING_CLOUD_CONFIG_ENABLED
+              value: 'false'
+            - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
+              value: 'true'
+            - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
+              value: 'true'
+            - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
+              value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.7.0-SNAPSHOT'
+            - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
+              value: 'false'
+            - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
+              value: 'false'
+            - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
+              value: /etc/secrets
+            - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
+              value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
+              # Provide the Skipper service location
+            - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
+              value: 'http://${SKIPPER_SERVICE_HOST}:${SKIPPER_SERVICE_PORT}/api'
+              # Add Maven repo for metadata artifact resolution for all stream apps
+            - name: SPRING_APPLICATION_JSON
+              value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
       initContainers:
-      - name: init-mysql-wait
-        image: busybox
-        command: ['sh', '-c', 'until nc -w3 -z mysql 3306; do echo waiting for mysql; sleep 3; done;']
+        - name: init-mysql-wait
+          image: busybox
+          command: ['sh', '-c', 'until nc -w3 -z mysql 3306; do echo waiting for mysql; sleep 3; done;']
       serviceAccountName: scdf-sa
       volumes:
         - name: config
           configMap:
             name: scdf-server
             items:
-            - key: application.yaml
-              path: application.yaml
+              - key: application.yaml
+                path: application.yaml
         - name: database
           secret:
             secretName: mysql
-        - name: ctr-registry
-          secret:
-            secretName: scdf-metadata-regcred

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -15,76 +15,76 @@ spec:
         app: scdf-server
     spec:
       containers:
-        - name: scdf-server
-          image: springcloud/spring-cloud-dataflow-server:2.7.0-SNAPSHOT
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: config
-              mountPath: /config
-              readOnly: true
-            - name: database
-              mountPath: /etc/secrets/database
-              readOnly: true
-          ports:
-            - containerPort: 80
-          livenessProbe:
-            httpGet:
-              path: /management/health
-              port: 80
-            initialDelaySeconds: 45
-          readinessProbe:
-            httpGet:
-              path: /management/info
-              port: 80
-            initialDelaySeconds: 45
-          resources:
-            limits:
-              cpu: 1.0
-              memory: 2048Mi
-            requests:
-              cpu: 0.5
-              memory: 1024Mi
-          env:
-            - name: KUBERNETES_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: "metadata.namespace"
-            - name: SERVER_PORT
-              value: '80'
-            - name: SPRING_CLOUD_CONFIG_ENABLED
-              value: 'false'
-            - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
-              value: 'true'
-            - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
-              value: 'true'
-            - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
-              value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.7.0-SNAPSHOT'
-            - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
-              value: 'false'
-            - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
-              value: 'false'
-            - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
-              value: /etc/secrets
-            - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
-              value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
-              # Provide the Skipper service location
-            - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
-              value: 'http://${SKIPPER_SERVICE_HOST}:${SKIPPER_SERVICE_PORT}/api'
-              # Add Maven repo for metadata artifact resolution for all stream apps
-            - name: SPRING_APPLICATION_JSON
-              value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
+      - name: scdf-server
+        image: springcloud/spring-cloud-dataflow-server:2.7.0-SNAPSHOT
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: config
+            mountPath: /config
+            readOnly: true
+          - name: database
+            mountPath: /etc/secrets/database
+            readOnly: true
+        ports:
+        - containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /management/health
+            port: 80
+          initialDelaySeconds: 45
+        readinessProbe:
+          httpGet:
+            path: /management/info
+            port: 80
+          initialDelaySeconds: 45
+        resources:
+          limits:
+            cpu: 1.0
+            memory: 2048Mi
+          requests:
+            cpu: 0.5
+            memory: 1024Mi
+        env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
+        - name: SERVER_PORT
+          value: '80'
+        - name: SPRING_CLOUD_CONFIG_ENABLED
+          value: 'false'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
+          value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.7.0-SNAPSHOT'
+        - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
+          value: 'false'
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
+          value: 'false'
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
+          value: /etc/secrets
+        - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
+          value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
+          # Provide the Skipper service location
+        - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
+          value: 'http://${SKIPPER_SERVICE_HOST}:${SKIPPER_SERVICE_PORT}/api'
+          # Add Maven repo for metadata artifact resolution for all stream apps
+        - name: SPRING_APPLICATION_JSON
+          value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } } }"
       initContainers:
-        - name: init-mysql-wait
-          image: busybox
-          command: ['sh', '-c', 'until nc -w3 -z mysql 3306; do echo waiting for mysql; sleep 3; done;']
+      - name: init-mysql-wait
+        image: busybox
+        command: ['sh', '-c', 'until nc -w3 -z mysql 3306; do echo waiting for mysql; sleep 3; done;']
       serviceAccountName: scdf-sa
       volumes:
         - name: config
           configMap:
             name: scdf-server
             items:
-              - key: application.yaml
-                path: application.yaml
+            - key: application.yaml
+              path: application.yaml
         - name: database
           secret:
             secretName: mysql


### PR DESCRIPTION
  - Replace the probe url from https://<registry-host/v2/_catalog to https://<registry-host/v2/
  - Remove the base auth when hitting the probe registry url.
  - Improve the error handling. Check of potential NPE and throw AppMetadataResolutionException instead.
  - Reduce the logging messages in case of registry configuration problem. Don't print the exception traces for non debug level.
  - Minor code improvements.

  Resolves #4178