### PR TITLE
Removed the type hint from the job params on job restarts.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -231,7 +231,7 @@ public class DefaultTaskJobService implements TaskJobService {
 					}
 				}
 				if(!existsFlag) {
-					result.add(String.format("%s(%s)=%s", key, jobParametersMap.get(key).getType().toString().toLowerCase(), jobParameters.getString(key)));
+					result.add(String.format("%s=%s", key,  jobParameters.getString(key)));
 				}
 			}
 		}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -136,7 +136,7 @@ public class DefaultTaskJobServiceTests {
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
 		appDeploymentRequest.getCommandlineArguments().contains("--spring.cloud.data.flow.platformname=demo");
-		assertTrue(appDeploymentRequest.getCommandlineArguments().contains("identifying.param(string)=testparam"));
+		assertTrue(appDeploymentRequest.getCommandlineArguments().contains("identifying.param=testparam"));
 	}
 
 	private void initializeJobs() {


### PR DESCRIPTION
resolved #4204

The original intent was to use the entire key that was returned from batch.
However when relaunching a job from CF it will fail.  That is because the build pack requires a triple escape to use `(` character ie.`\\\(`
This also causes a problem when passing this value as a property when using shell entrypoint for k8s.

So since this is just a hint to batch, we will remove this info and let batch figure out the correct type.