### PR TITLE
Support HTTPS docker-compose ITs

### DIFF
--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -182,6 +182,48 @@ Use the `-Dtest.docker.compose.dood=true` property to activate the DooD (Docker-
 
 Use the `-Dit.test=class-name#method-name` to filter only selected tests.
 
+=== Run Integration Tests with HTTPS connections
+
+----
+./mvnw clean test-compile integration-test -pl spring-cloud-dataflow-server -Pfailsafe -Dgroups="docker-compose" \
+   -Dtest.docker.compose.paths=../src/docker-compose/docker-compose.yml,../src/docker-compose/docker-compose-ssl.yml \
+   -Dtest.docker.compose.dataflow.uri=https://dataflow-server:9393 \
+   -Dtest.docker.compose.skipper.uri=https://skipper-server:7577 \
+   -Dtest.docker.compose.waiting.for.service.format=https://$HOST:$EXTERNAL_PORT \
+   -Dit.test=DataFlowIT#streamPartitioning \
+   -Dspring.cloud.dataflow.client.server-uri=https://localhost:9393 \
+   -Dspring.cloud.dataflow.client.skip-ssl-validation=true \
+   -Dtest.platform.connection.application-over-https=true
+----
+
+Use the following env. variables to run an IT test from IDE:
+----
+TEST_DOCKER_COMPOSE_PATHS=../src/docker-compose/docker-compose.yml,../src/docker-compose/docker-compose-ssl.yml
+TEST_DOCKER_COMPOSE_SKIPPER_URI=https://skipper-server:7577
+TEST_DOCKER_COMPOSE_DATAFLOW_URI=https://dataflow-server:9393
+TEST_DOCKER_COMPOSE_WAITING_FOR_SERVICE_FORMAT=https://$HOST:$EXTERNAL_PORT
+TEST_PLATFORM_CONNECTION_APPLICATIONOVERHTTPS=true
+SPRING_CLOUD_DATAFLOW_CLIENT_SKIPSSLVALIDATION=true
+SPRING_CLOUD_DATAFLOW_CLIENT_SERVERURI=https://localhost:9393
+COMPOSE_HTTP_TIMEOUT=300
+----
+
+Use the following env. variables to run an IT test from IDE with existing docker-compose cluster:
+----
+TEST_DOCKER_COMPOSE_DISABLE_EXTENSION=true
+SPRING_CLOUD_DATAFLOW_CLIENT_SERVERURI=https://localhost:9393
+SPRING_CLOUD_DATAFLOW_CLIENT_SKIPSSLVALIDATION=true
+TEST_PLATFORM_CONNECTION_APPLICATIONOVERHTTPS=true
+----
+
+Create HTTPS docker-compose from shell:
+----
+export DATAFLOW_URI=https://dataflow-server:9393
+export SKIPPER_URI=https://skipper-server:7577
+docker-compose -f ./src/docker-compose/docker-compose.yml -f ./src/docker-compose/docker-compose-ssl.yml
+----
+
+
 == Run Integration Tests against k8s
 
 For this you need a pre-installed Data Flow on GKE or minikube.

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowOperationsITConfiguration.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowOperationsITConfiguration.java
@@ -73,7 +73,8 @@ public class DataFlowOperationsITConfiguration {
 			IntegrationTestProperties testProperties) {
 
 		return new RuntimeApplicationHelper(dataFlowOperations,
-				testProperties.getPlatform().getConnection().getPlatformName());
+				testProperties.getPlatform().getConnection().getPlatformName(),
+				testProperties.getPlatform().getConnection().isApplicationOverHttps());
 	}
 
 	static class AcceptCharsetInterceptor implements ClientHttpRequestInterceptor {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -104,6 +104,11 @@ public class IntegrationTestProperties {
 		 */
 		private String influxUrl = "http://localhost:8086";
 
+		/**
+		 * Streaming applications are behind HTTPS.
+		 */
+		private boolean applicationOverHttps;
+
 		public String getPlatformName() {
 			return platformName;
 		}
@@ -126,6 +131,14 @@ public class IntegrationTestProperties {
 
 		public void setInfluxUrl(String influxUrl) {
 			this.influxUrl = influxUrl;
+		}
+
+		public boolean isApplicationOverHttps() {
+			return applicationOverHttps;
+		}
+
+		public void setApplicationOverHttps(boolean applicationOverHttps) {
+			this.applicationOverHttps = applicationOverHttps;
 		}
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactoryProperties.java
@@ -69,6 +69,16 @@ public class DockerComposeFactoryProperties {
 	public static final String TEST_DOCKER_COMPOSE_SKIPPER_VERSIONN = PREFIX + "skipper.version";
 
 	/**
+	 * The DataFlow Server URI. Defaults to http://dataflow-server:9393
+	 */
+	public static final String TEST_DOCKER_COMPOSE_DATAFLOW_URI = PREFIX + "dataflow.uri";
+
+	/**
+	 * The Skipper Server URI. Defaults to http://skipper-server:7577
+	 */
+	public static final String TEST_DOCKER_COMPOSE_SKIPPER_URI = PREFIX + "skipper.uri";
+
+	/**
 	 * Set the app starters bulk install url.
 	 */
 	public static final String TEST_DOCKER_COMPOSE_TASK_APPS_URI = PREFIX + "task.apps.uri";
@@ -92,6 +102,9 @@ public class DockerComposeFactoryProperties {
 	 * Set to false to keep the exited Docker containers (applicable only in DooD mode).
 	 */
 	public static final String TEST_DOCKER_COMPOSE_DOCKER_DELETE_CONTAINER_ON_EXIT = PREFIX + "docker.delete.container.on.exit";
+
+
+	public static final String TEST_DOCKER_COMPOSE_WAITING_FOR_SERVICE_FORMAT = PREFIX + "waiting.for.service.format";
 
 	public static boolean getBoolean(String propertyName, boolean defaultValue) {
 		String value = get(propertyName, "" + defaultValue);

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/RuntimeApplicationHelper.java
@@ -54,7 +54,10 @@ public class RuntimeApplicationHelper {
 
 	private final Version dataflowServerVersion;
 
-	public RuntimeApplicationHelper(DataFlowTemplate dataFlowTemplate, String platformName) {
+	private boolean httpsStreamApplications;
+
+	public RuntimeApplicationHelper(DataFlowTemplate dataFlowTemplate, String platformName, boolean httpsStreamApplications) {
+		this.httpsStreamApplications = httpsStreamApplications;
 		Assert.notNull(dataFlowTemplate, "Valid dataFlowOperations is expected but was: " + dataFlowTemplate);
 		Assert.hasText(platformName, "Empty platform name: " + platformName);
 		logger.debug("platform Name: [" + platformName + "]");
@@ -177,7 +180,7 @@ public class RuntimeApplicationHelper {
 	}
 
 	private String localApplicationInstanceUrl(Map<String, String> instanceAttributes) {
-		return String.format("http://localhost:%s",
+		return String.format("%s://localhost:%s", httpsStreamApplications ? "https" : "http",
 				instanceAttributes.get(StreamRuntimePropertyKeys.ATTRIBUTE_PORT)); // Local Platform only
 	}
 


### PR DESCRIPTION
Allows the integration tests configuration to install HTTPS based SCDF, Skipper and OOTB apps (using docker-compose) and run the ITs agains it.

- Add additional ITs properties to configure the HTTPS docker-compose installation programmatically. 
- Add workaround to skip ssl-validation for the palantir docker-compose/fork in case of https services.
- Add README samples.