### PR TITLE
Fixes gh-4303 #4304

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
 		<semver.version>2.2.0</semver.version>
+		<cronutils.version>9.1.3</cronutils.version>
 		<apache-directory-server.version>1.5.5</apache-directory-server.version>
 		<codearte-props2yml.version>0.5</codearte-props2yml.version>
 		<json-unit.version>2.11.1</json-unit.version>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -188,6 +188,11 @@
 			<artifactId>jsr305</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.cronutils</groupId>
+			<artifactId>cron-utils</artifactId>
+			<version>${cronutils.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
@@ -55,8 +55,8 @@ import org.springframework.core.io.ResourceLoader;
 
 @Configuration
 @Conditional({ SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
-@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class,
-	SchedulerServiceProperties.class, TaskPlatformConfigurationProperties.class})
+@EnableConfigurationProperties({ TaskConfigurationProperties.class, CommonApplicationProperties.class,
+		SchedulerServiceProperties.class, TaskPlatformConfigurationProperties.class })
 public class SchedulerConfiguration {
 
 	private static Logger logger = LoggerFactory.getLogger(SchedulerConfiguration.class);
@@ -67,19 +67,19 @@ public class SchedulerConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SchedulerService schedulerService(CommonApplicationProperties commonApplicationProperties,
-		List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
-		AppRegistryService registry, ResourceLoader resourceLoader,
-		TaskConfigurationProperties taskConfigurationProperties,
-		DataSourceProperties dataSourceProperties,
-		ApplicationConfigurationMetadataResolver metaDataResolver,
-		SchedulerServiceProperties schedulerServiceProperties,
-		AuditRecordService auditRecordService,
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
+			List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
+			AppRegistryService registry, ResourceLoader resourceLoader,
+			TaskConfigurationProperties taskConfigurationProperties,
+			DataSourceProperties dataSourceProperties,
+			ApplicationConfigurationMetadataResolver metaDataResolver,
+			SchedulerServiceProperties schedulerServiceProperties,
+			AuditRecordService auditRecordService,
+			ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
-			taskPlatforms, taskDefinitionRepository, registry, resourceLoader,
-			taskConfigurationProperties, dataSourceProperties,
-			this.dataflowServerUri, metaDataResolver, schedulerServiceProperties, auditRecordService,
-			composedTaskRunnerConfigurationProperties);
+				taskPlatforms, taskDefinitionRepository, registry, resourceLoader,
+				taskConfigurationProperties, dataSourceProperties,
+				this.dataflowServerUri, metaDataResolver, schedulerServiceProperties, auditRecordService,
+				composedTaskRunnerConfigurationProperties);
 	}
 
 	public static class SchedulerConfigurationPropertyChecker extends AllNestedConditions {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/SchedulerConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.dataflow.server.service.SchedulerServicePropert
 import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.TaskPlatformConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -49,12 +50,13 @@ import org.springframework.core.io.ResourceLoader;
  * @author Glenn Renfro
  * @author Gunnar Hillert
  * @author David Turanski
+ * @author 23king
  */
 
 @Configuration
 @Conditional({ SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
-@EnableConfigurationProperties({ TaskConfigurationProperties.class, CommonApplicationProperties.class,
-		SchedulerServiceProperties.class })
+@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class,
+	SchedulerServiceProperties.class, TaskPlatformConfigurationProperties.class})
 public class SchedulerConfiguration {
 
 	private static Logger logger = LoggerFactory.getLogger(SchedulerConfiguration.class);
@@ -65,19 +67,19 @@ public class SchedulerConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public SchedulerService schedulerService(CommonApplicationProperties commonApplicationProperties,
-			List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
-			AppRegistryService registry, ResourceLoader resourceLoader,
-			TaskConfigurationProperties taskConfigurationProperties,
-			DataSourceProperties dataSourceProperties,
-			ApplicationConfigurationMetadataResolver metaDataResolver,
-			SchedulerServiceProperties schedulerServiceProperties,
-			AuditRecordService auditRecordService,
-			ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
+		List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
+		AppRegistryService registry, ResourceLoader resourceLoader,
+		TaskConfigurationProperties taskConfigurationProperties,
+		DataSourceProperties dataSourceProperties,
+		ApplicationConfigurationMetadataResolver metaDataResolver,
+		SchedulerServiceProperties schedulerServiceProperties,
+		AuditRecordService auditRecordService,
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
 		return new DefaultSchedulerService(commonApplicationProperties,
-				taskPlatforms, taskDefinitionRepository, registry, resourceLoader,
-				taskConfigurationProperties, dataSourceProperties,
-				this.dataflowServerUri, metaDataResolver, schedulerServiceProperties, auditRecordService,
-				composedTaskRunnerConfigurationProperties);
+			taskPlatforms, taskDefinitionRepository, registry, resourceLoader,
+			taskConfigurationProperties, dataSourceProperties,
+			this.dataflowServerUri, metaDataResolver, schedulerServiceProperties, auditRecordService,
+			composedTaskRunnerConfigurationProperties);
 	}
 
 	public static class SchedulerConfigurationPropertyChecker extends AllNestedConditions {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -51,7 +51,16 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskJobService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.*;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.TaskPlatformConfigurationProperties;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
@@ -75,9 +84,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @ConditionalOnTasksEnabled
-@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class,
-	DockerValidatorProperties.class, LocalPlatformProperties.class, ComposedTaskRunnerConfigurationProperties.class,
-	TaskPlatformConfigurationProperties.class
+@EnableConfigurationProperties({ TaskConfigurationProperties.class, CommonApplicationProperties.class,
+		DockerValidatorProperties.class, LocalPlatformProperties.class, ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class
 })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 @EnableTransactionManagement
@@ -189,7 +198,7 @@ public class TaskConfiguration {
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao,
 			@Nullable OAuth2TokenUtilsService oauth2TokenUtilsService,
 			TaskSaveService taskSaveService) {
-		DefaultTaskExecutionService defaultTaskExecutionService =  new DefaultTaskExecutionService(
+		DefaultTaskExecutionService defaultTaskExecutionService = new DefaultTaskExecutionService(
 				launcherRepository, auditRecordService, taskRepository,
 				taskExecutionInfoService, taskDeploymentRepository, taskExecutionRepositoryService,
 				taskAppDeploymentRequestCreator, taskExplorer, dataflowTaskExecutionDao,

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -51,15 +51,7 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskJobService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.*;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.TaskRepository;
@@ -83,8 +75,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @ConditionalOnTasksEnabled
-@EnableConfigurationProperties({ TaskConfigurationProperties.class, CommonApplicationProperties.class,
-		DockerValidatorProperties.class, LocalPlatformProperties.class, ComposedTaskRunnerConfigurationProperties.class
+@EnableConfigurationProperties({TaskConfigurationProperties.class, CommonApplicationProperties.class,
+	DockerValidatorProperties.class, LocalPlatformProperties.class, ComposedTaskRunnerConfigurationProperties.class,
+	TaskPlatformConfigurationProperties.class
 })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 @EnableTransactionManagement

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.audit.service.AuditServiceUtils;
@@ -57,14 +60,21 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import com.cronutils.converter.CalendarToCronTransformer;
+import com.cronutils.converter.CronConverter;
+import com.cronutils.converter.CronToCalendarTransformer;
+
 /**
  * Default implementation of the {@link SchedulerService} interface. Provide service methods
  * for Scheduling tasks.
  *
  * @author Glenn Renfro
  * @author Chris Schaefer
+ * @author 23king
  */
 public class DefaultSchedulerService implements SchedulerService {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultStreamService.class);
 
 	private final static int MAX_SCHEDULE_NAME_LEN = 52;
 
@@ -97,17 +107,17 @@ public class DefaultSchedulerService implements SchedulerService {
 	 */
 	@Deprecated
 	public DefaultSchedulerService(CommonApplicationProperties commonApplicationProperties,
-								   List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
-								   AppRegistryService registry, ResourceLoader resourceLoader,
-								   TaskConfigurationProperties taskConfigurationProperties,
-								   DataSourceProperties dataSourceProperties, String dataflowServerUri,
-								   ApplicationConfigurationMetadataResolver metaDataResolver,
-								   SchedulerServiceProperties schedulerServiceProperties,
-								   AuditRecordService auditRecordService) {
+		List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
+		AppRegistryService registry, ResourceLoader resourceLoader,
+		TaskConfigurationProperties taskConfigurationProperties,
+		DataSourceProperties dataSourceProperties, String dataflowServerUri,
+		ApplicationConfigurationMetadataResolver metaDataResolver,
+		SchedulerServiceProperties schedulerServiceProperties,
+		AuditRecordService auditRecordService) {
 
 		this(commonApplicationProperties, taskPlatforms, taskDefinitionRepository, registry, resourceLoader,
-				taskConfigurationProperties, dataSourceProperties, dataflowServerUri, metaDataResolver,
-				schedulerServiceProperties, auditRecordService, null);
+			taskConfigurationProperties, dataSourceProperties, dataflowServerUri, metaDataResolver,
+			schedulerServiceProperties, auditRecordService, null);
 	}
 
 	/**
@@ -127,14 +137,14 @@ public class DefaultSchedulerService implements SchedulerService {
 	 *                                                  service
 	 */
 	public DefaultSchedulerService(CommonApplicationProperties commonApplicationProperties,
-			List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
-			AppRegistryService registry, ResourceLoader resourceLoader,
-			TaskConfigurationProperties taskConfigurationProperties,
-			DataSourceProperties dataSourceProperties, String dataflowServerUri,
-			ApplicationConfigurationMetadataResolver metaDataResolver,
-			SchedulerServiceProperties schedulerServiceProperties,
-			AuditRecordService auditRecordService,
-			ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
+		List<TaskPlatform> taskPlatforms, TaskDefinitionRepository taskDefinitionRepository,
+		AppRegistryService registry, ResourceLoader resourceLoader,
+		TaskConfigurationProperties taskConfigurationProperties,
+		DataSourceProperties dataSourceProperties, String dataflowServerUri,
+		ApplicationConfigurationMetadataResolver metaDataResolver,
+		SchedulerServiceProperties schedulerServiceProperties,
+		AuditRecordService auditRecordService,
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
 
 		Assert.notNull(commonApplicationProperties, "commonApplicationProperties must not be null");
 		Assert.notNull(taskPlatforms, "taskPlatforms must not be null");
@@ -162,17 +172,17 @@ public class DefaultSchedulerService implements SchedulerService {
 
 	@Override
 	public void schedule(String scheduleName, String taskDefinitionName, Map<String, String> taskDeploymentProperties,
-			List<String> commandLineArgs) {
+		List<String> commandLineArgs) {
 		schedule(scheduleName, taskDefinitionName, taskDeploymentProperties, commandLineArgs, null);
 	}
 
 	@Override
 	public void schedule(String scheduleName, String taskDefinitionName, Map<String, String> taskDeploymentProperties,
-			List<String> commandLineArgs, String platformName) {
+		List<String> commandLineArgs, String platformName) {
 		Assert.hasText(taskDefinitionName, "The provided taskName must not be null or empty.");
 		Assert.notNull(taskDeploymentProperties, "The provided taskDeploymentProperties must not be null.");
 		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskDefinitionName)
-				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
+			.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
 		TaskParser taskParser = new TaskParser(taskDefinition.getName(), taskDefinition.getDslText(), true, true);
 		TaskNode taskNode = taskParser.parse();
 		AppRegistration appRegistration;
@@ -180,15 +190,15 @@ public class DefaultSchedulerService implements SchedulerService {
 		// runner and executable graph.
 		if (taskNode.isComposed()) {
 			taskDefinition = new TaskDefinition(taskDefinition.getName(),
-					TaskServiceUtils.createComposedTaskDefinition(
-							taskNode.toExecutableDSL()));
+				TaskServiceUtils.createComposedTaskDefinition(
+					taskNode.toExecutableDSL()));
 			taskDeploymentProperties = TaskServiceUtils.establishComposedTaskProperties(taskDeploymentProperties, taskNode);
 			TaskServiceUtils.addImagePullSecretProperty(taskDeploymentProperties,
-					this.composedTaskRunnerConfigurationProperties);
+				this.composedTaskRunnerConfigurationProperties);
 			try {
 				appRegistration = new AppRegistration(ComposedTaskRunnerConfigurationProperties.COMPOSED_TASK_RUNNER_NAME,
-						ApplicationType.task, new URI(TaskServiceUtils.getComposedTaskLauncherUri(this.taskConfigurationProperties,
-						this.composedTaskRunnerConfigurationProperties)));
+					ApplicationType.task, new URI(TaskServiceUtils.getComposedTaskLauncherUri(this.taskConfigurationProperties,
+					this.composedTaskRunnerConfigurationProperties)));
 			}
 			catch (URISyntaxException e) {
 				throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
@@ -196,52 +206,75 @@ public class DefaultSchedulerService implements SchedulerService {
 		}
 		else {
 			appRegistration = this.registry.find(taskDefinition.getRegisteredAppName(),
-					ApplicationType.task);
+				ApplicationType.task);
 		}
 		Assert.notNull(appRegistration, "Unknown task app: " + taskDefinition.getRegisteredAppName());
 		Resource metadataResource = this.registry.getAppMetadataResource(appRegistration);
 		Launcher launcher = getTaskLauncher(platformName);
 		taskDefinition = TaskServiceUtils.updateTaskProperties(taskDefinition, this.dataSourceProperties,
-				TaskServiceUtils.addDatabaseCredentials(this.taskConfigurationProperties.isUseKubernetesSecretsForDbCredentials(), launcher.getType()));
+			TaskServiceUtils.addDatabaseCredentials(this.taskConfigurationProperties.isUseKubernetesSecretsForDbCredentials(), launcher.getType()));
 
 		Map<String, String> appDeploymentProperties = new HashMap<>(commonApplicationProperties.getTask());
 		appDeploymentProperties.putAll(
-				TaskServiceUtils.extractAppProperties(taskDefinition.getRegisteredAppName(), taskDeploymentProperties));
+			TaskServiceUtils.extractAppProperties(taskDefinition.getRegisteredAppName(), taskDeploymentProperties));
 
 		// Merge the common properties defined via the spring.cloud.dataflow.common-properties.task-resource file.
 		// Doesn't override existing properties!
 		// The placeholders defined in the task-resource file are not resolved by SCDF but passed to the apps as they are.
 		TaskServiceUtils.contributeCommonProperties(this.commonApplicationProperties.getTaskResourceProperties(),
-				appDeploymentProperties, "common");
+			appDeploymentProperties, "common");
 		TaskServiceUtils.contributeCommonProperties(this.commonApplicationProperties.getTaskResourceProperties(),
-				appDeploymentProperties, launcher.getType().toLowerCase());
+			appDeploymentProperties, launcher.getType().toLowerCase());
 
 		Map<String, String> deployerDeploymentProperties = DeploymentPropertiesUtils
-				.extractAndQualifyDeployerProperties(taskDeploymentProperties, taskDefinition.getRegisteredAppName());
+			.extractAndQualifyDeployerProperties(taskDeploymentProperties, taskDefinition.getRegisteredAppName());
 		if (StringUtils.hasText(this.dataflowServerUri) && taskNode.isComposed()) {
 			TaskServiceUtils.updateDataFlowUriIfNeeded(this.dataflowServerUri, appDeploymentProperties, commandLineArgs);
 		}
 		AppDefinition revisedDefinition = TaskServiceUtils.mergeAndExpandAppProperties(taskDefinition, metadataResource,
-				appDeploymentProperties, visibleProperties);
+			appDeploymentProperties, visibleProperties);
 		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
-		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
+		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties, taskConfigurationProperties.getPlatformTimezone());
 
 		scheduleName = validateScheduleNameForPlatform(launcher.getType(), scheduleName);
 
 		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition, taskDeploymentProperties,
-				deployerDeploymentProperties, commandLineArgs, scheduleName, getTaskResource(taskDefinitionName));
+			deployerDeploymentProperties, commandLineArgs, scheduleName, getTaskResource(taskDefinitionName));
+
 		launcher.getScheduler().schedule(scheduleRequest);
 
 		this.auditRecordService.populateAndSaveAuditRecordUsingMapData(AuditOperationType.SCHEDULE, AuditActionType.CREATE,
-				scheduleRequest.getScheduleName(), this.auditServiceUtils.convertScheduleRequestToAuditData(scheduleRequest),
-				launcher.getName());
+			scheduleRequest.getScheduleName(), this.auditServiceUtils.convertScheduleRequestToAuditData(scheduleRequest),
+			launcher.getName());
+	}
+
+	private static String convertCronExpressionForPlatformTimeZone(String cronExpression, ZoneId platformTimezone) {
+		if (platformTimezone != null) {
+			final CronConverter cronConverter = new CronConverter(new CronToCalendarTransformer(), new CalendarToCronTransformer());
+			return cronConverter.using(cronExpression)
+				.from(ZoneId.systemDefault())
+				.to(platformTimezone)
+				.convert();
+		}
+		return cronExpression;
+	}
+
+	private static String convertCronExpressionForServerTimeZone(String cronExpression, ZoneId platformTimezone) {
+		if (platformTimezone != null) {
+			final CronConverter cronConverter = new CronConverter(new CronToCalendarTransformer(), new CalendarToCronTransformer());
+			return cronConverter.using(cronExpression)
+				.from(platformTimezone)
+				.to(ZoneId.systemDefault())
+				.convert();
+		}
+		return cronExpression;
 	}
 
 	private String validateScheduleNameForPlatform(String type, String scheduleName) {
 		if (type.equals(TaskPlatformFactory.KUBERNETES_PLATFORM_TYPE)) {
 			if (scheduleName.length() > MAX_SCHEDULE_NAME_LEN) {
 				throw new IllegalArgumentException(String.format("the name specified " +
-						"exceeds the maximum schedule name length of %s.", MAX_SCHEDULE_NAME_LEN));
+					"exceeds the maximum schedule name length of %s.", MAX_SCHEDULE_NAME_LEN));
 			}
 			scheduleName = scheduleName.toLowerCase();
 		}
@@ -276,8 +309,8 @@ public class DefaultSchedulerService implements SchedulerService {
 		}
 		if (launcherCount > 1) {
 			throw new IllegalArgumentException("Must select a platform.  " +
-					"A default could not be determined because more than one platform" +
-					" had an associated scheduler");
+				"A default could not be determined because more than one platform" +
+				" had an associated scheduler");
 		}
 		if (platformName != null && launcherToUse == null) {
 			throw new IllegalArgumentException(String.format("The platform %s does not support a scheduler service.", platformName));
@@ -317,10 +350,10 @@ public class DefaultSchedulerService implements SchedulerService {
 			Launcher launcher = getTaskLauncher(platformName);
 			launcher.getScheduler().unschedule(scheduleInfo.getScheduleName());
 			this.auditRecordService.populateAndSaveAuditRecord(
-					AuditOperationType.SCHEDULE,
-					AuditActionType.DELETE, scheduleInfo.getScheduleName(),
-					scheduleInfo.getTaskDefinitionName(),
-					platformName);
+				AuditOperationType.SCHEDULE,
+				AuditActionType.DELETE, scheduleInfo.getScheduleName(),
+				scheduleInfo.getTaskDefinitionName(),
+				platformName);
 		}
 	}
 
@@ -359,14 +392,9 @@ public class DefaultSchedulerService implements SchedulerService {
 	public List<ScheduleInfo> list(String taskDefinitionName, String platformName) {
 		Launcher launcher = getTaskLauncher(platformName);
 		List<ScheduleInfo> list = launcher.getScheduler().list();
-		List<ScheduleInfo> result = new ArrayList<>();
-		for (ScheduleInfo scheduleInfo : list) {
-			if (scheduleInfo.getTaskDefinitionName().equals(taskDefinitionName)) {
-				result.add(scheduleInfo);
-			}
-		}
+		List<ScheduleInfo> result = updateCronExpressionByResult(taskDefinitionName, list);
 		return limitScheduleInfoResultSize(result,
-				this.schedulerServiceProperties.getMaxSchedulesReturned());
+			this.schedulerServiceProperties.getMaxSchedulesReturned());
 	}
 
 	@Override
@@ -377,22 +405,26 @@ public class DefaultSchedulerService implements SchedulerService {
 	@Override
 	public List<ScheduleInfo> listForPlatform(String platformName) {
 		Launcher launcher = getTaskLauncher(platformName);
-		return limitScheduleInfoResultSize(launcher.getScheduler().list(),
-				this.schedulerServiceProperties.getMaxSchedulesReturned());
+		List<ScheduleInfo> list = launcher.getScheduler().list();
+		List<ScheduleInfo> result = updateCronExpressionByResult(list);
+		return limitScheduleInfoResultSize(result,
+			this.schedulerServiceProperties.getMaxSchedulesReturned());
 	}
 
 	@Override
 	public List<ScheduleInfo> list() {
 		Launcher launcher = getTaskLauncher(null);
-		return limitScheduleInfoResultSize(launcher.getScheduler().list(),
-				this.schedulerServiceProperties.getMaxSchedulesReturned());
+		List<ScheduleInfo> list = launcher.getScheduler().list();
+		List<ScheduleInfo> result = updateCronExpressionByResult(list);
+		return limitScheduleInfoResultSize(result,
+			this.schedulerServiceProperties.getMaxSchedulesReturned());
 	}
 
 	@Override
 	public ScheduleInfo getSchedule(String scheduleName, String platformName) {
 		List<ScheduleInfo> result = listForPlatform(platformName).stream()
-				.filter(scheduleInfo -> scheduleInfo.getScheduleName().equals(scheduleName))
-				.collect(Collectors.toList());
+			.filter(scheduleInfo -> scheduleInfo.getScheduleName().equals(scheduleName))
+			.collect(Collectors.toList());
 		Assert.isTrue(!(result.size() > 1), "more than one schedule was returned for scheduleName, should only be one");
 		return result.size() > 0 ? result.get(0) : null;
 	}
@@ -402,8 +434,29 @@ public class DefaultSchedulerService implements SchedulerService {
 		return getSchedule(scheduleName, null);
 	}
 
+	private List<ScheduleInfo> updateCronExpressionByResult(List<ScheduleInfo> list) {
+		return updateCronExpressionByResult(null, list);
+	}
+
+	private List<ScheduleInfo> updateCronExpressionByResult(String taskDefinitionName, List<ScheduleInfo> list) {
+		return list.stream()
+			.filter(v -> taskDefinitionName == null ? true : v.getTaskDefinitionName().equals(taskDefinitionName))
+			.map(this::convertCronExpressionByResult)
+			.collect(Collectors.toList());
+	}
+
+	private ScheduleInfo convertCronExpressionByResult(ScheduleInfo scheduleInfo) {
+		final Map<String, String> scheduleProperties = scheduleInfo.getScheduleProperties();
+		final String prefix = "spring.cloud.scheduler";
+		scheduleInfo.setScheduleProperties(
+			scheduleProperties.entrySet().stream()
+				.filter(kv -> kv.getKey().startsWith(prefix))
+				.collect(Collectors.toMap(Map.Entry::getKey, mv -> convertCronExpressionForServerTimeZone(mv.getValue(), taskConfigurationProperties.getPlatformTimezone()), (fromWildcard, fromApp) -> fromApp)));
+		return scheduleInfo;
+	}
+
 	private List<ScheduleInfo> limitScheduleInfoResultSize(List<ScheduleInfo> resultSet,
-			int schedulerLimitResultSize) {
+		int schedulerLimitResultSize) {
 		if (resultSet.size() > schedulerLimitResultSize) {
 			resultSet = resultSet.subList(0, schedulerLimitResultSize);
 		}
@@ -418,24 +471,24 @@ public class DefaultSchedulerService implements SchedulerService {
 	 * @param input the scheduler properties
 	 * @return scheduler properties for the task
 	 */
-	private static Map<String, String> extractAndQualifySchedulerProperties(Map<String, String> input) {
+	private static Map<String, String> extractAndQualifySchedulerProperties(Map<String, String> input, ZoneId platformTimezone) {
 		final String prefix = "scheduler.";
 		final int prefixLength = prefix.length();
 
 		return new TreeMap<>(input).entrySet().stream()
-				.filter(kv -> kv.getKey().startsWith(prefix))
-				.collect(Collectors.toMap(kv -> "spring.cloud.scheduler." + kv.getKey().substring(prefixLength), Map.Entry::getValue,
-						(fromWildcard, fromApp) -> fromApp));
+			.filter(kv -> kv.getKey().startsWith(prefix))
+			.collect(Collectors.toMap(kv -> "spring.cloud.scheduler." + kv.getKey().substring(prefixLength), mv -> convertCronExpressionForPlatformTimeZone(mv.getValue(), platformTimezone),
+				(fromWildcard, fromApp) -> fromApp));
 	}
 
 	protected Resource getTaskResource(String taskDefinitionName) {
 		TaskDefinition taskDefinition = this.taskDefinitionRepository.findById(taskDefinitionName)
-				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
+			.orElseThrow(() -> new NoSuchTaskDefinitionException(taskDefinitionName));
 		AppRegistration appRegistration = null;
 		if (TaskServiceUtils.isComposedTaskDefinition(taskDefinition.getDslText())) {
 			URI composedTaskUri = null;
 			String composedTaskLauncherUri = TaskServiceUtils.getComposedTaskLauncherUri(this.taskConfigurationProperties,
-					this.composedTaskRunnerConfigurationProperties);
+				this.composedTaskRunnerConfigurationProperties);
 			try {
 				composedTaskUri = new URI(composedTaskLauncherUri);
 			}
@@ -443,10 +496,9 @@ public class DefaultSchedulerService implements SchedulerService {
 				throw new IllegalArgumentException("Invalid Composed Task Url: " + composedTaskLauncherUri);
 			}
 			appRegistration = new AppRegistration(ComposedTaskRunnerConfigurationProperties.COMPOSED_TASK_RUNNER_NAME, ApplicationType.task, composedTaskUri);
-		}
-		else {
+		} else {
 			appRegistration = this.registry.find(taskDefinition.getRegisteredAppName(),
-					ApplicationType.task);
+				ApplicationType.task);
 		}
 		Assert.notNull(appRegistration, "Unknown task app: " + taskDefinition.getRegisteredAppName());
 		return this.registry.getAppResource(appRegistration);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -26,6 +26,10 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import com.cronutils.converter.CalendarToCronTransformer;
+import com.cronutils.converter.CronConverter;
+import com.cronutils.converter.CronToCalendarTransformer;
+
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.audit.service.AuditServiceUtils;
@@ -57,10 +61,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import com.cronutils.converter.CalendarToCronTransformer;
-import com.cronutils.converter.CronConverter;
-import com.cronutils.converter.CronToCalendarTransformer;
 
 /**
  * Default implementation of the {@link SchedulerService} interface. Provide service methods

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.service.impl;
 
+import java.time.ZoneId;
+import java.time.zone.ZoneRulesException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +34,7 @@ import org.springframework.validation.annotation.Validated;
  * @author Glenn Renfro
  * @author David Turanski
  * @author Chris Schaefer
+ * @author 23king
  */
 @Validated
 @ConfigurationProperties(prefix = TaskConfigurationProperties.TASK_PREFIX)
@@ -44,6 +48,9 @@ public class TaskConfigurationProperties {
 
 	@Autowired
 	private ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties;
+
+	@Autowired
+	private TaskPlatformConfigurationProperties taskPlatformConfigurationProperties;
 
 	/**
 	 * Whether the server should auto create task definitions if one does not exist for a launch request and
@@ -77,6 +84,15 @@ public class TaskConfigurationProperties {
 		}
 	}
 
+	public ZoneId getPlatformTimezone() {
+		try {
+			return taskPlatformConfigurationProperties.getTimezone() == null ? null : ZoneId.of(taskPlatformConfigurationProperties.getTimezone());
+		} catch (ZoneRulesException ex) {
+			LOGGER.warn(ex.getMessage());
+		}
+		return null;
+	}
+
 	public DeployerProperties getDeployerProperties() {
 		return deployerProperties;
 	}
@@ -98,7 +114,7 @@ public class TaskConfigurationProperties {
 		logDeprecationWarning();
 
 		return this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken() == null ? false :
-				this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
+			this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
 	}
 
 	@Deprecated
@@ -165,14 +181,20 @@ public class TaskConfigurationProperties {
 	private void logDeprecationWarning(String newMethodName) {
 		String callingMethodName = Thread.currentThread().getStackTrace()[2].getMethodName();
 		LOGGER.warn(this.getClass().getName() + "." + callingMethodName
-				+ " is deprecated. Please use " + ComposedTaskRunnerConfigurationProperties.class.getName() + "."
-				+ (newMethodName != null ? newMethodName : callingMethodName));
+			+ " is deprecated. Please use " + ComposedTaskRunnerConfigurationProperties.class.getName() + "."
+			+ (newMethodName != null ? newMethodName : callingMethodName));
 	}
 
 	void setComposedTaskRunnerConfigurationProperties(ComposedTaskRunnerConfigurationProperties
-							composedTaskRunnerConfigurationProperties) {
+		composedTaskRunnerConfigurationProperties) {
 		if (composedTaskRunnerConfigurationProperties != null) {
 			this.composedTaskRunnerConfigurationProperties = composedTaskRunnerConfigurationProperties;
+		}
+	}
+
+	void setTaskPlatformConfigurationProperties(TaskPlatformConfigurationProperties taskPlatformConfigurationProperties) {
+		if (taskPlatformConfigurationProperties != null) {
+			this.taskPlatformConfigurationProperties = taskPlatformConfigurationProperties;
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.time.ZoneId;
-import java.time.zone.ZoneRulesException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,12 +84,8 @@ public class TaskConfigurationProperties {
 	}
 
 	public ZoneId getPlatformTimezone() {
-		try {
-			return taskPlatformConfigurationProperties.getTimezone() == null ? null : ZoneId.of(taskPlatformConfigurationProperties.getTimezone());
-		} catch (ZoneRulesException ex) {
-			LOGGER.warn(ex.getMessage());
-		}
-		return null;
+		return taskPlatformConfigurationProperties.getTimezone() == null ? null
+				: ZoneId.of(taskPlatformConfigurationProperties.getTimezone());
 	}
 
 	public DeployerProperties getDeployerProperties() {
@@ -114,7 +109,7 @@ public class TaskConfigurationProperties {
 		logDeprecationWarning();
 
 		return this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken() == null ? false :
-			this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
+				this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
 	}
 
 	@Deprecated
@@ -181,18 +176,19 @@ public class TaskConfigurationProperties {
 	private void logDeprecationWarning(String newMethodName) {
 		String callingMethodName = Thread.currentThread().getStackTrace()[2].getMethodName();
 		LOGGER.warn(this.getClass().getName() + "." + callingMethodName
-			+ " is deprecated. Please use " + ComposedTaskRunnerConfigurationProperties.class.getName() + "."
-			+ (newMethodName != null ? newMethodName : callingMethodName));
+				+ " is deprecated. Please use " + ComposedTaskRunnerConfigurationProperties.class.getName() + "."
+				+ (newMethodName != null ? newMethodName : callingMethodName));
 	}
 
 	void setComposedTaskRunnerConfigurationProperties(ComposedTaskRunnerConfigurationProperties
-		composedTaskRunnerConfigurationProperties) {
+	composedTaskRunnerConfigurationProperties) {
 		if (composedTaskRunnerConfigurationProperties != null) {
 			this.composedTaskRunnerConfigurationProperties = composedTaskRunnerConfigurationProperties;
 		}
 	}
 
-	void setTaskPlatformConfigurationProperties(TaskPlatformConfigurationProperties taskPlatformConfigurationProperties) {
+	void setTaskPlatformConfigurationProperties(
+			TaskPlatformConfigurationProperties taskPlatformConfigurationProperties) {
 		if (taskPlatformConfigurationProperties != null) {
 			this.taskPlatformConfigurationProperties = taskPlatformConfigurationProperties;
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskPlatformConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskPlatformConfigurationProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = TaskPlatformConfigurationProperties.TASK_PLATFORM_PREFIX)
 public class TaskPlatformConfigurationProperties {
 	static final String TASK_PLATFORM_PREFIX = TaskConfigurationProperties.TASK_PREFIX + ".platform";
+
 	private String timezone;
 
 	public String getTimezone() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskPlatformConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskPlatformConfigurationProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * This property is used in Deploy Platform in Task of Spring Cloud Data Flow.
+ *
+ * @author 23king
+ */
+@ConfigurationProperties(prefix = TaskPlatformConfigurationProperties.TASK_PLATFORM_PREFIX)
+public class TaskPlatformConfigurationProperties {
+	static final String TASK_PLATFORM_PREFIX = TaskConfigurationProperties.TASK_PREFIX + ".platform";
+	private String timezone;
+
+	public String getTimezone() {
+		return timezone;
+	}
+
+	public void setTimezone(String timezone) {
+		this.timezone = timezone;
+	}
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -83,7 +83,17 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskJobService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.*;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultLauncherService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.TaskPlatformConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
@@ -137,8 +147,9 @@ import static org.mockito.Mockito.mock;
 		"org.springframework.cloud.dataflow.audit.repository"
 })
 @EnableJpaAuditing
-@EnableConfigurationProperties({DockerValidatorProperties.class, TaskConfigurationProperties.class,
-	TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class, TaskPlatformConfigurationProperties.class})
+@EnableConfigurationProperties({ DockerValidatorProperties.class, TaskConfigurationProperties.class,
+		TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 public class JobDependencies {
 
@@ -203,7 +214,6 @@ public class JobDependencies {
 	LauncherService launcherService(LauncherRepository launcherRepository) {
 		return new DefaultLauncherService(launcherRepository);
 	}
-
 
 	@Bean
 	public TaskLogsController taskLogsController(TaskExecutionService taskExecutionService) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -83,16 +83,7 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskJobService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultLauncherService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.*;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
@@ -146,8 +137,8 @@ import static org.mockito.Mockito.mock;
 		"org.springframework.cloud.dataflow.audit.repository"
 })
 @EnableJpaAuditing
-@EnableConfigurationProperties({ DockerValidatorProperties.class, TaskConfigurationProperties.class,
-		TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class})
+@EnableConfigurationProperties({DockerValidatorProperties.class, TaskConfigurationProperties.class,
+	TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class, TaskPlatformConfigurationProperties.class})
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 public class JobDependencies {
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -69,15 +69,7 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.*;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -124,13 +116,14 @@ import static org.mockito.Mockito.when;
 		FlywayAutoConfiguration.class,
 		RestTemplateAutoConfiguration.class })
 @EnableWebMvc
-@EnableConfigurationProperties({ CommonApplicationProperties.class,
-		VersionInfoProperties.class,
-		DockerValidatorProperties.class,
-		TaskConfigurationProperties.class,
-		TaskProperties.class,
-		DockerValidatorProperties.class,
-		ComposedTaskRunnerConfigurationProperties.class })
+@EnableConfigurationProperties({CommonApplicationProperties.class,
+	VersionInfoProperties.class,
+	DockerValidatorProperties.class,
+	TaskConfigurationProperties.class,
+	TaskProperties.class,
+	DockerValidatorProperties.class,
+	ComposedTaskRunnerConfigurationProperties.class,
+	TaskPlatformConfigurationProperties.class})
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
 		"org.springframework.cloud.dataflow.core"

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -69,7 +69,16 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.*;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.TaskPlatformConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -116,14 +125,14 @@ import static org.mockito.Mockito.when;
 		FlywayAutoConfiguration.class,
 		RestTemplateAutoConfiguration.class })
 @EnableWebMvc
-@EnableConfigurationProperties({CommonApplicationProperties.class,
-	VersionInfoProperties.class,
-	DockerValidatorProperties.class,
-	TaskConfigurationProperties.class,
-	TaskProperties.class,
-	DockerValidatorProperties.class,
-	ComposedTaskRunnerConfigurationProperties.class,
-	TaskPlatformConfigurationProperties.class})
+@EnableConfigurationProperties({ CommonApplicationProperties.class,
+		VersionInfoProperties.class,
+		DockerValidatorProperties.class,
+		TaskConfigurationProperties.class,
+		TaskProperties.class,
+		DockerValidatorProperties.class,
+		ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class })
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
 		"org.springframework.cloud.dataflow.core"

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -122,7 +122,19 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.*;
+import org.springframework.cloud.dataflow.server.service.impl.AppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultLauncherService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
+import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.TaskPlatformConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultStreamValidationService;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
@@ -183,15 +195,15 @@ import static org.mockito.Mockito.when;
 		FlywayAutoConfiguration.class,
 		RestTemplateAutoConfiguration.class })
 @EnableWebMvc
-@EnableConfigurationProperties({CommonApplicationProperties.class,
-	VersionInfoProperties.class,
-	DockerValidatorProperties.class,
-	TaskConfigurationProperties.class,
-	TaskProperties.class,
-	DockerValidatorProperties.class,
-	DataflowMetricsProperties.class,
-	ComposedTaskRunnerConfigurationProperties.class,
-	TaskPlatformConfigurationProperties.class})
+@EnableConfigurationProperties({ CommonApplicationProperties.class,
+		VersionInfoProperties.class,
+		DockerValidatorProperties.class,
+		TaskConfigurationProperties.class,
+		TaskProperties.class,
+		DockerValidatorProperties.class,
+		DataflowMetricsProperties.class,
+		ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class })
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
 		"org.springframework.cloud.dataflow.core"
@@ -456,7 +468,6 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	public TaskPlatformController taskPlatformController(LauncherService launcherService) {
 		return new TaskPlatformController(launcherService);
 	}
-
 
 	@Bean
 	LauncherService launcherService(LauncherRepository launcherRepository) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -122,18 +122,7 @@ import org.springframework.cloud.dataflow.server.service.TaskExecutionInfoServic
 import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
 import org.springframework.cloud.dataflow.server.service.TaskValidationService;
-import org.springframework.cloud.dataflow.server.service.impl.AppDeploymentRequestCreator;
-import org.springframework.cloud.dataflow.server.service.impl.ComposedTaskRunnerConfigurationProperties;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultLauncherService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultStreamService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskDeleteService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionInfoService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionRepositoryService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
-import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
-import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
-import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
+import org.springframework.cloud.dataflow.server.service.impl.*;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultStreamValidationService;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
@@ -194,14 +183,15 @@ import static org.mockito.Mockito.when;
 		FlywayAutoConfiguration.class,
 		RestTemplateAutoConfiguration.class })
 @EnableWebMvc
-@EnableConfigurationProperties({ CommonApplicationProperties.class,
-		VersionInfoProperties.class,
-		DockerValidatorProperties.class,
-		TaskConfigurationProperties.class,
-		TaskProperties.class,
-		DockerValidatorProperties.class,
-		DataflowMetricsProperties.class,
-		ComposedTaskRunnerConfigurationProperties.class })
+@EnableConfigurationProperties({CommonApplicationProperties.class,
+	VersionInfoProperties.class,
+	DockerValidatorProperties.class,
+	TaskConfigurationProperties.class,
+	TaskProperties.class,
+	DockerValidatorProperties.class,
+	DataflowMetricsProperties.class,
+	ComposedTaskRunnerConfigurationProperties.class,
+	TaskPlatformConfigurationProperties.class})
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
 		"org.springframework.cloud.dataflow.core"

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
@@ -79,17 +79,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {TaskServiceDependencies.class,
-	DefaultSchedulerServiceMultiplatformTests.MultiplatformTaskConfiguration.class,
-	PropertyPlaceholderAutoConfiguration.class}, properties = {
-	"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
-	"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
-	"spring.main.allow-bean-definition-overriding=true",
-	"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
-	"spring.cloud.dataflow.task.platform.timezone=UTC",
-	"spring.cloud.dataflow.features.schedules-enabled=true"})
-@EnableConfigurationProperties({CommonApplicationProperties.class, TaskConfigurationProperties.class,
-	DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class, TaskPlatformConfigurationProperties.class})
+@SpringBootTest(classes = { TaskServiceDependencies.class,
+		DefaultSchedulerServiceMultiplatformTests.MultiplatformTaskConfiguration.class,
+		PropertyPlaceholderAutoConfiguration.class }, properties = {
+				"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
+				"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
+				"spring.main.allow-bean-definition-overriding=true",
+				"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
+				"spring.cloud.dataflow.task.platform.timezone=UTC",
+				"spring.cloud.dataflow.features.schedules-enabled=true" })
+@EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class,
+		DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 public class DefaultSchedulerServiceMultiplatformTests {
@@ -136,7 +137,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	private ResourceLoader resourceLoader;
 
 	@Autowired
-	private  AuditRecordService auditRecordService;
+	private AuditRecordService auditRecordService;
 
 	@Autowired
 	private ApplicationConfigurationMetadataResolver metaDataResolver;
@@ -151,9 +152,11 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	List<String> commandLineArgs;
 
 	@Before
-	public void setup() throws Exception{
-		this.appRegistry.save("demo", ApplicationType.task, "1.0.0.", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
-		this.appRegistry.save("demo2", ApplicationType.task, "1.0.0", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
+	public void setup() throws Exception {
+		this.appRegistry.save("demo", ApplicationType.task, "1.0.0.", new URI("file:src/test/resources/apps/foo-task"),
+				new URI("file:src/test/resources/apps/foo-task"));
+		this.appRegistry.save("demo2", ApplicationType.task, "1.0.0", new URI("file:src/test/resources/apps/foo-task"),
+				new URI("file:src/test/resources/apps/foo-task"));
 
 		taskDefinitionRepository.save(new TaskDefinition(BASE_DEFINITION_NAME, "demo"));
 		taskDefinitionRepository.save(new TaskDefinition(CTR_DEFINITION_NAME, "demo && demo2"));
@@ -170,11 +173,11 @@ public class DefaultSchedulerServiceMultiplatformTests {
 
 	@After
 	public void tearDown() {
-		((SimpleTestScheduler)simpleTestScheduler).getSchedules().clear();
+		((SimpleTestScheduler) simpleTestScheduler).getSchedules().clear();
 	}
 
 	@Test
-	public void testSchedule(){
+	public void testSchedule() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
@@ -183,7 +186,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
 		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
 				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
-			this.commandLineArgs, null);
+				this.commandLineArgs, null);
 	}
 
 	@Test
@@ -202,41 +205,41 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform(KUBERNETES_PLATFORM, launchers));
 
 		return new DefaultSchedulerService(this.commonApplicationProperties,
-			taskPlatform, this.taskDefinitionRepository,
-			this.appRegistry, this.resourceLoader,
-			this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
-			this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
-			this.composedTaskRunnerConfigurationProperties);
+				taskPlatform, this.taskDefinitionRepository,
+				this.appRegistry, this.resourceLoader,
+				this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
+				this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
+				this.composedTaskRunnerConfigurationProperties);
 	}
 
-	public void testScheduleWithLongName(){
+	public void testScheduleWithLongName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456",
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, null);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, null);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 
 	@Test
-	public void testScheduleCTR(){
+	public void testScheduleCTR() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME));
 	}
 
 	@Test(expected = CreateScheduleException.class)
-	public void testDuplicate(){
+	public void testDuplicate() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-			this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-			this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 	}
 
 	@Test
-	public void testMultipleSchedules(){
+	public void testMultipleSchedules() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -244,13 +247,13 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	}
 
 	@Test
-	public void testGetSchedule(){
+	public void testGetSchedule() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 
 		ScheduleInfo schedule = schedulerService.getSchedule(BASE_SCHEDULE_NAME + 1, KUBERNETES_PLATFORM);
 		verifyScheduleExistsInScheduler(schedule);
@@ -263,13 +266,13 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	@Test
 	public void testRemoveSchedulesForTaskDefinitionName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 4,
-			CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		validateSchedulesCount(4);
 		schedulerService.unscheduleForTaskDefinition(BASE_DEFINITION_NAME);
 		validateSchedulesCount(1);
@@ -278,13 +281,13 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	}
 
 	@Test
-	public void testUnschedule(){
+	public void testUnschedule() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -297,20 +300,20 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	}
 
 	@Test
-	public void testEmptyUnschedule(){
+	public void testEmptyUnschedule() {
 		validateSchedulesCount(0);
 		schedulerService.unschedule(BASE_SCHEDULE_NAME + 2, KUBERNETES_PLATFORM);
 		validateSchedulesCount(0);
 	}
 
 	@Test
-	public void testList(){
+	public void testList() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 
 		List<ScheduleInfo> schedules = schedulerService.listForPlatform(KUBERNETES_PLATFORM);
 		assertThat(schedules.size()).isEqualTo(3);
@@ -325,7 +328,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		schedulerServiceProperties.setMaxSchedulesReturned(MAX_COUNT);
 		for (int i = 0; i < MAX_COUNT + 1; i++) {
 			schedulerService.schedule(BASE_SCHEDULE_NAME + i,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+					BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		}
 		List<ScheduleInfo> schedules = schedulerService.listForPlatform(KUBERNETES_PLATFORM);
 		assertThat(schedules.size()).isEqualTo(MAX_COUNT);
@@ -345,11 +348,11 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	public void testListWithParams() {
 		taskDefinitionRepository.save(new TaskDefinition(BASE_DEFINITION_NAME + 1, "demo"));
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
 
 		List<ScheduleInfo> schedules = schedulerService.list(BASE_DEFINITION_NAME + 1, KUBERNETES_PLATFORM);
 		assertThat(schedules.size()).isEqualTo(1);
@@ -366,7 +369,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	}
 
 	@Test
-	public void testScheduleWithCommandLineArguments() throws Exception{
+	public void testScheduleWithCommandLineArguments() throws Exception {
 		List<String> commandLineArguments = getCommandLineArguments(Arrays.asList("--myArg1", "--myArg2"));
 
 		assertNotNull("Command line arguments should not be null", commandLineArguments);
@@ -393,19 +396,19 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		launchers.add(launcher);
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
 		SchedulerService mockSchedulerService = new DefaultSchedulerService(mock(CommonApplicationProperties.class),
-			taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
-			this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
-			mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
-			mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
+				taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
+				this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
+				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
+				mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
 
 		TaskDefinition taskDefinition = new TaskDefinition(BASE_DEFINITION_NAME, "timestamp");
 
 		when(mockTaskDefinitionRepository.findById(BASE_DEFINITION_NAME)).thenReturn(Optional.of(taskDefinition));
 		when(mockAppRegistryService.getAppResource(any())).thenReturn(new DockerResource("springcloudtask/timestamp-task:latest"));
 		when(mockAppRegistryService.find(taskDefinition.getRegisteredAppName(), ApplicationType.task))
-			.thenReturn(new AppRegistration());
+				.thenReturn(new AppRegistration());
 		mockSchedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties,
-			commandLineArguments, null);
+				commandLineArguments, null);
 
 		ArgumentCaptor<ScheduleRequest> scheduleRequestArgumentCaptor = ArgumentCaptor.forClass(ScheduleRequest.class);
 		verify(mockScheduler).schedule(scheduleRequestArgumentCaptor.capture());
@@ -416,23 +419,20 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	private void verifyScheduleExistsInScheduler(ScheduleInfo scheduleInfo) {
 		List<ScheduleInfo> scheduleInfos = schedulerService.listForPlatform(KUBERNETES_PLATFORM);
 		scheduleInfos = scheduleInfos.stream().filter(s -> s.getScheduleName().
-			equals(scheduleInfo.getScheduleName())).
-			collect(Collectors.toList());
+				equals(scheduleInfo.getScheduleName())).collect(Collectors.toList());
 
 		assertThat(scheduleInfos.size()).isEqualTo(1);
 		assertThat(scheduleInfos.get(0).getTaskDefinitionName()).isEqualTo(
-			scheduleInfo.getTaskDefinitionName());
+				scheduleInfo.getTaskDefinitionName());
 
-		for(String key: scheduleInfo.getScheduleProperties().keySet()) {
-			assertThat(scheduleInfos.get(0).getScheduleProperties().
-				get(key)).
-				isEqualTo(scheduleInfo.getScheduleProperties().get(key));
+		for (String key : scheduleInfo.getScheduleProperties().keySet()) {
+			assertThat(scheduleInfos.get(0).getScheduleProperties().get(key))
+					.isEqualTo(scheduleInfo.getScheduleProperties().get(key));
 		}
 	}
 
 	private void validateSchedulesCount(int expectedScheduleCount) {
-		assertThat(((SimpleTestScheduler) simpleTestScheduler).
-			getSchedules().size()).isEqualTo(expectedScheduleCount);
+		assertThat(((SimpleTestScheduler) simpleTestScheduler).getSchedules().size()).isEqualTo(expectedScheduleCount);
 	}
 
 	private ScheduleInfo createScheduleInfo(String scheduleName) {
@@ -449,7 +449,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 
 	private void initializeSuccessfulRegistry() {
 		when(this.appRegistry.find(anyString(), any(ApplicationType.class)))
-			.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
+				.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
 		when(this.appRegistry.getAppResource(any())).thenReturn(mock(Resource.class));
 		when(this.appRegistry.getAppMetadataResource(any())).thenReturn(null);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -78,16 +78,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {TaskServiceDependencies.class,
-	PropertyPlaceholderAutoConfiguration.class}, properties = {
-	"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
-	"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
-	"spring.main.allow-bean-definition-overriding=true",
-	"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
-	"spring.cloud.dataflow.task.platform.timezone=UTC",
-	"spring.cloud.dataflow.features.schedules-enabled=true"})
-@EnableConfigurationProperties({CommonApplicationProperties.class, TaskConfigurationProperties.class,
-	DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class, TaskPlatformConfigurationProperties.class})
+@SpringBootTest(classes = { TaskServiceDependencies.class,
+		PropertyPlaceholderAutoConfiguration.class }, properties = {
+				"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
+				"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
+				"spring.main.allow-bean-definition-overriding=true",
+				"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
+				"spring.cloud.dataflow.task.platform.timezone=UTC",
+				"spring.cloud.dataflow.features.schedules-enabled=true" })
+@EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class,
+		DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class,
+		TaskPlatformConfigurationProperties.class })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 public class DefaultSchedulerServiceTests {
@@ -100,7 +101,7 @@ public class DefaultSchedulerServiceTests {
 
 	private static final String BASE_DEFINITION_NAME = "myTaskDefinition";
 
-	private static final String CTR_DEFINITION_NAME= "myCtrDefinition";
+	private static final String CTR_DEFINITION_NAME = "myCtrDefinition";
 
 	@Autowired
 	private Scheduler simpleTestScheduler;
@@ -130,7 +131,7 @@ public class DefaultSchedulerServiceTests {
 	private ResourceLoader resourceLoader;
 
 	@Autowired
-	private  AuditRecordService auditRecordService;
+	private AuditRecordService auditRecordService;
 
 	@Autowired
 	private ApplicationConfigurationMetadataResolver metaDataResolver;
@@ -174,9 +175,17 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testScheduleByPlatformTimezone() {
+	public void testScheduleByK8SPlatformTimezone() {
 		this.testProperties.put(DATA_FLOW_SCHEDULER_PREFIX + "TEST", "0 0 * * *");
 		this.resolvedProperties.put(SCHEDULER_PREFIX + "TEST", "0 0 * * *");
+		schedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
+	}
+
+	@Test
+	public void testScheduleByCFPlatformTimezone() {
+		this.testProperties.put(DATA_FLOW_SCHEDULER_PREFIX + "TEST", "*/1 0 ? * *");
+		this.resolvedProperties.put(SCHEDULER_PREFIX + "TEST", "*/1 0 ? * *");
 		schedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
@@ -185,7 +194,7 @@ public class DefaultSchedulerServiceTests {
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
 		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
 				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
-			this.commandLineArgs, null);
+				this.commandLineArgs, null);
 	}
 
 	@Test
@@ -204,11 +213,11 @@ public class DefaultSchedulerServiceTests {
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
 
 		return new DefaultSchedulerService(this.commonApplicationProperties,
-			taskPlatform, this.taskDefinitionRepository,
-			this.appRegistry, this.resourceLoader,
-			this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
-			this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
-			this.composedTaskRunnerConfigurationProperties);
+				taskPlatform, this.taskDefinitionRepository,
+				this.appRegistry, this.resourceLoader,
+				this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
+				this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
+				this.composedTaskRunnerConfigurationProperties);
 	}
 
 	private SchedulerService getMockedKubernetesSchedulerServiceByPlatformTimeZone() {
@@ -220,16 +229,16 @@ public class DefaultSchedulerServiceTests {
 		taskPlatformConfigurationProperties.setTimezone("UTC");
 		taskConfigurationProperties.setTaskPlatformConfigurationProperties(taskPlatformConfigurationProperties);
 		return new DefaultSchedulerService(this.commonApplicationProperties,
-			taskPlatform, this.taskDefinitionRepository,
-			this.appRegistry, this.resourceLoader,
-			this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
-			this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
-			this.composedTaskRunnerConfigurationProperties);
+				taskPlatform, this.taskDefinitionRepository,
+				this.appRegistry, this.resourceLoader,
+				this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
+				this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
+				this.composedTaskRunnerConfigurationProperties);
 	}
 
 	public void testScheduleWithLongName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456",
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 
@@ -240,21 +249,21 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test(expected = CreateScheduleException.class)
-	public void testDuplicate(){
+	public void testDuplicate() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-			this.testProperties, this.commandLineArgs);
+				this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-			this.testProperties, this.commandLineArgs);
+				this.testProperties, this.commandLineArgs);
 	}
 
 	@Test
-	public void testMultipleSchedules(){
+	public void testMultipleSchedules() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -264,13 +273,13 @@ public class DefaultSchedulerServiceTests {
 	@Test
 	public void testRemoveSchedulesForTaskDefinitionName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 4,
-			CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		validateSchedulesCount(4);
 		schedulerService.unscheduleForTaskDefinition(BASE_DEFINITION_NAME);
 		validateSchedulesCount(1);
@@ -279,13 +288,13 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testUnschedule(){
+	public void testUnschedule() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -298,20 +307,20 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testEmptyUnschedule(){
+	public void testEmptyUnschedule() {
 		validateSchedulesCount(0);
 		schedulerService.unschedule(BASE_SCHEDULE_NAME + 2);
 		validateSchedulesCount(0);
 	}
 
 	@Test
-	public void testList(){
+	public void testList() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		List<ScheduleInfo> schedules = schedulerService.list();
 		assertThat(schedules.size()).isEqualTo(3);
@@ -321,13 +330,13 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testGetSchedule(){
+	public void testGetSchedule() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		ScheduleInfo schedule = schedulerService.getSchedule(BASE_SCHEDULE_NAME + 1);
 		verifyScheduleExistsInScheduler(schedule);
@@ -337,14 +346,13 @@ public class DefaultSchedulerServiceTests {
 		verifyScheduleExistsInScheduler(schedule);
 	}
 
-
 	@Test
 	public void testListMaxEntry() {
 		final int MAX_COUNT = 500;
 		schedulerServiceProperties.setMaxSchedulesReturned(MAX_COUNT);
 		for (int i = 0; i < MAX_COUNT + 1; i++) {
 			schedulerService.schedule(BASE_SCHEDULE_NAME + i,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+					BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		}
 		List<ScheduleInfo> schedules = schedulerService.list();
 		assertThat(schedules.size()).isEqualTo(MAX_COUNT);
@@ -364,11 +372,11 @@ public class DefaultSchedulerServiceTests {
 	public void testListWithParams() {
 		taskDefinitionRepository.save(new TaskDefinition(BASE_DEFINITION_NAME + 1, "demo"));
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-			BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		List<ScheduleInfo> schedules = schedulerService.list(BASE_DEFINITION_NAME + 1);
 		assertThat(schedules.size()).isEqualTo(1);
@@ -385,7 +393,7 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testScheduleWithCommandLineArguments() throws Exception{
+	public void testScheduleWithCommandLineArguments() throws Exception {
 		List<String> commandLineArguments = getCommandLineArguments(Arrays.asList("--myArg1", "--myArg2"));
 
 		assertNotNull("Command line arguments should not be null", commandLineArguments);
@@ -423,19 +431,19 @@ public class DefaultSchedulerServiceTests {
 		launchers.add(launcher);
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
 		SchedulerService mockSchedulerService = new DefaultSchedulerService(mock(CommonApplicationProperties.class),
-			taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
-			this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
-			mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
-			mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
+				taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
+				this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
+				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
+				mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
 
 		TaskDefinition taskDefinition = new TaskDefinition(BASE_DEFINITION_NAME, definition);
 
 		when(mockTaskDefinitionRepository.findById(BASE_DEFINITION_NAME)).thenReturn(Optional.of(taskDefinition));
 		when(mockAppRegistryService.getAppResource(any())).thenReturn(new DockerResource(resourceToReturn));
 		when(mockAppRegistryService.find(taskDefinition.getRegisteredAppName(), ApplicationType.task))
-			.thenReturn(new AppRegistration());
+				.thenReturn(new AppRegistration());
 		mockSchedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties,
-			commandLineArguments, null);
+				commandLineArguments, null);
 
 		ArgumentCaptor<ScheduleRequest> scheduleRequestArgumentCaptor = ArgumentCaptor.forClass(ScheduleRequest.class);
 		verify(mockScheduler).schedule(scheduleRequestArgumentCaptor.capture());
@@ -444,24 +452,21 @@ public class DefaultSchedulerServiceTests {
 
 	private void verifyScheduleExistsInScheduler(ScheduleInfo scheduleInfo) {
 		List<ScheduleInfo> scheduleInfos = schedulerService.list();
-		scheduleInfos = scheduleInfos.stream().filter(s -> s.getScheduleName().
-			equals(scheduleInfo.getScheduleName())).
-			collect(Collectors.toList());
+		scheduleInfos = scheduleInfos.stream().filter(s -> s.getScheduleName().equals(scheduleInfo.getScheduleName()))
+				.collect(Collectors.toList());
 
 		assertThat(scheduleInfos.size()).isEqualTo(1);
 		assertThat(scheduleInfos.get(0).getTaskDefinitionName()).isEqualTo(
-			scheduleInfo.getTaskDefinitionName());
+				scheduleInfo.getTaskDefinitionName());
 
-		for(String key: scheduleInfo.getScheduleProperties().keySet()) {
-			assertThat(scheduleInfos.get(0).getScheduleProperties().
-				get(key)).
-				isEqualTo(scheduleInfo.getScheduleProperties().get(key));
+		for (String key : scheduleInfo.getScheduleProperties().keySet()) {
+			assertThat(scheduleInfos.get(0).getScheduleProperties().get(key))
+					.isEqualTo(scheduleInfo.getScheduleProperties().get(key));
 		}
 	}
 
 	private void validateSchedulesCount(int expectedScheduleCount) {
-		assertThat(((SimpleTestScheduler) simpleTestScheduler).
-			getSchedules().size()).isEqualTo(expectedScheduleCount);
+		assertThat(((SimpleTestScheduler) simpleTestScheduler).getSchedules().size()).isEqualTo(expectedScheduleCount);
 	}
 
 	private ScheduleInfo createScheduleInfo(String scheduleName) {
@@ -478,7 +483,7 @@ public class DefaultSchedulerServiceTests {
 
 	private void initializeSuccessfulRegistry() {
 		when(this.appRegistry.find(anyString(), any(ApplicationType.class)))
-			.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
+				.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
 		when(this.appRegistry.getAppResource(any())).thenReturn(mock(Resource.class));
 		when(this.appRegistry.getAppMetadataResource(any())).thenReturn(null);
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -78,15 +78,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { TaskServiceDependencies.class,
-		PropertyPlaceholderAutoConfiguration.class }, properties = {
-		"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
-		"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
-		"spring.main.allow-bean-definition-overriding=true",
-		"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
-		"spring.cloud.dataflow.features.schedules-enabled=true"})
-@EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class,
-		DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class})
+@SpringBootTest(classes = {TaskServiceDependencies.class,
+	PropertyPlaceholderAutoConfiguration.class}, properties = {
+	"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
+	"spring.cloud.dataflow.applicationProperties.stream.globalstreamkey=nothere",
+	"spring.main.allow-bean-definition-overriding=true",
+	"spring.cloud.dataflow.task.scheduler-task-launcher-url=https://test.test",
+	"spring.cloud.dataflow.task.platform.timezone=UTC",
+	"spring.cloud.dataflow.features.schedules-enabled=true"})
+@EnableConfigurationProperties({CommonApplicationProperties.class, TaskConfigurationProperties.class,
+	DockerValidatorProperties.class, ComposedTaskRunnerConfigurationProperties.class, TaskPlatformConfigurationProperties.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 public class DefaultSchedulerServiceTests {
@@ -163,11 +164,19 @@ public class DefaultSchedulerServiceTests {
 
 	@After
 	public void tearDown() {
-		((SimpleTestScheduler)simpleTestScheduler).getSchedules().clear();
+		((SimpleTestScheduler) simpleTestScheduler).getSchedules().clear();
 	}
 
 	@Test
-	public void testSchedule(){
+	public void testSchedule() {
+		schedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
+	}
+
+	@Test
+	public void testScheduleByPlatformTimezone() {
+		this.testProperties.put(DATA_FLOW_SCHEDULER_PREFIX + "TEST", "0 0 * * *");
+		this.resolvedProperties.put(SCHEDULER_PREFIX + "TEST", "0 0 * * *");
 		schedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
@@ -176,7 +185,7 @@ public class DefaultSchedulerServiceTests {
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
 		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
 				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
-				this.commandLineArgs, null);
+			this.commandLineArgs, null);
 	}
 
 	@Test
@@ -195,21 +204,37 @@ public class DefaultSchedulerServiceTests {
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
 
 		return new DefaultSchedulerService(this.commonApplicationProperties,
-				taskPlatform, this.taskDefinitionRepository,
-				this.appRegistry, this.resourceLoader,
-				this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
-				this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
-				this.composedTaskRunnerConfigurationProperties);
+			taskPlatform, this.taskDefinitionRepository,
+			this.appRegistry, this.resourceLoader,
+			this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
+			this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
+			this.composedTaskRunnerConfigurationProperties);
 	}
 
-	public void testScheduleWithLongName(){
+	private SchedulerService getMockedKubernetesSchedulerServiceByPlatformTimeZone() {
+		Launcher launcher = new Launcher("default", "Kubernetes", Mockito.mock(TaskLauncher.class), scheduler);
+		List<Launcher> launchers = new ArrayList<>();
+		launchers.add(launcher);
+		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
+		TaskPlatformConfigurationProperties taskPlatformConfigurationProperties = new TaskPlatformConfigurationProperties();
+		taskPlatformConfigurationProperties.setTimezone("UTC");
+		taskConfigurationProperties.setTaskPlatformConfigurationProperties(taskPlatformConfigurationProperties);
+		return new DefaultSchedulerService(this.commonApplicationProperties,
+			taskPlatform, this.taskDefinitionRepository,
+			this.appRegistry, this.resourceLoader,
+			this.taskConfigurationProperties, mock(DataSourceProperties.class), null,
+			this.metaDataResolver, this.schedulerServiceProperties, this.auditRecordService,
+			this.composedTaskRunnerConfigurationProperties);
+	}
+
+	public void testScheduleWithLongName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + "12345677890123456",
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 
 	@Test
-	public void testScheduleCTR(){
+	public void testScheduleCTR() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME));
 	}
@@ -217,19 +242,19 @@ public class DefaultSchedulerServiceTests {
 	@Test(expected = CreateScheduleException.class)
 	public void testDuplicate(){
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs);
+			this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs);
+			this.testProperties, this.commandLineArgs);
 	}
 
 	@Test
 	public void testMultipleSchedules(){
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -239,13 +264,13 @@ public class DefaultSchedulerServiceTests {
 	@Test
 	public void testRemoveSchedulesForTaskDefinitionName() {
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 4,
-				CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			CTR_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		validateSchedulesCount(4);
 		schedulerService.unscheduleForTaskDefinition(BASE_DEFINITION_NAME);
 		validateSchedulesCount(1);
@@ -256,11 +281,11 @@ public class DefaultSchedulerServiceTests {
 	@Test
 	public void testUnschedule(){
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 1));
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME + 2));
@@ -282,11 +307,11 @@ public class DefaultSchedulerServiceTests {
 	@Test
 	public void testList(){
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		List<ScheduleInfo> schedules = schedulerService.list();
 		assertThat(schedules.size()).isEqualTo(3);
@@ -298,11 +323,11 @@ public class DefaultSchedulerServiceTests {
 	@Test
 	public void testGetSchedule(){
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		ScheduleInfo schedule = schedulerService.getSchedule(BASE_SCHEDULE_NAME + 1);
 		verifyScheduleExistsInScheduler(schedule);
@@ -319,7 +344,7 @@ public class DefaultSchedulerServiceTests {
 		schedulerServiceProperties.setMaxSchedulesReturned(MAX_COUNT);
 		for (int i = 0; i < MAX_COUNT + 1; i++) {
 			schedulerService.schedule(BASE_SCHEDULE_NAME + i,
-					BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		}
 		List<ScheduleInfo> schedules = schedulerService.list();
 		assertThat(schedules.size()).isEqualTo(MAX_COUNT);
@@ -339,11 +364,11 @@ public class DefaultSchedulerServiceTests {
 	public void testListWithParams() {
 		taskDefinitionRepository.save(new TaskDefinition(BASE_DEFINITION_NAME + 1, "demo"));
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 1,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 2,
-				BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME + 1, this.testProperties, this.commandLineArgs);
 		schedulerService.schedule(BASE_SCHEDULE_NAME + 3,
-				BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
+			BASE_DEFINITION_NAME, this.testProperties, this.commandLineArgs);
 
 		List<ScheduleInfo> schedules = schedulerService.list(BASE_DEFINITION_NAME + 1);
 		assertThat(schedules.size()).isEqualTo(1);
@@ -398,19 +423,19 @@ public class DefaultSchedulerServiceTests {
 		launchers.add(launcher);
 		List<TaskPlatform> taskPlatform = Collections.singletonList(new TaskPlatform("testTaskPlatform", launchers));
 		SchedulerService mockSchedulerService = new DefaultSchedulerService(mock(CommonApplicationProperties.class),
-				taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
-				this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
-				mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
-				mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
+			taskPlatform, mockTaskDefinitionRepository, mockAppRegistryService, mock(ResourceLoader.class),
+			this.taskConfigurationProperties, mock(DataSourceProperties.class), "uri",
+			mock(ApplicationConfigurationMetadataResolver.class), mock(SchedulerServiceProperties.class),
+			mock(AuditRecordService.class), this.composedTaskRunnerConfigurationProperties);
 
 		TaskDefinition taskDefinition = new TaskDefinition(BASE_DEFINITION_NAME, definition);
 
 		when(mockTaskDefinitionRepository.findById(BASE_DEFINITION_NAME)).thenReturn(Optional.of(taskDefinition));
 		when(mockAppRegistryService.getAppResource(any())).thenReturn(new DockerResource(resourceToReturn));
 		when(mockAppRegistryService.find(taskDefinition.getRegisteredAppName(), ApplicationType.task))
-				.thenReturn(new AppRegistration());
+			.thenReturn(new AppRegistration());
 		mockSchedulerService.schedule(BASE_SCHEDULE_NAME, BASE_DEFINITION_NAME, this.testProperties,
-				commandLineArguments, null);
+			commandLineArguments, null);
 
 		ArgumentCaptor<ScheduleRequest> scheduleRequestArgumentCaptor = ArgumentCaptor.forClass(ScheduleRequest.class);
 		verify(mockScheduler).schedule(scheduleRequestArgumentCaptor.capture());
@@ -420,23 +445,23 @@ public class DefaultSchedulerServiceTests {
 	private void verifyScheduleExistsInScheduler(ScheduleInfo scheduleInfo) {
 		List<ScheduleInfo> scheduleInfos = schedulerService.list();
 		scheduleInfos = scheduleInfos.stream().filter(s -> s.getScheduleName().
-				equals(scheduleInfo.getScheduleName())).
-				collect(Collectors.toList());
+			equals(scheduleInfo.getScheduleName())).
+			collect(Collectors.toList());
 
 		assertThat(scheduleInfos.size()).isEqualTo(1);
 		assertThat(scheduleInfos.get(0).getTaskDefinitionName()).isEqualTo(
-				scheduleInfo.getTaskDefinitionName());
+			scheduleInfo.getTaskDefinitionName());
 
 		for(String key: scheduleInfo.getScheduleProperties().keySet()) {
 			assertThat(scheduleInfos.get(0).getScheduleProperties().
-					get(key)).
-					isEqualTo(scheduleInfo.getScheduleProperties().get(key));
+				get(key)).
+				isEqualTo(scheduleInfo.getScheduleProperties().get(key));
 		}
 	}
 
 	private void validateSchedulesCount(int expectedScheduleCount) {
-		assertThat(((SimpleTestScheduler)simpleTestScheduler).
-				getSchedules().size()).isEqualTo(expectedScheduleCount);
+		assertThat(((SimpleTestScheduler) simpleTestScheduler).
+			getSchedules().size()).isEqualTo(expectedScheduleCount);
 	}
 
 	private ScheduleInfo createScheduleInfo(String scheduleName) {
@@ -453,7 +478,7 @@ public class DefaultSchedulerServiceTests {
 
 	private void initializeSuccessfulRegistry() {
 		when(this.appRegistry.find(anyString(), any(ApplicationType.class)))
-				.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
+			.thenReturn(new AppRegistration("demo", ApplicationType.task, URI.create("https://helloworld")));
 		when(this.appRegistry.getAppResource(any())).thenReturn(mock(Resource.class));
 		when(this.appRegistry.getAppMetadataResource(any())).thenReturn(null);
 	}


### PR DESCRIPTION
Fixes #4303
add TaskPlatformConfigurationProperties.java (set platform timezone)
add cronutils dependency (9.1.3)

If the timzone of the platform exists, the cron expression is changed to the cron expression of the platform.
and
This changes the cron expression of the platform to the cron expression of the server even when importing the task.

@sabbyanandan 
Check this commit https://github.com/spring-cloud/spring-cloud-dataflow/pull/4304/commits/627d8c04b69e132ed8b448102bf7ca8156b186f4