### PR TITLE
Implement database IT tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
 		<joda-time.version>2.10.6</joda-time.version>
 		<aws-java-sdk-ecr.version>1.11.731</aws-java-sdk-ecr.version>
 		<commons-text.version>1.8</commons-text.version>
+		<testcontainers.version>1.15.2</testcontainers.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-container-registry</module>
@@ -147,6 +148,13 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dataflow-dependencies</artifactId>
 				<version>2.8.0-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>${testcontainers.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -80,6 +80,36 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mariadb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -178,17 +208,6 @@
 	</reporting>
 
 	<profiles>
-		<profile>
-			<id>failsafe</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-failsafe-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.core.ApplicationType;
+import org.springframework.cloud.dataflow.integration.test.tags.DockerCompose;
 import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactory;
 import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactoryProperties;
 import org.springframework.cloud.dataflow.integration.test.util.ResourceExtractor;
@@ -164,6 +165,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableConfigurationProperties({ IntegrationTestProperties.class })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Import(DataFlowOperationsITConfiguration.class)
+@DockerCompose
 public class DataFlowIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(DataFlowIT.class);

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -24,7 +24,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "test")
 public class IntegrationTestProperties {
 
+	private DatabaseProperties database = new DatabaseProperties();
 	private PlatformProperties platform = new PlatformProperties();
+
+	public DatabaseProperties getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(DatabaseProperties database) {
+		this.database = database;
+	}
 
 	public PlatformProperties getPlatform() {
 		return platform;
@@ -32,6 +41,37 @@ public class IntegrationTestProperties {
 
 	public void setPlatform(PlatformProperties platform) {
 		this.platform = platform;
+	}
+
+	public static class DatabaseProperties {
+
+		private String dataflowVersion;
+		private String skipperVersion;
+		private boolean sharedDatabase;
+
+		public String getDataflowVersion() {
+			return dataflowVersion;
+		}
+
+		public void setDataflowVersion(String dataflowVersion) {
+			this.dataflowVersion = dataflowVersion;
+		}
+
+		public String getSkipperVersion() {
+			return skipperVersion;
+		}
+
+		public void setSkipperVersion(String skipperVersion) {
+			this.skipperVersion = skipperVersion;
+		}
+
+		public boolean isSharedDatabase() {
+			return sharedDatabase;
+		}
+
+		public void setSharedDatabase(boolean sharedDatabase) {
+			this.sharedDatabase = sharedDatabase;
+		}
 	}
 
 	public static class PlatformProperties {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.dataflow.integration.test.tags.Database;
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseSlow;
+import org.springframework.cloud.dataflow.integration.test.tags.DataflowAll;
+import org.springframework.cloud.dataflow.integration.test.tags.DataflowMain;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * Base test class for a spesific database and defines actual tests we should
+ * have for all databases.
+ *
+ * @author Janne Valkealahti
+ */
+@Database
+public abstract class AbstractDatabaseTests extends AbstractDataflowTests {
+
+	private final Logger log = LoggerFactory.getLogger(AbstractDatabaseTests.class);
+	protected abstract String getDatabaseTag();
+
+	/**
+	 * Simply tests a bootstrap of servers with latest versions using a shared
+	 * database.
+	 */
+	@Test
+	@DataflowMain
+	public void testLatestSharedDb() {
+		log.info("Running testLatestSharedDb()");
+		// start defined database
+		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
+		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
+
+		// start defined skipper server and check it started
+		this.dataflowCluster.startSkipper(TagNames.SKIPPER_main);
+		assertSkipperServerRunning(this.dataflowCluster);
+
+		// start defined dataflow server and check it started
+		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main);
+		assertDataflowServerRunning(this.dataflowCluster);
+	}
+
+	protected Integer runCountQuery(String sql) {
+		try {
+			return runQuery(sql, Integer.class);
+		} catch (Exception e) {
+		}
+		// return negative if error, ie table doesn't exist, etc.
+		return -1;
+	}
+
+	protected <T> T runQuery(String sql, Class<T> requiredType) {
+		JdbcTemplate jdbcTemplate = getJdbcTemplate();
+		return jdbcTemplate.queryForObject(sql, requiredType);
+	}
+
+	protected void runExecute(String sql) {
+		JdbcTemplate jdbcTemplate = getJdbcTemplate();
+		jdbcTemplate.execute(sql);
+	}
+
+	protected JdbcTemplate getJdbcTemplate() {
+		String jdbcUrl = this.dataflowCluster.getDataflowDatabaseHostJdbcUrl();
+		SingleConnectionDataSource dataSource = new SingleConnectionDataSource(jdbcUrl, "spring", "spring", false);
+		return new JdbcTemplate(dataSource);
+	}
+
+	/**
+	 * Test full migration flow with defined versions going through from a defined
+	 * expected skipper/dataflow combinations.
+	 */
+	@Test
+	@DataflowAll
+	@DatabaseSlow
+	public void testFullMigrationFlow() {
+		log.info("Running testFullMigrationFlow()");
+		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
+		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
+
+		this.dataflowCluster.startSkipper(TagNames.SKIPPER_2_0);
+		assertSkipperServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_2_0);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceDataflow(TagNames.DATAFLOW_2_1);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_1, TagNames.DATAFLOW_2_2);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_2, TagNames.DATAFLOW_2_3);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_3, TagNames.DATAFLOW_2_4);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_4, TagNames.DATAFLOW_2_5);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_5, TagNames.DATAFLOW_2_6);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+
+		this.dataflowCluster.replaceSkipperAndDataflow(TagNames.SKIPPER_2_6, TagNames.DATAFLOW_2_7);
+		assertSkipperServerRunning(this.dataflowCluster);
+		assertDataflowServerRunning(this.dataflowCluster);
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.dataflow.integration.test.IntegrationTestProperties;
+import org.springframework.cloud.dataflow.integration.test.db.container.DataflowCluster;
+import org.springframework.cloud.dataflow.integration.test.db.container.DataflowCluster.ClusterContainer;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.cloud.dataflow.integration.test.util.AssertUtils;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Base test class for all database integration tests providing foundation for
+ * images and basic features.
+ *
+ * @author Janne Valkealahti
+ */
+@Testcontainers
+@SpringBootTest(classes = {AbstractDataflowTests.EmptyConfig.class})
+@EnableConfigurationProperties({ IntegrationTestProperties.class })
+public abstract class AbstractDataflowTests {
+
+	@Configuration
+	protected static class EmptyConfig {
+	}
+
+	public final static String DATAFLOW_IMAGE_PREFIX = "springcloud/spring-cloud-dataflow-server:";
+	public final static String SKIPPER_IMAGE_PREFIX = "springcloud/spring-cloud-skipper-server:";
+	public final static List<ClusterContainer> DATAFLOW_CONTAINERS = Arrays.asList(
+			ClusterContainer.from(TagNames.DATAFLOW_2_0, DATAFLOW_IMAGE_PREFIX + "2.0.3.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_1, DATAFLOW_IMAGE_PREFIX + "2.1.2.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_2, DATAFLOW_IMAGE_PREFIX + "2.2.3.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_3, DATAFLOW_IMAGE_PREFIX + "2.3.1.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_4, DATAFLOW_IMAGE_PREFIX + "2.4.2.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_5, DATAFLOW_IMAGE_PREFIX + "2.5.4.RELEASE"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_6, DATAFLOW_IMAGE_PREFIX + "2.6.5"),
+			ClusterContainer.from(TagNames.DATAFLOW_2_7, DATAFLOW_IMAGE_PREFIX + "2.7.1")
+			);
+	public final static List<ClusterContainer> SKIPPER_CONTAINERS = Arrays.asList(
+			ClusterContainer.from(TagNames.SKIPPER_2_0, SKIPPER_IMAGE_PREFIX + "2.0.3.RELEASE"),
+			ClusterContainer.from(TagNames.SKIPPER_2_1, SKIPPER_IMAGE_PREFIX + "2.1.4.RELEASE"),
+			ClusterContainer.from(TagNames.SKIPPER_2_2, SKIPPER_IMAGE_PREFIX + "2.2.2.RELEASE"),
+			ClusterContainer.from(TagNames.SKIPPER_2_3, SKIPPER_IMAGE_PREFIX + "2.3.2.RELEASE"),
+			ClusterContainer.from(TagNames.SKIPPER_2_4, SKIPPER_IMAGE_PREFIX + "2.4.3.RELEASE"),
+			ClusterContainer.from(TagNames.SKIPPER_2_5, SKIPPER_IMAGE_PREFIX + "2.5.4"),
+			ClusterContainer.from(TagNames.SKIPPER_2_6, SKIPPER_IMAGE_PREFIX + "2.6.1")
+			);
+	public final static List<ClusterContainer> DATABASE_CONTAINERS = Arrays.asList(
+			ClusterContainer.from(TagNames.POSTGRES_10, "postgres:10", TagNames.POSTGRES),
+			ClusterContainer.from(TagNames.MYSQL_5_7, "mysql:5.7", TagNames.MYSQL),
+			ClusterContainer.from(TagNames.MYSQL_8_0, "mysql:8.0", TagNames.MYSQL),
+			ClusterContainer.from(TagNames.MARIADB_10_2, "mariadb:10.5", TagNames.MARIADB),
+			ClusterContainer.from(TagNames.MARIADB_10_3, "mariadb:10.5", TagNames.MARIADB),
+			ClusterContainer.from(TagNames.MARIADB_10_4, "mariadb:10.5", TagNames.MARIADB),
+			ClusterContainer.from(TagNames.MARIADB_10_5, "mariadb:10.5", TagNames.MARIADB)
+			);
+
+	@Autowired
+    private IntegrationTestProperties testProperties;
+
+	@AfterEach
+	public void cleanCluster() {
+		if (dataflowCluster != null) {
+			dataflowCluster.stop();
+		}
+		dataflowCluster = null;
+	}
+
+	@BeforeEach
+	public void setupCluster() {
+		this.dataflowCluster = new DataflowCluster(getDatabaseContainers(), getSkipperContainers(),
+				getDataflowContainers(), testProperties.getDatabase().isSharedDatabase());
+	}
+
+	protected DataflowCluster dataflowCluster;
+
+	protected String getDataflowLatestVersion() {
+		return this.testProperties.getDatabase().getDataflowVersion();
+	}
+
+	protected String getSkipperLatestVersion() {
+		return this.testProperties.getDatabase().getSkipperVersion();
+	}
+
+	protected List<ClusterContainer> getDatabaseContainers() {
+		ArrayList<ClusterContainer> containers = new ArrayList<>(DATABASE_CONTAINERS);
+		return containers;
+	}
+
+	protected List<ClusterContainer> getSkipperContainers() {
+		ArrayList<ClusterContainer> containers = new ArrayList<>(SKIPPER_CONTAINERS);
+		containers.add(ClusterContainer.from(TagNames.SKIPPER_main, SKIPPER_IMAGE_PREFIX + getSkipperLatestVersion()));
+		return containers;
+	}
+
+	protected List<ClusterContainer> getDataflowContainers() {
+		ArrayList<ClusterContainer> containers = new ArrayList<>(DATAFLOW_CONTAINERS);
+		containers.add(ClusterContainer.from(TagNames.DATAFLOW_main, DATAFLOW_IMAGE_PREFIX + getDataflowLatestVersion()));
+		return containers;
+	}
+
+	protected static void assertSkipperServerRunning(DataflowCluster dataflowCluster) {
+		AssertUtils.assertSkipperServerRunning(dataflowCluster.getSkipperUrl());
+	}
+
+	protected static void assertSkipperServerNotRunning(DataflowCluster dataflowCluster) {
+		AssertUtils.assertSkipperServerNotRunning(dataflowCluster.getSkipperUrl());
+	}
+
+	protected static void assertDataflowServerRunning(DataflowCluster dataflowCluster) {
+		AssertUtils.assertDataflowServerRunning(dataflowCluster.getDataflowUrl());
+	}
+
+	protected static void assertDataflowServerNotRunning(DataflowCluster dataflowCluster) {
+		AssertUtils.assertDataflowServerNotRunning(dataflowCluster.getDataflowUrl());
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ContainerLaunchException;
+
+import org.springframework.cloud.dataflow.integration.test.tags.Database;
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseFailure;
+import org.springframework.cloud.dataflow.integration.test.tags.DataflowMain;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Database
+public abstract class AbstractPostgresDatabaseTests extends AbstractDatabaseTests {
+
+	private final Logger log = LoggerFactory.getLogger(AbstractPostgresDatabaseTests.class);
+
+	@Test
+	@DataflowMain
+	@DatabaseFailure
+	public void testMigrationError() {
+		log.info("Running testMigrationError()");
+		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
+		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
+
+		// break db
+		runExecute(getTestMigrationErrorBreakClause());
+
+		this.dataflowCluster.startSkipper(TagNames.SKIPPER_main);
+		assertSkipperServerRunning(this.dataflowCluster);
+
+		assertThatThrownBy(() -> {
+			this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main);
+		}).isInstanceOf(ContainerLaunchException.class);
+
+		Integer count = runCountQuery("select count(*) from flyway_schema_history_dataflow");
+		assertThat(count).isEqualTo(-1);
+
+		// fix db
+		runExecute(getTestMigrationErrorFixClause());
+
+		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main);
+		assertDataflowServerRunning(this.dataflowCluster);
+		count = runCountQuery("select count(*) from flyway_schema_history_dataflow");
+		assertThat(count).isGreaterThan(1);
+	}
+
+	protected abstract String getTestMigrationErrorBreakClause();
+	protected abstract String getTestMigrationErrorFixClause();
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MysqlSeparateDbIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MysqlSeparateDbIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseSeparate;
+import org.springframework.cloud.dataflow.integration.test.tags.Mysql;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Database tests for {@code mysql 5.7} using separate db's.
+ */
+@Mysql
+@DatabaseSeparate
+@ActiveProfiles({TagNames.PROFILE_DB_SEPARATE})
+public class MysqlSeparateDbIT extends AbstractDatabaseTests {
+
+	@Override
+	protected String getDatabaseTag() {
+		return TagNames.MYSQL_5_7;
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MysqlSharedDbIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MysqlSharedDbIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseShared;
+import org.springframework.cloud.dataflow.integration.test.tags.Mysql;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Database tests for {@code mysql 5.7} using shared db.
+ */
+@Mysql
+@DatabaseShared
+@ActiveProfiles({TagNames.PROFILE_DB_SHARED})
+public class MysqlSharedDbIT extends AbstractDatabaseTests {
+
+	@Override
+	protected String getDatabaseTag() {
+		return TagNames.MYSQL_5_7;
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/PostgresSeparateDbIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/PostgresSeparateDbIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseSeparate;
+import org.springframework.cloud.dataflow.integration.test.tags.Postgres;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Database tests for {@code postgres 10} using separate db's.
+ */
+@Postgres
+@DatabaseSeparate
+@ActiveProfiles({TagNames.PROFILE_DB_SEPARATE})
+public class PostgresSeparateDbIT extends AbstractPostgresDatabaseTests {
+
+	@Override
+	protected String getDatabaseTag() {
+		return TagNames.POSTGRES_10;
+	}
+
+	@Override
+	protected String getTestMigrationErrorBreakClause() {
+		return "CREATE SEQUENCE TASK_SEQ MAXVALUE 9223372036854775807 NO CYCLE";
+	}
+
+	@Override
+	protected String getTestMigrationErrorFixClause() {
+		return "DROP SEQUENCE TASK_SEQ";
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/PostgresSharedDbIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/PostgresSharedDbIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db;
+
+import org.springframework.cloud.dataflow.integration.test.tags.DatabaseShared;
+import org.springframework.cloud.dataflow.integration.test.tags.Postgres;
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Database tests for {@code postgres 10} using shared db.
+ */
+@Postgres
+@DatabaseShared
+@ActiveProfiles({TagNames.PROFILE_DB_SHARED})
+public class PostgresSharedDbIT extends AbstractPostgresDatabaseTests {
+
+	@Override
+	protected String getDatabaseTag() {
+		return TagNames.POSTGRES_10;
+	}
+
+	@Override
+	protected String getTestMigrationErrorBreakClause() {
+		return "CREATE SEQUENCE TASK_SEQ MAXVALUE 9223372036854775807 NO CYCLE";
+	}
+
+	@Override
+	protected String getTestMigrationErrorFixClause() {
+		return "DROP SEQUENCE TASK_SEQ";
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowCluster.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowCluster.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db.container;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startable;
+
+import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+public class DataflowCluster implements Startable {
+
+	private final static Logger logger = LoggerFactory.getLogger(DataflowCluster.class);
+	private final int DATAFLOW_PORT = 9393;
+	private final int SKIPPER_PORT = 7577;
+	private final int POSTGRES_PORT = 5432;
+	private final int MYSQL_PORT = 3306;
+	private final int MARIADB_PORT = 3306;
+	private final Map<String, ClusterContainer> dataflowImages;
+	private final Map<String, ClusterContainer> skipperImages;
+	private final Map<String, ClusterContainer> databaseImages;
+	private final boolean sharedDatabase;
+	private JdbcDatabaseContainer<?> runningDatabase;
+	private JdbcDatabaseContainer<?> runningSkipperDatabase;
+	private JdbcDatabaseContainer<?> runningDataflowDatabase;
+	private SkipperContainer<?> runningSkipper;
+	private DataflowContainer<?> runningDataflow;
+	private ClusterContainer skipperDatabaseClusterContainer;
+	private ClusterContainer dataflowDatabaseClusterContainer;
+	private Network network;
+
+	public DataflowCluster(List<ClusterContainer> databaseContainers, List<ClusterContainer> skipperContainers,
+			List<ClusterContainer> dataflowContainers, boolean sharedDatabase) {
+		Assert.notNull(databaseContainers, "databaseContainers must be set");
+		Assert.notNull(skipperContainers, "skipperContainers must be set");
+		Assert.notNull(dataflowContainers, "dataflowContainers must be set");
+		this.databaseImages = databaseContainers.stream().collect(Collectors.toMap(cc -> cc.id, cc -> cc));
+		this.skipperImages = skipperContainers.stream().collect(Collectors.toMap(cc -> cc.id, cc -> cc));
+		this.dataflowImages = dataflowContainers.stream().collect(Collectors.toMap(cc -> cc.id, cc -> cc));
+		this.sharedDatabase = sharedDatabase;
+		this.network = Network.newNetwork();
+	}
+
+	@Override
+	public void start() {
+	}
+
+	@Override
+	public void stop() {
+		stopSkipper();
+		stopDataflow();
+		stopDatabase();
+		this.network.close();
+	}
+
+	public void startSkipperDatabase(String id) {
+		String skipperDatabaseAlias = sharedDatabase ? "database" : "skipperdatabase";
+		if (sharedDatabase) {
+			ClusterContainer clusterContainer = this.databaseImages.get(id);
+			if (runningDatabase == null) {
+				Assert.notNull(clusterContainer, String.format("Unknown database %s", id));
+				JdbcDatabaseContainer<?> databaseContainer = buildDatabaseContainer(clusterContainer,
+						skipperDatabaseAlias);
+				databaseContainer.start();
+				runningDatabase = databaseContainer;
+			}
+			skipperDatabaseClusterContainer = clusterContainer;
+		} else {
+			Assert.state(runningSkipperDatabase == null, "There's a running skipper database");
+			ClusterContainer clusterContainer = this.databaseImages.get(id);
+			Assert.notNull(clusterContainer, String.format("Unknown database %s", id));
+			JdbcDatabaseContainer<?> databaseContainer = buildDatabaseContainer(clusterContainer, skipperDatabaseAlias);
+			databaseContainer.start();
+			runningSkipperDatabase = databaseContainer;
+			skipperDatabaseClusterContainer = clusterContainer;
+		}
+	}
+
+	public void startDataflowDatabase(String id) {
+		String dataflowDatabaseAlias = sharedDatabase ? "database" : "dataflowdatabase";
+		if (sharedDatabase) {
+			ClusterContainer clusterContainer = this.databaseImages.get(id);
+			if (runningDatabase == null) {
+				Assert.notNull(clusterContainer, String.format("Unknown database %s", id));
+				JdbcDatabaseContainer<?> databaseContainer = buildDatabaseContainer(clusterContainer,
+						dataflowDatabaseAlias);
+				databaseContainer.start();
+				runningDatabase = databaseContainer;
+			}
+			dataflowDatabaseClusterContainer = clusterContainer;
+		} else {
+			Assert.state(runningDataflowDatabase == null, "There's a running dataflow database");
+			ClusterContainer clusterContainer = this.databaseImages.get(id);
+			Assert.notNull(clusterContainer, String.format("Unknown database %s", id));
+			JdbcDatabaseContainer<?> databaseContainer = buildDatabaseContainer(clusterContainer,
+					dataflowDatabaseAlias);
+			databaseContainer.start();
+			runningDataflowDatabase = databaseContainer;
+			dataflowDatabaseClusterContainer = clusterContainer;
+		}
+	}
+
+	public void stopDatabase() {
+		if (runningDatabase != null) {
+			runningDatabase.stop();
+		}
+		if (runningSkipperDatabase != null) {
+			runningSkipperDatabase.stop();
+		}
+		if (runningDataflowDatabase != null) {
+			runningDataflowDatabase.stop();
+		}
+	}
+
+	private JdbcDatabaseContainer<?> getSkipperDatabaseContainer() {
+		return sharedDatabase ? runningDatabase : runningSkipperDatabase;
+	}
+
+	private JdbcDatabaseContainer<?> getDataflowDatabaseContainer() {
+		return sharedDatabase ? runningDatabase : runningDataflowDatabase;
+	}
+
+	public void startSkipper(String id) {
+		Assert.state(runningSkipper == null, "There's a running skipper");
+		ClusterContainer clusterContainer = this.skipperImages.get(id);
+		Assert.notNull(clusterContainer, String.format("Unknown skipper %s", id));
+		String skipperDatabaseAlias = sharedDatabase ? "database" : "skipperdatabase";
+		SkipperContainer<?> skipperContainer = buildSkipperContainer(clusterContainer, getSkipperDatabaseContainer(),
+				skipperDatabaseAlias);
+		skipperContainer.start();
+		runningSkipper = skipperContainer;
+	}
+
+	public void stopSkipper() {
+		if (runningSkipper != null) {
+			runningSkipper.stop();
+			runningSkipper = null;
+		}
+	}
+
+	public void replaceSkipper(String id) {
+		Assert.state(runningSkipper != null, "There's no running skipper");
+		ClusterContainer clusterContainer = this.skipperImages.get(id);
+		Assert.notNull(clusterContainer, String.format("Unknown skipper %s", id));
+		stopSkipper();
+		startSkipper(id);
+	}
+
+	public void replaceSkipperAndDataflow(String skipperId, String dataflowId) {
+		Assert.state(runningSkipper != null, "There's no running skipper");
+		Assert.state(runningDataflow != null, "There's no running dataflow");
+
+		ClusterContainer skipperClusterContainer = this.skipperImages.get(skipperId);
+		Assert.notNull(skipperClusterContainer, String.format("Unknown skipper %s", skipperId));
+		ClusterContainer dataflowClusterContainer = this.dataflowImages.get(dataflowId);
+		Assert.notNull(dataflowClusterContainer, String.format("Unknown dataflow %s", dataflowId));
+
+		stopSkipper();
+		stopDataflow();
+
+		startSkipper(skipperId);
+		startDataflow(dataflowId);
+	}
+
+	public String getSkipperUrl() {
+		Assert.state(runningSkipper != null, "There's no running skipper");
+		return String.format("http://%s:%s/api/about", runningSkipper.getHost(),
+				runningSkipper.getMappedPort(SKIPPER_PORT));
+	}
+
+	public void startDataflow(String id) {
+		Assert.state(runningDataflow == null, "There's a running dataflow");
+		Assert.state(runningSkipper != null, "There's no running skipper");
+		ClusterContainer clusterContainer = this.dataflowImages.get(id);
+		Assert.notNull(clusterContainer, String.format("Unknown dataflow %s", id));
+		String dataflowDatabaseAlias = sharedDatabase ? "database" : "dataflowdatabase";
+		String skipperDatabaseAlias = sharedDatabase ? "database" : "skipperdatabase";
+		DataflowContainer<?> dataflowContainer = buildDataflowContainer(clusterContainer,
+				getDataflowDatabaseContainer(), runningSkipper, dataflowDatabaseAlias, skipperDatabaseAlias);
+		dataflowContainer.start();
+		runningDataflow = dataflowContainer;
+	}
+
+	public void stopDataflow() {
+		if (runningDataflow != null) {
+			runningDataflow.stop();
+			runningDataflow = null;
+		}
+	}
+
+	public void replaceDataflow(String id) {
+		Assert.state(runningDataflow != null, "There's no running dataflow");
+		ClusterContainer clusterContainer = this.dataflowImages.get(id);
+		Assert.notNull(clusterContainer, String.format("Unknown dataflow %s", id));
+		stopDataflow();
+		startDataflow(id);
+	}
+
+	public String getDataflowUrl() {
+		Assert.state(runningDataflow != null, "There's no running dataflow");
+		return String.format("http://%s:%s/about", runningDataflow.getHost(),
+				runningDataflow.getMappedPort(DATAFLOW_PORT));
+	}
+
+	private JdbcDatabaseContainer<?> buildDatabaseContainer(ClusterContainer clusterContainer, String databaseAlias) {
+		if (StringUtils.hasText(clusterContainer.tag)) {
+			if (clusterContainer.tag.startsWith(TagNames.POSTGRES)) {
+				PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>(clusterContainer.image);
+				databaseContainer.withExposedPorts(POSTGRES_PORT);
+				databaseContainer.withDatabaseName("dataflow");
+				databaseContainer.withUsername("spring");
+				databaseContainer.withPassword("spring");
+				databaseContainer.withNetworkAliases(databaseAlias);
+				databaseContainer.withNetwork(network);
+				return databaseContainer;
+			} else if (clusterContainer.tag.startsWith(TagNames.MYSQL)) {
+				MySQLMariaDriverContainer<?> databaseContainer = new MySQLMariaDriverContainer<>(
+						clusterContainer.image);
+				databaseContainer.withExposedPorts(MYSQL_PORT);
+				databaseContainer.withDatabaseName("dataflow");
+				databaseContainer.withUsername("spring");
+				databaseContainer.withPassword("spring");
+				databaseContainer.withNetworkAliases(databaseAlias);
+				databaseContainer.withNetwork(network);
+				return databaseContainer;
+			} else if (clusterContainer.tag.startsWith(TagNames.MARIADB)) {
+				MariaDBContainer<?> databaseContainer = new MariaDBContainer<>(clusterContainer.image);
+				databaseContainer.withExposedPorts(MARIADB_PORT);
+				databaseContainer.withDatabaseName("dataflow");
+				databaseContainer.withUsername("spring");
+				databaseContainer.withPassword("spring");
+				databaseContainer.withNetworkAliases(databaseAlias);
+				databaseContainer.withNetwork(network);
+				return databaseContainer;
+			}
+		}
+		throw new IllegalArgumentException(String.format("Can't handle database %s", clusterContainer.tag));
+	}
+
+	public String getSkipperDatabaseHostJdbcUrl() {
+		JdbcDatabaseContainer<?> container = getSkipperDatabaseContainer();
+		Assert.notNull(container, "Skipper database not running");
+		return container.getJdbcUrl();
+	}
+
+	public String getDataflowDatabaseHostJdbcUrl() {
+		JdbcDatabaseContainer<?> container = getDataflowDatabaseContainer();
+		Assert.notNull(container, "Dataflow database not running");
+		return container.getJdbcUrl();
+	}
+
+	private SkipperContainer<?> buildSkipperContainer(ClusterContainer clusterContainer,
+			JdbcDatabaseContainer<?> databaseContainer, String skipperDatabaseAlias) {
+		logger.info("Building skipper container for {}", clusterContainer);
+		SkipperContainer<?> skipperContainer = new SkipperContainer<>(clusterContainer.image);
+		skipperContainer.withExposedPorts(SKIPPER_PORT);
+		if (ObjectUtils.nullSafeEquals(skipperDatabaseClusterContainer.tag, TagNames.POSTGRES)) {
+			skipperContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:postgresql://%s:%s/dataflow", skipperDatabaseAlias, POSTGRES_PORT));
+			skipperContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.postgresql.Driver");
+		} else if (ObjectUtils.nullSafeEquals(skipperDatabaseClusterContainer.tag, TagNames.MYSQL)) {
+			skipperContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:mariadb://%s:%s/dataflow", skipperDatabaseAlias, MYSQL_PORT));
+			skipperContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.mariadb.jdbc.Driver");
+		} else if (ObjectUtils.nullSafeEquals(skipperDatabaseClusterContainer.tag, TagNames.MARIADB)) {
+			skipperContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:mariadb://%s:%s/dataflow", skipperDatabaseAlias, MARIADB_PORT));
+			skipperContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.mariadb.jdbc.Driver");
+		}
+		skipperContainer.withEnv("SPRING_DATASOURCE_USERNAME", "spring");
+		skipperContainer.withEnv("SPRING_DATASOURCE_PASSWORD", "spring");
+		skipperContainer.withLogConsumer(new Slf4jLogConsumer(logger));
+		skipperContainer.withNetworkAliases("skipper");
+		skipperContainer.withNetwork(network);
+		return skipperContainer;
+	}
+
+	private DataflowContainer<?> buildDataflowContainer(ClusterContainer clusterContainer,
+			JdbcDatabaseContainer<?> databaseContainer, SkipperContainer<?> skipperContainer,
+			String dataflowDatabaseAlias, String skipperDatabaseAlias) {
+		logger.info("Building dataflow container for {}", clusterContainer);
+		DataflowContainer<?> dataflowContainer = new DataflowContainer<>(clusterContainer.image);
+		dataflowContainer.withExposedPorts(DATAFLOW_PORT);
+		if (ObjectUtils.nullSafeEquals(dataflowDatabaseClusterContainer.tag, TagNames.POSTGRES)) {
+			dataflowContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:postgresql://%s:%s/dataflow", dataflowDatabaseAlias, POSTGRES_PORT));
+			dataflowContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.postgresql.Driver");
+		} else if (ObjectUtils.nullSafeEquals(dataflowDatabaseClusterContainer.tag, TagNames.MYSQL)) {
+			dataflowContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:mariadb://%s:%s/dataflow", dataflowDatabaseAlias, MYSQL_PORT));
+			dataflowContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.mariadb.jdbc.Driver");
+		} else if (ObjectUtils.nullSafeEquals(dataflowDatabaseClusterContainer.tag, TagNames.MARIADB)) {
+			dataflowContainer.withEnv("SPRING_DATASOURCE_URL",
+					String.format("jdbc:mariadb://%s:%s/dataflow", dataflowDatabaseAlias, MARIADB_PORT));
+			dataflowContainer.withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.mariadb.jdbc.Driver");
+		}
+		dataflowContainer.withEnv("SPRING_DATASOURCE_USERNAME", "spring");
+		dataflowContainer.withEnv("SPRING_DATASOURCE_PASSWORD", "spring");
+		dataflowContainer.withEnv("SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI",
+				String.format("http://%s:%s/api", "skipper", SKIPPER_PORT));
+		dataflowContainer.withLogConsumer(new Slf4jLogConsumer(logger));
+		databaseContainer.withNetworkAliases("dataflow");
+		dataflowContainer.withNetwork(network);
+		return dataflowContainer;
+	}
+
+	public static class ClusterContainer {
+		String id;
+		String image;
+		String tag;
+
+		ClusterContainer(String id, String image, String tag) {
+			this.id = id;
+			this.image = image;
+			this.tag = tag;
+		}
+
+		public static ClusterContainer from(String id, String image) {
+			return from(id, image, null);
+		}
+
+		public static ClusterContainer from(String id, String image, String tag) {
+			return new ClusterContainer(id, image, tag);
+		}
+
+		@Override
+		public String toString() {
+			return "ClusterContainer [id=" + id + ", image=" + image + ", tag=" + tag + "]";
+		}
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowContainer.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowContainer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db.container;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class DataflowContainer<SELF extends DataflowContainer<SELF>> extends GenericContainer<SELF> {
+
+    public DataflowContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public DataflowContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/MySQLMariaDriverContainer.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/MySQLMariaDriverContainer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db.container;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MySQLMariaDriverContainer<SELF extends MySQLMariaDriverContainer<SELF>> extends MySQLContainer<SELF> {
+
+	public MySQLMariaDriverContainer(DockerImageName dockerImageName) {
+		super(dockerImageName);
+	}
+
+	public MySQLMariaDriverContainer(String dockerImageName) {
+		super(dockerImageName);
+	}
+
+	@Override
+	public String getDriverClassName() {
+        return "org.mariadb.jdbc.Driver";
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/SkipperContainer.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/SkipperContainer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.db.container;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class SkipperContainer<SELF extends SkipperContainer<SELF>> extends GenericContainer<SELF> {
+
+    public SkipperContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public SkipperContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Database.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Database.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATABASE)
+public @interface Database {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseFailure.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseFailure.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATABASE_FAILURE)
+public @interface DatabaseFailure {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseSeparate.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseSeparate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATABASE_SEPARATE)
+public @interface DatabaseSeparate {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseShared.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseShared.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATABASE_SHARED)
+public @interface DatabaseShared {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseSlow.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DatabaseSlow.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATABASE_SLOW)
+public @interface DatabaseSlow {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DataflowAll.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DataflowAll.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATAFLOW_2_0)
+@Tag(TagNames.DATAFLOW_2_1)
+@Tag(TagNames.DATAFLOW_2_2)
+@Tag(TagNames.DATAFLOW_2_3)
+@Tag(TagNames.DATAFLOW_2_4)
+@Tag(TagNames.DATAFLOW_2_5)
+@Tag(TagNames.DATAFLOW_2_6)
+@Tag(TagNames.DATAFLOW_2_7)
+@Tag(TagNames.SKIPPER_2_0)
+@Tag(TagNames.SKIPPER_2_1)
+@Tag(TagNames.SKIPPER_2_2)
+@Tag(TagNames.SKIPPER_2_3)
+@Tag(TagNames.SKIPPER_2_4)
+@Tag(TagNames.SKIPPER_2_5)
+@Tag(TagNames.SKIPPER_2_6)
+public @interface DataflowAll {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DataflowMain.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DataflowMain.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DATAFLOW_main)
+@Tag(TagNames.SKIPPER_main)
+public @interface DataflowMain {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DockerCompose.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/DockerCompose.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.DOCKER_COMPOSE)
+public @interface DockerCompose {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.MYSQL)
+public @interface Mysql {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql_5_7.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql_5_7.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.MYSQL_5_7)
+@Mysql
+public @interface Mysql_5_7 {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql_8_0.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Mysql_8_0.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.MYSQL_8_0)
+@Mysql
+public @interface Mysql_8_0 {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Postgres.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Postgres.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.POSTGRES)
+public @interface Postgres {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Postgres_10.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Postgres_10.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.POSTGRES_10)
+@Postgres
+public @interface Postgres_10 {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Slow.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/Slow.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(TagNames.SLOW)
+public @interface Slow {
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/TagNames.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tags/TagNames.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.tags;
+
+public abstract class TagNames {
+
+	public static final String PROFILE_DB_SHARED = "dbtests-shared";
+	public static final String PROFILE_DB_SEPARATE = "dbtests-separate";
+
+	public static final String DOCKER_COMPOSE = "docker-compose";
+	public static final String SLOW = "slow";
+
+	public static final String DATABASE = "database";
+	public static final String DATABASE_SLOW = "database-slow";
+	public static final String DATABASE_SHARED = "database-shared";
+	public static final String DATABASE_SEPARATE = "database-separate";
+	public static final String DATABASE_FAILURE = "database-failure";
+
+	public static final String POSTGRES = "postgres";
+	public static final String POSTGRES_10 = "postgres_10";
+
+	public static final String MARIADB = "mariadb";
+	public static final String MARIADB_10_2 = "mariadb_10_2";
+	public static final String MARIADB_10_3 = "mariadb_10_3";
+	public static final String MARIADB_10_4 = "mariadb_10_4";
+	public static final String MARIADB_10_5 = "mariadb_10_5";
+
+	public static final String MYSQL = "mysql";
+	public static final String MYSQL_5_7 = "mysql_5_7";
+	public static final String MYSQL_8_0 = "mysql_8_0";
+
+	public static final String MSSQL = "mssql";
+
+	public static final String ORACLE = "oracle";
+
+	public static final String DB2 = "db2";
+
+	public static final String SKIPPER = "skipper";
+	public static final String SKIPPER_2_0 = "skipper_2_0";
+	public static final String SKIPPER_2_1 = "skipper_2_1";
+	public static final String SKIPPER_2_2 = "skipper_2_2";
+	public static final String SKIPPER_2_3 = "skipper_2_3";
+	public static final String SKIPPER_2_4 = "skipper_2_4";
+	public static final String SKIPPER_2_5 = "skipper_2_5";
+	public static final String SKIPPER_2_6 = "skipper_2_6";
+	public static final String SKIPPER_main = "skipper_main";
+
+	public static final String DATAFLOW = "dataflow";
+	public static final String DATAFLOW_2_0 = "dataflow_2_0";
+	public static final String DATAFLOW_2_1 = "dataflow_2_1";
+	public static final String DATAFLOW_2_2 = "dataflow_2_2";
+	public static final String DATAFLOW_2_3 = "dataflow_2_3";
+	public static final String DATAFLOW_2_4 = "dataflow_2_4";
+	public static final String DATAFLOW_2_5 = "dataflow_2_5";
+	public static final String DATAFLOW_2_6 = "dataflow_2_6";
+	public static final String DATAFLOW_2_7 = "dataflow_2_7";
+	public static final String DATAFLOW_main = "dataflow_main";
+}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/AssertUtils.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/AssertUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.integration.test.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.with;
+
+/**
+ * Various assert utils.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AssertUtils {
+
+	private static final Logger log = LoggerFactory.getLogger(AssertUtils.class);
+
+	public static void assertDataflowServerNotRunning(String url) {
+		assertThatThrownBy(() -> {
+			assertServerResponse("Spring Cloud Data Flow", url, 1, TimeUnit.SECONDS, 60,
+			TimeUnit.SECONDS);
+		});
+	}
+
+	public static void assertDataflowServerRunning(String url) {
+		assertServerResponse("Spring Cloud Data Flow", url, 1, TimeUnit.SECONDS, 60,
+				TimeUnit.SECONDS);
+	}
+
+	public static void assertSkipperServerNotRunning(String url) {
+		assertThatThrownBy(() -> {
+			assertServerResponse("Spring Cloud Skipper Server", url, 1, TimeUnit.SECONDS, 60,
+			TimeUnit.SECONDS);
+		});
+	}
+
+	public static void assertSkipperServerRunning(String url) {
+		assertServerResponse("Spring Cloud Skipper Server", url, 1, TimeUnit.SECONDS, 60,
+				TimeUnit.SECONDS);
+	}
+
+	public static void assertServerResponse(String responseContains, String url, long pollInterval,
+			TimeUnit pollTimeUnit, long awaitInterval, TimeUnit awaitTimeUnit) {
+		RestTemplate template = new RestTemplate();
+		with()
+			.pollInterval(pollInterval, pollTimeUnit)
+			.and()
+			.await()
+				.ignoreExceptions()
+				.atMost(awaitInterval, awaitTimeUnit)
+				.until(() -> {
+					log.debug("Checking url {}", url);
+					String response = template.getForObject(url, String.class);
+					log.debug("Response is {}", response);
+					boolean ok = response.contains(responseContains);
+					log.info("Check {} for url {}", ok, url);
+					return ok;
+				});
+	}
+}

--- a/spring-cloud-dataflow-server/src/test/resources/application-dbtests-separate.yml
+++ b/spring-cloud-dataflow-server/src/test/resources/application-dbtests-separate.yml
@@ -1,0 +1,5 @@
+test:
+  database:
+    dataflow-version: "@project.version@"
+    skipper-version: "@spring-cloud-skipper.version@"
+    shared-database: false

--- a/spring-cloud-dataflow-server/src/test/resources/application-dbtests-shared.yml
+++ b/spring-cloud-dataflow-server/src/test/resources/application-dbtests-shared.yml
@@ -1,0 +1,9 @@
+spring:
+  autoconfigure:
+    exclude:
+    - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+test:
+  database:
+    dataflow-version: "@project.version@"
+    skipper-version: "@spring-cloud-skipper.version@"
+    shared-database: true


### PR DESCRIPTION
- New subsystem to build a "cluster" using test containers so that we can control
  when to bring things up/down when testing different scenarios.
- For now, just a base things like testing migration for just mysql/postgres.
- Lot of junit5 tags so that we can disect different tests.
- DataFlowIT has been tagged with `docker-compose`
- There's no default tags other that what we inherited into build from
  spring-cloud when we did our own parent. There tags `slow` and `docker`
  is excluded on default. (we probably need to revisit those).
- For example to just run new database tests, do:
  ./mvnw integration-test -Pfailsafe -pl spring-cloud-dataflow-server -Dgroups="database"
- To get current dep versions of dataflow/skipper, we rely on maven testresource resolving
  which creates `./spring-cloud-dataflow-server/target/test-classes/application-dbtests-shared.yml`
  and we can load that via boot tests using an activated profile.
- Fixes #4424