### PR TITLE
Handle task deployment properties via ctr options

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
@@ -125,7 +125,7 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 
 		taskLauncherTasklet.setArguments(argumentsToUse);
 
-		log.debug("dedoced composed-task-app-properties {}", composedTaskProperties.getComposedTaskAppProperties());
+		log.debug("decoded composed-task-app-properties {}", composedTaskProperties.getComposedTaskAppProperties());
 
 		Map<String, String> propertiesFrom = Base64Utils
 				.decodeMap(this.composedTaskProperties.getComposedTaskAppProperties()).entrySet().stream()

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
@@ -23,12 +23,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties;
+import org.springframework.cloud.dataflow.core.Base64Utils;
 import org.springframework.cloud.task.configuration.TaskConfigurer;
 import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
@@ -47,6 +51,8 @@ import org.springframework.util.Assert;
  * @author Michael Minella
  */
 public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
+
+	private final static Logger log = LoggerFactory.getLogger(ComposedTaskRunnerStepFactory.class);
 
 	@Autowired
 	private ComposedTaskProperties composedTaskProperties;
@@ -119,14 +125,20 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 
 		taskLauncherTasklet.setArguments(argumentsToUse);
 
-		Map<String, String> propertiesFrom = this.composedTaskProperties.getComposedTaskAppProperties().entrySet().stream()
-			.filter(e -> e.getKey().startsWith("app." + taskNameId))
-			.collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+		log.debug("dedoced composed-task-app-properties {}", composedTaskProperties.getComposedTaskAppProperties());
+
+		Map<String, String> propertiesFrom = Base64Utils
+				.decodeMap(this.composedTaskProperties.getComposedTaskAppProperties()).entrySet().stream()
+				.filter(e -> e.getKey().startsWith("app." + taskNameId)
+						|| e.getKey().startsWith("deployer." + taskNameId) || e.getKey().startsWith("deployer.*"))
+				.collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+
 		Map<String, String> propertiesToUse = new HashMap<>();
 		propertiesToUse.putAll(this.taskSpecificProps);
 		propertiesToUse.putAll(propertiesFrom);
 
 		taskLauncherTasklet.setProperties(propertiesToUse);
+		log.debug("Properties to use {}", propertiesToUse);
 
 		String stepName = this.taskName;
 

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.dataflow.core.Base64Utils;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 
@@ -101,16 +102,20 @@ public class ComposedTaskPropertiesTests {
 					map.put("composed-task-app-arguments.app.AAA", "arg1");
 					map.put("composed-task-app-arguments.app.AAA.1", "arg2");
 					map.put("composed-task-app-arguments.app.AAA.2", "arg3");
+					map.put("composed-task-app-arguments." + Base64Utils.encode("app.*.3"), Base64Utils.encode("arg4"));
+					map.put("composed-task-app-arguments." + Base64Utils.encode("app.*.4"), "arg5");
 					context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
 						StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, map));
 				})
 				.withUserConfiguration(Config1.class)
 				.run((context) -> {
 					ComposedTaskProperties properties = context.getBean(ComposedTaskProperties.class);
-					assertThat(properties.getComposedTaskAppArguments()).hasSize(3);
+					assertThat(properties.getComposedTaskAppArguments()).hasSize(5);
 					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA", "arg1");
 					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA.1", "arg2");
 					assertThat(properties.getComposedTaskAppArguments()).containsEntry("app.AAA.2", "arg3");
+					assertThat(Base64Utils.decodeMap(properties.getComposedTaskAppArguments())).containsEntry("app.*.3", "arg4");
+					assertThat(Base64Utils.decodeMap(properties.getComposedTaskAppArguments())).containsEntry("app.*.4", "arg5");
 				});
 	}
 

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Base64Utils.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Base64Utils.java
@@ -22,6 +22,8 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Base64 utils to encode/decode boot properties so that we can have special
  * characters in keys.
@@ -34,8 +36,8 @@ public class Base64Utils {
 	private static final String PREFIX = "base64_";
 
 	public static String encode(String str) {
-		if (str == null) {
-			return null;
+		if (!StringUtils.hasLength(str)) {
+			return str;
 		}
 		// need to use without padding as boot will remove '=' chars from keys
 		return PREFIX + new String(Base64.getEncoder().withoutPadding().encode(str.getBytes(DEFAULT_CHARSET)),
@@ -43,8 +45,8 @@ public class Base64Utils {
 	}
 
 	public static String decode(String str) {
-		if (str == null) {
-			return null;
+		if (!StringUtils.hasLength(str)) {
+			return str;
 		}
 		if (str.startsWith(PREFIX)) {
 			return new String(Base64.getDecoder().decode(str.substring(PREFIX.length())), DEFAULT_CHARSET);

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Base64Utils.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/Base64Utils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.core;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Base64 utils to encode/decode boot properties so that we can have special
+ * characters in keys.
+ *
+ * @author Janne Valkealahti
+ */
+public class Base64Utils {
+
+	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+	private static final String PREFIX = "base64_";
+
+	public static String encode(String str) {
+		if (str == null) {
+			return null;
+		}
+		// need to use without padding as boot will remove '=' chars from keys
+		return PREFIX + new String(Base64.getEncoder().withoutPadding().encode(str.getBytes(DEFAULT_CHARSET)),
+				DEFAULT_CHARSET);
+	}
+
+	public static String decode(String str) {
+		if (str == null) {
+			return null;
+		}
+		if (str.startsWith(PREFIX)) {
+			return new String(Base64.getDecoder().decode(str.substring(PREFIX.length())), DEFAULT_CHARSET);
+		} else {
+			return str;
+		}
+	}
+
+	public static Map<String, String> decodeMap(Map<String, String> map) {
+		if (map == null) {
+			return map;
+		}
+		return map.entrySet().stream().collect(Collectors.toMap(e -> decode(e.getKey()), e -> decode(e.getValue())));
+	}
+}

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/Base64UtilsTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/Base64UtilsTests.java
@@ -32,6 +32,7 @@ public class Base64UtilsTests {
 		assertThat(Base64Utils.decode(null)).isNull();
 		assertThat(Base64Utils.encode(null)).isNull();
 		assertThat(Base64Utils.decode(Base64Utils.encode("foo"))).isEqualTo("foo");
+		assertThat(Base64Utils.decode(Base64Utils.encode("foo.*.1"))).isEqualTo("foo.*.1");
 		assertThat(Base64Utils.decode("juststring")).isEqualTo("juststring");
 	}
 }

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/Base64UtilsTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/Base64UtilsTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@code Base64Utils}.
+ *
+ * @author Janne Valkealahti
+ */
+public class Base64UtilsTests {
+
+	@Test
+	public void testBase64() {
+		assertThat(Base64Utils.decode(null)).isNull();
+		assertThat(Base64Utils.encode(null)).isNull();
+		assertThat(Base64Utils.decode(Base64Utils.encode("foo"))).isEqualTo("foo");
+		assertThat(Base64Utils.decode("juststring")).isEqualTo("juststring");
+	}
+}


### PR DESCRIPTION
- Essentially reverts previous PR #4557 as it was a bad
  fix and broke more that it fixed.
- This change now tries to pass in task deployment properties
  via crt composed-task-app-properties option.
- Property key part is now base64 encoded with prefix base64_ because
  boot with its binding will silenly remove special characters from
  map keys and we could not use wildcards like deployer.*.local.working-directories-root
- Encoded values are then decoded on ctr side.
- One onnoying this is that these base64 encoded values are visible in a manifest but
  never directly interact with a user.
- Fixes #4551