### PR TITLE
Enable running ITs with k8s on GEK minikube

### DIFF
--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -202,10 +202,12 @@ Replace the `prometheus-67896dcc8-7wm4h` with your pod name.
 
 Or use the `test.docker.compose.prometheusUrl` property to set an alternative Prometheus url.
 
-#### Integration Tests with minikube
+#### Integration Tests with Minikube
 
-Minikube does not come with a load balancer implementation out of the box, which causes issues when one wants to use services exposed as a LoadBalancer.
-MetalLB is a lightweight load balancer implementation for Kubernetes.
+The Integration Tests require that the Kubernetes cluster running Data Flow provides a https://kubernetes.io/docs/concepts/services-networking/[Load Balancer] service.
+
+Most cloud providers offer the Load Balancer service by default. For Minikube, you would need to install one yourself.
+The https://metallb.universe.tf/[MetalLB] is a lightweight load balancer implementation for Kubernetes and is one option to provide the `LoadBalancer` service on Minikube.
 
 * Install MetalLB
 ----
@@ -231,9 +233,8 @@ data:
 EOF
 ----
 
-NOTE: The IP block that is listed in the addresses section is based on my setup. I am running Minikube via the default VirtualBox driver.
-My network adapter 1 is "NAT", adapter 2 is "Host-only". My default Minikube IP is 192.168.99.100.
-Depending on your setup, this may work out of the box, or you may need to customize it as needed.
+NOTE: The IP in the addresses section is based on running Minikube via the default VirtualBox driver with default Minikube IP  is `192.168.99.100`.
+For different Minikube configurations, you might need to customize the address.
 
 * Apply the ConfigMap:
 

--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -177,3 +177,74 @@ The `test.docker.compose.paths` property accepts comma separated list of docker 
    -Dtest.docker.compose.dood=true \
    -Dtest.docker.compose.pullOnStartup=false
 ----
+
+## Run Integration Tests against k8s
+
+For this you need a pre-installed Data Flow on GKE or minikube.
+Register the OOTB kafka/docker and task/docker apps and the run:
+
+----
+./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
+    -Dtest.docker.compose.disable.extension=true \
+    -Dtest.docker.compose.dataflowServerUrl=http://your-k8s-scdf-server \
+    -Pfailsafe
+----
+
+* replace `http://your-k8s-scdf-server` with the url of your Data Flow server.
+* the `test.docker.compose.disable.extension=true` property disables the docker-compose fixture.
+* the `test.docker.compose.dataflowServerUrl=` property points to the pre-installed DataFlow REST API.
+
+For the analytic tests you need to pre-install Prometheus according to the installation instructions and forward the prometheus server's 9090 port
+----
+kubectl port-forward prometheus-67896dcc8-7wm4h 9090:9090
+----
+Replace the `prometheus-67896dcc8-7wm4h` with your pod name.
+
+Or use the `test.docker.compose.prometheusUrl` property to set an alternative Prometheus url.
+
+#### Integration Tests with minikube
+
+Minikube does not come with a load balancer implementation out of the box, which causes issues when one wants to use services exposed as a LoadBalancer.
+MetalLB is a lightweight load balancer implementation for Kubernetes.
+
+* Install MetalLB
+----
+kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.3/manifests/metallb.yaml
+----
+
+* Create a ConfigMap with the appropriate settings
+
+----
+cat <<EOF >metallbcm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.99.116/28
+EOF
+----
+
+NOTE: The IP block that is listed in the addresses section is based on my setup. I am running Minikube via the default VirtualBox driver.
+My network adapter 1 is "NAT", adapter 2 is "Host-only". My default Minikube IP is 192.168.99.100.
+Depending on your setup, this may work out of the box, or you may need to customize it as needed.
+
+* Apply the ConfigMap:
+
+----
+kubectl apply -f metallbcm.yaml
+----
+
+At this point MetalLB is setup and ready to hand out IP's to any service of type LoadBalancer, just as things would work in say GKE.
+
+* If a change is made to the ConfigMap and re-applied, bounce the pods in the metallb-system namespace to pick-up the new changes, ie:
+
+----
+kubectl delete pod --all -n metallb-system
+----

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -742,9 +742,9 @@ public class DataFlowIT {
 				.put("app.*.management.endpoints.web.exposure.include", "*")
 				.put("app.*.spring.cloud.streamapp.security.enabled", "false");
 
-		// TODO this misterious 80 port set for K8s comes from the ATs and i'm not sure why. But without it partition tests fail.
 		if (this.runtimeApps.getPlatformType().equalsIgnoreCase(RuntimeApplicationHelper.KUBERNETES_PLATFORM_TYPE)) {
 			propertiesBuilder.put("app.*.server.port", "80");
+			propertiesBuilder.put("deployer.*.kubernetes.createLoadBalancer", "true"); // requires metallb
 		}
 
 		return propertiesBuilder.build();

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -744,7 +744,7 @@ public class DataFlowIT {
 
 		if (this.runtimeApps.getPlatformType().equalsIgnoreCase(RuntimeApplicationHelper.KUBERNETES_PLATFORM_TYPE)) {
 			propertiesBuilder.put("app.*.server.port", "80");
-			propertiesBuilder.put("deployer.*.kubernetes.createLoadBalancer", "true"); // requires metallb
+			propertiesBuilder.put("deployer.*.kubernetes.createLoadBalancer", "true"); // requires LoadBalancer support on the platform
 		}
 
 		return propertiesBuilder.build();

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
@@ -171,36 +171,11 @@ public class RuntimeApplicationHelper {
 	}
 
 	/**
-	 * Special installation for SCDF on ATs K8s environments involves ngix ingress server + special watchdog daemon that
-	 * exposes the host names of all Deployed names.
-	 *
-	 * For single instance app the watch dog uses the name convention:
-	 *  - https://[spring.deployment.id].[kubernetesAppHostSuffix] (For example  https://partitioning-test-log-v1.hydra.springapps.io/)
-	 *
-	 * For multiple instances app the watch dog uses the 2 name conventions:
-	 *  - https://[spring.deployment.id].[kubernetesAppHostSuffix] - round robing across all instances (for example  https://partitioning-test-log-v1.hydra.springapps.io/)
-	 *  - https://[pod.name].[kubernetesAppHostSuffix] - to target a particular instance ( for example https://partitioning-test-log-v1-0.hydra.springapps.io/)
-	 *
 	 * @param instanceAttributes runtime attributes of the app instance.
 	 * @return Externally accessible app instance URL
 	 */
 	private String kubernetesApplicationInstanceUrl(Map<String, String> instanceAttributes) {
-		String appHost = isKubernetesMultipleInstanceApp(instanceAttributes) ? instanceAttributes.get("pod.name")
-				: instanceAttributes.get("spring.deployment.id");
-		String appUrl = String.format("https://%s.%s", appHost, this.kubernetesAppHostSuffix);
-		return appUrl;
-	}
-
-	/**
-	 * Hack that uses the pod.name (e.g. instance id) suffix to determine if this is a single or multiple app instances.
-	 * If uses the pod.name suffix to determine if the app instance belongs to a stateful set or not.
-	 * The K8s deployer uses stateful set for multiple instances apps.
-	 */
-	private boolean isKubernetesMultipleInstanceApp(Map<String, String> instanceAttributes) {
-		String deploymentId = instanceAttributes.get("spring.deployment.id");
-		String instanceId = instanceAttributes.get("pod.name");
-		return instanceId.replace(deploymentId, "").toLowerCase().chars()
-				.filter(ch -> ch >= 'a' && ch <= 'z').distinct().count() == 0;
+		return instanceAttributes.get("url");
 	}
 
 	/**


### PR DESCRIPTION
  - Fix the app url resolution using the k8s deployer's "url" attribute. Later requires a LB to be exposed.
  - Add README instructions to run the IT test agains remote k8s/GKE or local minikube. Add instructions to install `metallb`.

  Resolves #4239