### PR TITLE
Upgrade docker compose Kafka to 5.4.3

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - 3306
 
   kafka-broker:
-    image: confluentinc/cp-kafka:5.4.3
+    image: confluentinc/cp-kafka:5.5.2
     container_name: dataflow-kafka
     expose:
       - "9092"
@@ -46,7 +46,7 @@ services:
       - zookeeper
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.3
+    image: confluentinc/cp-zookeeper:5.5.2
     container_name: dataflow-kafka-zookeeper
     expose:
       - "2181"

--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - 3306
 
   kafka-broker:
-    image: confluentinc/cp-kafka:5.3.1
+    image: confluentinc/cp-kafka:5.4.3
     container_name: dataflow-kafka
     expose:
       - "9092"
@@ -46,7 +46,7 @@ services:
       - zookeeper
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: confluentinc/cp-zookeeper:5.4.3
     container_name: dataflow-kafka-zookeeper
     expose:
       - "2181"
@@ -63,6 +63,8 @@ services:
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_STREAMS_BINDER_BROKERS=PLAINTEXT://kafka-broker:9092
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_BINDER_ZKNODES=zookeeper:2181
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_CLOUD_STREAM_KAFKA_STREAMS_BINDER_ZKNODES=zookeeper:2181
+
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_KAFKA_STREAMS_PROPERTIES_METRICS_RECORDING_LEVEL=DEBUG
 
       - SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI=http://skipper-server:7577/api
 


### PR DESCRIPTION
 - Upgrade docker compose Kafka and Zookeeper to 5.4.3.
 - Set the Kafka metrics.recording.level to DEBUG to enable detailed Kafka Stream & Task Metrics collection:
   https://docs.confluent.io/current/streams/monitoring.html#configuring-metrics-granularity

 Part of #4209