### PR TITLE
Fixes NPE issue when restarting externally launched jobs

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -208,8 +208,8 @@ public class TaskConfiguration {
 
 	@Bean
 	public TaskJobService taskJobExecutionRepository(JobService service, TaskExplorer taskExplorer,
-			TaskDefinitionRepository taskDefinitionRepository, TaskExecutionService taskExecutionService) {
-		return new DefaultTaskJobService(service, taskExplorer, taskDefinitionRepository, taskExecutionService);
+			TaskDefinitionRepository taskDefinitionRepository, TaskExecutionService taskExecutionService, LauncherRepository launcherRepository) {
+		return new DefaultTaskJobService(service, taskExplorer, taskDefinitionRepository, taskExecutionService, launcherRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -242,8 +242,9 @@ public class JobDependencies {
 
 	@Bean
 	public TaskJobService taskJobExecutionRepository(JobService jobService, TaskExplorer taskExplorer,
-			TaskDefinitionRepository taskDefinitionRepository, TaskExecutionService taskExecutionService) {
-		return new DefaultTaskJobService(jobService, taskExplorer, taskDefinitionRepository, taskExecutionService);
+			TaskDefinitionRepository taskDefinitionRepository, TaskExecutionService taskExecutionService,
+			LauncherRepository launcherRepository) {
+		return new DefaultTaskJobService(jobService, taskExplorer, taskDefinitionRepository, taskExecutionService, launcherRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -18,9 +18,11 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -61,22 +63,26 @@ import org.springframework.core.io.FileUrlResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { TaskServiceDependencies.class, JobDependencies.class, BatchProperties.class}, properties = {
-		"spring.main.allow-bean-definition-overriding=true" })
+@SpringBootTest(classes = {TaskServiceDependencies.class, JobDependencies.class, BatchProperties.class}, properties = {
+		"spring.main.allow-bean-definition-overriding=true"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 public class DefaultTaskJobServiceTests {
 
 	private final static String BASE_JOB_NAME = "myJob";
 
 	private final static String JOB_NAME_ORIG = BASE_JOB_NAME + "_ORIG";
+
+	private static long jobInstanceCount = 0;
 
 	@Autowired
 	TaskDefinitionRepository taskDefinitionRepository;
@@ -110,28 +116,30 @@ public class DefaultTaskJobServiceTests {
 
 	private JobParameters jobParameters;
 
-		@Before
-		public void setup() {
-			// not adding platform name as default as we want to check that this only one
-			// gets replaced
-			this.launcherRepository.save(new Launcher("fakeplatformname", "local", this.taskLauncher));
-			this.launcherRepository.save(new Launcher("demo", "local", this.taskLauncher));
-			Map<String, JobParameter> jobParameterMap = new HashMap<>();
-			jobParameterMap.put("identifying.param", new JobParameter("testparam"));
-			this.jobParameters = new JobParameters(jobParameterMap);
+	@Before
+	public void setup() {
+		Map<String, JobParameter> jobParameterMap = new HashMap<>();
+		jobParameterMap.put("identifying.param", new JobParameter("testparam"));
+		this.jobParameters = new JobParameters(jobParameterMap);
 
-			JdbcTemplate template = new JdbcTemplate(this.dataSource);
-			template.execute("DELETE FROM TASK_EXECUTION_PARAMS");
-			template.execute("DELETE FROM TASK_EXECUTION;");
-			initializeSuccessfulRegistry(this.appRegistry);
-			template.execute("INSERT INTO TASK_EXECUTION (TASK_EXECUTION_ID, TASK_NAME) VALUES (0, 'myTask_ORIG');");
-			initializeJobs();
-			when(this.taskLauncher.launch(any())).thenReturn("1234");
-		}
+		JdbcTemplate template = new JdbcTemplate(this.dataSource);
+		template.execute("DELETE FROM TASK_EXECUTION_PARAMS");
+		template.execute("DELETE FROM TASK_TASK_BATCH");
+		template.execute("DELETE FROM task_execution_metadata");
+		template.execute("DELETE FROM TASK_EXECUTION;");
+		initializeSuccessfulRegistry(this.appRegistry);
+		template.execute("INSERT INTO TASK_EXECUTION (TASK_EXECUTION_ID, TASK_NAME) VALUES (0, 'myTask_ORIG');");
+		reset(this.taskLauncher);
+		when(this.taskLauncher.launch(any())).thenReturn("1234");
+		clearLaunchers();
+	}
 
 	@Test
 	public void testRestart() throws Exception {
-		this.taskJobService.restartJobExecution(1L);
+		createBaseLaunchers();
+		initializeJobs(true);
+
+		this.taskJobService.restartJobExecution(jobInstanceCount);
 		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
@@ -139,34 +147,70 @@ public class DefaultTaskJobServiceTests {
 		assertTrue(appDeploymentRequest.getCommandlineArguments().contains("identifying.param(string)=testparam"));
 	}
 
-	private void initializeJobs() {
-		this.taskDefinitionRepository.save(new TaskDefinition(JOB_NAME_ORIG, "some-name"));
-		createSampleJob(this.jobRepository, this.taskBatchDao, this.taskExecutionDao,
-				JOB_NAME_ORIG, 1, BatchStatus.FAILED);
+	@Test
+	public void testRestartNoPlatform() {
+		createBaseLaunchers();
+		initializeJobs(false);
+		Exception exception = assertThrows(IllegalStateException.class, () -> {
+			this.taskJobService.restartJobExecution(jobInstanceCount);
+		});
+		assertTrue(exception.getMessage().contains("Did not find platform for taskName=[myJob_ORIG"));
 	}
 
+	@Test
+	public void testRestartOnePlatform() throws Exception {
+		this.launcherRepository.save(new Launcher("demo", "local", this.taskLauncher));
+
+		initializeJobs(false);
+		this.taskJobService.restartJobExecution(jobInstanceCount);
+		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, times(1)).launch(argument.capture());
+		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
+		assertTrue(appDeploymentRequest.getCommandlineArguments().contains("identifying.param(string)=testparam"));
+	}
+
+	private void initializeJobs(boolean insertTaskExecutionMetadata) {
+		this.taskDefinitionRepository.save(new TaskDefinition(JOB_NAME_ORIG + jobInstanceCount, "some-name"));
+		createSampleJob(this.jobRepository, this.taskBatchDao, this.taskExecutionDao,
+				JOB_NAME_ORIG + jobInstanceCount, BatchStatus.FAILED, insertTaskExecutionMetadata);
+		jobInstanceCount++;
+
+	}
 
 	private void createSampleJob(JobRepository jobRepository, TaskBatchDao taskBatchDao,
 			TaskExecutionDao taskExecutionDao, String jobName,
-			int jobExecutionCount, BatchStatus status) {
+			BatchStatus status, boolean insertTaskExecutionMetadata) {
 		JobInstance instance = jobRepository.createJobInstance(jobName, new JobParameters());
 		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), Collections.emptyList(), null);
 		JobExecution jobExecution;
 		JdbcTemplate template = new JdbcTemplate(this.dataSource);
 		template.execute("ALTER SEQUENCE task_execution_metadata_seq RESTART WITH 50");
-		template.execute("INSERT INTO task_execution_metadata (id, task_execution_id, task_execution_manifest) VALUES (1, 1, '{\"taskDeploymentRequest\":{\"definition\":{\"name\":\"bd0917a\",\"properties\":{\"spring.datasource.username\":\"root\",\"spring.cloud.task.name\":\"bd0917a\",\"spring.datasource.url\":\"jdbc:mariadb://localhost:3306/task\",\"spring.datasource.driverClassName\":\"org.mariadb.jdbc.Driver\",\"spring.datasource.password\":\"password\"}},\"resource\":\"file:/Users/glennrenfro/tmp/batchdemo-0.0.1-SNAPSHOT.jar\",\"deploymentProperties\":{},\"commandlineArguments\":[\"run.id_long=1\",\"--spring.cloud.task.executionid=201\"]},\"platformName\":\"demo\"}')");
-
-		for (int i = 0; i < jobExecutionCount; i++) {
-			jobExecution = jobRepository.createJobExecution(instance,
-					this.jobParameters, null);
-			StepExecution stepExecution = new StepExecution("foo", jobExecution, 1L);
-			stepExecution.setId(null);
-			jobRepository.add(stepExecution);
-			taskBatchDao.saveRelationship(taskExecution, jobExecution);
-			jobExecution.setStatus(status);
-			jobExecution.setStartTime(new Date());
-			jobRepository.update(jobExecution);
+		template.execute("ALTER SEQUENCE task_seq RESTART WITH 1");
+		if (insertTaskExecutionMetadata) {
+			template.execute(String.format("INSERT INTO task_execution_metadata (id, task_execution_id, task_execution_manifest) VALUES (%s, %s, '{\"taskDeploymentRequest\":{\"definition\":{\"name\":\"bd0917a\",\"properties\":{\"spring.datasource.username\":\"root\",\"spring.cloud.task.name\":\"bd0917a\",\"spring.datasource.url\":\"jdbc:mariadb://localhost:3306/task\",\"spring.datasource.driverClassName\":\"org.mariadb.jdbc.Driver\",\"spring.datasource.password\":\"password\"}},\"resource\":\"file:/Users/glennrenfro/tmp/batchdemo-0.0.1-SNAPSHOT.jar\",\"deploymentProperties\":{},\"commandlineArguments\":[\"run.id_long=1\",\"--spring.cloud.task.executionid=201\"]},\"platformName\":\"demo\"}')", taskExecution.getExecutionId(), taskExecution.getExecutionId()));
 		}
+		jobExecution = jobRepository.createJobExecution(instance,
+				this.jobParameters, null);
+		StepExecution stepExecution = new StepExecution("foo", jobExecution, 1L);
+		stepExecution.setId(null);
+		jobRepository.add(stepExecution);
+		taskBatchDao.saveRelationship(taskExecution, jobExecution);
+		jobExecution.setStatus(status);
+		jobExecution.setStartTime(new Date());
+		jobRepository.update(jobExecution);
+	}
+
+	private void clearLaunchers() {
+		List<Launcher> launchers = new ArrayList<>();
+		this.launcherRepository.findAll().forEach(launcher1 -> launchers.add(launcher1));
+		launchers.stream().forEach(launcher -> this.launcherRepository.delete(launcher));
+	}
+
+	private void createBaseLaunchers() {
+		// not adding platform name as default as we want to check that this only one
+		// gets replaced
+		this.launcherRepository.save(new Launcher("fakeplatformname", "local", this.taskLauncher));
+		this.launcherRepository.save(new Launcher("demo", "local", this.taskLauncher));
 	}
 
 	private static void initializeSuccessfulRegistry(AppRegistryService appRegistry) {


### PR DESCRIPTION
resolves #4484

This PR resolves the NPE that was reported and allows dataflow to
restart apps if there is only one platform.  If there is more than
one platform, there is no metadata to know which one is the correct platform.
The solution is to start storing metadata on schedule launches.