### PR TITLE
Define non simple ctr props as nested

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Configuration properties used to setup the ComposedTaskRunner.
@@ -126,11 +127,13 @@ public class ComposedTaskProperties {
 	/**
 	 * Properties for defining task app arguments.
 	 */
+	@NestedConfigurationProperty
 	private Map<String, String> composedTaskAppArguments = new HashMap<>();
 
 	/**
 	 * Properties for defining task app properties.
 	 */
+	@NestedConfigurationProperty
 	private Map<String, String> composedTaskAppProperties = new HashMap<>();
 
 	/**


### PR DESCRIPTION
- Makes composedTaskAppArguments and composedTaskAppProperties as
  groups as values of those are maps.
- Fixes #4529