### PR TITLE
HTTP Proxy support for Container registry access

### DIFF
--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -47,7 +46,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.client.RestTemplate;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -118,14 +116,6 @@ public class BootVersionsCompletionProviderTests {
 
 		@MockBean
 		private DefaultContainerImageMetadataResolver containerImageMetadataResolver;
-
-		@MockBean
-		@Qualifier("containerRestTemplate")
-		private RestTemplate containerRestTemplate;
-
-		@MockBean
-		@Qualifier("noSslVerificationContainerRestTemplate")
-		private RestTemplate noSslVerificationContainerRestTemplate;
 
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionTestsMocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.audit.service.DefaultAuditRecordService;
@@ -45,7 +44,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.util.Assert;
-import org.springframework.web.client.RestTemplate;
 
 import static org.mockito.Mockito.mock;
 
@@ -64,14 +62,6 @@ public class CompletionTestsMocks {
 			CompletionTestsMocks.class.getPackage().getName().replace('.', '/') + "/apps");
 
 	private static final FileFilter FILTER = pathname -> pathname.isDirectory() && pathname.getName().matches(".+-.+");
-
-	@MockBean
-	@Qualifier("containerRestTemplate")
-	private RestTemplate containerRestTemplate;
-
-	@MockBean
-	@Qualifier("noSslVerificationContainerRestTemplate")
-	private RestTemplate noSslVerificationContainerRestTemplate;
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
@@ -68,12 +68,21 @@ public class DefaultContainerImageMetadataResolver implements ContainerImageMeta
 								imageName));
 			}
 
-			String configBlob = this.containerRegistryService.getImageBlob(registryRequest, configDigest, String.class);
+			Object configBlobObj = this.containerRegistryService.getImageBlob(registryRequest, configDigest, Object.class);
 
 			// Parse the config blob string into JSON instance.
 			try {
-				Map<String, Object> configBlobMap = new ObjectMapper().readValue(configBlob, Map.class);
-
+				Map<String, Object> configBlobMap = null;
+				if (configBlobObj instanceof String) {
+					configBlobMap = new ObjectMapper().readValue((String) configBlobObj, Map.class);
+				} else if (configBlobObj instanceof Map) {
+					configBlobMap = (Map<String, Object>) configBlobObj;
+				} else {
+					throw new ContainerRegistryException(
+							String.format(
+									"Configuration json for image [%s] with digest [%s] has incorrect Config Blog element",
+									imageName, configDigest));
+				}
 				if (!isNotNullMap(configBlobMap.get("config"))) {
 					throw new ContainerRegistryException(
 							String.format(

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/container/DefaultContainerImageMetadataResolver.java
@@ -19,10 +19,6 @@ package org.springframework.cloud.dataflow.configuration.metadata.container;
 import java.util.Collections;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.springframework.cloud.dataflow.configuration.metadata.AppMetadataResolutionException;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryException;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryRequest;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryService;
@@ -68,36 +64,25 @@ public class DefaultContainerImageMetadataResolver implements ContainerImageMeta
 								imageName));
 			}
 
-			Object configBlobObj = this.containerRegistryService.getImageBlob(registryRequest, configDigest, Object.class);
+			Map<String, Object> configBlobMap = this.containerRegistryService.getImageBlob(registryRequest, configDigest, Map.class);
 
-			// Parse the config blob string into JSON instance.
-			try {
-				Map<String, Object> configBlobMap = null;
-				if (configBlobObj instanceof String) {
-					configBlobMap = new ObjectMapper().readValue((String) configBlobObj, Map.class);
-				} else if (configBlobObj instanceof Map) {
-					configBlobMap = (Map<String, Object>) configBlobObj;
-				} else {
-					throw new ContainerRegistryException(
-							String.format(
-									"Configuration json for image [%s] with digest [%s] has incorrect Config Blog element",
-									imageName, configDigest));
-				}
-				if (!isNotNullMap(configBlobMap.get("config"))) {
-					throw new ContainerRegistryException(
-							String.format(
-									"Configuration json for image [%s] with digest [%s] has incorrect Config Blog element",
-									imageName, configDigest));
-				}
-
-				Map<String, Object> configElement = (Map<String, Object>) configBlobMap.get("config");
-
-				return isNotNullMap(configElement.get("Labels")) ?
-						(Map<String, String>) configElement.get("Labels") : Collections.emptyMap();
+			if (configBlobMap == null) {
+				throw new ContainerRegistryException(
+						String.format("Failed to retrieve configuration json for image [%s] with digest [%s]",
+								imageName, configDigest));
 			}
-			catch (JsonProcessingException e) {
-				throw new AppMetadataResolutionException("Unable to extract the labels from the Config blob", e);
+
+			if (!isNotNullMap(configBlobMap.get("config"))) {
+				throw new ContainerRegistryException(
+						String.format(
+								"Configuration json for image [%s] with digest [%s] has incorrect Config Blog element",
+								imageName, configDigest));
 			}
+
+			Map<String, Object> configElement = (Map<String, Object>) configBlobMap.get("config");
+
+			return isNotNullMap(configElement.get("Labels")) ?
+					(Map<String, String>) configElement.get("Labels") : Collections.emptyMap();
 		}
 		else {
 			throw new ContainerRegistryException(

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
+import org.springframework.cloud.dataflow.container.registry.ContainerImageRestTemplateFactory;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryAutoConfiguration;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryConfiguration;
 import org.springframework.cloud.dataflow.container.registry.authorization.DockerOAuth2RegistryAuthorizer;
@@ -55,14 +57,25 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = ApplicationConfigurationMetadataResolverAutoConfigurationTest.TestConfig.class)
 @TestPropertySource(properties = {
-		".dockerconfigjson={\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}",
+		".dockerconfigjson={\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}" +
+				",\"demo2.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}",
 		"spring.cloud.dataflow.container.registry-configurations[demorepositoryio].registry-host=demo.repository.io",
 		"spring.cloud.dataflow.container.registry-configurations[demorepositoryio].disable-ssl-verification=true",
+
+		"spring.cloud.dataflow.container.registry-configurations[demorepositoryio2].registry-host=demo2.repository.io",
+		"spring.cloud.dataflow.container.registry-configurations[demorepositoryio2].disable-ssl-verification=true",
+		"spring.cloud.dataflow.container.registry-configurations[demorepositoryio2].use-http-proxy=true",
 
 		"spring.cloud.dataflow.container.registry-configurations[goharbor].registry-host=demo.goharbor.io",
 		"spring.cloud.dataflow.container.registry-configurations[goharbor].authorization-type=dockeroauth2",
 		"spring.cloud.dataflow.container.registry-configurations[goharbor].user=admin",
-		"spring.cloud.dataflow.container.registry-configurations[goharbor].secret=Harbor12345"
+		"spring.cloud.dataflow.container.registry-configurations[goharbor].secret=Harbor12345",
+
+		"spring.cloud.dataflow.container.registry-configurations[goharbor2].registry-host=demo2.goharbor.io",
+		"spring.cloud.dataflow.container.registry-configurations[goharbor2].authorization-type=dockeroauth2",
+		"spring.cloud.dataflow.container.registry-configurations[goharbor2].user=admin",
+		"spring.cloud.dataflow.container.registry-configurations[goharbor2].secret=Harbor12345",
+		"spring.cloud.dataflow.container.registry-configurations[goharbor2].use-http-proxy=true"
 })
 public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 
@@ -73,6 +86,9 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 	ContainerImageMetadataResolver containerImageMetadataResolver;
 
 	@Autowired
+	ContainerImageRestTemplateFactory containerImageRestTemplateFactory;
+
+	@Autowired
 	@Qualifier("noSslVerificationContainerRestTemplate")
 	RestTemplate noSslVerificationContainerRestTemplate;
 
@@ -80,9 +96,17 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 	@Qualifier("containerRestTemplate")
 	RestTemplate containerRestTemplate;
 
+	@Autowired
+	@Qualifier("noSslVerificationContainerRestTemplateWithHttpProxy")
+	RestTemplate noSslVerificationContainerRestTemplateWithHttpProxy;
+
+	@Autowired
+	@Qualifier("containerRestTemplateWithHttpProxy")
+	RestTemplate containerRestTemplateWithHttpProxy;
+
 	@Test
 	public void registryConfigurationBeanCreationTest() {
-		assertThat(registryConfigurationMap).hasSize(2);
+		assertThat(registryConfigurationMap).hasSize(4);
 
 		ContainerRegistryConfiguration secretConf = registryConfigurationMap.get("demo.repository.io");
 		assertThat(secretConf).isNotNull();
@@ -97,6 +121,19 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 		assertThat(secretConf.getExtra().get(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY))
 				.isEqualTo("https://demo.repository.io/service/token?service=demo-registry&scope=repository:{repository}:pull");
 
+		ContainerRegistryConfiguration secretConf2 = registryConfigurationMap.get("demo2.repository.io");
+		assertThat(secretConf2).isNotNull();
+		assertThat(secretConf2.getRegistryHost()).isEqualTo("demo2.repository.io");
+		assertThat(secretConf2.getAuthorizationType()).isEqualTo(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2);
+		assertThat(secretConf2.getUser()).isEqualTo("testuser");
+		assertThat(secretConf2.getSecret()).isEqualTo("testpassword");
+		assertThat(secretConf2.isDisableSslVerification())
+				.describedAs("The explicit disable-ssl-verification=true property should augment the .dockerconfigjson based config")
+				.isTrue();
+		assertThat(secretConf2.getExtra()).isNotEmpty();
+		assertThat(secretConf2.getExtra().get(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY))
+				.isEqualTo("https://demo2.repository.io/service/token?service=demo-registry&scope=repository:{repository}:pull");
+
 		ContainerRegistryConfiguration goharborConf = registryConfigurationMap.get("demo.goharbor.io");
 		assertThat(goharborConf).isNotNull();
 		assertThat(goharborConf.getRegistryHost()).isEqualTo("demo.goharbor.io");
@@ -107,6 +144,18 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 		assertThat(goharborConf.getExtra()).isNotEmpty();
 		assertThat(goharborConf.getExtra().get(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY))
 				.isEqualTo("https://demo.goharbor.io/service/token?service=demo-registry2&scope=repository:{repository}:pull");
+
+
+		ContainerRegistryConfiguration goharborConf2 = registryConfigurationMap.get("demo2.goharbor.io");
+		assertThat(goharborConf2).isNotNull();
+		assertThat(goharborConf2.getRegistryHost()).isEqualTo("demo2.goharbor.io");
+		assertThat(goharborConf2.getAuthorizationType()).isEqualTo(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2);
+		assertThat(goharborConf2.getUser()).isEqualTo("admin");
+		assertThat(goharborConf2.getSecret()).isEqualTo("Harbor12345");
+		assertThat(goharborConf2.isDisableSslVerification()).isFalse();
+		assertThat(goharborConf2.getExtra()).isNotEmpty();
+		assertThat(goharborConf2.getExtra().get(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY))
+				.isEqualTo("https://demo2.goharbor.io/service/token?service=demo-registry2&scope=repository:{repository}:pull");
 	}
 
 	@Test
@@ -153,8 +202,23 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 				eq(HttpMethod.GET), any(), eq(String.class));
 	}
 
-	@ImportAutoConfiguration({ContainerRegistryAutoConfiguration.class, ApplicationConfigurationMetadataResolverAutoConfiguration.class})
+	@ImportAutoConfiguration({ ContainerRegistryAutoConfiguration.class, ApplicationConfigurationMetadataResolverAutoConfiguration.class })
 	static class TestConfig {
+
+		@Bean
+		@ConditionalOnMissingBean(name = "containerImageRestTemplateFactory")
+		public ContainerImageRestTemplateFactory containerImageRestTemplateFactory(
+				@Qualifier("noSslVerificationContainerRestTemplate") RestTemplate noSslVerificationContainerRestTemplate,
+				@Qualifier("noSslVerificationContainerRestTemplateWithHttpProxy") RestTemplate noSslVerificationContainerRestTemplateWithHttpProxy,
+				@Qualifier("containerRestTemplate") RestTemplate containerRestTemplate,
+				@Qualifier("containerRestTemplateWithHttpProxy") RestTemplate containerRestTemplateWithHttpProxy) {
+			ContainerImageRestTemplateFactory containerImageRestTemplateFactory = Mockito.mock(ContainerImageRestTemplateFactory.class);
+			when(containerImageRestTemplateFactory.getContainerRestTemplate(eq(true), eq(false))).thenReturn(noSslVerificationContainerRestTemplate);
+			when(containerImageRestTemplateFactory.getContainerRestTemplate(eq(true), eq(true))).thenReturn(noSslVerificationContainerRestTemplateWithHttpProxy);
+			when(containerImageRestTemplateFactory.getContainerRestTemplate(eq(false), eq(false))).thenReturn(containerRestTemplate);
+			when(containerImageRestTemplateFactory.getContainerRestTemplate(eq(false), eq(true))).thenReturn(containerRestTemplateWithHttpProxy);
+			return containerImageRestTemplateFactory;
+		}
 
 		@Bean(name = "noSslVerificationContainerRestTemplate")
 		RestTemplate noSslVerificationContainerRestTemplate() throws URISyntaxException {
@@ -221,6 +285,75 @@ public class ApplicationConfigurationMetadataResolverAutoConfigurationTest {
 							eq(new URI("https://demo.goharbor.io/v2/test/image/blobs/test_digest")),
 							eq(HttpMethod.GET), any(), eq(String.class)))
 					.thenReturn(new ResponseEntity<>("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }", HttpStatus.OK));
+
+			return restTemplate;
+		}
+
+		@Bean(name = "containerRestTemplateWithHttpProxy")
+		RestTemplate containerRestTemplateWithHttpProxy() throws URISyntaxException {
+			RestTemplate restTemplate = Mockito.mock(RestTemplate.class);
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.goharbor.io/service/token?service=demo-registry2&scope=repository:test/image:pull")),
+							eq(HttpMethod.GET), any(), eq(Map.class)))
+					.thenReturn(new ResponseEntity<>(Collections.singletonMap("token", "my_token_999"), HttpStatus.OK));
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.goharbor.io/v2/test/image/manifests/1.0.0")),
+							eq(HttpMethod.GET), any(), eq(Map.class)))
+					.thenReturn(new ResponseEntity<>(Collections.singletonMap("config", Collections.singletonMap("digest", "test_digest")), HttpStatus.OK));
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.goharbor.io/v2/test/image/blobs/test_digest")),
+							eq(HttpMethod.GET), any(), eq(String.class)))
+					.thenReturn(new ResponseEntity<>("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }", HttpStatus.OK));
+
+			return restTemplate;
+		}
+
+		@Bean(name = "noSslVerificationContainerRestTemplateWithHttpProxy")
+		RestTemplate noSslVerificationContainerRestTemplateWithHttpProxy() throws URISyntaxException {
+			RestTemplate restTemplate = Mockito.mock(RestTemplate.class);
+
+			// demo.repository.io
+			HttpHeaders authenticateHeader = new HttpHeaders();
+			authenticateHeader.add("Www-Authenticate", "Bearer realm=\"https://demo2.repository.io/service/token\",service=\"demo-registry\",scope=\"registry:category:pull\"");
+			HttpClientErrorException httpClientErrorException =
+					HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "", authenticateHeader, new byte[0], null);
+
+			when(restTemplate.exchange(eq(new URI("https://demo2.repository.io/v2/")),
+					eq(HttpMethod.GET), any(), eq(Map.class))).thenThrow(httpClientErrorException);
+
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.repository.io/service/token?service=demo-registry&scope=repository:disabledssl/image:pull")),
+							eq(HttpMethod.GET), any(), eq(Map.class)))
+					.thenReturn(new ResponseEntity<>(Collections.singletonMap("token", "my_token_999"), HttpStatus.OK));
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.repository.io/v2/disabledssl/image/manifests/1.0.0")),
+							eq(HttpMethod.GET), any(), eq(Map.class)))
+					.thenReturn(new ResponseEntity<>(Collections.singletonMap("config", Collections.singletonMap("digest", "test_digest")), HttpStatus.OK));
+
+			when(restTemplate
+					.exchange(
+							eq(new URI("https://demo2.repository.io/v2/disabledssl/image/blobs/test_digest")),
+							eq(HttpMethod.GET), any(), eq(String.class)))
+					.thenReturn(new ResponseEntity<>("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }", HttpStatus.OK));
+
+			// demo.goharbor.io
+			HttpHeaders authenticateHeader2 = new HttpHeaders();
+			authenticateHeader2.add("Www-Authenticate", "Bearer realm=\"https://demo2.goharbor.io/service/token\",service=\"demo-registry2\",scope=\"registry:category:pull\"");
+			HttpClientErrorException httpClientErrorException2 =
+					HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, "", authenticateHeader2, new byte[0], null);
+
+			when(restTemplate.exchange(eq(new URI("https://demo2.goharbor.io/v2/")),
+					eq(HttpMethod.GET), any(), eq(Map.class))).thenThrow(httpClientErrorException2);
 
 			return restTemplate;
 		}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import org.springframework.cloud.dataflow.container.registry.ContainerImageRestTemplateFactory;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryConfiguration;
+import org.springframework.cloud.dataflow.container.registry.ContainerRegistryProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -39,6 +41,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -50,12 +53,16 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 	@Mock
 	private RestTemplate mockRestTemplate;
 
+	@Mock
+	private ContainerImageRestTemplateFactory containerImageRestTemplateFactory;
+
 	private DockerConfigJsonSecretToRegistryConfigurationConverter converter;
 
 	@Before
 	public void init() {
 		MockitoAnnotations.initMocks(this);
-		converter = new DockerConfigJsonSecretToRegistryConfigurationConverter(mockRestTemplate);
+		when(containerImageRestTemplateFactory.getContainerRestTemplate(anyBoolean(), anyBoolean())).thenReturn(mockRestTemplate);
+		converter = new DockerConfigJsonSecretToRegistryConfigurationConverter(new ContainerRegistryProperties(), containerImageRestTemplateFactory);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -138,10 +138,14 @@ public class ContainerImageRestTemplateFactory {
 	}
 
 	private RestTemplate initRestTemplate(HttpClientBuilder clientBuilder, boolean withHttpProxy) {
-		StringHttpMessageConverter octetToStringMessageConverter = new StringHttpMessageConverter();
+		StringHttpMessageConverter octetToStringMessageConverter = new StringHttpMessageConverter() {
+			@Override
+			public boolean supports(Class<?> clazz) {
+				return true;
+			}
+		};
 		List<MediaType> mediaTypeList = new ArrayList(octetToStringMessageConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
-		mediaTypeList.add(new MediaType("application", "*+json"));
 		octetToStringMessageConverter.setSupportedMediaTypes(mediaTypeList);
 
 		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -141,6 +141,7 @@ public class ContainerImageRestTemplateFactory {
 		StringHttpMessageConverter octetToStringMessageConverter = new StringHttpMessageConverter();
 		List<MediaType> mediaTypeList = new ArrayList(octetToStringMessageConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
+		mediaTypeList.add(new MediaType("application", "*+json"));
 		octetToStringMessageConverter.setSupportedMediaTypes(mediaTypeList);
 
 		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.container.registry;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.dataflow.container.registry.authorization.DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ContainerImageRestTemplateFactory {
+
+	private final RestTemplateBuilder restTemplateBuilder;
+
+	private final ContainerRegistryProperties properties;
+
+	private final Map<CacheKey, RestTemplate> restTemplateCache;
+
+	private static class CacheKey {
+		private final boolean disablesSslVerification;
+		private final boolean useHttpProxy;
+
+		public CacheKey(boolean disablesSslVerification, boolean useHttpProxy) {
+			this.disablesSslVerification = disablesSslVerification;
+			this.useHttpProxy = useHttpProxy;
+		}
+
+		static CacheKey of(boolean disablesSslVerification, boolean useHttpProxy) {
+			return new CacheKey(disablesSslVerification, useHttpProxy);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			CacheKey cacheKey = (CacheKey) o;
+			return disablesSslVerification == cacheKey.disablesSslVerification && useHttpProxy == cacheKey.useHttpProxy;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(disablesSslVerification, useHttpProxy);
+		}
+	}
+
+	public ContainerImageRestTemplateFactory(RestTemplateBuilder restTemplateBuilder, ContainerRegistryProperties properties) {
+		this.restTemplateBuilder = restTemplateBuilder;
+		this.properties = properties;
+		this.restTemplateCache = new ConcurrentHashMap();
+	}
+
+	public RestTemplate getContainerRestTemplate(boolean skipSslVerification, boolean withHttpProxy) {
+		try {
+			CacheKey cacheKey = CacheKey.of(skipSslVerification, withHttpProxy);
+			if (!this.restTemplateCache.containsKey(cacheKey)) {
+				RestTemplate restTemplate = createContainerRestTemplate(skipSslVerification, withHttpProxy);
+				this.restTemplateCache.putIfAbsent(cacheKey, restTemplate);
+			}
+			return this.restTemplateCache.get(cacheKey);
+		}
+		catch (Exception e) {
+			throw new ContainerRegistryException(
+					"Failed to create Container Image RestTemplate for disableSsl:"
+							+ skipSslVerification + ", httpProxy:" + withHttpProxy, e);
+		}
+	}
+
+	public RestTemplate createContainerRestTemplate(boolean skipSslVerification, boolean withHttpProxy)
+			throws NoSuchAlgorithmException, KeyManagementException {
+
+		if (!skipSslVerification) {
+			// Create a RestTemplate that uses custom request factory
+			return this.initRestTemplate(HttpClients.custom(), withHttpProxy);
+		}
+
+		// Trust manager that blindly trusts all SSL certificates.
+		TrustManager[] trustAllCerts = new TrustManager[] {
+				new X509TrustManager() {
+					public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+						return new X509Certificate[0];
+					}
+
+					public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+					}
+
+					public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+					}
+				}
+		};
+		SSLContext sslContext = SSLContext.getInstance("SSL");
+		// Install trust manager to SSL Context.
+		sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+
+		// Create a RestTemplate that uses custom request factory
+		return initRestTemplate(
+				HttpClients.custom()
+						.setSSLContext(sslContext)
+						.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE),
+				withHttpProxy);
+	}
+
+	private RestTemplate initRestTemplate(HttpClientBuilder clientBuilder, boolean withHttpProxy) {
+		StringHttpMessageConverter octetToStringMessageConverter = new StringHttpMessageConverter();
+		List<MediaType> mediaTypeList = new ArrayList(octetToStringMessageConverter.getSupportedMediaTypes());
+		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
+		octetToStringMessageConverter.setSupportedMediaTypes(mediaTypeList);
+
+		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());
+
+		// Set the HTTP proxy if configured.
+		if (withHttpProxy) {
+			HttpHost proxy = new HttpHost(properties.getHttpProxy().getHost(), properties.getHttpProxy().getPort());
+			clientBuilder.setProxy(proxy);
+		}
+
+		HttpComponentsClientHttpRequestFactory customRequestFactory =
+				new HttpComponentsClientHttpRequestFactory(
+						clientBuilder
+								.setRedirectStrategy(new DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy())
+								.build());
+
+		return restTemplateBuilder
+				.additionalMessageConverters(octetToStringMessageConverter)
+				.requestFactory(() -> customRequestFactory)
+				.build();
+	}
+}

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryAutoConfiguration.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,14 @@
  */
 package org.springframework.cloud.dataflow.container.registry;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
-import org.apache.http.HttpHost;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -47,16 +32,11 @@ import org.springframework.cloud.dataflow.container.registry.authorization.AwsEc
 import org.springframework.cloud.dataflow.container.registry.authorization.BasicAuthRegistryAuthorizer;
 import org.springframework.cloud.dataflow.container.registry.authorization.DockerConfigJsonSecretToRegistryConfigurationConverter;
 import org.springframework.cloud.dataflow.container.registry.authorization.DockerOAuth2RegistryAuthorizer;
-import org.springframework.cloud.dataflow.container.registry.authorization.DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy;
 import org.springframework.cloud.dataflow.container.registry.authorization.RegistryAuthorizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Auto configuration for Container Registry.
@@ -71,10 +51,8 @@ public class ContainerRegistryAutoConfiguration {
 	private static final Logger logger = LoggerFactory.getLogger(ContainerRegistryAutoConfiguration.class);
 
 	@Bean
-	public RegistryAuthorizer dockerOAuth2RegistryAuthorizer(
-			@Qualifier("containerRestTemplate") RestTemplate containerRestTemplate,
-			@Qualifier("noSslVerificationContainerRestTemplate") RestTemplate noSslVerificationContainerRestTemplate) {
-		return new DockerOAuth2RegistryAuthorizer(containerRestTemplate, noSslVerificationContainerRestTemplate);
+	public RegistryAuthorizer dockerOAuth2RegistryAuthorizer(ContainerImageRestTemplateFactory containerImageRestTemplateFactory) {
+		return new DockerOAuth2RegistryAuthorizer(containerImageRestTemplateFactory);
 	}
 
 	@Bean
@@ -101,12 +79,11 @@ public class ContainerRegistryAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public ContainerRegistryService containerRegistryService(
-			@Qualifier("containerRestTemplate") RestTemplate containerRestTemplate,
-			@Qualifier("noSslVerificationContainerRestTemplate") RestTemplate trustAnySslRestTemplate,
+			ContainerImageRestTemplateFactory containerImageRestTemplateFactory,
 			ContainerImageParser containerImageParser,
 			Map<String, ContainerRegistryConfiguration> registryConfigurationMap,
 			List<RegistryAuthorizer> registryAuthorizers) {
-		return new ContainerRegistryService(containerRestTemplate, trustAnySslRestTemplate,
+		return new ContainerRegistryService(containerImageRestTemplateFactory,
 				containerImageParser, registryConfigurationMap, registryAuthorizers);
 	}
 
@@ -120,13 +97,14 @@ public class ContainerRegistryAutoConfiguration {
 				properties.getRegistryConfigurations().entrySet().stream()
 						.collect(Collectors.toMap(e -> e.getValue().getRegistryHost(), Map.Entry::getValue));
 
-		// For dockeroauth2 configuration that doesn't have the Docker OAuth2 Access Token entry point set,
-		// use the secretToRegistryConfigurationConverter.getDockerTokenServiceUri() tor retrieve the entry point.
+		// For dockeroauth2 configuration that doesn't have the Docker OAuth2 Access Token entrypoint set explicitly,
+		// use the secretToRegistryConfigurationConverter.getDockerTokenServiceUri() to retrieve the entrypoint.
 		registryConfigurationMap.values().stream()
 				.filter(rc -> rc.getAuthorizationType()
 						== ContainerRegistryConfiguration.AuthorizationType.dockeroauth2)
 				.filter(rc -> !rc.getExtra().containsKey(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY))
-				.forEach(rc -> secretToRegistryConfigurationConverter.getDockerTokenServiceUri(rc.getRegistryHost())
+				.forEach(rc -> secretToRegistryConfigurationConverter.getDockerTokenServiceUri(rc.getRegistryHost(),
+						true, rc.isUseHttpProxy())
 						.ifPresent(tokenServiceUri -> rc.getExtra().put(
 								DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_AUTH_URI_KEY,
 								tokenServiceUri)));
@@ -162,6 +140,7 @@ public class ContainerRegistryAutoConfiguration {
 											propConf.getManifestMediaType() :
 											secretConf.getManifestMediaType());
 									rc.setDisableSslVerification(propConf.isDisableSslVerification());
+									rc.setUseHttpProxy(propConf.isUseHttpProxy());
 									rc.getExtra().putAll(secretConf.getExtra());
 									rc.getExtra().putAll(propConf.getExtra());
 									return rc;
@@ -177,73 +156,14 @@ public class ContainerRegistryAutoConfiguration {
 
 	@Bean
 	public DockerConfigJsonSecretToRegistryConfigurationConverter secretToRegistryConfigurationConverter(
-			@Qualifier("noSslVerificationContainerRestTemplate") RestTemplate trustAnySslRestTemplate) {
-		return new DockerConfigJsonSecretToRegistryConfigurationConverter(trustAnySslRestTemplate);
+			ContainerRegistryProperties properties,
+			ContainerImageRestTemplateFactory containerImageRestTemplate) {
+		return new DockerConfigJsonSecretToRegistryConfigurationConverter(properties, containerImageRestTemplate);
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(name = "containerRestTemplate")
-	public RestTemplate containerRestTemplate(RestTemplateBuilder builder, ContainerRegistryProperties properties) {
-		// Create a RestTemplate that uses custom request factory
-		return this.initRestTemplate(builder, HttpClients.custom(), properties);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(name = "noSslVerificationContainerRestTemplate")
-	public RestTemplate noSslVerificationContainerRestTemplate(RestTemplateBuilder builder, ContainerRegistryProperties properties)
-			throws NoSuchAlgorithmException, KeyManagementException {
-
-		// Trust manager that blindly trusts all SSL certificates.
-		TrustManager[] trustAllCerts = new TrustManager[] {
-				new X509TrustManager() {
-					public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-						return new X509Certificate[0];
-					}
-
-					public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
-					}
-
-					public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
-					}
-				}
-		};
-		SSLContext sslContext = SSLContext.getInstance("SSL");
-		// Install trust manager to SSL Context.
-		sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
-
-		// Create a RestTemplate that uses custom request factory
-		return initRestTemplate(builder,
-				HttpClients.custom()
-						.setSSLContext(sslContext)
-						.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE),
-				properties);
-	}
-
-	private RestTemplate initRestTemplate(RestTemplateBuilder restTemplateBuilder,
-			HttpClientBuilder clientBuilder,
-			ContainerRegistryProperties properties) {
-		StringHttpMessageConverter octetToStringMessageConverter = new StringHttpMessageConverter();
-		List<MediaType> mediaTypeList = new ArrayList(octetToStringMessageConverter.getSupportedMediaTypes());
-		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
-		octetToStringMessageConverter.setSupportedMediaTypes(mediaTypeList);
-
-		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());
-
-		// Set the HTTP proxy if configured.
-		if (properties.getHttpProxy().isEnabled()) {
-			HttpHost proxy = new HttpHost(properties.getHttpProxy().getHost(), properties.getHttpProxy().getPort());
-			clientBuilder.setProxy(proxy);
-		}
-
-		HttpComponentsClientHttpRequestFactory customRequestFactory =
-				new HttpComponentsClientHttpRequestFactory(
-						clientBuilder
-								.setRedirectStrategy(new DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy())
-								.build());
-
-		return restTemplateBuilder
-				.additionalMessageConverters(octetToStringMessageConverter)
-				.requestFactory(() -> customRequestFactory)
-				.build();
+	@ConditionalOnMissingBean(name = "containerImageRestTemplateFactory")
+	public ContainerImageRestTemplateFactory containerImageRestTemplateFactory(RestTemplateBuilder builder, ContainerRegistryProperties properties) {
+		return new ContainerImageRestTemplateFactory(builder, properties);
 	}
 }

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryConfiguration.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,6 +125,11 @@ public class ContainerRegistryConfiguration {
 	 */
 	private boolean disableSslVerification = false;
 
+	/**
+	 * If true all container registry communication will be channeled through a pre-configured Http Proxy.
+	 */
+	private boolean useHttpProxy = false;
+
 	public Map<String, String> getExtra() {
 		return extra;
 	}
@@ -181,6 +186,14 @@ public class ContainerRegistryConfiguration {
 		this.disableSslVerification = disableSslVerification;
 	}
 
+	public boolean isUseHttpProxy() {
+		return useHttpProxy;
+	}
+
+	public void setUseHttpProxy(boolean useHttpProxy) {
+		this.useHttpProxy = useHttpProxy;
+	}
+
 	@Override
 	public String toString() {
 		return "ContainerRegistryConfiguration{" +
@@ -189,7 +202,8 @@ public class ContainerRegistryConfiguration {
 				", secret='****'" + '\'' +
 				", authorizationType=" + authorizationType +
 				", manifestMediaType='" + manifestMediaType + '\'' +
-				", disableSslVerification='" + disableSslVerification + '\'' +
+				", disableSslVerification='" + disableSslVerification + '\''
+				+", useHttpProxy='" + useHttpProxy + '\'' +
 				", extra=" + extra +
 				'}';
 	}

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryProperties.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryProperties.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Christian Tzolov
@@ -57,6 +58,40 @@ public class ContainerRegistryProperties {
 	 * Registry authentication configuration
 	 */
 	private Map<String, ContainerRegistryConfiguration> registryConfigurations = new HashMap<>();
+
+	/**
+	 * HTTP Cache Proxy
+	 */
+	private HttpProxy httpProxy = new HttpProxy();
+
+	public static class HttpProxy {
+		private String host = "";
+		private int port = 0;
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host;
+		}
+
+		public int getPort() {
+			return port;
+		}
+
+		public void setPort(int port) {
+			this.port = port;
+		}
+
+		public boolean isEnabled() {
+			return StringUtils.hasText(host);
+		}
+	}
+
+	public HttpProxy getHttpProxy() {
+		return httpProxy;
+	}
 
 	public Map<String, ContainerRegistryConfiguration> getRegistryConfigurations() {
 		return registryConfigurations;

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
@@ -113,7 +113,7 @@ public class ContainerRegistryService {
 
 			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
 					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
-			return  (manifest != null) ? (List<String>) manifest.getBody().get(TAGS_FIELD) : null;
+			return  (List<String>) manifest.getBody().get(TAGS_FIELD);
 		}
 		catch (Exception e) {
 			logger.error(String.format("Exception getting tag information for the %s from %s", repositoryName, registryName));
@@ -149,7 +149,7 @@ public class ContainerRegistryService {
 
 			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
 					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
-			return (manifest != null) ? manifest.getBody() : null;
+			return manifest.getBody();
 		}
 		catch (Exception e) {
 			logger.error(String.format("Exception getting repositories from %s", registryName));
@@ -209,7 +209,7 @@ public class ContainerRegistryService {
 
 		ResponseEntity<T> manifest = registryRequest.getRestTemplate().exchange(manifestUriComponents.toUri(),
 				HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
-		return (manifest != null) ? manifest.getBody() : null;
+		return manifest.getBody();
 	}
 
 	public <T> T getImageBlob(ContainerRegistryRequest registryRequest, String configDigest, Class<T> responseClassType) {
@@ -227,6 +227,6 @@ public class ContainerRegistryService {
 		ResponseEntity<T> blob = registryRequest.getRestTemplate().exchange(blobUriComponents.toUri(),
 				HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
 
-		return (blob != null) ? blob.getBody() : null;
+		return blob.getBody();
 	}
 }

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
@@ -167,6 +167,10 @@ public class ContainerRegistryService {
 
 		// Find a registry configuration that matches the image's registry host
 		ContainerRegistryConfiguration registryConf = this.registryConfigurations.get(containerImage.getRegistryHost());
+		if (registryConf == null) {
+			throw new ContainerRegistryException(
+					"Could not find an Registry Configuration for: " + containerImage.getRegistryHost());
+		}
 
 		// Retrieve a registry authorizer that supports the configured authorization type.
 		RegistryAuthorizer registryAuthorizer = this.registryAuthorizerMap.get(registryConf.getAuthorizationType());

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.dataflow.container.registry.authorization.DockerOAuth2RegistryAuthorizer;
 import org.springframework.cloud.dataflow.container.registry.authorization.RegistryAuthorizer;
 import org.springframework.http.HttpEntity;
@@ -62,9 +61,7 @@ public class ContainerRegistryService {
 
 	private static final String IMAGE_BLOB_DIGEST_PATH = "v2/{repository}/blobs/{digest}";
 
-	private final RestTemplate containerRestTemplate;
-
-	private final RestTemplate noSslVerificationContainerRestTemplate;
+	private final ContainerImageRestTemplateFactory containerImageRestTemplateFactory;
 
 	private final ContainerImageParser containerImageParser;
 
@@ -72,13 +69,11 @@ public class ContainerRegistryService {
 
 	private final Map<ContainerRegistryConfiguration.AuthorizationType, RegistryAuthorizer> registryAuthorizerMap;
 
-	public ContainerRegistryService(@Qualifier("containerRestTemplate") RestTemplate containerRestTemplate,
-			@Qualifier("noSslVerificationContainerRestTemplate") RestTemplate trustAnySslRestTemplate,
+	public ContainerRegistryService(ContainerImageRestTemplateFactory containerImageRestTemplateFactory,
 			ContainerImageParser containerImageParser,
 			Map<String, ContainerRegistryConfiguration> registryConfigurations,
 			List<RegistryAuthorizer> registryAuthorizers) {
-		this.containerRestTemplate = containerRestTemplate;
-		this.noSslVerificationContainerRestTemplate  = trustAnySslRestTemplate;
+		this.containerImageRestTemplateFactory = containerImageRestTemplateFactory;
 		this.containerImageParser = containerImageParser;
 		this.registryConfigurations = registryConfigurations;
 		this.registryAuthorizerMap = new HashMap<>();
@@ -113,8 +108,9 @@ public class ContainerRegistryService {
 					.path(TAGS_LIST_PATH)
 					.build().expand(repositoryName);
 
-			RestTemplate requestRestTemplate = containerRegistryConfiguration.isDisableSslVerification() ?
-					this.noSslVerificationContainerRestTemplate : this.containerRestTemplate;
+			RestTemplate requestRestTemplate = this.containerImageRestTemplateFactory.getContainerRestTemplate(
+					containerRegistryConfiguration.isDisableSslVerification(), containerRegistryConfiguration.isUseHttpProxy());
+
 			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
 					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
 			return  (manifest != null) ? (List<String>) manifest.getBody().get(TAGS_FIELD) : null;
@@ -147,8 +143,9 @@ public class ContainerRegistryService {
 					.path(CATALOG_LIST_PATH)
 					.build();
 
-			RestTemplate requestRestTemplate = containerRegistryConfiguration.isDisableSslVerification() ?
-					this.noSslVerificationContainerRestTemplate : this.containerRestTemplate;
+
+			RestTemplate requestRestTemplate = this.containerImageRestTemplateFactory.getContainerRestTemplate(
+					containerRegistryConfiguration.isDisableSslVerification(), containerRegistryConfiguration.isUseHttpProxy());
 
 			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
 					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
@@ -186,8 +183,8 @@ public class ContainerRegistryService {
 					"Could not obtain authorized headers for: " + containerImage + ", config:" + registryConf);
 		}
 
-		RestTemplate requestRestTemplate = registryConf.isDisableSslVerification() ?
-				this.noSslVerificationContainerRestTemplate : this.containerRestTemplate;
+		RestTemplate requestRestTemplate = this.containerImageRestTemplateFactory.getContainerRestTemplate(
+				registryConf.isDisableSslVerification(), registryConf.isUseHttpProxy());
 
 		return new ContainerRegistryRequest(containerImage, registryConf, authHttpHeaders, requestRestTemplate);
 	}

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerOAuth2RegistryAuthorizer.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerOAuth2RegistryAuthorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.container.registry.authorization;
 import java.util.Map;
 
 import org.springframework.cloud.dataflow.container.registry.ContainerImage;
+import org.springframework.cloud.dataflow.container.registry.ContainerImageRestTemplateFactory;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryConfiguration;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -45,14 +46,12 @@ public class DockerOAuth2RegistryAuthorizer implements RegistryAuthorizer {
 
 	public static final String DOCKER_REGISTRY_REPOSITORY_FIELD_KEY = "repository";
 
-	private final RestTemplate restTemplate;
-	private final RestTemplate noSslVerificationContainerRestTemplate;
+	private final ContainerImageRestTemplateFactory containerImageRestTemplate;
 
-	public DockerOAuth2RegistryAuthorizer(RestTemplate restTemplate, RestTemplate noSslVerificationContainerRestTemplate) {
-		Assert.notNull(restTemplate, "Non null restTemplate is expected!");
-		Assert.notNull(noSslVerificationContainerRestTemplate, "Non null noSslVerificationContainerRestTemplate is expected!");
-		this.restTemplate = restTemplate;
-		this.noSslVerificationContainerRestTemplate = noSslVerificationContainerRestTemplate;
+	public DockerOAuth2RegistryAuthorizer(
+			ContainerImageRestTemplateFactory containerImageRestTemplate) {
+		Assert.notNull(containerImageRestTemplate, "Non null containerImageRestTemplate is expected!");
+		this.containerImageRestTemplate = containerImageRestTemplate;
 	}
 
 	@Override
@@ -123,7 +122,7 @@ public class DockerOAuth2RegistryAuthorizer implements RegistryAuthorizer {
 	}
 
 	private RestTemplate getRestTemplate(ContainerRegistryConfiguration registryConfiguration) {
-		return registryConfiguration.isDisableSslVerification() ?
-				this.noSslVerificationContainerRestTemplate : this.restTemplate;
+		return this.containerImageRestTemplate.getContainerRestTemplate(registryConfiguration.isDisableSslVerification(),
+				registryConfiguration.isUseHttpProxy());
 	}
 }

--- a/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest.java
+++ b/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import org.springframework.cloud.dataflow.container.registry.ContainerImageRestTemplateFactory;
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryConfiguration;
+import org.springframework.cloud.dataflow.container.registry.ContainerRegistryProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -39,6 +41,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -50,12 +53,16 @@ public class DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest
 	@Mock
 	private RestTemplate mockRestTemplate;
 
+	@Mock
+	private ContainerImageRestTemplateFactory containerImageRestTemplateFactory;
+
 	private DockerConfigJsonSecretToRegistryConfigurationConverter converter;
 
 	@Before
 	public void init() {
 		MockitoAnnotations.initMocks(this);
-		converter = new DockerConfigJsonSecretToRegistryConfigurationConverter(mockRestTemplate);
+		when(containerImageRestTemplateFactory.getContainerRestTemplate(anyBoolean(), anyBoolean())).thenReturn(mockRestTemplate);
+		converter = new DockerConfigJsonSecretToRegistryConfigurationConverter(new ContainerRegistryProperties(), containerImageRestTemplateFactory);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.21.0</version>
+				<version>0.33.0</version>
 				<configuration>
 				  <images>
 					<image>


### PR DESCRIPTION
  - Add spring.cloud.dataflow.container.httpProxy.host and spring.cloud.dataflow.container.httpProxy.port properties to configure HTTP Proxy for container registry access.
  - Update the RestTemplate to include the proxy configuration when the proxy host is not empty.

  Resolves #4295

Do not merge until E2E test with HTTP Proxy is performed. 