### PR TITLE
Complete task task resource cleanup on task deletion.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -733,6 +733,9 @@ public abstract class DefaultTaskExecutionServiceTests {
 			initializeSuccessfulRegistry(appRegistry);
 			taskSaveService.saveTaskDefinition(new TaskDefinition("simpleTask", "AAA --foo=bar"));
 			verifyTaskExistsInRepo("simpleTask", "AAA --foo=bar", taskDefinitionRepository);
+			taskDeleteService.deleteTaskDefinition("simpleTask", true);
+			String logEntries = outputCapture.toString();
+			assertTrue(logEntries.contains("Deleted task app resources for"));
 		}
 
 		@Test
@@ -748,6 +751,10 @@ public abstract class DefaultTaskExecutionServiceTests {
 			assertEquals(TASK_NAME_ORIG, taskDeployment.getTaskDefinitionName());
 			assertEquals("default", taskDeployment.getPlatformName());
 			assertNotNull("TaskDeployment createdOn field should not be null", taskDeployment.getCreatedOn());
+			taskDeleteService.deleteTaskDefinition(TASK_NAME_ORIG, true);
+			String logEntries = outputCapture.toString();
+			assertTrue(!logEntries.contains("Deleted task app resources for"));
+			assertTrue(!logEntries.contains("Attempted delete of app resources for"));
 		}
 
 		@Test
@@ -958,6 +965,19 @@ public abstract class DefaultTaskExecutionServiceTests {
 			if (!errorCaught) {
 				fail();
 			}
+		}
+
+		@Test
+		@DirtiesContext
+		public void executeDeleteNoDeploymentWithMultiplePlatforms() {
+			initializeSuccessfulRegistry(appRegistry);
+			when(taskLauncher.launch(any())).thenReturn("0");
+			this.launcherRepository.save(new Launcher("anotherPlatform", "local", taskLauncher));
+			taskDeleteService.deleteTaskDefinition(TASK_NAME_ORIG, true);
+			String logEntries = outputCapture.toString();
+			assertTrue(logEntries.contains("Deleted task app resources for myTask_ORIG in platform anotherPlatform"));
+			assertTrue(logEntries.contains("Deleted task app resources for myTask_ORIG in platform default"));
+			assertTrue(logEntries.contains("Deleted task app resources for myTask_ORIG in platform MyPlatform"));
 		}
 
 		@Test


### PR DESCRIPTION
If there is no task deployment when a task definition is deleted SCDF will delete all app resources for the task definition name across all platforms.
If there is a task deployment for that task definition, then it will only delete those app resources associated with that task deployment.
This is to resolve the case where a task launch failed on the platform and thus no task deployment record is created.  Hence we don't know what platform the launch attempt occured.

resolves #4574