### PR TITLE
Fix task execution cleanup

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDao.java
@@ -62,16 +62,16 @@ public class JdbcDataflowTaskExecutionDao implements DataflowTaskExecutionDao {
 	private static final String FIND_TASK_EXECUTION_IDS_BY_TASK_NAME = "SELECT TASK_EXECUTION_ID "
 			+ "from %PREFIX%EXECUTION where TASK_NAME = :taskName";
 
-	private static final String GET_COMPLETED_TASK_EXECUTIONS_COUNT = "SELECT COUNT(TASK_EXECUTION_ID) "
+	private static final String GET_COMPLETED_TASK_EXECUTIONS_COUNT = "SELECT COUNT(TASK_EXECUTION_ID) AS count "
 			+ "from %PREFIX%EXECUTION where END_TIME IS NOT NULL";
 
-	private static final String GET_ALL_TASK_EXECUTIONS_COUNT = "SELECT COUNT(TASK_EXECUTION_ID) "
+	private static final String GET_ALL_TASK_EXECUTIONS_COUNT = "SELECT COUNT(TASK_EXECUTION_ID) AS count "
 			+ "from %PREFIX%EXECUTION";
 
-	private static final String GET_COMPLETED_TASK_EXECUTIONS_COUNT_BY_TASK_NAME = "SELECT COUNT(TASK_EXECUTION_ID) "
+	private static final String GET_COMPLETED_TASK_EXECUTIONS_COUNT_BY_TASK_NAME = "SELECT COUNT(TASK_EXECUTION_ID) AS count "
 			+ "from %PREFIX%EXECUTION where END_TIME IS NOT NULL AND TASK_NAME = :taskName";
 
-	private static final String GET_ALL_TASK_EXECUTIONS_COUNT_BY_TASK_NAME = "SELECT COUNT(TASK_EXECUTION_ID) "
+	private static final String GET_ALL_TASK_EXECUTIONS_COUNT_BY_TASK_NAME = "SELECT COUNT(TASK_EXECUTION_ID) AS count "
 			+ "from %PREFIX%EXECUTION where TASK_NAME = :taskName";
 
 	private static final String FIND_ALL_COMPLETED_TASK_EXECUTION_IDS = "SELECT TASK_EXECUTION_ID "
@@ -210,7 +210,7 @@ public class JdbcDataflowTaskExecutionDao implements DataflowTaskExecutionDao {
 						public Integer extractData(ResultSet resultSet)
 								throws SQLException, DataAccessException {
 							if (resultSet.next()) {
-								return resultSet.getInt("COUNT(TASK_EXECUTION_ID)");
+								return resultSet.getInt("count");
 							}
 							return Integer.valueOf(0);
 						}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteService.java
@@ -131,7 +131,11 @@ public class DefaultTaskDeleteService implements TaskDeleteService {
 		TaskExecution taskExecution = taskExplorer.getTaskExecution(id);
 		Assert.notNull(taskExecution, "There was no task execution with id " + id);
 		String launchId = taskExecution.getExternalExecutionId();
-		Assert.hasLength(launchId, "The TaskExecution for id " + id + " did not have an externalExecutionId");
+		if (!StringUtils.hasText(launchId)) {
+			logger.warn(String.format("Did not find External execution ID for taskName = [%s], taskId = [%s].  Nothing to clean up.",
+					taskExecution.getTaskName(), id));
+			return;
+		}
 		TaskDeployment taskDeployment = this.taskDeploymentRepository.findByTaskDeploymentId(launchId);
 		if (taskDeployment == null) {
 			logger.warn(String.format("Did not find TaskDeployment for taskName = [%s], taskId = [%s].  Nothing to clean up.",


### PR DESCRIPTION
 - Fix the result set matching on the query. This is needed especially on Postgres
 - Fix the task cleanup to allow the task executions that don't have external execution IDs

Resolves #4532
Resolves #4533