### PR TITLE
Improve the ITs stability on Bamboo env

### DIFF
--- a/spring-cloud-dataflow-server/docker-compose-prometheus.yml
+++ b/spring-cloud-dataflow-server/docker-compose-prometheus.yml
@@ -10,7 +10,7 @@ services:
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_ENABLED=true
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_HOST=prometheus-rsocket-proxy
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_PORT=7001
-      - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
+      #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
       - SPRING_CLOUD_DATAFLOW_METRICS_DASHBOARD_URL=http://localhost:3000
 
   skipper-server:
@@ -19,7 +19,7 @@ services:
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_ENABLED=true
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_HOST=prometheus-rsocket-proxy
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_RSOCKET_PORT=7001
-      - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
+      #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
     image: micrometermetrics/prometheus-rsocket-proxy:1.0.0

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -132,7 +132,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * you can have the test feature that uses the local run SCDF/Skipper/MySQL to deploy and run Stream only test to the
  * remote K8s or CF environments. Note that Tasks can only be run locally!
  *
- * Follow the https://dataflow.spring.io/docs/2.3.0.SNAPSHOT/installation/local/docker-customize/#docker-compose-extensions
+ * Follow the https://dataflow.spring.io/docs/installation/local/docker-customize/#multi-platform-support
  * multi-platform instructions to prepare docker-compose-k8s.yml and docker-compose-cf.yml files.
  *
  * Stream tests on Kubernetes (k8s) platform:
@@ -234,7 +234,7 @@ public class DataFlowIT {
 
 		// Docker app with container image metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.source,
-				"docker:springcloudstream/time-source-kafka:2.1.2.BUILD-SNAPSHOT", null, true);
+				"docker:springcloudstream/time-source-kafka:2.1.4.RELEASE", null, true);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-container-metadata", ApplicationType.source, false);
 		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(6);


### PR DESCRIPTION
 - Replace the reference to test SNAPSHOT app image. Looks like bamboo caches or fails to retrieve latest images.
 - reduce the Dataflow logging churn.