### PR TITLE
Remove flyway transaction disable with postgres

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractBaselineCallback.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/AbstractBaselineCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,14 +57,7 @@ public abstract class AbstractBaselineCallback extends AbstractCallback {
 			commands.addAll(defaultCommands);
 		}
 
-		boolean migrateToInitial = true;
-		try {
-			JdbcTemplate jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
-			jdbcTemplate.execute("select 1 from APP_REGISTRATION");
-			migrateToInitial = false;
-		} catch (Exception e) {
-		}
-
+		boolean migrateToInitial = !doTableExists(context, "APP_REGISTRATION");
 		if (migrateToInitial) {
 			logger.info("Did not detect prior Data Flow schema, doing baseline.");
 			commands.addAll(initialSetupMigration.getCommands());
@@ -83,6 +76,16 @@ public abstract class AbstractBaselineCallback extends AbstractCallback {
 		}
 
 		return commands;
+	}
+
+	protected boolean doTableExists(Context context, String name) {
+		try {
+			JdbcTemplate jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
+			jdbcTemplate.execute("select 1 from APP_REGISTRATION");
+			return false;
+		} catch (Exception e) {
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
- Previously with postgres driver there was an
  attempt not to use transactions as those always
  abort it even with query errors. This as a naive
  way would cause migration issues if something
  else goes wrong and database may be left in
  a wrong state.
- With postgres, move back to transactions and
  do a table exists check which should be more
  reliable which then seem to survive in tests
  where we manually break database and next
  launch attempt after "fixing" database looks
  to bring things in a good condition.
- These new tests are not part of this commit
  but coming in with a new integation tests
  what I've run locally.
- Fixes #4370