### PR TITLE
Use correct version options with composed tasks

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -295,7 +295,15 @@ public class TaskServiceUtils {
 
 		String versionProperties = taskDeploymentProperties.entrySet().stream()
 				.filter(e -> e.getKey().startsWith(subTaskName1) || e.getKey().startsWith(subTaskName2))
-				.map(e -> String.format("%s.%s", subTaskName1, subTaskName3) + "=" + e.getValue())
+				.map(e -> {
+					// ctr subtasks are created like definition is, i.e with labels, need to use those
+					if (StringUtils.hasText(subTask.getLabel())) {
+						return String.format("%s.%s", subTaskName1, subTask.getLabel()) + "=" + e.getValue();
+					}
+					else {
+						return String.format("%s.%s", subTaskName1, subTaskName3) + "=" + e.getValue();
+					}
+				})
 				.collect(Collectors.joining(", "));
 		if (StringUtils.hasText(versionProperties)) {
 			if (result.length() != 0) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -1147,7 +1147,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			AppDeploymentRequest request = prepComposedTaskRunnerWithVersions(null);
 			assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 			assertTrue(request.getDefinition().getProperties().containsKey("composed-task-properties"));
-			assertEquals("version.seqTask-t1.some-name=1.0.0, version.seqTask-t2.some-name=1.0.1",
+			assertEquals("version.seqTask-t1.t1=1.0.0, version.seqTask-t2.t2=1.0.1",
 					request.getDefinition().getProperties().get("composed-task-properties"));
 			assertEquals("globalvalue", request.getDefinition().getProperties().get("globalkey"));
 			assertNull(request.getDefinition().getProperties().get("globalstreamkey"));


### PR DESCRIPTION
- With original impl for #4258 and #4265, we changed ctr subtask
  to get created with labels if those were in a dsl but forget
  to do same change when passing version info around.
- Now properly using label with version.