### PR TITLE
Overhaul task handling for versions and arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
 		<module>spring-cloud-dataflow-core</module>
 		<module>spring-cloud-dataflow-registry</module>
 		<module>spring-cloud-dataflow-rest-resource</module>
+		<module>spring-cloud-dataflow-composed-task-runner</module>
 		<module>spring-cloud-dataflow-server-core</module>
 		<module>spring-cloud-dataflow-autoconfigure</module>
 		<module>spring-cloud-dataflow-server</module>
@@ -117,7 +118,6 @@
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
 		<module>spring-cloud-dataflow-audit</module>
-		<module>spring-cloud-dataflow-composed-task-runner</module>
 		<module>spring-cloud-dataflow-test</module>
 	</modules>
 	<dependencyManagement>

--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2020 the original author or authors.
-  ~
-  ~  Licensed under the Apache License, Version 2.0 (the "License");
-  ~  you may not use this file except in compliance with the License.
-  ~  You may obtain a copy of the License at
-  ~
-  ~          https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  Unless required by applicable law or agreed to in writing, software
-  ~  distributed under the License is distributed on an "AS IS" BASIS,
-  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~  See the License for the specific language governing permissions and
-  ~  limitations under the License.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -116,8 +102,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-common-security-config-web</artifactId>
-			<version>${spring-cloud-common-security-config.version}</version>
+			<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,15 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 			.collect(Collectors.toList());
 
 		taskLauncherTasklet.setArguments(argumentsToUse);
-		taskLauncherTasklet.setProperties(this.taskSpecificProps);
+
+		Map<String, String> propertiesFrom = this.composedTaskProperties.getComposedTaskAppProperties().entrySet().stream()
+			.filter(e -> e.getKey().startsWith("app." + taskNameId))
+			.collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+		Map<String, String> propertiesToUse = new HashMap<>();
+		propertiesToUse.putAll(this.taskSpecificProps);
+		propertiesToUse.putAll(propertiesFrom);
+
+		taskLauncherTasklet.setProperties(propertiesToUse);
 
 		String stepName = this.taskName;
 

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,7 +242,6 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 	 */
 	static class TaskAppsMapCollector extends TaskVisitor {
 
-		// Map<String, Integer> taskApps = new HashMap<>();
 		Map<String, TaskAppNodeHolder> taskApps = new HashMap<>();
 
 		@Override
@@ -252,7 +251,6 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 				taskApps.put(taskApp.getName(), new TaskAppNodeHolder(taskApp, updatedCount));
 			}
 			else {
-				// taskApps.put(taskApp.getName(), 0);
 				taskApps.put(taskApp.getName(), new TaskAppNodeHolder(taskApp, 0));
 			}
 		}
@@ -265,7 +263,6 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), updatedCount));
 					}
 				else {
-					// taskApps.put(transition.getTargetApp().getName(), 0);
 					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), 0));
 				}
 			}
@@ -285,5 +282,4 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 			this.count = count;
 		}
 	}
-
 }

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.codehaus.plexus.util.cli.CommandLineUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -49,6 +51,8 @@ import org.springframework.util.StringUtils;
 public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistrar,
 		EnvironmentAware {
 
+	private final static Logger log = LoggerFactory.getLogger(StepBeanDefinitionRegistrar.class);
+
 	private Environment env;
 
 	private boolean firstAdd;
@@ -63,18 +67,19 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 		}
 		TaskParser taskParser = new TaskParser("bean-registration",
 				properties.getGraph(), false, true);
-		Map<String, Integer> taskSuffixMap = getTaskApps(taskParser);
+		Map<String, TaskAppNodeHolder> taskSuffixMap = getTaskApps(taskParser);
 		for (String taskName : taskSuffixMap.keySet()) {
-			//handles the possibility that multiple instances of
+			// handles the possibility that multiple instances of
 			// task definition exist in a composed task
-			for (int taskSuffix = 0; taskSuffixMap.get(taskName) >= taskSuffix; taskSuffix++) {
+			for (int taskSuffix = 0; taskSuffixMap.get(taskName).count >= taskSuffix; taskSuffix++) {
 				BeanDefinitionBuilder builder = BeanDefinitionBuilder
 						.rootBeanDefinition(ComposedTaskRunnerStepFactory.class);
 				builder.addConstructorArgValue(properties);
 				builder.addConstructorArgValue(String.format("%s_%s",
 						taskName, taskSuffix));
+				builder.addConstructorArgValue(taskName.replaceFirst(ctrName + "-", ""));
 				builder.addPropertyValue("taskSpecificProps",
-						getPropertiesForTask(taskName, properties));
+						getPropertiesForTask(taskName, properties, taskSuffixMap.get(taskName)));
 				String args = getCommandLineArgsForTask(properties.getComposedTaskArguments(), taskName, taskSuffixMap, ctrName);
 				builder.addPropertyValue("arguments", args);
 				registry.registerBeanDefinition(String.format("%s_%s",
@@ -82,7 +87,9 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 			}
 		}
 	}
-	private String getCommandLineArgsForTask(String arguments, String taskName, Map<String, Integer> taskSuffixMap, String ctrName ) {
+
+
+	private String getCommandLineArgsForTask(String arguments, String taskName, Map<String, TaskAppNodeHolder> taskSuffixMap, String ctrName ) {
 		String result = "";
 		if(!StringUtils.hasText(arguments)) {
 			return arguments;
@@ -150,12 +157,14 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 		return commandLineArgPrefix;
 	}
 
-	private Map<String, String> getPropertiesForTask(String taskName, ComposedTaskProperties properties) {
+	private Map<String, String> getPropertiesForTask(String taskName, ComposedTaskProperties properties, TaskAppNodeHolder holder) {
 		Map<String, String> taskDeploymentProperties =
 				DeploymentPropertiesUtils.parse(properties.getComposedTaskProperties());
 		Map<String, String> deploymentProperties = new HashMap<>();
 		updateDeploymentProperties(String.format("app.%s.", taskName), taskDeploymentProperties, deploymentProperties);
 		updateDeploymentProperties(String.format("deployer.%s.", taskName), taskDeploymentProperties, deploymentProperties);
+		String subTaskName = taskName.substring(taskName.indexOf('-') + 1);
+		updateVersionDeploymentProperties(taskName, subTaskName, taskDeploymentProperties, deploymentProperties);
 		return deploymentProperties;
 	}
 
@@ -165,6 +174,19 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 			if (entry.getKey().startsWith(prefix)) {
 				deploymentProperties.put(entry.getKey()
 						.substring(prefix.length()), entry.getValue());
+			}
+		}
+	}
+
+	private void updateVersionDeploymentProperties(String taskName,String subTaskName, Map<String, String> taskDeploymentProperties,
+			Map<String, String> deploymentProperties) {
+		String prefix = String.format("version.%s", taskName);
+		String key = String.format("version.%s", subTaskName);
+		for (Map.Entry<String, String> entry : taskDeploymentProperties.entrySet()) {
+			if (entry.getKey().startsWith(prefix)) {
+				String realkey = String.format("version%s", entry.getKey().replaceFirst("^" + prefix, ""));
+				log.debug("updateVersionDeploymentProperties {} {} {}", key, entry.getValue(), realkey);
+				deploymentProperties.put(realkey, entry.getValue());
 			}
 		}
 	}
@@ -208,7 +230,7 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 	 * @return a {@link Map} of task app name as the key and the number of times it occurs
 	 * as the value.
 	 */
-	private Map<String, Integer> getTaskApps(TaskParser taskParser) {
+	private Map<String, TaskAppNodeHolder> getTaskApps(TaskParser taskParser) {
 		TaskAppsMapCollector collector = new TaskAppsMapCollector();
 		taskParser.parse().accept(collector);
 		return collector.getTaskApps();
@@ -220,36 +242,48 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 	 */
 	static class TaskAppsMapCollector extends TaskVisitor {
 
-		Map<String, Integer> taskApps = new HashMap<>();
+		// Map<String, Integer> taskApps = new HashMap<>();
+		Map<String, TaskAppNodeHolder> taskApps = new HashMap<>();
 
 		@Override
 		public void visit(TaskAppNode taskApp) {
 			if (taskApps.containsKey(taskApp.getName())) {
-				Integer updatedCount = taskApps.get(taskApp.getName()) + 1;
-				taskApps.put(taskApp.getName(), updatedCount);
+				int updatedCount = taskApps.get(taskApp.getName()).count + 1;
+				taskApps.put(taskApp.getName(), new TaskAppNodeHolder(taskApp, updatedCount));
 			}
 			else {
-				taskApps.put(taskApp.getName(), 0);
+				// taskApps.put(taskApp.getName(), 0);
+				taskApps.put(taskApp.getName(), new TaskAppNodeHolder(taskApp, 0));
 			}
 		}
 
 		@Override
 		public void visit(TransitionNode transition) {
 			if (transition.isTargetApp()) {
-				if (taskApps.containsKey(transition.getTargetApp())) {
-					Integer updatedCount = taskApps.get(transition.getTargetApp()) + 1;
-					taskApps.put(transition.getTargetApp().getName(), updatedCount);
-				}
+				if (taskApps.containsKey(transition.getTargetApp().getName())) {
+					int updatedCount = taskApps.get(transition.getTargetApp().getName()).count + 1;
+					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), updatedCount));
+					}
 				else {
-					taskApps.put(transition.getTargetApp().getName(), 0);
+					// taskApps.put(transition.getTargetApp().getName(), 0);
+					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), 0));
 				}
 			}
 		}
 
-		public Map<String, Integer> getTaskApps() {
+		public Map<String, TaskAppNodeHolder> getTaskApps() {
 			return taskApps;
 		}
 
+	}
+
+	static class TaskAppNodeHolder {
+		TaskAppNode taskAppNode;
+		int count;
+		TaskAppNodeHolder(TaskAppNode taskAppNode, int count) {
+			this.taskAppNode = taskAppNode;
+			this.count = count;
+		}
 	}
 
 }

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -261,7 +261,7 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 				if (taskApps.containsKey(transition.getTargetApp().getName())) {
 					int updatedCount = taskApps.get(transition.getTargetApp().getName()).count + 1;
 					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), updatedCount));
-					}
+				}
 				else {
 					taskApps.put(transition.getTargetApp().getName(), new TaskAppNodeHolder(transition.getTargetApp(), 0));
 				}

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.composedtaskrunner.properties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -120,6 +122,11 @@ public class ComposedTaskProperties {
 	 * The arguments to be used for each of the tasks.
 	 */
 	private String composedTaskArguments;
+
+	/**
+	 * Properties for defining task app arguments.
+	 */
+	private Map<String, String> composedTaskAppArguments = new HashMap<>();
 
 	/**
 	 * Specifies whether to allow split core threads to timeout.
@@ -242,6 +249,14 @@ public class ComposedTaskProperties {
 
 	public void setComposedTaskArguments(String composedTaskArguments) {
 		this.composedTaskArguments = composedTaskArguments;
+	}
+
+	public Map<String, String> getComposedTaskAppArguments() {
+		return composedTaskAppArguments;
+	}
+
+	public void setComposedTaskAppArguments(Map<String, String> composedTaskAppArguments) {
+		this.composedTaskAppArguments = composedTaskAppArguments;
 	}
 
 	public boolean isSplitThreadAllowCoreThreadTimeout() {

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,11 @@ public class ComposedTaskProperties {
 	 * Properties for defining task app arguments.
 	 */
 	private Map<String, String> composedTaskAppArguments = new HashMap<>();
+
+	/**
+	 * Properties for defining task app properties.
+	 */
+	private Map<String, String> composedTaskAppProperties = new HashMap<>();
 
 	/**
 	 * Specifies whether to allow split core threads to timeout.
@@ -257,6 +262,14 @@ public class ComposedTaskProperties {
 
 	public void setComposedTaskAppArguments(Map<String, String> composedTaskAppArguments) {
 		this.composedTaskAppArguments = composedTaskAppArguments;
+	}
+
+	public Map<String, String> getComposedTaskAppProperties() {
+		return composedTaskAppProperties;
+	}
+
+	public void setComposedTaskAppProperties(Map<String, String> composedTaskAppProperties) {
+		this.composedTaskAppProperties = composedTaskAppProperties;
 	}
 
 	public boolean isSplitThreadAllowCoreThreadTimeout() {

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.composedtaskrunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration;
+import org.springframework.cloud.dataflow.composedtaskrunner.configuration.DataFlowTestConfiguration;
+import org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties;
+import org.springframework.cloud.dataflow.rest.client.TaskOperations;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Janne Valkealahti
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes={EmbeddedDataSourceConfiguration.class,
+		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
+		ComposedTaskRunnerConfiguration.class,
+		StepBeanDefinitionRegistrar.class})
+@TestPropertySource(properties = {"graph=ComposedTest-AAA && ComposedTest-BBB && ComposedTest-CCC","max-wait-time=1010",
+		"interval-time-between-checks=1100",
+        "composed-task-app-arguments.app.AAA.0=--arg1=value1",
+        "composed-task-app-arguments.app.AAA.1=--arg2=value2",
+		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
+@EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
+public class ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests {
+
+	@Autowired
+	private JobRepository jobRepository;
+
+	@Autowired
+	private Job job;
+
+	@Autowired
+	private TaskOperations taskOperations;
+
+	@Autowired
+	private ComposedTaskProperties composedTaskProperties;
+
+	@Test
+	@DirtiesContext
+	public void testComposedConfiguration() throws Exception {
+		JobExecution jobExecution = this.jobRepository.createJobExecution(
+				"ComposedTest", new JobParameters());
+		job.execute(jobExecution);
+
+		Map<String, String> props = new HashMap<>(1);
+		assertThat(composedTaskProperties.getComposedTaskProperties()).isNull();
+		assertThat(composedTaskProperties.getMaxWaitTime()).isEqualTo(1010);
+		assertThat(composedTaskProperties.getIntervalTimeBetweenChecks()).isEqualTo(1100);
+		assertThat(composedTaskProperties.getDataflowServerUri().toASCIIString()).isEqualTo("https://bar");
+		List<String> args = new ArrayList<>(1);
+		args.add("--arg2=value2");
+		args.add("--arg1=value1");
+		assertThat(job.getJobParametersIncrementer()).withFailMessage("JobParametersIncrementer must not be null.").isNotNull();
+		verify(this.taskOperations).launch("ComposedTest-AAA", props, args);
+	}
+}

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesNoLabelTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesNoLabelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -39,12 +41,14 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.Assert;
 
-import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Janne Valkealahti
+ * @author Glenn Renfro
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes={EmbeddedDataSourceConfiguration.class,
@@ -52,12 +56,12 @@ import static org.mockito.Mockito.verify;
 		ComposedTaskRunnerConfiguration.class,
 		StepBeanDefinitionRegistrar.class})
 @TestPropertySource(properties = {"graph=ComposedTest-AAA && ComposedTest-BBB && ComposedTest-CCC","max-wait-time=1010",
+		"composed-task-app-properties.app.AAA.format=yyyy",
 		"interval-time-between-checks=1100",
-        "composed-task-app-arguments.app.AAA.0=--arg1=value1",
-        "composed-task-app-arguments.app.AAA.1=--arg2=value2",
+		"composed-task-arguments=--baz=boo --AAA.foo=bar BBB.que=qui",
 		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
 @EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
-public class ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests {
+public class ComposedTaskRunnerConfigurationWithPropertiesNoLabelTests {
 
 	@Autowired
 	private JobRepository jobRepository;
@@ -79,14 +83,17 @@ public class ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests {
 		job.execute(jobExecution);
 
 		Map<String, String> props = new HashMap<>(1);
-		assertThat(composedTaskProperties.getComposedTaskProperties()).isNull();
-		assertThat(composedTaskProperties.getMaxWaitTime()).isEqualTo(1010);
-		assertThat(composedTaskProperties.getIntervalTimeBetweenChecks()).isEqualTo(1100);
-		assertThat(composedTaskProperties.getDataflowServerUri().toASCIIString()).isEqualTo("https://bar");
+		props.put("app.AAA.format", "yyyy");
+		Map<String, String> composedTaskAppProperties = new HashMap<>(1);
+		composedTaskAppProperties.put("app.AAA.format", "yyyy");
+
+		assertEquals(composedTaskAppProperties, composedTaskProperties.getComposedTaskAppProperties());
+		assertEquals(1010, composedTaskProperties.getMaxWaitTime());
+		assertEquals(1100, composedTaskProperties.getIntervalTimeBetweenChecks());
+		assertEquals("https://bar", composedTaskProperties.getDataflowServerUri().toASCIIString());
 		List<String> args = new ArrayList<>(1);
-		args.add("--arg2=value2");
-		args.add("--arg1=value1");
-		assertThat(job.getJobParametersIncrementer()).withFailMessage("JobParametersIncrementer must not be null.").isNotNull();
+		args.add("--baz=boo --foo=bar");
+		Assert.notNull(job.getJobParametersIncrementer(), "JobParametersIncrementer must not be null.");
 		verify(this.taskOperations).launch("ComposedTest-AAA", props, args);
 	}
 }

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithVersionPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithVersionPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithVersionPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithVersionPropertiesTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.composedtaskrunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration;
+import org.springframework.cloud.dataflow.composedtaskrunner.configuration.DataFlowTestConfiguration;
+import org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties;
+import org.springframework.cloud.dataflow.rest.client.TaskOperations;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Janne Valkealahti
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes={EmbeddedDataSourceConfiguration.class,
+		DataFlowTestConfiguration.class,StepBeanDefinitionRegistrar.class,
+		ComposedTaskRunnerConfiguration.class,
+		StepBeanDefinitionRegistrar.class})
+@TestPropertySource(properties = {"graph=ComposedTest-AAA && ComposedTest-BBB && ComposedTest-CCC","max-wait-time=1010",
+"composed-task-properties=" + ComposedTaskRunnerConfigurationWithVersionPropertiesTests.COMPOSED_TASK_PROPS ,
+		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo --AAA.foo=bar BBB.que=qui",
+		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
+@EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
+public class ComposedTaskRunnerConfigurationWithVersionPropertiesTests {
+
+	@Autowired
+	private JobRepository jobRepository;
+
+	@Autowired
+	private Job job;
+
+	@Autowired
+	private TaskOperations taskOperations;
+
+	@Autowired
+	private ComposedTaskProperties composedTaskProperties;
+
+	protected static final String COMPOSED_TASK_PROPS = "version.ComposedTest-AAA.AAA=1.0.0";
+
+	@Test
+	@DirtiesContext
+	public void testComposedConfiguration() throws Exception {
+		JobExecution jobExecution = this.jobRepository.createJobExecution(
+				"ComposedTest", new JobParameters());
+		job.execute(jobExecution);
+
+		Map<String, String> props = new HashMap<>(1);
+		props.put("version.AAA", "1.0.0");
+		assertThat(composedTaskProperties.getComposedTaskProperties()).isEqualTo(COMPOSED_TASK_PROPS);
+		assertThat(composedTaskProperties.getMaxWaitTime()).isEqualTo(1010);
+		assertThat(composedTaskProperties.getIntervalTimeBetweenChecks()).isEqualTo(1100);
+		assertThat(composedTaskProperties.getDataflowServerUri().toASCIIString()).isEqualTo("https://bar");
+		List<String> args = new ArrayList<>(1);
+		args.add("--baz=boo --foo=bar");
+		assertThat(job.getJobParametersIncrementer()).withFailMessage("JobParametersIncrementer must not be null.").isNotNull();
+		verify(this.taskOperations).launch("ComposedTest-AAA", props, args);
+	}
+}

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactoryTests.java
@@ -70,6 +70,11 @@ public class ComposedTaskRunnerStepFactoryTests {
 		public TaskOperations taskOperations;
 
 		@Bean
+		public ComposedTaskProperties composedTaskProperties() {
+			return new ComposedTaskProperties();
+		}
+
+		@Bean
 		public TaskProperties taskProperties() {
 			return new TaskProperties();
 		}
@@ -106,7 +111,7 @@ public class ComposedTaskRunnerStepFactoryTests {
 
 		@Bean
 		public ComposedTaskRunnerStepFactory stepFactory(TaskProperties taskProperties) {
-			return new ComposedTaskRunnerStepFactory(new ComposedTaskProperties(), "FOOBAR");
+			return new ComposedTaskRunnerStepFactory(new ComposedTaskProperties(), "FOOBAR", "BAR");
 		}
 	}
 }

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
@@ -18,9 +18,17 @@ package org.springframework.cloud.dataflow.composedtaskrunner.properties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,6 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @author Gunnar Hillert
  */
 public class ComposedTaskPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
 	@Test
 	public void testGettersAndSetters() throws URISyntaxException{
@@ -72,5 +82,30 @@ public class ComposedTaskPropertiesTests {
 		assertFalse(properties.isSplitThreadWaitForTasksToCompleteOnShutdown());
 		assertNull(properties.getDataflowServerUsername());
 		assertNull(properties.getDataflowServerPassword());
+	}
+
+	@Test
+	public void testComposedTaskAppArguments() {
+		this.contextRunner
+				.withInitializer(context -> {
+					Map<String, Object> map = new HashMap<>();
+					map.put("composed-task-app-arguments.app.AAA", "arg1");
+					map.put("composed-task-app-arguments.app.AAA.1", "arg2");
+					map.put("composed-task-app-arguments.app.AAA.2", "arg3");
+					context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+						StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
+				})
+				.withUserConfiguration(Config1.class)
+				.run((context) -> {
+					ComposedTaskProperties properties = context.getBean(ComposedTaskProperties.class);
+					assertThat(properties.getComposedTaskAppArguments()).hasSize(3);
+					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA", "arg1");
+					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA.1", "arg2");
+					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA.2", "arg3");
+				});
+	}
+
+	@EnableConfigurationProperties({ ComposedTaskProperties.class })
+	private static class Config1 {
 	}
 }

--- a/spring-cloud-dataflow-dependencies/pom.xml
+++ b/spring-cloud-dataflow-dependencies/pom.xml
@@ -76,6 +76,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dataflow-composed-task-runner</artifactId>
+				<version>2.8.0-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-server-core</artifactId>
 				<version>2.8.0-SNAPSHOT</version>
 			</dependency>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -265,7 +265,7 @@ public final class DeploymentPropertiesUtils {
 		for (Entry<String, String> property : properties.entrySet()) {
 			String key = property.getKey();
 			if (!key.startsWith("app.") && !key.startsWith("deployer.")
-					&& !key.startsWith("scheduler.")) {
+					&& !key.startsWith("scheduler.") && !key.startsWith("version.")) {
 				throw new IllegalArgumentException(
 						"Only deployment property keys starting with 'app.', 'deployer.' or, 'scheduler.' allowed, got '" + key + "'");
 			}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -480,34 +480,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 			throw new IllegalStateException("Deployment ID is null for the task:" + taskExecution.getTaskName());
 		}
 		this.updateExternalExecutionId(taskExecution.getExecutionId(), taskDeploymentId);
-	}
-
-	/**
-	 * Updates the deployment properties on the provided {@code AppDeploymentRequest}
-	 *
-	 * @param commandLineArgs command line args for the task execution
-	 * @param platformName name of the platform configuration to use
-	 * @param taskExecutionInformation details about the task execution request
-	 * @param taskExecution task execution data
-	 * @param deploymentProperties properties of the deployment
-	 * @return an updated {@code AppDeploymentRequest}
-	 */
-	private AppDeploymentRequest updateDeploymentProperties(List<String> commandLineArgs, String platformName,
-			String platformType,
-			TaskExecutionInformation taskExecutionInformation, TaskExecution taskExecution,
-			Map<String, String> deploymentProperties) {
-		AppDeploymentRequest appDeploymentRequest;
-		TaskExecutionInformation info = new TaskExecutionInformation();
-		info.setTaskDefinition(taskExecutionInformation.getTaskDefinition());
-		info.setAppResource(taskExecutionInformation.getAppResource());
-		info.setComposed(taskExecutionInformation.isComposed());
-		info.setMetadataResource(taskExecutionInformation.getMetadataResource());
-		info.setOriginalTaskDefinition(taskExecutionInformation.getOriginalTaskDefinition());
-		info.setTaskDeploymentProperties(deploymentProperties);
-
-		appDeploymentRequest = this.taskAppDeploymentRequestCreator.
-				createRequest(taskExecution, info, commandLineArgs, platformName, platformType);
-		return appDeploymentRequest;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.task.listener.TaskException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of the {@link DefaultTaskSaveService} interface. Provide service
@@ -98,8 +99,9 @@ public class DefaultTaskSaveService implements TaskSaveService {
 		if (taskNode.isComposed()) {
 			// Create the child task definitions needed for the composed task
 			taskNode.getTaskApps().forEach(task -> {
+				String labelPrefix = StringUtils.hasText(task.getLabel()) ? task.getLabel() + ":" : "";
 				// Add arguments to child task definitions
-				String generatedTaskDSL = task.getName() + task.getArguments().entrySet().stream()
+				String generatedTaskDSL = labelPrefix + task.getName() + task.getArguments().entrySet().stream()
 						.map(argument -> String.format(" --%s=%s", argument.getKey(),
 								DefinitionUtils.autoQuotes(argument.getValue())))
 						.collect(Collectors.joining());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskAppDeploymentRequestCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,9 +97,11 @@ public class TaskAppDeploymentRequestCreator {
 		TaskDefinition taskDefinition = taskExecutionInformation.getTaskDefinition();
 		String registeredAppName = taskDefinition.getRegisteredAppName();
 		Map<String, String> appDeploymentProperties = new HashMap<>(commonApplicationProperties.getTask());
+		String label = TaskServiceUtils.labelForSimpleTask(taskDefinition.getName(), taskDefinition.getDslText());
 		appDeploymentProperties.putAll(
 				TaskServiceUtils.extractAppProperties(
 						taskExecutionInformation.isComposed() ? "composed-task-runner" : registeredAppName,
+						label,
 						taskExecutionInformation.getTaskDeploymentProperties()));
 
 		// Merge the common properties defined via the spring.cloud.dataflow.common-properties.task-resource file.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -94,6 +94,7 @@ public class TaskServiceUtils {
 		for (TaskApp subTask : taskNode.getTaskApps()) {
 			result = updateProperties(taskNode, subTask, taskDeploymentProperties, result, "app");
 			result = updateProperties(taskNode, subTask, taskDeploymentProperties, result, "deployer");
+			result = updateVersionProperties(taskNode, subTask, taskDeploymentProperties, result, "version");
 		}
 		if (result.length() != 0) {
 			taskDeploymentProperties.put("app.composed-task-runner.composed-task-properties", result);
@@ -233,6 +234,29 @@ public class TaskServiceUtils {
 					taskProperty.substring(subTaskName.length()),
 					taskDeploymentProperties.get(taskProperty));
 			taskDeploymentProperties.remove(taskProperty);
+		}
+		return result;
+	}
+
+	private static String updateVersionProperties(TaskNode taskNode, TaskApp subTask, Map<String, String> taskDeploymentProperties,
+			String result, String prefix) {
+		String subTaskName1 = String.format("%s.%s-%s", prefix, taskNode.getName(),
+				(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
+		String subTaskName2 = String.format("%s.%s", prefix,
+				(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
+		// String subTaskName3 = subTask.getLabel() == null ? subTask.getName() : subTask.getLabel();
+		String subTaskName3 = subTask.getName();
+
+		String versionProperties = taskDeploymentProperties.entrySet().stream()
+				.filter(e -> e.getKey().startsWith(subTaskName1) || e.getKey().startsWith(subTaskName2))
+				// .map(e -> e.getKey() + "=" + e.getValue())
+				.map(e -> String.format("%s.%s", subTaskName1, subTaskName3) + "=" + e.getValue())
+				.collect(Collectors.joining(", "));
+		if (StringUtils.hasText(versionProperties)) {
+			if (result.length() != 0) {
+				result += ", ";
+			}
+			result += versionProperties;
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -96,7 +96,7 @@ public class TaskServiceUtils {
 		for (TaskApp subTask : taskNode.getTaskApps()) {
 			result = updateProperties(taskNode, subTask, taskDeploymentProperties, result, "app");
 			result = updateProperties(taskNode, subTask, taskDeploymentProperties, result, "deployer");
-			result = updateVersionProperties(taskNode, subTask, taskDeploymentProperties, result, "version");
+			result = updateVersionProperties(taskNode, subTask, taskDeploymentProperties, result);
 			taskAppProperties.putAll(getTaskAppProperties(taskNode, subTask, taskDeploymentProperties, "app"));
 		}
 		if (result.length() != 0) {
@@ -285,17 +285,16 @@ public class TaskServiceUtils {
 	}
 
 	private static String updateVersionProperties(TaskNode taskNode, TaskApp subTask, Map<String, String> taskDeploymentProperties,
-			String result, String prefix) {
+			String result) {
+		String prefix = "version";
 		String subTaskName1 = String.format("%s.%s-%s", prefix, taskNode.getName(),
 				(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
 		String subTaskName2 = String.format("%s.%s", prefix,
 				(subTask.getLabel() == null) ? subTask.getName() : subTask.getLabel());
-		// String subTaskName3 = subTask.getLabel() == null ? subTask.getName() : subTask.getLabel();
 		String subTaskName3 = subTask.getName();
 
 		String versionProperties = taskDeploymentProperties.entrySet().stream()
 				.filter(e -> e.getKey().startsWith(subTaskName1) || e.getKey().startsWith(subTaskName2))
-				// .map(e -> e.getKey() + "=" + e.getValue())
 				.map(e -> String.format("%s.%s", subTaskName1, subTaskName3) + "=" + e.getValue())
 				.collect(Collectors.joining(", "));
 		if (StringUtils.hasText(versionProperties)) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,13 +306,13 @@ public class TaskControllerTests {
 
 		TaskDefinition myTask1 = repository.findById("myTask-t1").get();
 		assertThat(myTask1.getProperties().get("foo")).isEqualTo("bar rab");
-		assertThat(myTask1.getDslText()).isEqualTo("task --foo='bar rab'");
+		assertThat(myTask1.getDslText()).isEqualTo("t1:task --foo='bar rab'");
 		assertThat(myTask1.getRegisteredAppName()).isEqualTo("task");
 		assertThat(myTask1.getName()).isEqualTo("myTask-t1");
 
 		TaskDefinition myTask2 = repository.findById("myTask-t2").get();
 		assertThat(myTask2.getProperties().get("foo")).isEqualTo("one two");
-		assertThat(myTask2.getDslText()).isEqualTo("task --foo='one two'");
+		assertThat(myTask2.getDslText()).isEqualTo("t2:task --foo='one two'");
 		assertThat(myTask2.getRegisteredAppName()).isEqualTo("task");
 		assertThat(myTask2.getName()).isEqualTo("myTask-t2");
 	}
@@ -589,7 +589,6 @@ public class TaskControllerTests {
 				"1.0.0", new URI("file:src/test/resources/apps/foo-task"), null);
 
 		mockMvc.perform(post("/tasks/executions")
-				// .param("name", "myTask3")
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.content(EntityUtils.toString(new UrlEncodedFormEntity(Arrays.asList(
 						new BasicNameValuePair("name", "myTask3"),

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -567,68 +567,64 @@ public abstract class DefaultTaskExecutionServiceTests {
 		}
 
 		private void setupUpgradeForCommandLineArgsChange() throws IOException {
-			 TaskExecution myTask = this.taskRepository.createTaskExecution(TASK_NAME_ORIG);
-			 TaskManifest manifest = new TaskManifest();
-			 manifest.setPlatformName("default");
-			 AppDeploymentRequest request = new AppDeploymentRequest(new AppDefinition("some-name", null),
-					 new FileUrlResource("src/test/resources/apps/foo-task"));
-			 manifest.setTaskDeploymentRequest(request);
+			TaskExecution myTask = this.taskRepository.createTaskExecution(TASK_NAME_ORIG);
+			TaskManifest manifest = new TaskManifest();
+			manifest.setPlatformName("default");
+			AppDeploymentRequest request = new AppDeploymentRequest(new AppDefinition("some-name", null),
+					new FileUrlResource("src/test/resources/apps/foo-task"));
+			manifest.setTaskDeploymentRequest(request);
 
-			 this.dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			 this.taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			 this.taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			this.dataflowTaskExecutionMetadataDao.save(myTask, manifest);
+			this.taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
+			this.taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
 
-			 initializeSuccessfulRegistry(appRegistry);
+			initializeSuccessfulRegistry(appRegistry);
 
-			 when(taskLauncher.launch(any())).thenReturn("0");
+			when(taskLauncher.launch(any())).thenReturn("0");
 
-			 Map<String,String> deploymentProperties = new HashMap<>(1);
+			Map<String,String> deploymentProperties = new HashMap<>(1);
 
-			 this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.singletonList("--foo=bar"));
-			 TaskManifest lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			 assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
-			 assertEquals("--foo=bar", lastManifest.getTaskDeploymentRequest().getCommandlineArguments().get(0));
+			this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.singletonList("--foo=bar"));
+			TaskManifest lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
+			assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
+			assertEquals("--foo=bar", lastManifest.getTaskDeploymentRequest().getCommandlineArguments().get(0));
 
-			 this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.emptyList());
-			 lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			 assertEquals(1, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
-		 }
+			this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.emptyList());
+			lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
+			assertEquals(1, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
+		}
 
-		 @Test
-		 @DirtiesContext
-		 public void testCommandLineArgAppPrefixes() throws IOException {
-			 this.setupCommandLineArgAppPrefixes();
+		@Test
+		@DirtiesContext
+		public void testCommandLineArgAppPrefixes() throws IOException {
+			this.setupCommandLineArgAppPrefixes();
 
-			 verify(this.taskLauncher, times(0)).destroy(TASK_NAME_ORIG);
-		 }
+			verify(this.taskLauncher, times(0)).destroy(TASK_NAME_ORIG);
+		}
 
-		 private void setupCommandLineArgAppPrefixes() throws IOException {
-			  TaskExecution myTask = this.taskRepository.createTaskExecution(TASK_NAME_ORIG);
-			  TaskManifest manifest = new TaskManifest();
-			  manifest.setPlatformName("default");
-			  AppDeploymentRequest request = new AppDeploymentRequest(new AppDefinition("some-name", null),
-					  new FileUrlResource("src/test/resources/apps/foo-task"));
-			  manifest.setTaskDeploymentRequest(request);
+		private void setupCommandLineArgAppPrefixes() throws IOException {
+			TaskExecution myTask = this.taskRepository.createTaskExecution(TASK_NAME_ORIG);
+			TaskManifest manifest = new TaskManifest();
+			manifest.setPlatformName("default");
+			AppDeploymentRequest request = new AppDeploymentRequest(new AppDefinition("some-name", null),
+					new FileUrlResource("src/test/resources/apps/foo-task"));
+			manifest.setTaskDeploymentRequest(request);
 
-			  this.dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			  this.taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			  this.taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			this.dataflowTaskExecutionMetadataDao.save(myTask, manifest);
+			this.taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
+			this.taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
 
-			  initializeSuccessfulRegistry(appRegistry);
+			initializeSuccessfulRegistry(appRegistry);
 
-			  when(taskLauncher.launch(any())).thenReturn("0");
+			when(taskLauncher.launch(any())).thenReturn("0");
 
-			  Map<String,String> deploymentProperties = new HashMap<>(1);
+			Map<String,String> deploymentProperties = new HashMap<>(1);
 
-			  this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.singletonList("app.demo.1=--foo=bar"));
-			  TaskManifest lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			  assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
-			  assertEquals("--foo=bar", lastManifest.getTaskDeploymentRequest().getCommandlineArguments().get(0));
-
-			//   this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.emptyList());
-			//   lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
-			//   assertEquals(1, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
-		  }
+			this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, Collections.singletonList("app.demo.1=--foo=bar"));
+			TaskManifest lastManifest = this.dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
+			assertEquals(2, lastManifest.getTaskDeploymentRequest().getCommandlineArguments().size());
+			assertEquals("--foo=bar", lastManifest.getTaskDeploymentRequest().getCommandlineArguments().get(0));
+		}
 
 		@Test
 		@DirtiesContext


### PR DESCRIPTION
- This commit is focusing two things, firstly able to
  use versions for task apps and secondly able to
  controll ctr tasks arguments better.
- Versions are in format of for simple:
  version.timestamp=2.1.1.RELEASE
- Versions are in format of for ctr:
  version.t1=2.0.0.RELEASE
  version.t2=2.1.1.RELEASE
- Arguments are in format of for simple:
  app.timestamp.0=--timestamp.format=yyyy
- Arguments are in format of for ctr:
  app.t1.0=--timestamp.format=yyyy
  app.t2.0=--timestamp.format=yyyyMM
- Fixes #4258
- Fixes #4265
- There's a few follow-up issues to hand after this, like
  shell is not yet changed and as we now support versions
  which cf is not ready to handle.
  
  You need to do maven install locally as crt app has changes.
  Use with UI PR spring-cloud/spring-cloud-dataflow-ui#1626