### PR TITLE
Nest options in DataFlowITProperties

### DIFF
--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -186,13 +186,13 @@ Register the OOTB kafka/docker and task/docker apps and the run:
 ----
 ./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
     -Dtest.docker.compose.disable.extension=true \
-    -Dtest.docker.compose.dataflowServerUrl=http://your-k8s-scdf-server \
+    -Dtest.platform.connection.dataflowServerUrl=http://your-k8s-scdf-server \
     -Pfailsafe
 ----
 
 * replace `http://your-k8s-scdf-server` with the url of your Data Flow server.
 * the `test.docker.compose.disable.extension=true` property disables the docker-compose fixture.
-* the `test.docker.compose.dataflowServerUrl=` property points to the pre-installed DataFlow REST API.
+* the `test.platform.connection.dataflowServerUrl=` property points to the pre-installed DataFlow REST API.
 
 For the analytic tests you need to pre-install Prometheus according to the installation instructions and forward the prometheus server's 9090 port
 ----
@@ -200,7 +200,7 @@ kubectl port-forward prometheus-67896dcc8-7wm4h 9090:9090
 ----
 Replace the `prometheus-67896dcc8-7wm4h` with your pod name.
 
-Or use the `test.docker.compose.prometheusUrl` property to set an alternative Prometheus url.
+Or use the `test.platform.connection.prometheusUrl` property to set an alternative Prometheus url.
 
 #### Integration Tests with Minikube
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowITProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowITProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,78 +21,106 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author Christian Tzolov
  */
-@ConfigurationProperties(prefix = "test.docker.compose")
+@ConfigurationProperties(prefix = "test")
 public class DataFlowITProperties {
 
-	/**
-	 * Default url to connect to dataflow
-	 */
-	private String dataflowServerUrl = "http://localhost:9393";
+	private DockerProperties docker = new DockerProperties();
 
-	/**
-	 * default - local platform (e.g. docker-compose)
-	 * cf - Cloud Foundry platform, configured in docker-compose-cf.yml
-	 * k8s - GKE/Kubernetes platform, configured via docker-compose-k8s.yml.
-	 */
-	private String platformName = "default";
-
-	/**
-	 * Default url to connect to SCDF's Prometheus TSDB
-	 */
-	private String prometheusUrl = "http://localhost:9090";
-
-	/**
-	 * Default url to connect to SCDF's Influx TSDB
-	 */
-	private String influxUrl = "http://localhost:8086";
-
-	/**
-	 * Kubernetes tests require nginx-ingress and watchdog mechanism to expose the apps  URL
-	 * to public access. Later requires a preconfigured ingress servers domain name suffix.
-	 *
-	 * For example the Hydra AT environment hash the 'hydra.springapps.io' host name and app Urls
-	 * will have the form  https://partitioning-test-log-v1.hydra.springapps.io
-	 * or  https://partitioning-test-log-v1-1.hydra.springapps.io for multiple instance.
-	 */
-	private String kubernetesAppHostSuffix = "";
-
-	public String getDataflowServerUrl() {
-		return dataflowServerUrl;
+	public DockerProperties getDocker() {
+		return docker;
 	}
 
-	public void setDataflowServerUrl(String dataflowServerUrl) {
-		this.dataflowServerUrl = dataflowServerUrl;
+	public void setDocker(DockerProperties docker) {
+		this.docker = docker;
 	}
 
-	public String getPlatformName() {
-		return platformName;
+	public class DockerProperties {
+
+		private DockerComposeProperties compose = new DockerComposeProperties();
+
+		public DockerComposeProperties getCompose() {
+			return compose;
+		}
+
+		public void setCompose(DockerComposeProperties compose) {
+			this.compose = compose;
+		}
 	}
 
-	public void setPlatformName(String platformName) {
-		this.platformName = platformName;
-	}
+	public class DockerComposeProperties {
 
-	public String getPrometheusUrl() {
-		return prometheusUrl;
-	}
+		/**
+		 * Default url to connect to dataflow
+		 */
+		private String dataflowServerUrl = "http://localhost:9393";
 
-	public void setPrometheusUrl(String prometheusUrl) {
-		this.prometheusUrl = prometheusUrl;
-	}
+		/**
+		 * default - local platform (e.g. docker-compose) cf - Cloud Foundry platform,
+		 * configured in docker-compose-cf.yml k8s - GKE/Kubernetes platform, configured
+		 * via docker-compose-k8s.yml.
+		 */
+		private String platformName = "default";
 
-	public String getInfluxUrl() {
-		return influxUrl;
-	}
+		/**
+		 * Default url to connect to SCDF's Prometheus TSDB
+		 */
+		private String prometheusUrl = "http://localhost:9090";
 
-	public void setInfluxUrl(String influxUrl) {
-		this.influxUrl = influxUrl;
-	}
+		/**
+		 * Default url to connect to SCDF's Influx TSDB
+		 */
+		private String influxUrl = "http://localhost:8086";
 
-	public String getKubernetesAppHostSuffix() {
-		return kubernetesAppHostSuffix;
-	}
+		/**
+		 * Kubernetes tests require nginx-ingress and watchdog mechanism to expose the
+		 * apps URL to public access. Later requires a preconfigured ingress servers
+		 * domain name suffix.
+		 *
+		 * For example the Hydra AT environment hash the 'hydra.springapps.io' host name
+		 * and app Urls will have the form
+		 * https://partitioning-test-log-v1.hydra.springapps.io or
+		 * https://partitioning-test-log-v1-1.hydra.springapps.io for multiple instance.
+		 */
+		private String kubernetesAppHostSuffix = "";
 
-	public void setKubernetesAppHostSuffix(String kubernetesAppHostSuffix) {
-		this.kubernetesAppHostSuffix = kubernetesAppHostSuffix;
+		public String getDataflowServerUrl() {
+			return dataflowServerUrl;
+		}
+
+		public void setDataflowServerUrl(String dataflowServerUrl) {
+			this.dataflowServerUrl = dataflowServerUrl;
+		}
+
+		public String getPlatformName() {
+			return platformName;
+		}
+
+		public void setPlatformName(String platformName) {
+			this.platformName = platformName;
+		}
+
+		public String getPrometheusUrl() {
+			return prometheusUrl;
+		}
+
+		public void setPrometheusUrl(String prometheusUrl) {
+			this.prometheusUrl = prometheusUrl;
+		}
+
+		public String getInfluxUrl() {
+			return influxUrl;
+		}
+
+		public void setInfluxUrl(String influxUrl) {
+			this.influxUrl = influxUrl;
+		}
+
+		public String getKubernetesAppHostSuffix() {
+			return kubernetesAppHostSuffix;
+		}
+
+		public void setKubernetesAppHostSuffix(String kubernetesAppHostSuffix) {
+			this.kubernetesAppHostSuffix = kubernetesAppHostSuffix;
+		}
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -22,32 +22,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Christian Tzolov
  */
 @ConfigurationProperties(prefix = "test")
-public class DataFlowITProperties {
+public class IntegrationTestProperties {
 
-	private DockerProperties docker = new DockerProperties();
+	private PlatformProperties platform = new PlatformProperties();
 
-	public DockerProperties getDocker() {
-		return docker;
+	public PlatformProperties getPlatform() {
+		return platform;
 	}
 
-	public void setDocker(DockerProperties docker) {
-		this.docker = docker;
+	public void setPlatform(PlatformProperties platform) {
+		this.platform = platform;
 	}
 
-	public class DockerProperties {
+	public static class PlatformProperties {
 
-		private DockerComposeProperties compose = new DockerComposeProperties();
+		private PlatformConnectionProperties connection = new PlatformConnectionProperties();
 
-		public DockerComposeProperties getCompose() {
-			return compose;
+		public PlatformConnectionProperties getConnection() {
+			return connection;
 		}
 
-		public void setCompose(DockerComposeProperties compose) {
-			this.compose = compose;
+		public void setConnection(PlatformConnectionProperties connection) {
+			this.connection = connection;
 		}
 	}
 
-	public class DockerComposeProperties {
+	public static class PlatformConnectionProperties {
 
 		/**
 		 * Default url to connect to dataflow
@@ -55,9 +55,7 @@ public class DataFlowITProperties {
 		private String dataflowServerUrl = "http://localhost:9393";
 
 		/**
-		 * default - local platform (e.g. docker-compose) cf - Cloud Foundry platform,
-		 * configured in docker-compose-cf.yml k8s - GKE/Kubernetes platform, configured
-		 * via docker-compose-k8s.yml.
+		 * default - local platform, cf - Cloud Foundry platform, k8s - GKE/Kubernetes platform
 		 */
 		private String platformName = "default";
 


### PR DESCRIPTION
- Prepare to be able to add more sub-keys
  under `test` and simply nest `test.docker.compose`.
- Fixes #4418