### PR TITLE
Task ctr execution doesn't handle wildcard in arguments

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerStepFactory.java
@@ -115,8 +115,9 @@ public class ComposedTaskRunnerStepFactory implements FactoryBean<Step> {
 				this.clientRegistrations, this.clientCredentialsTokenResponseClient, taskConfigurer.getTaskExplorer(),
 				this.composedTaskPropertiesFromEnv, this.taskName, taskProperties);
 
-		List<String> argumentsFromAppProperties = this.composedTaskProperties.getComposedTaskAppArguments().entrySet().stream()
-			.filter(e -> e.getKey().startsWith("app." + taskNameId))
+		List<String> argumentsFromAppProperties = Base64Utils
+			.decodeMap(this.composedTaskProperties.getComposedTaskAppArguments()).entrySet().stream()
+			.filter(e -> e.getKey().startsWith("app." + taskNameId) || e.getKey().startsWith("app.*."))
 			.map(e -> e.getValue())
 			.collect(Collectors.toList());
 

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"interval-time-between-checks=1100",
         "composed-task-app-arguments.app.AAA.0=--arg1=value1",
         "composed-task-app-arguments.app.AAA.1=--arg2=value2",
+        "composed-task-app-arguments.base64_YXBwLiouMA=--arg3=value3",
 		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
 @EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 public class ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests {
@@ -83,8 +84,8 @@ public class ComposedTaskRunnerConfigurationWithAppArgumentsPropertiesTests {
 
 		TaskLauncherTasklet tasklet = ComposedTaskRunnerTaskletTestUtils.getTaskletLauncherTasklet(context, "ComposedTest-AAA_0");
 		List<String> result = ComposedTaskRunnerTaskletTestUtils.getTaskletArgumentsViaReflection(tasklet);
-		assertThat(result).contains("--arg1=value1", "--arg2=value2");
-		assertThat(result.size()).isEqualTo(2);
+		assertThat(result).contains("--arg1=value1", "--arg2=value2", "--arg3=value3");
+		assertThat(result.size()).isEqualTo(3);
 		Map<String, String> taskletProperties = ComposedTaskRunnerTaskletTestUtils.getTaskletPropertiesViaReflection(tasklet);
 		assertThat(taskletProperties.size()).isEqualTo(0);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.common.security.core.support.OAuth2TokenUtilsSe
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
 import org.springframework.cloud.dataflow.core.AuditActionType;
 import org.springframework.cloud.dataflow.core.AuditOperationType;
+import org.springframework.cloud.dataflow.core.Base64Utils;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.cloud.dataflow.core.TaskDeployment;
@@ -304,7 +305,13 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 			List<String> composedTaskArguments = new ArrayList<>();
 			commandLineArgs.forEach(arg -> {
 				if (arg.startsWith("app.")) {
-					composedTaskArguments.add("--composed-task-app-arguments." + arg);
+					String[] split = arg.split("=", 2);
+					if (split.length == 2) {
+						composedTaskArguments.add("--composed-task-app-arguments." + Base64Utils.encode(split[0]) + "=" + split[1]);
+					}
+					else {
+						composedTaskArguments.add("--composed-task-app-arguments." + arg);
+					}
 				}
 				else {
 					composedTaskArguments.add(arg);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -1413,7 +1413,10 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 			Map<String, String> properties = new HashMap<>();
 			properties.put("app.t1.timestamp.format", "YYYY");
-			assertEquals(1L, this.taskExecutionService.executeTask("seqTask", properties, new LinkedList<>()));
+			List<String> arguments = new ArrayList<>();
+			arguments.add("app.t1.0=foo1");
+			arguments.add("app.*.0=foo2");
+			assertEquals(1L, this.taskExecutionService.executeTask("seqTask", properties, arguments));
 			ArgumentCaptor<AppDeploymentRequest> argumentCaptor = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 			verify(this.taskLauncher, atLeast(1)).launch(argumentCaptor.capture());
 
@@ -1421,6 +1424,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			assertEquals("seqTask", request.getDefinition().getProperties().get("spring.cloud.task.name"));
 			String keyWithEncoding = "composed-task-app-properties." + Base64Utils.encode("app.t1.timestamp.format");
 			assertEquals("YYYY", request.getDefinition().getProperties().get(keyWithEncoding));
+			assertTrue(request.getCommandlineArguments().contains("--composed-task-app-arguments." + Base64Utils.encode("app.t1.0") + "=foo1"));
+			assertTrue(request.getCommandlineArguments().contains("--composed-task-app-arguments." + Base64Utils.encode("app.*.0") + "=foo2"));
 		}
 
 		@Test


### PR DESCRIPTION
- Add handling of wildcard and base64 encode passed keys with ctr.
- Fixes #4566