### PR TITLE
Restore task app version from manifest

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskExecutionInfoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,12 @@ public interface TaskExecutionInfoService {
 	 * @param taskName the name of the task definition
 	 * @param taskDeploymentProperties the deployment properties to use for the {@link TaskExecutionInformation}
 	 * @param addDatabaseCredentials  true if database credentials should be added to the {@link TaskExecutionInformation}
+	 * @param previousTaskDeploymentProperties the previous deployment properties to use for the {@link TaskExecutionInformation}
 	 * @return instance of {@link TaskExecutionInformation}
 	 */
 	TaskExecutionInformation findTaskExecutionInformation(String taskName,
-			Map<String, String> taskDeploymentProperties, boolean addDatabaseCredentials);
+			Map<String, String> taskDeploymentProperties, boolean addDatabaseCredentials,
+			Map<String, String> previousTaskDeploymentProperties);
 
 	AllPlatformsTaskExecutionInformation findAllPlatformTaskExecutionInformation();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
@@ -149,7 +149,7 @@ public class DefaultTaskExecutionInfoService implements TaskExecutionInfoService
 
 	@Override
 	public TaskExecutionInformation findTaskExecutionInformation(String taskName,
-			Map<String, String> taskDeploymentProperties, boolean addDatabaseCredentials) {
+			Map<String, String> taskDeploymentProperties, boolean addDatabaseCredentials, Map<String, String> previousTaskDeploymentProperties) {
 		Assert.hasText(taskName, "The provided taskName must not be null or empty.");
 		Assert.notNull(taskDeploymentProperties, "The provided runtimeProperties must not be null.");
 
@@ -201,6 +201,10 @@ public class DefaultTaskExecutionInfoService implements TaskExecutionInfoService
 				}
 			}
 			String version = taskDeploymentProperties.get("version." + label);
+			if (version == null) {
+				// restore from previous "manifest"
+				version = previousTaskDeploymentProperties.get("version." + label);
+			}
 			// if we have version, use that or rely on default version set
 			if (version == null) {
 				appRegistration = appRegistryService.find(taskDefinitionToUse.getRegisteredAppName(),


### PR DESCRIPTION
- If version is not explicitely passed in with launch,
  don't switch back to default version.
- This fixes default case with shell when you just relaunch,
  but doesn't change anything on a UI side where version is
  still the one defined in a form(not yet rehydrated from
  previous manifest).
- Fixes #4381