### PR TITLE
Use s-c-d-f-rest-client for all IT/AT connections

### DIFF
--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -186,13 +186,13 @@ Register the OOTB kafka/docker and task/docker apps and the run:
 ----
 ./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
     -Dtest.docker.compose.disable.extension=true \
-    -Dtest.platform.connection.dataflowServerUrl=http://your-k8s-scdf-server \
+    -Dspring.cloud.dataflow.client.server-uri=http://your-k8s-scdf-server \
     -Pfailsafe
 ----
 
 * replace `http://your-k8s-scdf-server` with the url of your Data Flow server.
 * the `test.docker.compose.disable.extension=true` property disables the docker-compose fixture.
-* the `test.platform.connection.dataflowServerUrl=` property points to the pre-installed DataFlow REST API.
+* the `spring.cloud.dataflow.client.server-uri=` property points to the pre-installed DataFlow REST API.
 
 For the analytic tests you need to pre-install Prometheus according to the installation instructions and forward the prometheus server's 9090 port
 ----

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -35,7 +35,6 @@ import com.jayway.jsonpath.JsonPath;
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.assertj.core.api.Condition;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,10 +177,13 @@ public class DataFlowIT {
 	protected RuntimeApplicationHelper runtimeApps;
 
 	/**
-	 * Folder that collects the external docker-compose YAML files such as
-	 * coming from external classpath, http/https or file locations.
+	 * Folder that collects the external docker-compose YAML files such as coming from external classpath,
+	 * http/https or file locations.
+	 * Note: Needs to be static, because as a part of the dockerCompose extension it is shared with all tests.
+	 * TODO: Explore if the temp-folder can be created and destroyed internally inside the dockerCompose extension.
 	 */
-	static Path tempYamlFolder = DockerComposeFactory.createTempDirectory();
+	@TempDir
+	static Path tempDockerComposeYamlFolder;
 
 	/**
 	 * A JUnit 5 extension to bring up Docker containers defined in docker-compose-xxx.yml files before running tests.
@@ -188,14 +191,7 @@ public class DataFlowIT {
 	 * disable the extension.
 	 */
 	@RegisterExtension
-	public static Extension dockerCompose = DockerComposeFactory.startDockerCompose(tempYamlFolder);
-
-	@AfterAll
-	public static void afterAll() {
-		if (tempYamlFolder != null && tempYamlFolder.toFile().exists()) {
-			tempYamlFolder.toFile().delete();
-		}
-	}
+	public static Extension dockerCompose = DockerComposeFactory.startDockerCompose(tempDockerComposeYamlFolder);
 
 	@BeforeEach
 	public void before() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -59,7 +59,6 @@ import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFac
 import org.springframework.cloud.dataflow.integration.test.util.DockerComposeFactoryProperties;
 import org.springframework.cloud.dataflow.integration.test.util.ResourceExtractor;
 import org.springframework.cloud.dataflow.integration.test.util.RuntimeApplicationHelper;
-import org.springframework.cloud.dataflow.integration.test.util.SkipSslRestHelper;
 import org.springframework.cloud.dataflow.rest.client.DataFlowClientException;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
 import org.springframework.cloud.dataflow.rest.client.dsl.DeploymentPropertiesBuilder;
@@ -72,10 +71,10 @@ import org.springframework.cloud.dataflow.rest.resource.DetailedAppRegistrationR
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionStatus;
 import org.springframework.cloud.dataflow.rest.resource.about.AboutResource;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.StreamUtils;
-import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -118,7 +117,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <code>
  *    ./mvnw clean install -pl spring-cloud-dataflow-server -Dtest=foo -DfailIfNoTests=false \
  *        -Dtest.docker.compose.disable.extension=true \
- *        -Dtest.platform.connection.dataflowServerUrl=https://scdf-server.gke.io \
+ *        -Dspring.cloud.dataflow.client.server-uri=https://scdf-server.gke.io \
  *        -Pfailsafe
  * </code>
  *
@@ -160,6 +159,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties({ IntegrationTestProperties.class })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Import(DataFlowOperationsITConfiguration.class)
 public class DataFlowIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(DataFlowIT.class);
@@ -170,9 +170,11 @@ public class DataFlowIT {
 	/**
 	 * REST and DSL clients used to interact with the SCDF server and run the tests.
 	 */
+	@Autowired
 	protected DataFlowTemplate dataFlowOperations;
+
+	@Autowired
 	protected RuntimeApplicationHelper runtimeApps;
-	protected RestTemplate restTemplate;
 
 	/**
 	 * Folder that collects the external docker-compose YAML files such as
@@ -197,12 +199,6 @@ public class DataFlowIT {
 
 	@BeforeEach
 	public void before() {
-		dataFlowOperations = SkipSslRestHelper
-				.dataFlowTemplate(testProperties.getPlatform().getConnection().getDataflowServerUrl());
-		runtimeApps = new RuntimeApplicationHelper(dataFlowOperations,
-				testProperties.getPlatform().getConnection().getPlatformName());
-		restTemplate = SkipSslRestHelper.restTemplate(); // used for HTTP post in tests
-
 		Awaitility.setDefaultPollInterval(Duration.ofSeconds(5));
 		Awaitility.setDefaultTimeout(Duration.ofMinutes(15));
 	}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -50,11 +50,6 @@ public class IntegrationTestProperties {
 	public static class PlatformConnectionProperties {
 
 		/**
-		 * Default url to connect to dataflow
-		 */
-		private String dataflowServerUrl = "http://localhost:9393";
-
-		/**
 		 * default - local platform, cf - Cloud Foundry platform, k8s - GKE/Kubernetes platform
 		 */
 		private String platformName = "default";
@@ -68,26 +63,6 @@ public class IntegrationTestProperties {
 		 * Default url to connect to SCDF's Influx TSDB
 		 */
 		private String influxUrl = "http://localhost:8086";
-
-		/**
-		 * Kubernetes tests require nginx-ingress and watchdog mechanism to expose the
-		 * apps URL to public access. Later requires a preconfigured ingress servers
-		 * domain name suffix.
-		 *
-		 * For example the Hydra AT environment hash the 'hydra.springapps.io' host name
-		 * and app Urls will have the form
-		 * https://partitioning-test-log-v1.hydra.springapps.io or
-		 * https://partitioning-test-log-v1-1.hydra.springapps.io for multiple instance.
-		 */
-		private String kubernetesAppHostSuffix = "";
-
-		public String getDataflowServerUrl() {
-			return dataflowServerUrl;
-		}
-
-		public void setDataflowServerUrl(String dataflowServerUrl) {
-			this.dataflowServerUrl = dataflowServerUrl;
-		}
 
 		public String getPlatformName() {
 			return platformName;
@@ -111,14 +86,6 @@ public class IntegrationTestProperties {
 
 		public void setInfluxUrl(String influxUrl) {
 			this.influxUrl = influxUrl;
-		}
-
-		public String getKubernetesAppHostSuffix() {
-			return kubernetesAppHostSuffix;
-		}
-
-		public void setKubernetesAppHostSuffix(String kubernetesAppHostSuffix) {
-			this.kubernetesAppHostSuffix = kubernetesAppHostSuffix;
 		}
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -169,6 +169,12 @@ public class DockerComposeFactory {
 	}
 
 	public static Path createTempDirectory() {
+
+		// Temp directory is not required when the docker-compose is not used.
+		if (DockerComposeFactoryProperties.isDockerComposeDisabled()) {
+			return null;
+		}
+
 		try {
 			Path tempDirPath = Files.createTempDirectory(null);
 			logger.info("Temp directory: " + tempDirPath);

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.integration.test.util;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
@@ -145,10 +143,11 @@ public class DockerComposeFactory {
 
 		// If DooD is enabled but the docker-compose-dood.yml is not listed in the dockerComposePaths then
 		// add it explicitly at the end of the list.
-		if (isDood ) {
+		if (isDood) {
 			dockerComposePaths = addDockerComposeToPath(dockerComposePaths, "../src/docker-compose/docker-compose-dood.yml");
 			dockerComposePaths = addDockerComposeToPath(dockerComposePaths, "./src/test/resources/docker-compose-docker-it-task-import.yml");
-		} else {
+		}
+		else {
 			dockerComposePaths = addDockerComposeToPath(dockerComposePaths, "./src/test/resources/docker-compose-maven-it-task-import.yml");
 		}
 
@@ -166,22 +165,5 @@ public class DockerComposeFactory {
 				// set to false to test with local dataflow and skipper images.
 				.pullOnStartup(DockerComposeFactoryProperties.getBoolean(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_PULLONSTARTUP, true))
 				.build();
-	}
-
-	public static Path createTempDirectory() {
-
-		// Temp directory is not required when the docker-compose is not used.
-		if (DockerComposeFactoryProperties.isDockerComposeDisabled()) {
-			return null;
-		}
-
-		try {
-			Path tempDirPath = Files.createTempDirectory(null);
-			logger.info("Temp directory: " + tempDirPath);
-			return tempDirPath;
-		}
-		catch (IOException e) {
-			throw new IllegalStateException("Could not create the temp directory");
-		}
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/resources/application.properties
+++ b/spring-cloud-dataflow-server/src/test/resources/application.properties
@@ -1,4 +1,4 @@
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.cloud.dataflow.features.streams-enabled=false
-spring.autoconfigure.exclude=org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration
+spring.cloud.dataflow.client.skip-ssl-validation=true
+spring.cloud.dataflow.client.enable-dsl=true
 

--- a/spring-cloud-dataflow-server/src/test/resources/application.properties
+++ b/spring-cloud-dataflow-server/src/test/resources/application.properties
@@ -1,4 +1,4 @@
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.cloud.dataflow.client.skip-ssl-validation=true
-spring.cloud.dataflow.client.enable-dsl=true
+
 

--- a/spring-cloud-dataflow-server/src/test/resources/application.properties
+++ b/spring-cloud-dataflow-server/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.cloud.dataflow.client.skip-ssl-validation=true
+spring.autoconfigure.exclude=org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration
 
 


### PR DESCRIPTION
 - Replace the proprietary dataflowTemplate builder by s-c-d-f-rest-client#DataFlowClientAutoConfiguration
 - Remove the custom test.platform.connection.dataflowServerUrl property in favor or spring.cloud.dataflow.client.server-uri .
 - Use spring.cloud.dataflow.client.skipSslValidation to disable SSL validation.
 - Create a DataFlowOperationsITConfiguration configuration to be used by ITs/ATs for configuring the DataFlowTemplate and the RuntimeApplicationHelper instances.
 - Streamline the ITs/ATs implementation to ensure that all interactions with the SCDF server (including http-post and app/actuators) are funneled through the single dataflowTemplate + restTemplate.

 Resolves #4433