### PR TITLE
Fix azure container registry access

### DIFF
--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -36,7 +36,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.cloud.dataflow.container.registry.authorization.DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy;
+import org.springframework.cloud.dataflow.container.registry.authorization.DropAuthorizationHeaderRequestRedirectStrategy;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -190,7 +190,9 @@ public class ContainerImageRestTemplateFactory {
 		HttpComponentsClientHttpRequestFactory customRequestFactory =
 				new HttpComponentsClientHttpRequestFactory(
 						clientBuilder
-								.setRedirectStrategy(new DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy())
+								.setRedirectStrategy(new DropAuthorizationHeaderRequestRedirectStrategy())
+								// Azure redirects may contain double slashes and on default those are normilised
+								.setDefaultRequestConfig(RequestConfig.custom().setNormalizeUri(false).build())
 								.build());
 
 		// DockerHub response's media-type is application/octet-stream although the content is in JSON.

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderRequestRedirectStrategy.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderRequestRedirectStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,9 +45,13 @@ import org.apache.http.protocol.HttpContext;
  * Solution is to implement a HTTP redirect strategy that removes the original Authorization headers when the request is
  * redirected toward an Amazon signed URL.
  *
+ * Azure have same type of issues as S3 so header needs to be dropped as well.
+ * (https://docs.microsoft.com/en-us/azure/container-registry/container-registry-faq#authentication-information-is-not-given-in-the-correct-format-on-direct-rest-api-calls)
+ *
  * @author Adam J. Weigold
+ * @author Janne Valkealahti
  */
-public class DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy extends DefaultRedirectStrategy {
+public class DropAuthorizationHeaderRequestRedirectStrategy extends DefaultRedirectStrategy {
 
 	private static final String AMZ_CREDENTIAL = "X-Amz-Credential";
 
@@ -67,6 +71,11 @@ public class DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy extends De
 					&& (method.equalsIgnoreCase(HttpHead.METHOD_NAME) || method.equalsIgnoreCase(HttpGet.METHOD_NAME))) {
 				return new DropAuthorizationHeaderHttpRequestBase(httpUriRequest.getURI(), method);
 			}
+		}
+
+		if (request.getRequestLine().getUri().contains("azurecr.io")) {
+			final String method = request.getRequestLine().getMethod();
+			return new DropAuthorizationHeaderHttpRequestBase(httpUriRequest.getURI(), method);
 		}
 
 		return httpUriRequest;


### PR DESCRIPTION
- Rename DropAuthorizationHeaderOnSignedS3RequestRedirectStrategy to
  DropAuthorizationHeaderRequestRedirectStrategy
- Add same auth header drop with azure as with s3
- Configure http client not to normalise url's as azure may
  add double slashes
- No new or changed tests as we need to prepare some new integration
  test infras as unit or mocking may not be enough
- Fixes #4412