### PR TITLE
Fix changes in cloud 2020.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,6 @@
 		<spring-cloud-deployer-cloudfoundry.version>2.6.0-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<spring-cloud-deployer-kubernetes.version>2.6.0-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
 
-		<kubernetes-client.version>4.10.2</kubernetes-client.version>
-
 		<spring-cloud-skipper.version>2.7.0-SNAPSHOT</spring-cloud-skipper.version>
 
 		<spring-cloud-task.version>2.3.0</spring-cloud-task.version>
@@ -231,11 +229,6 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>${commons-lang.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.fabric8</groupId>
-				<artifactId>kubernetes-client</artifactId>
-				<version>${kubernetes-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
@@ -27,10 +27,6 @@
 		  <optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.pivotal.cfenv</groupId>
 			<artifactId>java-cfenv-boot</artifactId>
 		</dependency>
@@ -38,10 +34,6 @@
 			<groupId>io.pivotal.cfenv</groupId>
 			<artifactId>java-cfenv-boot-pivotal-sso</artifactId>
 			<version>${java-cfenv-boot.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.pivotal.spring.cloud</groupId>
-			<artifactId>spring-cloud-services-starter-config-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -162,10 +162,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -32,6 +32,14 @@
 			<artifactId>spring-cloud-starter-dataflow-server</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.pivotal.spring.cloud</groupId>
+			<artifactId>spring-cloud-services-starter-config-client</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.fabric8</groupId>
 			<artifactId>kubernetes-client</artifactId>
 		</dependency>


### PR DESCRIPTION
- Remove dep handling of fabric8
- Move config-client starters from core packages into
  server module. This fixes testing issues and let
  those runtime deps to be in fatjars.
- Fixes #4506
- Fixes #4507