### PR TITLE
Generate standalone ITs tests jar

### DIFF
--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -153,6 +153,17 @@
 				  </images>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -326,12 +326,9 @@ public class DataFlowIT {
 
 			Awaitility.await().until(() -> stream.getStatus().equals(DEPLOYED));
 
-			Map<String, String> httpApp = runtimeApps.getApplicationInstances(stream.getName(), "http")
-					.values().iterator().next();
-
 			String message = "Unique Test message: " + new Random().nextInt();
 
-			httpPost(runtimeApps.getApplicationInstanceUrl(httpApp), message);
+			httpPost(runtimeApps.getApplicationInstanceUrl(stream.getName(), "http"), message);
 
 			Awaitility.await().until(() -> stream.logs(app("log")).contains(message.toUpperCase()));
 		}
@@ -360,13 +357,8 @@ public class DataFlowIT {
 
 			Awaitility.await().until(() -> stream.getStatus().equals(DEPLOYED));
 
-			Map<String, String> httpApp = runtimeApps.getApplicationInstances(stream.getName(), "http")
-					.values().iterator().next();
-
-			String httpAppUrl = runtimeApps.getApplicationInstanceUrl(httpApp);
-
 			String message = "How much wood would a woodchuck chuck if a woodchuck could chuck wood";
-			httpPost(httpAppUrl, message);
+			httpPost(runtimeApps.getApplicationInstanceUrl(stream.getName(), "http"), message);
 
 			Awaitility.await().until(() -> {
 				Collection<String> logs = runtimeApps.applicationInstanceLogs(stream.getName(), "log").values();
@@ -509,8 +501,7 @@ public class DataFlowIT {
 
 			String message = "Unique Test message: " + new Random().nextInt();
 
-			String httpAppUrl = runtimeApps.getApplicationInstanceUrl(httpStream.getName(), "http");
-			httpPost(httpAppUrl, message);
+			httpPost(runtimeApps.getApplicationInstanceUrl(httpStream.getName(), "http"), message);
 
 			Awaitility.await().until(() -> logStream.logs(app("log")).contains(message));
 		}
@@ -536,8 +527,7 @@ public class DataFlowIT {
 
 			String message = "Unique Test message: " + new Random().nextInt();
 
-			String httpAppUrl = runtimeApps.getApplicationInstanceUrl(httpLogStream.getName(), "http");
-			httpPost(httpAppUrl, message);
+			httpPost(runtimeApps.getApplicationInstanceUrl(httpLogStream.getName(), "http"), message);
 
 			Awaitility.await().until(
 					() -> tapStream.logs(app("log")).contains(message));
@@ -570,16 +560,14 @@ public class DataFlowIT {
 
 			String messageOne = "Unique Test message: " + new Random().nextInt();
 
-			String httpAppUrl = runtimeApps.getApplicationInstanceUrl(httpStreamOne.getName(), "http");
-			httpPost(httpAppUrl, messageOne);
+			httpPost(runtimeApps.getApplicationInstanceUrl(httpStreamOne.getName(), "http"), messageOne);
 
 			Awaitility.await().until(
 					() -> logStream.logs(app("log")).contains(messageOne));
 
 			String messageTwo = "Unique Test message: " + new Random().nextInt();
 
-			String httpAppUrl2 = runtimeApps.getApplicationInstanceUrl(httpStreamTwo.getName(), "http");
-			httpPost(httpAppUrl2, messageTwo);
+			httpPost(runtimeApps.getApplicationInstanceUrl(httpStreamTwo.getName(), "http"), messageTwo);
 
 			Awaitility.await().until(
 					() -> logStream.logs(app("log")).contains(messageTwo));
@@ -735,15 +723,15 @@ public class DataFlowIT {
 	private Map<String, String> testDeploymentProperties() {
 		DeploymentPropertiesBuilder propertiesBuilder = new DeploymentPropertiesBuilder()
 				.put(SPRING_CLOUD_DATAFLOW_SKIPPER_PLATFORM_NAME, runtimeApps.getPlatformName())
-				.put("app.*.logging.file", "${PID}-test.log") // Keep it for Boot 2.x compatibility.
-				.put("app.*.logging.file.name", "${PID}-test.log")
+				.put("app.*.logging.file", "/tmp/${PID}-test.log") // Keep it for Boot 2.x compatibility.
+				.put("app.*.logging.file.name", "/tmp/${PID}-test.log")
 				.put("app.*.endpoints.logfile.sensitive", "false")
 				.put("app.*.endpoints.logfile.enabled", "true")
 				.put("app.*.management.endpoints.web.exposure.include", "*")
 				.put("app.*.spring.cloud.streamapp.security.enabled", "false");
 
 		if (this.runtimeApps.getPlatformType().equalsIgnoreCase(RuntimeApplicationHelper.KUBERNETES_PLATFORM_TYPE)) {
-			propertiesBuilder.put("app.*.server.port", "80");
+			propertiesBuilder.put("app.*.server.port", "8080");
 			propertiesBuilder.put("deployer.*.kubernetes.createLoadBalancer", "true"); // requires LoadBalancer support on the platform
 		}
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,6 +109,10 @@ public class RuntimeApplicationHelper {
 	 * @return Returns a map of app instance GUIDs and their Log content. A single entry per app instance.
 	 */
 	public Map<String, String> applicationInstanceLogs(String streamName, String appName) {
+		// For K8s platforms the availability of the app's external URI is not dependent on the application state but
+		// on the availability of the configured Load Balancer. So we need to wait until valid URI is returned.
+		Awaitility.await().until(() -> getApplicationInstanceUrl(getApplicationInstances(streamName, appName)
+				.values().iterator().next()) != null );
 		return this.appInstanceAttributes().values().stream()
 				.filter(v -> v.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_RELEASE_NAME).equals(streamName))
 				.filter(v -> v.get(StreamRuntimePropertyKeys.ATTRIBUTE_SKIPPER_APPLICATION_NAME).equals(appName))
@@ -123,9 +128,12 @@ public class RuntimeApplicationHelper {
 	 * @return Application URL
 	 */
 	public String getApplicationInstanceUrl(String streamName, String appName) {
-		Map<String, String> instanceAttributes = getApplicationInstances(streamName, appName)
-				.values().iterator().next();
-		return getApplicationInstanceUrl(instanceAttributes);
+		// For K8s platforms the availability of the app's external URI is not dependent on the application state but
+		// on the availability of the configured Load Balancer. So we need to wait until valid URI is returned.
+		Awaitility.await().until(() -> getApplicationInstanceUrl(getApplicationInstances(streamName, appName)
+				.values().iterator().next()) != null );
+		return getApplicationInstanceUrl(getApplicationInstances(streamName, appName)
+				.values().iterator().next());
 	}
 
 	/**


### PR DESCRIPTION
 - use the maven-jar-plugin to generate standalone jar for the ITs.
 - Harden the ITs getApplicationUri utilities to ensure it works with k8s platforms.
 - Fix an issue with the logfile path to ensure proper working with K8s platforms.

 Resolves #4400

 Part of the https://github.com/spring-cloud/spring-cloud-dataflow-acceptance-tests/issues/332 Epic.