### PR TITLE
Handle cases where an invalid platform is specified.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -266,6 +266,9 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 			}
 		}
 		Launcher launcher = this.launcherRepository.findByName(platformName);
+		if(launcher == null) {
+			throw new IllegalStateException(String.format("No launcher was available for platform %s", platformName));
+		}
 		validateTaskName(taskName, launcher);
 		// Remove since the key for task platform name will not pass validation for app,
 		// deployer, or scheduler prefix.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -102,6 +102,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -938,6 +939,22 @@ public abstract class DefaultTaskExecutionServiceTests {
 			assertEquals("", this.taskExecutionService.getLog(platformName, taskDeploymentId));
 		}
 
+		@Test
+		@DirtiesContext
+		public void executeSameTaskDefinitionWithInvalidPlatform() {
+			initializeSuccessfulRegistry(appRegistry);
+			when(taskLauncher.launch(any())).thenReturn("0");
+
+			Map<String, String> deploymentProperties = new HashMap<>();
+			deploymentProperties.put(DefaultTaskExecutionService.TASK_PLATFORM_NAME, "noplatformhere");
+
+			IllegalStateException thrown = assertThrows(
+					IllegalStateException.class,
+					() -> this.taskExecutionService.executeTask(TASK_NAME_ORIG, deploymentProperties, new LinkedList<>())
+			);
+
+			assertTrue(thrown.getMessage().contains("No launcher was available for platform noplatformhere"));
+		}
 
 		@Test
 		@DirtiesContext


### PR DESCRIPTION
Now SCDF will not throw a NPE

resolves #4575