### PR TITLE
Fix app list wrong version count

### DIFF
--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepositoryImpl.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepositoryImpl.java
@@ -85,6 +85,7 @@ public class AppRegistrationRepositoryImpl implements AppRegistrationRepositoryC
 		if (defaultVersion) {
 			resultList.forEach(appRegistration -> {
 				HashSet<String> versions = appRegistrationRepository.findAllByName(appRegistration.getName()).stream()
+						.filter(ar -> ar.getType() == appRegistration.getType())
 						.map(AppRegistration::getVersion).collect(Collectors.toCollection(HashSet::new));
 				appRegistration.setVersions(versions);
 			});

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -305,13 +305,21 @@ public class AppRegistryControllerTests {
 	public void testListAppsWithMultiVersions() throws Exception {
 		this.appRegistryService.importAll(false, new ClassPathResource("META-INF/test-apps-multi-versions.properties"));
 		mockMvc.perform(get("/apps").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
-				.andExpect(jsonPath("content", hasSize(6)));
+				.andExpect(jsonPath("$.content[*]", hasSize(9)));
 		mockMvc.perform(get("/apps?defaultVersion=true").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk())
-				.andExpect(jsonPath("content", hasSize(4)))
-				.andExpect(jsonPath("$.content[*].versions", containsInAnyOrder(hasSize(1), hasSize(2), hasSize(2), hasSize(1))))
-				.andExpect(jsonPath("$.content[*].versions", containsInAnyOrder(contains("1.0.0.BUILD-SNAPSHOT"), containsInAnyOrder("1.0.0.RELEASE", "1.0.0.BUILD-SNAPSHOT"),
-						contains("1.0.0.BUILD-SNAPSHOT"), containsInAnyOrder("1.0.0.RELEASE","1.0.0.BUILD-SNAPSHOT"))))
-				.andExpect(jsonPath("$.content[*].defaultVersion", contains(true, true, true, true)));
+				.andExpect(jsonPath("$.content[*]", hasSize(6)))
+				.andExpect(jsonPath("$.content[?(@.name == 'time' && @.type == 'source')]", hasSize(1)))
+				.andExpect(jsonPath("$.content[?(@.name == 'time' && @.type == 'source')].defaultVersion", contains(true)))
+				.andExpect(jsonPath("$.content[?(@.name == 'log' && @.type == 'sink')]", hasSize(1)))
+				.andExpect(jsonPath("$.content[?(@.name == 'log' && @.type == 'sink')].defaultVersion", contains(true)))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'source')]", hasSize(1)))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'source')].defaultVersion", contains(true)))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'sink')]", hasSize(1)))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'sink')].defaultVersion", contains(true)))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'source')].versions[*]",
+						containsInAnyOrder("3.0.1")))
+				.andExpect(jsonPath("$.content[?(@.name == 'file' && @.type == 'sink')].versions[*]",
+						containsInAnyOrder("3.0.0", "3.0.1")));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-multi-versions.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-multi-versions.properties
@@ -1,2 +1,8 @@
 source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.RELEASE
 sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.RELEASE
+source.file=maven://org.springframework.cloud.stream.app:file-source-rabbit:3.0.1
+source.file.metadata=maven://org.springframework.cloud.stream.app:file-source-rabbit:jar:metadata:3.0.1
+sink.file=maven://org.springframework.cloud.stream.app:file-sink-rabbit:3.0.1
+sink.file.metadata=maven://org.springframework.cloud.stream.app:file-sink-rabbit:jar:metadata:3.0.1
+sink.file=maven://org.springframework.cloud.stream.app:file-sink-rabbit:3.0.0
+sink.file.metadata=maven://org.springframework.cloud.stream.app:file-sink-rabbit:jar:metadata:3.0.0


### PR DESCRIPTION
- When building appRegistrationResourceList, do filtering per type so that
  sink and sources with same name gets accurate registered versions.
- Fixes #4570