### PR TITLE
App name length 255

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -439,6 +439,13 @@ public class AppRegistryController {
 	}
 
 	private void validateApplicationName(String name) {
+
+		// Check for length of name to be less than 256 character.
+		if (name.length() > 255) {
+			throw new IllegalArgumentException("Length of application name must be less than 256 characters");
+		}
+
+		// Check for invalid characters.
 		char[] invalidWildCards = new char[]{':'};
 		StringBuilder invalidChars = new StringBuilder();
 		for (char invalidWildCard : invalidWildCards) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -140,6 +140,15 @@ public class AppRegistryControllerTests {
 	}
 
 	@Test
+	public void testRegisterAppWithNameLongerThan255Characters() throws Exception {
+		mockMvc.perform(post(
+				"/apps/sink/sinkAppToTestIfLengthIsGreaterThanTwoHundredAndFiftyFiveCharacterssinkAppToTestIfLengthIsGreaterThanTwoHundredAndFiftyFiveCharacterssinkAppToTestIfLengthIsGreaterThanTwoHundredAndFiftyFiveCharacterssinkAppToTestIfLengthIsGreaterThanTwoHundredAndFiftyFiveCharacters")
+						.param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE")
+						.accept(MediaType.APPLICATION_JSON))
+				.andDo(print()).andExpect(status().is5xxServerError());
+	}
+
+	@Test
 	public void testRegisterApp() throws Exception {
 		mockMvc.perform(post("/apps/sink/log1").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());


### PR DESCRIPTION
This PR adds a feature as part of #4189 

The following are the changes made - 
- Added validation to check if app name length is > 255 characters, returning a meaningful message in that case
- Added test case to check for failure if app name length is. > 255 characters.