### PR TITLE
Inject WF tracing properties to the stream apps

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/application-stream-common-properties-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/application-stream-common-properties-defaults.yml
@@ -11,7 +11,10 @@ common:
 
         # Tags required to use the Wavefront Spring Boot tile.
         application: ${spring.cloud.dataflow.stream.name:unknown}-${spring.cloud.dataflow.stream.app.label:unknown}-${spring.cloud.dataflow.stream.app.type:unknown}
-        service: "stream-application"
+
+  # Properties required for Wavefront Tracing.
+  wavefront.application.name: ${spring.cloud.dataflow.stream.name:unknown}
+  wavefront.application.service: ${spring.cloud.dataflow.stream.app.label:unknown}-${spring.cloud.dataflow.stream.app.type:unknown}
 
 local:
 


### PR DESCRIPTION
 - inject wf.application.name and wf.service properties to the deployed streaming apps to enable the WF tracing support.

 Resolves #4333