### PR TITLE
Expose compose task runner options

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -32,6 +32,11 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-client</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ import org.springframework.cloud.dataflow.server.controller.StreamDefinitionCont
 import org.springframework.cloud.dataflow.server.controller.StreamDeploymentController;
 import org.springframework.cloud.dataflow.server.controller.StreamLogsController;
 import org.springframework.cloud.dataflow.server.controller.StreamValidationController;
+import org.springframework.cloud.dataflow.server.controller.TaskCtrController;
 import org.springframework.cloud.dataflow.server.controller.TaskDefinitionController;
 import org.springframework.cloud.dataflow.server.controller.TaskExecutionController;
 import org.springframework.cloud.dataflow.server.controller.TaskLogsController;
@@ -241,6 +242,12 @@ public class DataFlowControllerAutoConfiguration {
 					streamService,
 					appRegistry,
 					metadataResolver, appRegistryFJPFB, streamDefinitionService, appRegistrationAssemblerProvider);
+		}
+
+		@Bean
+		public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
+				TaskConfigurationProperties taskConfigurationProperties, AppResourceCommon appResourceCommon) {
+			return new TaskCtrController(metadataResolver, taskConfigurationProperties, appResourceCommon);
 		}
 
 		@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -107,6 +107,7 @@ import org.springframework.cloud.dataflow.server.service.TaskJobService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
 import org.springframework.cloud.dataflow.server.service.impl.AppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultLauncherService;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
@@ -246,8 +247,11 @@ public class DataFlowControllerAutoConfiguration {
 
 		@Bean
 		public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
-				TaskConfigurationProperties taskConfigurationProperties, AppResourceCommon appResourceCommon) {
-			return new TaskCtrController(metadataResolver, taskConfigurationProperties, appResourceCommon);
+				TaskConfigurationProperties taskConfigurationProperties,
+				ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties,
+				AppResourceCommon appResourceCommon) {
+			return new TaskCtrController(metadataResolver, taskConfigurationProperties,
+					composedTaskRunnerConfigurationProperties, appResourceCommon);
 		}
 
 		@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -246,15 +246,6 @@ public class DataFlowControllerAutoConfiguration {
 		}
 
 		@Bean
-		public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
-				TaskConfigurationProperties taskConfigurationProperties,
-				ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties,
-				AppResourceCommon appResourceCommon) {
-			return new TaskCtrController(metadataResolver, taskConfigurationProperties,
-					composedTaskRunnerConfigurationProperties, appResourceCommon);
-		}
-
-		@Bean
 		@ConditionalOnMissingBean
 		public AppRegistrationAssemblerProvider appRegistryAssemblerProvider() {
 			return new DefaultAppRegistrationAssemblerProvider();
@@ -343,6 +334,15 @@ public class DataFlowControllerAutoConfiguration {
 		@Bean
 		public LauncherService launcherService(LauncherRepository launcherRepository) {
 			return new DefaultLauncherService(launcherRepository);
+		}
+
+		@Bean
+		public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
+				TaskConfigurationProperties taskConfigurationProperties,
+				ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties,
+				AppResourceCommon appResourceCommon) {
+			return new TaskCtrController(metadataResolver, taskConfigurationProperties,
+					composedTaskRunnerConfigurationProperties, appResourceCommon);
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -42,13 +43,16 @@ public class TaskCtrController {
 
 	private final ApplicationConfigurationMetadataResolver metadataResolver;
 	private final TaskConfigurationProperties taskConfigurationProperties;
+	private final ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties;
 	private final AppResourceCommon appResourceCommon;
 
 	public TaskCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
 			TaskConfigurationProperties taskConfigurationProperties,
+			ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties,
 			AppResourceCommon appResourceCommon) {
 		this.metadataResolver = metadataResolver;
 		this.taskConfigurationProperties = taskConfigurationProperties;
+		this.composedTaskRunnerConfigurationProperties = composedTaskRunnerConfigurationProperties;
 		this.appResourceCommon = appResourceCommon;
 	}
 
@@ -57,7 +61,9 @@ public class TaskCtrController {
 	public List<ConfigurationMetadataProperty> options() {
 		URI ctrUri = null;
 		try {
-			ctrUri = new URI(this.taskConfigurationProperties.getComposedTaskRunnerUri());
+			ctrUri = new URI(composedTaskRunnerConfigurationProperties.getUri() != null
+					? composedTaskRunnerConfigurationProperties.getUri()
+					: this.taskConfigurationProperties.getComposedTaskRunnerUri());
 		} catch (Exception e) {
 			throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller to expose boot configuration metadata from an ctr app as it's now
+ * just defined as an property and thus its metadata cannot be resolved via
+ * registered apps. This is essentially a support endpoint for UI features.
+ *
+ * @author Janne Valkealahti
+ */
+@RestController
+@RequestMapping("/tasks/ctr")
+public class TaskCtrController {
+
+	private final ApplicationConfigurationMetadataResolver metadataResolver;
+	private final TaskConfigurationProperties taskConfigurationProperties;
+	private final AppResourceCommon appResourceCommon;
+
+	public TaskCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
+			TaskConfigurationProperties taskConfigurationProperties,
+			AppResourceCommon appResourceCommon) {
+		this.metadataResolver = metadataResolver;
+		this.taskConfigurationProperties = taskConfigurationProperties;
+		this.appResourceCommon = appResourceCommon;
+	}
+
+	@RequestMapping(value = "/options", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public List<ConfigurationMetadataProperty> options() {
+		URI ctrUri = null;
+		try {
+			ctrUri = new URI(this.taskConfigurationProperties.getComposedTaskRunnerUri());
+		} catch (Exception e) {
+			throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
+		}
+
+		Resource resource = this.appResourceCommon.getMetadataResource(ctrUri, null);
+		List<ConfigurationMetadataProperty> properties = this.metadataResolver.listProperties(resource);
+		return properties;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -227,6 +227,9 @@ spring:
             # Task Logs
             - GET /tasks/logs/*                       => hasRole('ROLE_VIEW')
 
+            # Task Ctr
+            - GET    /tasks/ctr/*                     => hasRole('ROLE_VIEW')
+
             # Tools
 
             - POST   /tools/**                       => hasRole('ROLE_VIEW')

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -274,8 +274,11 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
-			TaskConfigurationProperties taskConfigurationProperties, AppResourceCommon appResourceCommon) {
-		return new TaskCtrController(metadataResolver, taskConfigurationProperties, appResourceCommon);
+			TaskConfigurationProperties taskConfigurationProperties,
+			ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties,
+			AppResourceCommon appResourceCommon) {
+		return new TaskCtrController(metadataResolver, taskConfigurationProperties,
+				composedTaskRunnerConfigurationProperties, appResourceCommon);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -89,6 +89,7 @@ import org.springframework.cloud.dataflow.server.controller.StreamDefinitionCont
 import org.springframework.cloud.dataflow.server.controller.StreamDeploymentController;
 import org.springframework.cloud.dataflow.server.controller.StreamLogsController;
 import org.springframework.cloud.dataflow.server.controller.StreamValidationController;
+import org.springframework.cloud.dataflow.server.controller.TaskCtrController;
 import org.springframework.cloud.dataflow.server.controller.TaskDefinitionController;
 import org.springframework.cloud.dataflow.server.controller.TaskExecutionController;
 import org.springframework.cloud.dataflow.server.controller.TaskPlatformController;
@@ -269,6 +270,12 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	@Bean
 	public StreamLogsController streamLogsController(StreamDeployer streamDeployer) {
 		return new StreamLogsController(streamDeployer);
+	}
+
+	@Bean
+	public TaskCtrController tasksCtrController(ApplicationConfigurationMetadataResolver metadataResolver,
+			TaskConfigurationProperties taskConfigurationProperties, AppResourceCommon appResourceCommon) {
+		return new TaskCtrController(metadataResolver, taskConfigurationProperties, appResourceCommon);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
+import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestDependencies.class)
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+public class TaskCtrControllerTests {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WebApplicationContext wac;
+
+	@MockBean
+	private ApplicationConfigurationMetadataResolver metadataResolver;
+
+	@Before
+	public void setupMocks() {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
+		ConfigurationMetadataProperty p = new ConfigurationMetadataProperty();
+		p.setId("oauth2-client-credentials-scopes");
+		p.setName("oauth2-client-credentials-scopes");
+		List<ConfigurationMetadataProperty> props = Arrays.asList(p);
+		Mockito.when(metadataResolver.listProperties(any())).thenReturn(props);
+	}
+
+	@Test
+	public void testOptions() throws Exception {
+		mockMvc.perform(get("/tasks/ctr/options").accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.[?(@.id == 'oauth2-client-credentials-scopes')].name", hasItems("oauth2-client-credentials-scopes")));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
@@ -40,10 +40,14 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Tests for TaskCtrController
+ *
+ * @author Janne Valkealahti
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -71,7 +75,6 @@ public class TaskCtrControllerTests {
 	@Test
 	public void testOptions() throws Exception {
 		mockMvc.perform(get("/tasks/ctr/options").accept(MediaType.APPLICATION_JSON))
-			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.[?(@.id == 'oauth2-client-credentials-scopes')].name", hasItems("oauth2-client-credentials-scopes")));
 	}


### PR DESCRIPTION
- Add boot metadata to ctr jar
- Add controller /tasks/ctr/options to expose
  those from a server to get used by UI.
- Fixes #4257