### PR TITLE
Align task ITs with latest ATs

### DIFF
--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/task/Task.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/dsl/task/Task.java
@@ -249,6 +249,16 @@ public class Task implements AutoCloseable {
 						.collect(Collectors.toList());
 	}
 
+	/**
+	 * @param childTaskLabel Name of the child composed task (excluding the parent prefix).
+	 * @return The child composed task for the given name.
+	 */
+	public Optional<Task> composedTaskChildTaskByLabel(String childTaskLabel) {
+		return this.composedTaskChildTasks().stream()
+				.filter(childTask -> childTask.getTaskName().endsWith("-" + childTaskLabel)).findFirst();
+	}
+
+
 	//--------------------------------------------------------------------------------------------------------
 	//                                    TASK JOBS
 	//--------------------------------------------------------------------------------------------------------

--- a/spring-cloud-dataflow-server/docker-compose-dood.yml
+++ b/spring-cloud-dataflow-server/docker-compose-dood.yml
@@ -71,4 +71,5 @@ services:
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-latest&force=true}';
         echo 'Docker Stream apps imported'
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-latest&force=true}';
+        wget -qO- 'http://dataflow-server:9393/apps/task/scenario/0.0.1-SNAPSHOT' --post-data='uri=docker:springcloudtask/scenario-task:0.0.1-SNAPSHOT';
         echo 'Docker Task apps imported'"

--- a/spring-cloud-dataflow-server/docker-compose.yml
+++ b/spring-cloud-dataflow-server/docker-compose.yml
@@ -92,6 +92,7 @@ services:
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-latest&force=true}';
         echo 'Maven Stream apps imported'
         wget -qO- 'http://dataflow-server:9393/apps' --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-latest&force=true}';
+        wget -qO- 'http://dataflow-server:9393/apps/task/scenario/0.0.1-SNAPSHOT' --post-data='uri=maven://io.spring:scenario-task:0.0.1-SNAPSHOT';
         echo 'Maven Task apps imported'"
 
   skipper-server:

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -76,8 +77,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestTemplate;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -961,7 +961,7 @@ public class DataFlowIT {
 		assertThat(taskBuilder.allTasks().size()).isEqualTo(0);
 	}
 
-		@Test
+	@Test
 	public void ctrFailedGraph() {
 		logger.info("composed-task-ctrFailedGraph-test");
 		mixedSuccessfulFailedAndUnknownExecutions("ctrFailedGraph",
@@ -1314,5 +1314,13 @@ public class DataFlowIT {
 
 	private String randomJobName() {
 		return "job-" + UUID.randomUUID().toString().substring(0, 10);
+	}
+
+	private static List<String> asList(String... names) {
+		return Arrays.asList(names);
+	}
+
+	private static List<String> emptyList() {
+		return Collections.emptyList();
 	}
 }


### PR DESCRIPTION
Align task ITs with latest ATs

- Port the following (newly added) task ATs as ITs (docker-compose run). Retain the test names as provided in the ATs.
   ctrFailedGraph()
   ctrSplit()
   ctrSequential()
   ctrSequentialTransitionAndSplitWithScenarioFailed()
   ctrSequentialTransitionAndSplitWithScenarioOk()
   ctrNestedSplit()
   testEmbeddedFailedGraph()
   twoSplitTest()
   sequentialAndSplitTest()
   sequentialTransitionAndSplitFailedInvalidTest()
   sequentialAndSplitWithFlowTest()
   sequentialAndFailedSplitTest()
   failedBasicTransitionTest()
   successBasicTransitionTest()
   basicTransitionWithTransitionTest()
   wildCardOnlyInLastPositionTest()
   failedCTRRetryTest()
- Support for the `scenario` task app for both Maven/jar and Docker test.