### PR TITLE
Updated docs to discuss maximum char length for definition names.

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -73,6 +73,8 @@ The xref:getting-started#getting-started[Getting Started] section shows you how 
 
 Note that the shell calls the Data Flow Server's REST API. For more information on making HTTP requests directly to the server, see the <<api-guide, REST API Guide>>.
 
+NOTE: When naming a stream definition, keep in mind that each application in the stream will be created on the platform with the name in the format of `<stream name>-<app name>`.   Thus, the total length of the generated application name can't exceed 58 characters.
+
 [[spring-cloud-dataflow-stream-app-dsl]]
 === Stream Application DSL
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -162,6 +162,19 @@ Created new task 'mytask'
 You can obtain a listing of the current task definitions through the RESTful API or the shell.
 To get the task definition list by using the shell, use the `task list` command.
 
+==== Maximum Task Definition Name Length
+The maximum character length of a task definition name is dependent on the platform.
+
+.Maximum Task Definition Name Character Length by Platform
+|===
+|Kubernetes Bare Pods |Kubernetes Jobs | Cloud Foundry | Local
+
+|63
+|52
+|63
+|255
+|===
+
 ==== Automating the Creation of Task Definitions
 
 As of version 2.3.0, you can configure the Data Flow server to automatically create task definitions by setting `spring.cloud.dataflow.task.autocreate-task-definitions` to `true`.
@@ -1260,6 +1273,18 @@ Created schedule 'mytaskschedule'
 In the earlier example, we created a schedule called `mytaskschedule` for the task definition called `mytask`.  This schedule launches `mytask` once a minute.
 
 NOTE: If using Cloud Foundry, the `cron` expression above would be: `*/1 * ? * *`. This is because Cloud Foundry uses the Quartz `cron` expression format.
+
+===== Maximum Length for a Schedule Name
+The maximum character length of a schedule name is dependent on the platform.
+
+.Maximum Schedule Name Character Length by Platform
+|===
+|Kubernetes | Cloud Foundry | Local
+
+|52
+|63
+|N/A
+|===
 
 [[spring-cloud-data-flow-schedule-unscheduling]]
 ==== Deleting a Schedule


### PR DESCRIPTION
resolves #4191 