### PR TITLE
Back-port the Metrics replication config for k8s

### DIFF
--- a/src/kubernetes/grafana/grafana-deployment.yaml
+++ b/src/kubernetes/grafana/grafana-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: grafana
     spec:
       containers:
-        - image: springcloud/spring-cloud-dataflow-grafana-prometheus:2.6.2-SNAPSHOT
+        - image: springcloud/spring-cloud-dataflow-grafana-prometheus:2.6.4-SNAPSHOT
           name: grafana
           env:
             - name: GF_SECURITY_ADMIN_USER

--- a/src/kubernetes/server/server-config.yaml
+++ b/src/kubernetes/server/server-config.yaml
@@ -6,30 +6,18 @@ metadata:
     app: scdf-server
 data:
   application.yaml: |-
+    management:
+      metrics:
+        export:
+          prometheus:
+            enabled: true
+            rsocket:
+              enabled: true
+              host: prometheus-proxy
+              port: 7001
     spring:
       cloud:
         dataflow:
-          applicationProperties:
-            stream:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: prometheus-proxy
-                        port: 7001
-            task:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: prometheus-proxy
-                        port: 7001
           metrics.dashboard:
             url: 'https://grafana:3000'
             type: 'GRAFANA'

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: scdf-server
-        image: springcloud/spring-cloud-dataflow-server:2.6.2-SNAPSHOT
+        image: springcloud/spring-cloud-dataflow-server:2.6.4-SNAPSHOT
         imagePullPolicy: Always
         volumeMounts:
           - name: config
@@ -58,7 +58,7 @@ spec:
         - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
           value: 'true'
         - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
-          value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.6.2-SNAPSHOT'
+          value: 'docker://springcloud/spring-cloud-dataflow-composed-task-runner:2.6.4-SNAPSHOT'
         - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
           value: 'false'
         - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API

--- a/src/kubernetes/skipper/skipper-deployment.yaml
+++ b/src/kubernetes/skipper/skipper-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: skipper
-        image: springcloud/spring-cloud-skipper-server:2.5.2
+        image: springcloud/spring-cloud-skipper-server:2.5.3-SNAPSHOT
         imagePullPolicy: Always
         volumeMounts:
           - name: config

--- a/src/templates/kubernetes/server/server-config.yaml
+++ b/src/templates/kubernetes/server/server-config.yaml
@@ -6,30 +6,18 @@ metadata:
     app: scdf-server
 data:
   application.yaml: |-
+    management:
+      metrics:
+        export:
+          prometheus:
+            enabled: true
+            rsocket:
+              enabled: true
+              host: prometheus-proxy
+              port: 7001
     spring:
       cloud:
         dataflow:
-          applicationProperties:
-            stream:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: prometheus-proxy
-                        port: 7001
-            task:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: prometheus-proxy
-                        port: 7001
           metrics.dashboard:
             url: 'https://grafana:3000'
             type: 'GRAFANA'


### PR DESCRIPTION
  - Use a single (Data Flow server) metrics configuration and let the MetricsReplicationEnvironmentPostProcessor replicate the metrics to the Stream and App configurations.

  Part of #4103