### PR TITLE
Remove postgres from test dependency

### DIFF
--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -105,11 +105,6 @@
 			<artifactId>mariadb</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
- This will bring back driver to a fat-jar.
- Fixes #4454