### PR TITLE
Deprecates the use of scheduler properties

### DIFF
--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryTaskLauncher;
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -63,7 +63,7 @@ public abstract class AbstractSchedulerPerPlatformTest {
 		@ConditionalOnCloudPlatform(CloudPlatform.CLOUD_FOUNDRY)
 		public static class CloudFoundryMockConfig {
 			@MockBean
-			protected CloudFoundrySchedulerProperties cloudFoundrySchedulerProperties;
+			protected CloudFoundryDeploymentProperties cloudFoundryDeploymentProperties;
 
 			@Bean
 			@Primary

--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesSchedulerProperties;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.junit.Assert.assertFalse;
@@ -88,8 +87,6 @@ public class SchedulerPerPlatformTest {
 			assertFalse("K8s should be disabled", context.getEnvironment().containsProperty("kubernetes_service_host"));
 			assertTrue("CF should be enabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
 
-			CloudFoundrySchedulerProperties props = context.getBean(CloudFoundrySchedulerProperties.class);
-			assertNotNull(props);
 		}
 	}
 }

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryPlatformProperties.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryPlatformProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.springframework.cloud.dataflow.core.AbstractPlatformProperties;
 import org.springframework.cloud.dataflow.server.config.cloudfoundry.CloudFoundryPlatformProperties.CloudFoundryProperties;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties;
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 
 /**
  * @author Mark Pollack
@@ -40,8 +39,6 @@ public class CloudFoundryPlatformProperties extends AbstractPlatformProperties<C
 
 		private CloudFoundryDeploymentProperties deployment;
 
-		private CloudFoundrySchedulerProperties scheduler;
-
 		public CloudFoundryConnectionProperties getConnection() {
 			return connection;
 		}
@@ -56,14 +53,6 @@ public class CloudFoundryPlatformProperties extends AbstractPlatformProperties<C
 
 		public void setDeployment(CloudFoundryDeploymentProperties deployment) {
 			this.deployment = deployment;
-		}
-
-		public CloudFoundrySchedulerProperties getScheduler() {
-			return scheduler;
-		}
-
-		public void setScheduler(CloudFoundrySchedulerProperties scheduler) {
-			this.scheduler = scheduler;
 		}
 	}
 }

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundrySchedulerClientProvider.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundrySchedulerClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,10 @@
 
 package org.springframework.cloud.dataflow.server.config.cloudfoundry;
 
-import java.util.Optional;
-
 import io.pivotal.reactor.scheduler.ReactorSchedulerClient;
 import io.pivotal.scheduler.SchedulerClient;
 import reactor.core.publisher.Mono;
 
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 
 /**
  * @author David Turanski
@@ -33,29 +30,25 @@ public class CloudFoundrySchedulerClientProvider {
 
 	private final CloudFoundryPlatformTokenProvider platformTokenProvider;
 
-	private final Optional<CloudFoundrySchedulerProperties> schedulerProperties;
+	private final CloudFoundryPlatformProperties platformProperties;
 
 	public CloudFoundrySchedulerClientProvider(
 		CloudFoundryPlatformConnectionContextProvider connectionContextProvider,
 		CloudFoundryPlatformTokenProvider platformTokenProvider,
-		Optional<CloudFoundrySchedulerProperties> schedulerProperties) {
+		CloudFoundryPlatformProperties platformProperties) {
 
 
 		this.connectionContextProvider = connectionContextProvider;
 		this.platformTokenProvider = platformTokenProvider;
-		this.schedulerProperties = schedulerProperties;
+		this.platformProperties = platformProperties;
 	}
 
 	public SchedulerClient cloudFoundrySchedulerClient(String account) {
 		return ReactorSchedulerClient.builder()
 				.connectionContext(connectionContextProvider.connectionContext(account))
 				.tokenProvider(platformTokenProvider.tokenProvider(account))
-				.root(Mono.just(schedulerProperties().getSchedulerUrl()))
+				.root(Mono.just(platformProperties.getAccounts().get(account).getDeployment().getSchedulerUrl()))
 				.build();
-	}
-
-	public CloudFoundrySchedulerProperties schedulerProperties() {
-		return this.schedulerProperties.orElseGet(CloudFoundrySchedulerProperties::new);
 	}
 
 }

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformAutoConfiguration.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.dataflow.server.config.CloudProfileProvider;
 import org.springframework.cloud.dataflow.server.config.features.ConditionalOnTasksEnabled;
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -72,9 +71,9 @@ public class CloudFoundryTaskPlatformAutoConfiguration {
 	public CloudFoundrySchedulerClientProvider schedulerClientProvider(
 			CloudFoundryPlatformConnectionContextProvider connectionContextProvider,
 			CloudFoundryPlatformTokenProvider platformTokenProvider,
-			Optional<CloudFoundrySchedulerProperties> schedulerProperties) {
+			CloudFoundryPlatformProperties cloudFoundryPlatformProperties) {
 		return new CloudFoundrySchedulerClientProvider(
-				connectionContextProvider, platformTokenProvider, schedulerProperties);
+				connectionContextProvider, platformTokenProvider, cloudFoundryPlatformProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-platform-kubernetes/src/main/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactory.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/main/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactory.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.cloud.dataflow.core.AbstractTaskPlatformFactory;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.deployer.spi.kubernetes.ContainerFactory;
@@ -28,7 +27,6 @@ import org.springframework.cloud.deployer.spi.kubernetes.DefaultContainerFactory
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesClientFactory;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesScheduler;
-import org.springframework.cloud.deployer.spi.kubernetes.KubernetesSchedulerProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesTaskLauncher;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesTaskLauncherProperties;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
@@ -65,9 +63,7 @@ public class KubernetesTaskPlatformFactory extends AbstractTaskPlatformFactory<K
 		KubernetesTaskLauncher kubernetesTaskLauncher = new KubernetesTaskLauncher(
 				kubernetesProperties, taskLauncherProperties, kubernetesClient, containerFactory);
 
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		BeanUtils.copyProperties(kubernetesProperties, kubernetesSchedulerProperties);
-		Scheduler scheduler = getScheduler(kubernetesSchedulerProperties, kubernetesClient);
+		Scheduler scheduler = getScheduler(kubernetesProperties, kubernetesClient);
 
 		Launcher launcher = new Launcher(account, KUBERNETES_PLATFORM_TYPE, kubernetesTaskLauncher, scheduler);
 
@@ -97,12 +93,12 @@ public class KubernetesTaskPlatformFactory extends AbstractTaskPlatformFactory<K
 		return launchers;
 	}
 
-	private Scheduler getScheduler(KubernetesSchedulerProperties kubernetesSchedulerProperties,
+	private Scheduler getScheduler(KubernetesDeployerProperties kubernetesDeployerProperties,
 			KubernetesClient kubernetesClient) {
 		Scheduler scheduler = null;
 
 		if (schedulesEnabled) {
-			scheduler = new KubernetesScheduler(kubernetesClient, kubernetesSchedulerProperties);
+			scheduler = new KubernetesScheduler(kubernetesClient, kubernetesDeployerProperties);
 		}
 
 		return scheduler;

--- a/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactoryTests.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactoryTests.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
-import org.springframework.cloud.deployer.spi.kubernetes.KubernetesSchedulerProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesTaskLauncher;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesTaskLauncherProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.RestartPolicy;
@@ -77,7 +76,7 @@ public class KubernetesTaskPlatformFactoryTests {
 		assertThat(taskPlatform.getName()).isEqualTo("Kubernetes");
 		assertThat(taskPlatform.getLaunchers()).hasSize(1);
 		Launcher taskLauncher = taskPlatform.getLaunchers().get(0);
-		KubernetesSchedulerProperties properties = (KubernetesSchedulerProperties) ReflectionTestUtils.getField(taskLauncher.getScheduler(), "properties");
+		KubernetesDeployerProperties properties = (KubernetesDeployerProperties) ReflectionTestUtils.getField(taskLauncher.getScheduler(), "properties");
 		assertThat(properties.getLimits().getMemory()).isEqualTo("5555Mi");
 
 		assertThat(taskLauncher.getScheduler()).isNotNull();
@@ -110,7 +109,7 @@ public class KubernetesTaskPlatformFactoryTests {
 		for (Launcher taskLauncher: taskPlatform.getLaunchers()) {
 			assertThat(taskLauncher.getName().equals("k8s") || taskLauncher.getName().equals("test")).isTrue();
 			if (taskLauncher.getName().equals("k8s")) {
-				KubernetesSchedulerProperties properties = (KubernetesSchedulerProperties) ReflectionTestUtils.getField(taskLauncher.getScheduler(), "properties");
+				KubernetesDeployerProperties properties = (KubernetesDeployerProperties) ReflectionTestUtils.getField(taskLauncher.getScheduler(), "properties");
 				assertThat(properties.getLimits().getMemory()).isEqualTo("5555Mi");
 
 				assertThat(taskLauncher.getScheduler()).isNotNull();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,11 +225,9 @@ public class DefaultSchedulerService implements SchedulerService {
 				appDeploymentProperties, visibleProperties);
 		DeploymentPropertiesUtils.validateDeploymentProperties(taskDeploymentProperties);
 		taskDeploymentProperties = extractAndQualifySchedulerProperties(taskDeploymentProperties);
-
+		deployerDeploymentProperties.putAll(taskDeploymentProperties);
 		scheduleName = validateScheduleNameForPlatform(launcher.getType(), scheduleName);
-
-		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition, taskDeploymentProperties,
-				deployerDeploymentProperties, commandLineArgs, scheduleName, getTaskResource(taskDefinitionName));
+		ScheduleRequest scheduleRequest = new ScheduleRequest(revisedDefinition, deployerDeploymentProperties, commandLineArgs, scheduleName, getTaskResource(taskDefinitionName));
 		launcher.getScheduler().schedule(scheduleRequest);
 
 		this.auditRecordService.populateAndSaveAuditRecordUsingMapData(AuditOperationType.SCHEDULE, AuditActionType.CREATE,
@@ -418,13 +416,14 @@ public class DefaultSchedulerService implements SchedulerService {
 	 * @param input the scheduler properties
 	 * @return scheduler properties for the task
 	 */
+	@Deprecated
 	private static Map<String, String> extractAndQualifySchedulerProperties(Map<String, String> input) {
 		final String prefix = "scheduler.";
 		final int prefixLength = prefix.length();
 
 		return new TreeMap<>(input).entrySet().stream()
 				.filter(kv -> kv.getKey().startsWith(prefix))
-				.collect(Collectors.toMap(kv -> "spring.cloud.scheduler." + kv.getKey().substring(prefixLength), Map.Entry::getValue,
+				.collect(Collectors.toMap(kv -> "spring.cloud.deployer." + kv.getKey().substring(prefixLength), Map.Entry::getValue,
 						(fromWildcard, fromApp) -> fromApp));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/SimpleTestScheduler.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/SimpleTestScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,10 @@ public class SimpleTestScheduler implements Scheduler {
 	public void schedule(ScheduleRequest scheduleRequest) {
 		ScheduleInfo schedule = new ScheduleInfo();
 		schedule.setScheduleName(scheduleRequest.getScheduleName());
-		schedule.setScheduleProperties(scheduleRequest.getSchedulerProperties());
+		schedule.setScheduleProperties(scheduleRequest.getDeploymentProperties());
 		schedule.setTaskDefinitionName(scheduleRequest.getDefinition().getName());
-		if (schedule.getScheduleProperties().containsKey("spring.cloud.scheduler.cron.expression") &&
-				schedule.getScheduleProperties().get("spring.cloud.scheduler.cron.expression")
+		if (schedule.getScheduleProperties().containsKey("spring.cloud.deployer.cron.expression") &&
+				schedule.getScheduleProperties().get("spring.cloud.deployer.cron.expression")
 						.equals(INVALID_CRON_EXPRESSION)) {
 			throw new CreateScheduleException("Invalid Cron Expression", new IllegalArgumentException());
 		}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -195,7 +195,7 @@ public class TaskSchedulerControllerTests {
 		ScheduleInfo scheduleInfo = simpleTestScheduler.list().get(0);
 		assertEquals(createdScheduleName, scheduleInfo.getScheduleName());
 		assertEquals(1, scheduleInfo.getScheduleProperties().size());
-		assertEquals("* * * * *", scheduleInfo.getScheduleProperties().get("spring.cloud.scheduler.cron.expression"));
+		assertEquals("* * * * *", scheduleInfo.getScheduleProperties().get("spring.cloud.deployer.cron.expression"));
 
 		final List<AuditRecord> auditRecords = auditRecordRepository.findAll();
 
@@ -213,7 +213,7 @@ public class TaskSchedulerControllerTests {
 				"\"spring.datasource.driverClassName\":null," +
 				"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
 				"\"spring.cloud.task.name\":\"testDefinition\"}," +
-				"\"deploymentProperties\":{}}", auditRecord.getAuditData());
+				"\"deploymentProperties\":{\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}", auditRecord.getAuditData());
 	}
 
 	@Test
@@ -227,7 +227,7 @@ public class TaskSchedulerControllerTests {
 						"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
 						"\"spring.cloud.task.name\":\"testDefinition\"}," +
 						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\"," +
-						"\"spring.cloud.deployer.prop2.password\":\"******\"}}",
+						"\"spring.cloud.deployer.prop2.password\":\"******\",\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
 				auditData);
 	}
 
@@ -243,7 +243,7 @@ public class TaskSchedulerControllerTests {
 						"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
 						"\"spring.cloud.task.name\":\"testDefinition\"}," +
 						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\"," +
-						"\"spring.cloud.deployer.prop2.password\":\"******\"}}",
+						"\"spring.cloud.deployer.prop2.password\":\"******\",\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
 				auditData);
 	}
 
@@ -260,8 +260,8 @@ public class TaskSchedulerControllerTests {
 		assertEquals(1, simpleTestScheduler.list().size());
 		ScheduleInfo scheduleInfo = simpleTestScheduler.list().get(0);
 		assertEquals("mySchedule", scheduleInfo.getScheduleName());
-		assertEquals(1, scheduleInfo.getScheduleProperties().size());
-		assertEquals("* * * * *", scheduleInfo.getScheduleProperties().get("spring.cloud.scheduler.cron.expression"));
+		assertEquals(3, scheduleInfo.getScheduleProperties().size());
+		assertEquals("* * * * *", scheduleInfo.getScheduleProperties().get("spring.cloud.deployer.cron.expression"));
 
 		final List<AuditRecord> auditRecords = auditRecordRepository.findAll();
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 
 	private static final String DATA_FLOW_SCHEDULER_PREFIX = "scheduler.";
 
-	private static final String SCHEDULER_PREFIX = "spring.cloud.scheduler.";
+	private static final String DEPLOYER_PREFIX = "spring.cloud.deployer.";
 
 	private static final String BASE_SCHEDULE_NAME = "mytaskschedule";
 
@@ -160,8 +160,8 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		this.testProperties.put(DATA_FLOW_SCHEDULER_PREFIX + "AAAA", "* * * * *");
 		this.testProperties.put(DATA_FLOW_SCHEDULER_PREFIX + "EXPRESSION", "* * * * *");
 		this.resolvedProperties = new HashMap<>();
-		this.resolvedProperties.put(SCHEDULER_PREFIX + "AAAA", "* * * * *");
-		this.resolvedProperties.put(SCHEDULER_PREFIX + "EXPRESSION", "* * * * *");
+		this.resolvedProperties.put(DEPLOYER_PREFIX + "AAAA", "* * * * *");
+		this.resolvedProperties.put(DEPLOYER_PREFIX + "EXPRESSION", "* * * * *");
 		this.commandLineArgs = new ArrayList<>();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class DefaultSchedulerServiceTests {
 
 	private static final String DATA_FLOW_SCHEDULER_PREFIX = "scheduler.";
 
-	private static final String SCHEDULER_PREFIX = "spring.cloud.scheduler.";
+	private static final String SCHEDULER_PREFIX = "spring.cloud.deployer.";
 
 	private static final String BASE_SCHEDULE_NAME = "myTaskSchedule";
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.springframework.cloud.dataflow.server.config.cloudfoundry.CloudFoundr
 import org.springframework.cloud.dataflow.server.config.cloudfoundry.CloudFoundryPlatformTokenProvider;
 import org.springframework.cloud.dataflow.server.config.cloudfoundry.CloudFoundrySchedulerClientProvider;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
-import org.springframework.cloud.deployer.spi.scheduler.cloudfoundry.CloudFoundrySchedulerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -67,7 +66,7 @@ import static org.mockito.Mockito.when;
 	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.url=https://localhost",
 	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.org=org",
 	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.space=space",
-	"spring.cloud.scheduler.cloudfoundry.scheduler-url=https://localhost"
+	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].deployment.schedulerurl=https://localhost"
 	})
 @RunWith(SpringRunner.class)
 public class CloudFoundrySchedulerTests {
@@ -138,8 +137,6 @@ public class CloudFoundrySchedulerTests {
 				mock(CloudFoundrySchedulerClientProvider.class);
 			when(cloudFoundrySchedulerClientProvider.cloudFoundrySchedulerClient(anyString()))
 				.thenReturn(mock(SchedulerClient.class));
-			when(cloudFoundrySchedulerClientProvider.schedulerProperties()).thenReturn(
-				new CloudFoundrySchedulerProperties());
 			return cloudFoundrySchedulerClientProvider;
 		}
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.url=https://localhost",
 		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.org=org",
 		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.space=space",
-		"spring.cloud.scheduler.cloudfoundry.scheduler-url=https://localhost"
+		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].deployment.scheduler-url=https://localhost"
 	})
 @RunWith(SpringRunner.class)
 public class MultiplePlatformTypeTests {


### PR DESCRIPTION
resolves #4262

Updated to support deployer props instead of scheduler props.

The following issues need to be reviewed and merged first:
https://github.com/spring-cloud/spring-cloud-deployer/pull/349
https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/pull/457
https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/pull/378
These need to be built prior to building dataflow.

Also note that for CF deployments there has been a change in the properties
`    SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[default]_SCHEDULER_SCHEDULERURL: https://scheduler.sys.somewhere.com`
`SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[default]_DEPLOYMENT_SCHEDULERURL: https://scheduler.sys.somewhere.com`