### PR TITLE
refactor: JUnit 5 migration

### DIFF
--- a/spring-cloud-dataflow-audit/src/test/java/org/springframework/cloud/dataflow/server/audit/service/DefaultAuditRecordServiceTests.java
+++ b/spring-cloud-dataflow-audit/src/test/java/org/springframework/cloud/dataflow/server/audit/service/DefaultAuditRecordServiceTests.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.dataflow.audit.repository.AuditRecordRepository;
@@ -32,8 +32,8 @@ import org.springframework.cloud.dataflow.core.AuditOperationType;
 import org.springframework.cloud.dataflow.core.AuditRecord;
 import org.springframework.data.domain.PageRequest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -50,7 +50,7 @@ public class DefaultAuditRecordServiceTests {
 
 	private AuditRecordRepository auditRecordRepository;
 
-	@Before
+	@BeforeEach
 	public void setupMock() {
 		this.auditRecordRepository = mock(AuditRecordRepository.class);
 	}

--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/AbstractSchedulerPerPlatformTest.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.autoconfigure.local;
 
 import io.pivotal.reactor.scheduler.ReactorSchedulerClient;
 import org.cloudfoundry.operations.CloudFoundryOperations;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,12 +38,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Christian Tzolov
  */
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		classes = AbstractSchedulerPerPlatformTest.AutoConfigurationApplication.class)
 @DirtiesContext

--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/ProfileApplicationListenerTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/ProfileApplicationListenerTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.dataflow.autoconfigure.local;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -46,7 +46,7 @@ public class ProfileApplicationListenerTest {
 
 	private ProfileApplicationListener profileApplicationListener;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		environment = new MockEnvironment();
 		when(event.getEnvironment()).thenReturn(environment);

--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.dataflow.autoconfigure.local;
 
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -26,9 +26,10 @@ import org.springframework.cloud.deployer.spi.kubernetes.KubernetesSchedulerProp
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.test.context.TestPropertySource;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Christian Tzolov
@@ -39,11 +40,13 @@ public class SchedulerPerPlatformTest {
 	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=false" })
 	public static class AllSchedulerDisabledTests extends AbstractSchedulerPerPlatformTest {
 
-		@Test(expected = NoSuchBeanDefinitionException.class)
+		@Test
 		public void testLocalSchedulerEnabled() {
-			assertFalse(context.getEnvironment().containsProperty("kubernetes_service_host"));
-			assertFalse(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
-			context.getBean(Scheduler.class);
+			assertThrows(NoSuchBeanDefinitionException.class, () -> {
+				assertFalse(context.getEnvironment().containsProperty("kubernetes_service_host"));
+				assertFalse(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+				context.getBean(Scheduler.class);
+			});
 		}
 	}
 
@@ -52,8 +55,8 @@ public class SchedulerPerPlatformTest {
 
 		@Test
 		public void testLocalSchedulerEnabled() {
-			assertFalse("K8s should be disabled", context.getEnvironment().containsProperty("kubernetes_service_host"));
-			assertFalse("CF should be disabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+			assertFalse(context.getEnvironment().containsProperty("kubernetes_service_host"), "K8s should be disabled");
+			assertFalse(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()), "CF should be disabled");
 
 			Scheduler scheduler = context.getBean(Scheduler.class);
 
@@ -68,8 +71,8 @@ public class SchedulerPerPlatformTest {
 
 		@Test
 		public void testKubernetesSchedulerEnabled() {
-			assertTrue("K8s should be enabled", context.getEnvironment().containsProperty("kubernetes_service_host"));
-			assertFalse("CF should be disabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+			assertTrue(context.getEnvironment().containsProperty("kubernetes_service_host"), "K8s should be enabled");
+			assertFalse(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()), "CF should be disabled");
 
 
 			KubernetesSchedulerProperties props = context.getBean(KubernetesSchedulerProperties.class);
@@ -84,8 +87,8 @@ public class SchedulerPerPlatformTest {
 
 		@Test
 		public void testCloudFoundryScheudlerEnabled() {
-			assertFalse("K8s should be disabled", context.getEnvironment().containsProperty("kubernetes_service_host"));
-			assertTrue("CF should be enabled", CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()));
+			assertFalse(context.getEnvironment().containsProperty("kubernetes_service_host"), "K8s should be disabled");
+			assertTrue(CloudPlatform.CLOUD_FOUNDRY.isActive(context.getEnvironment()), "CF should be enabled");
 
 		}
 	}

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import javax.servlet.RequestDispatcher;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.rest.Version;
 import org.springframework.restdocs.payload.JsonFieldType;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.http.MediaType;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AuditRecordsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AuditRecordsDocumentation.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -37,12 +37,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Gunnar Hillert
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class AuditRecordsDocumentation extends BaseDocumentation {
 
 	private static boolean setUpIsDone = false;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (setUpIsDone) {
 			return;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
@@ -25,9 +25,9 @@ import java.util.concurrent.Callable;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatchers;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
@@ -81,7 +81,7 @@ public abstract class BaseDocumentation {
 	@ClassRule
 	public final static LocalDataflowResource springDataflowServer = new LocalDataflowResource(
 				"classpath:rest-docs-config.yml", true, true, true, true, skipperServerPort);
-	@Before
+	@BeforeEach
 	public void setupMocks() throws Exception{
 		reset(springDataflowServer.getSkipperClient());
 

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
@@ -21,9 +21,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -48,7 +47,6 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -67,7 +65,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { EmbeddedDataSourceConfiguration.class })
 @DirtiesContext
 public class JobExecutionsDocumentation extends BaseDocumentation {
@@ -81,7 +78,7 @@ public class JobExecutionsDocumentation extends BaseDocumentation {
 	private JdbcTemplate jdbcTemplate;
 
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (!initialized) {
 			registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobInstancesDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobInstancesDocumentation.java
@@ -19,9 +19,8 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 import java.util.ArrayList;
 import java.util.Date;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -38,7 +37,6 @@ import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -55,7 +53,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { EmbeddedDataSourceConfiguration.class })
 @DirtiesContext
 public class JobInstancesDocumentation extends BaseDocumentation {
@@ -67,7 +64,7 @@ public class JobInstancesDocumentation extends BaseDocumentation {
 	private TaskExecutionDao dao;
 	private TaskBatchDao taskBatchDao;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (!initialized) {
 			registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobStepExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobStepExecutionsDocumentation.java
@@ -19,9 +19,8 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 import java.util.ArrayList;
 import java.util.Date;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -39,7 +38,6 @@ import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -56,7 +54,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { EmbeddedDataSourceConfiguration.class })
 @DirtiesContext
 public class JobStepExecutionsDocumentation extends BaseDocumentation {
@@ -68,7 +65,7 @@ public class JobStepExecutionsDocumentation extends BaseDocumentation {
 	private TaskExecutionDao dao;
 	private TaskBatchDao taskBatchDao;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (!initialized) {
 			registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeAppsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeAppsDocumentation.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.skipper.domain.Info;
@@ -45,14 +45,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext
 public class RuntimeAppsDocumentation extends BaseDocumentation {
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		registerApp(ApplicationType.source, "http", "1.2.0.RELEASE");
 		registerApp(ApplicationType.sink, "log", "1.2.0.RELEASE");
 		createStream("mystream", "http | log", true);
 	}
 
-	@After
+	@AfterEach
 	public void cleanup() throws Exception {
 		destroyStream("mystream");
 		unregisterApp(ApplicationType.source, "http");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeStreamStatusForStreamAppsWithoutCollectorDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/RuntimeStreamStatusForStreamAppsWithoutCollectorDocumentation.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.http.MediaType;
 
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  */
-@Ignore
+@Disabled
 public class RuntimeStreamStatusForStreamAppsWithoutCollectorDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
@@ -18,10 +18,10 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import java.util.Arrays;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -43,12 +43,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class StreamDefinitionsDocumentation extends BaseDocumentation {
 
 	private static boolean setUpIsDone = false;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (setUpIsDone) {
 			return;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
@@ -23,10 +23,10 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -50,12 +50,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class StreamDeploymentsDocumentation extends BaseDocumentation {
 
 	private static boolean setUpIsDone = false;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (setUpIsDone) {
 			return;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamLogsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamLogsDocumentation.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.server.rest.documentation;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.skipper.domain.LogInfo;
 
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Ilayaperumal Gopinathan
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class StreamLogsDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamValidationDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamValidationDocumentation.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -35,12 +35,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class StreamValidationDocumentation extends BaseDocumentation {
 
 	private static boolean setUpIsDone = false;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (setUpIsDone) {
 			return;

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -43,15 +43,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  */
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskDefinitionsDocumentation extends BaseDocumentation {
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		unregisterApp(ApplicationType.task, "timestamp");
 	}

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -44,10 +44,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author David Turanski
  * @author Gunnar Hillert
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskExecutionsDocumentation extends BaseDocumentation {
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");
 		createTaskDefinition("taskA");
@@ -55,7 +55,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		destroyTaskDefinition("taskA");
 		destroyTaskDefinition("taskB");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Ilayaperumal Gopinathan
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskLogsDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskPlatformDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskPlatformDocumentation.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Ilayaperumal Gopinathan
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskPlatformDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -40,16 +40,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskSchedulerDocumentation extends BaseDocumentation {
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");
 		createTaskDefinition("mytaskname");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		destroyTaskDefinition("mytaskname");
 		unregisterApp(ApplicationType.task, "timestamp");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskValidationDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskValidationDocumentation.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -39,16 +39,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Glenn Renfro
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TaskValidationDocumentation extends BaseDocumentation {
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");
         createTaskDefinition("taskC");
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         destroyTaskDefinition("taskC");
         unregisterApp(ApplicationType.task, "timestamp");

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TasksInfoDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TasksInfoDocumentation.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 
@@ -38,10 +38,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Ilayaperumal Gopinathan
  */
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class TasksInfoDocumentation extends BaseDocumentation {
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		registerApp(ApplicationType.task, "timestamp", "1.2.0.RELEASE");
 		createTaskDefinition("taskA");
@@ -49,7 +49,7 @@ public class TasksInfoDocumentation extends BaseDocumentation {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		destroyTaskDefinition("taskA");
 		destroyTaskDefinition("taskB");

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/BootVersionsCompletionProviderTests.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -45,11 +45,9 @@ import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResourceLoader;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -60,7 +58,6 @@ import static org.mockito.Mockito.mock;
  * @author Eric Bottard
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { CompletionConfiguration.class,
 		BootVersionsCompletionProviderTests.Mocks.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
@@ -73,30 +70,30 @@ public class BootVersionsCompletionProviderTests {
 	@Test
 	public void testBoot13Layout() {
 		List<CompletionProposal> result = completionProvider.complete("boot13 --", 0);
-		assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --level=")), Proposals.proposalThat(is("boot13 --number=")),
+		MatcherAssert.assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --level=")), Proposals.proposalThat(is("boot13 --number=")),
 				Proposals.proposalThat(is("boot13 --some-string="))));
 
 		// Test that custom classes can also be loaded correctly
 		result = completionProvider.complete("boot13 --level=", 0);
-		assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --level=low")), Proposals.proposalThat(is("boot13 --level=high"))));
+		MatcherAssert.assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --level=low")), Proposals.proposalThat(is("boot13 --level=high"))));
 
 		result = completionProvider.complete("boot13 --number=", 0);
-		assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --number=one")), Proposals.proposalThat(is("boot13 --number=two"))));
+		MatcherAssert.assertThat(result, hasItems(Proposals.proposalThat(is("boot13 --number=one")), Proposals.proposalThat(is("boot13 --number=two"))));
 	}
 
 	@Test
 	public void testBoot14Layout() {
 		List<CompletionProposal> result = completionProvider.complete("boot14 --", 0);
-		assertThat(result, hasItems(Proposals.proposalThat(is("boot14 --level=")), Proposals.proposalThat(is("boot14 --number=")),
+		MatcherAssert.assertThat(result, hasItems(Proposals.proposalThat(is("boot14 --level=")), Proposals.proposalThat(is("boot14 --number=")),
 				Proposals.proposalThat(is("boot14 --some-string="))));
 
 		// Test that custom classes can also be loaded correctly
 		result = completionProvider.complete("boot14 --level=", 0);
-		assertThat(result,
+		MatcherAssert.assertThat(result,
 				hasItems(Proposals.proposalThat(is("boot14 --level=very_low")), Proposals.proposalThat(is("boot14 --level=very_high"))));
 
 		result = completionProvider.complete("boot14 --number=", 0);
-		assertThat(result, hasItems(Proposals.proposalThat(is("boot14 --number=one")), Proposals.proposalThat(is("boot14 --number=two"))));
+		MatcherAssert.assertThat(result, hasItems(Proposals.proposalThat(is("boot14 --number=one")), Proposals.proposalThat(is("boot14 --number=two"))));
 
 	}
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionUtilsTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/CompletionUtilsTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.dataflow.completion;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.DefaultStreamDefinitionService;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
@@ -37,15 +37,15 @@ public class CompletionUtilsTests {
 	@Test
 	public void testLabelQualification() {
 		StreamDefinition streamDefinition = new StreamDefinition("foo", "http | filter");
-		Assert.assertThat(CompletionUtils.maybeQualifyWithLabel("filter",
+		MatcherAssert.assertThat(CompletionUtils.maybeQualifyWithLabel("filter",
 				this.streamDefinitionService.getAppDefinitions(streamDefinition)), is("filter2: filter"));
 
 		streamDefinition = new StreamDefinition("foo", "http | filter");
-		Assert.assertThat(CompletionUtils.maybeQualifyWithLabel("transform",
+		MatcherAssert.assertThat(CompletionUtils.maybeQualifyWithLabel("transform",
 				this.streamDefinitionService.getAppDefinitions(streamDefinition)), is("transform"));
 
 		streamDefinition = new StreamDefinition("foo", "http | filter | filter2: filter");
-		Assert.assertThat(CompletionUtils.maybeQualifyWithLabel("filter",
+		MatcherAssert.assertThat(CompletionUtils.maybeQualifyWithLabel("filter",
 				this.streamDefinitionService.getAppDefinitions(streamDefinition)), is("filter3: filter"));
 	}
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/StreamCompletionProviderTests.java
@@ -16,20 +16,18 @@
 
 package org.springframework.cloud.dataflow.completion;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 /**
  * Integration tests for StreamCompletionProvider.
@@ -43,7 +41,6 @@ import static org.junit.Assert.assertThat;
  * @author Eric Bottard
  * @author Mark Fisher
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { CompletionConfiguration.class, CompletionTestsMocks.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 @SuppressWarnings("unchecked")
@@ -55,138 +52,138 @@ public class StreamCompletionProviderTests {
 	@Test
 	// <TAB> => file,http,etc
 	public void testEmptyStartShouldProposeSourceOrUnboundApps() {
-		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange")),
+		MatcherAssert.assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange")),
 			Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
-		assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
+		MatcherAssert.assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
 	}
 
 	@Test
 	// fi<TAB> => file
 	public void testUnfinishedAppNameShouldReturnCompletions() {
-		assertThat(completionProvider.complete("h", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
-		assertThat(completionProvider.complete("ht", 1), hasItems(Proposals.proposalThat(is("http"))));
-		assertThat(completionProvider.complete("ht", 1), not(hasItems(Proposals.proposalThat(is("hdfs")))));
+		MatcherAssert.assertThat(completionProvider.complete("h", 1), hasItems(Proposals.proposalThat(is("http")), Proposals.proposalThat(is("hdfs"))));
+		MatcherAssert.assertThat(completionProvider.complete("ht", 1), hasItems(Proposals.proposalThat(is("http"))));
+		MatcherAssert.assertThat(completionProvider.complete("ht", 1), not(hasItems(Proposals.proposalThat(is("hdfs")))));
 	}
 
 	@Test
 	public void testUnfinishedUnboundAppNameShouldReturnCompletions2() {
-		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange"))));
-		assertThat(completionProvider.complete("o", 1), hasItems(Proposals.proposalThat(is("orange"))));
-		assertThat(completionProvider.complete("oran", 1), hasItems(Proposals.proposalThat(is("orange"))));
-		assertThat(completionProvider.complete("orange", 1), hasItems(Proposals.proposalThat(is("orange --expression=")),
+		MatcherAssert.assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("o", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("oran", 1), hasItems(Proposals.proposalThat(is("orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("orange", 1), hasItems(Proposals.proposalThat(is("orange --expression=")),
 				Proposals.proposalThat(is("orange --fooble=")),Proposals.proposalThat(is("orange --expresso="))));
-		assertThat(completionProvider.complete("o1: orange||", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
-		assertThat(completionProvider.complete("o1: orange|| ", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
-		assertThat(completionProvider.complete("o1: orange ||", 1), hasItems(Proposals.proposalThat(is("o1: orange || orange"))));
-		assertThat(completionProvider.complete("o1: orange|| or", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
-		assertThat(completionProvider.complete("http | o", 1), empty());
-		assertThat(completionProvider.complete("http|| o", 1), hasItems(Proposals.proposalThat(is("http|| orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("o1: orange||", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("o1: orange|| ", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("o1: orange ||", 1), hasItems(Proposals.proposalThat(is("o1: orange || orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("o1: orange|| or", 1), hasItems(Proposals.proposalThat(is("o1: orange|| orange"))));
+		MatcherAssert.assertThat(completionProvider.complete("http | o", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http|| o", 1), hasItems(Proposals.proposalThat(is("http|| orange"))));
 	}
 
 	@Test
 	// file | filter <TAB> => file | filter | foo, etc
 	public void testValidSubStreamDefinitionShouldReturnPipe() {
-		assertThat(completionProvider.complete("http | filter ", 1), hasItems(Proposals.proposalThat(is("http | filter | log"))));
-		assertThat(completionProvider.complete("http | filter ", 1),
+		MatcherAssert.assertThat(completionProvider.complete("http | filter ", 1), hasItems(Proposals.proposalThat(is("http | filter | log"))));
+		MatcherAssert.assertThat(completionProvider.complete("http | filter ", 1),
 				not(hasItems(Proposals.proposalThat(is("http | filter | http")))));
 	}
 
 	@Test
 	// file | filter<TAB> => file | filter --foo=, etc
 	public void testValidSubStreamDefinitionShouldReturnAppOptions() {
-		assertThat(completionProvider.complete("http | filter ", 1), hasItems(
+		MatcherAssert.assertThat(completionProvider.complete("http | filter ", 1), hasItems(
 				Proposals.proposalThat(is("http | filter --expression=")), Proposals.proposalThat(is("http | filter --expresso="))));
 		// Same as above, no final space
-		assertThat(completionProvider.complete("http | filter", 1), hasItems(
+		MatcherAssert.assertThat(completionProvider.complete("http | filter", 1), hasItems(
 				Proposals.proposalThat(is("http | filter --expression=")), Proposals.proposalThat(is("http | filter --expresso="))));
 	}
 
 	@Test
 	// file | filter -<TAB> => file | filter --foo,etc
 	public void testOneDashShouldReturnTwoDashes() {
-		assertThat(completionProvider.complete("http | filter -", 1), hasItems(
+		MatcherAssert.assertThat(completionProvider.complete("http | filter -", 1), hasItems(
 				Proposals.proposalThat(is("http | filter --expression=")), Proposals.proposalThat(is("http | filter --expresso="))));
 	}
 
 	@Test
 	// file | filter --<TAB> => file | filter --foo,etc
 	public void testTwoDashesShouldReturnOptions() {
-		assertThat(completionProvider.complete("http | filter --", 1), hasItems(
+		MatcherAssert.assertThat(completionProvider.complete("http | filter --", 1), hasItems(
 				Proposals.proposalThat(is("http | filter --expression=")), Proposals.proposalThat(is("http | filter --expresso="))));
 	}
 
 	@Test
 	// file |<TAB> => file | foo,etc
 	public void testDanglingPipeShouldReturnExtraApps() {
-		assertThat(completionProvider.complete("http |", 1), hasItems(Proposals.proposalThat(is("http | filter"))));
-		assertThat(completionProvider.complete("http | filter |", 1),
+		MatcherAssert.assertThat(completionProvider.complete("http |", 1), hasItems(Proposals.proposalThat(is("http | filter"))));
+		MatcherAssert.assertThat(completionProvider.complete("http | filter |", 1),
 				hasItems(Proposals.proposalThat(is("http | filter | log")), Proposals.proposalThat(is("http | filter | filter2: filter"))));
 	}
 
 	@Test
 	// file --p<TAB> => file --preventDuplicates=, file --pattern=
 	public void testUnfinishedOptionNameShouldComplete() {
-		assertThat(completionProvider.complete("http --p", 1), hasItems(Proposals.proposalThat(is("http --port="))));
+		MatcherAssert.assertThat(completionProvider.complete("http --p", 1), hasItems(Proposals.proposalThat(is("http --port="))));
 	}
 
 	@Test
 	// file | counter --name=foo --inputType=bar<TAB> => we're done
 	public void testSinkWithAllOptionsSetCantGoFurther() {
-		assertThat(completionProvider.complete("http | log --port=1234 --level=debug", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http | log --port=1234 --level=debug", 1), empty());
 	}
 
 	@Test
 	// file | counter --name=<TAB> => nothing
 	public void testInGenericOptionValueCantProposeAnything() {
-		assertThat(completionProvider.complete("http --port=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http --port=", 1), empty());
 	}
 
 	@Test
 	// :foo > <TAB> ==> add app names
 	public void testDestinationIntoApps() {
-		assertThat(completionProvider.complete(":foo >", 1),
+		MatcherAssert.assertThat(completionProvider.complete(":foo >", 1),
 				hasItems(Proposals.proposalThat(is(":foo > filter")), Proposals.proposalThat(is(":foo > log"))));
-		assertThat(completionProvider.complete(":foo >", 1), not(hasItems(Proposals.proposalThat(is(":foo > http")))));
+		MatcherAssert.assertThat(completionProvider.complete(":foo >", 1), not(hasItems(Proposals.proposalThat(is(":foo > http")))));
 	}
 
 	@Test
 	// :foo > <TAB> ==> add app names
 	public void testDestinationIntoAppsVariant() {
-		assertThat(completionProvider.complete(":foo >", 1),
+		MatcherAssert.assertThat(completionProvider.complete(":foo >", 1),
 				hasItems(Proposals.proposalThat(is(":foo > filter")), Proposals.proposalThat(is(":foo > log"))));
 	}
 
 	@Test
 	// http<TAB> (no space) => NOT "http2: http"
 	public void testAutomaticAppLabellingDoesNotGetInTheWay() {
-		assertThat(completionProvider.complete("http", 1), not(hasItems(Proposals.proposalThat(is("http2: http")))));
+		MatcherAssert.assertThat(completionProvider.complete("http", 1), not(hasItems(Proposals.proposalThat(is("http2: http")))));
 	}
 
 	@Test
 	// http --use-ssl=<TAB> => propose true|false
 	public void testValueHintForBooleans() {
-		assertThat(completionProvider.complete("http --use-ssl=", 1),
+		MatcherAssert.assertThat(completionProvider.complete("http --use-ssl=", 1),
 				hasItems(Proposals.proposalThat(is("http --use-ssl=true")), Proposals.proposalThat(is("http --use-ssl=false"))));
 	}
 
 	@Test
 	// .. foo --enum-value=<TAB> => propose enum values
 	public void testValueHintForEnums() {
-		assertThat(completionProvider.complete("http | filter --expresso=", 1),
+		MatcherAssert.assertThat(completionProvider.complete("http | filter --expresso=", 1),
 				hasItems(Proposals.proposalThat(is("http | filter --expresso=SINGLE")),
 						Proposals.proposalThat(is("http | filter --expresso=DOUBLE"))));
 	}
 
 	@Test
 	public void testUnrecognizedPrefixesDontBlowUp() {
-		assertThat(completionProvider.complete("foo", 1), empty());
-		assertThat(completionProvider.complete("foo --", 1), empty());
-		assertThat(completionProvider.complete("http --notavalidoption", 1), empty());
-		assertThat(completionProvider.complete("http --notavalidoption=", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option=", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option=prefix", 1), empty());
-		assertThat(
+		MatcherAssert.assertThat(completionProvider.complete("foo", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http --notavalidoption", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http --notavalidoption=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option=prefix", 1), empty());
+		MatcherAssert.assertThat(
 				completionProvider.complete(
 						"http | filter --port=12 --expression=something " + "--expresso=not-a-valid-prefix", 1),
 				empty());
@@ -198,7 +195,7 @@ public class StreamCompletionProviderTests {
 	 */
 	@Test
 	public void testClosedSetValuesShouldBeExclusive() {
-		assertThat(completionProvider.complete("http --use-ssl=tr", 1),
+		MatcherAssert.assertThat(completionProvider.complete("http --use-ssl=tr", 1),
 				not(hasItems(Proposals.proposalThat(startsWith("http --use-ssl=tr --port")))));
 	}
 

--- a/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
+++ b/spring-cloud-dataflow-completion/src/test/java/org/springframework/cloud/dataflow/completion/TaskCompletionProviderTests.java
@@ -16,20 +16,18 @@
 
 package org.springframework.cloud.dataflow.completion;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 
 /**
  * Integration tests for TaskCompletionProvider.
@@ -45,7 +43,6 @@ import static org.junit.Assert.assertThat;
  * @author Andy Clement
  */
 @SuppressWarnings("unchecked")
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { CompletionConfiguration.class, CompletionTestsMocks.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 public class TaskCompletionProviderTests {
@@ -56,77 +53,77 @@ public class TaskCompletionProviderTests {
 	@Test
 	// <TAB> => basic,plum,etc
 	public void testEmptyStartShouldProposeSourceApps() {
-		assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("basic")), Proposals.proposalThat(is("plum"))));
-		assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
+		MatcherAssert.assertThat(completionProvider.complete("", 1), hasItems(Proposals.proposalThat(is("basic")), Proposals.proposalThat(is("plum"))));
+		MatcherAssert.assertThat(completionProvider.complete("", 1), not(hasItems(Proposals.proposalThat(is("log")))));
 	}
 
 	@Test
 	// b<TAB> => basic
 	public void testUnfinishedAppNameShouldReturnCompletions() {
-		assertThat(completionProvider.complete("b", 1), hasItems(Proposals.proposalThat(is("basic"))));
-		assertThat(completionProvider.complete("ba", 1), hasItems(Proposals.proposalThat(is("basic"))));
-		assertThat(completionProvider.complete("pl", 1), not(hasItems(Proposals.proposalThat(is("basic")))));
+		MatcherAssert.assertThat(completionProvider.complete("b", 1), hasItems(Proposals.proposalThat(is("basic"))));
+		MatcherAssert.assertThat(completionProvider.complete("ba", 1), hasItems(Proposals.proposalThat(is("basic"))));
+		MatcherAssert.assertThat(completionProvider.complete("pl", 1), not(hasItems(Proposals.proposalThat(is("basic")))));
 	}
 
 	@Test
 	// basic<TAB> => basic --foo=, etc
 	public void testValidTaskDefinitionShouldReturnAppOptions() {
-		assertThat(completionProvider.complete("basic ", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic ", 1),
 				hasItems(Proposals.proposalThat(is("basic --expression=")), Proposals.proposalThat(is("basic --expresso="))));
 		// Same as above, no final space
-		assertThat(completionProvider.complete("basic", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic", 1),
 				hasItems(Proposals.proposalThat(is("basic --expression=")), Proposals.proposalThat(is("basic --expresso="))));
 	}
 
 	@Test
 	// file | filter -<TAB> => file | filter --foo,etc
 	public void testOneDashShouldReturnTwoDashes() {
-		assertThat(completionProvider.complete("basic -", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic -", 1),
 				hasItems(Proposals.proposalThat(is("basic --expression=")), Proposals.proposalThat(is("basic --expresso="))));
 	}
 
 	@Test
 	// basic --<TAB> => basic --foo,etc
 	public void testTwoDashesShouldReturnOptions() {
-		assertThat(completionProvider.complete("basic --", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic --", 1),
 				hasItems(Proposals.proposalThat(is("basic --expression=")), Proposals.proposalThat(is("basic --expresso="))));
 	}
 
 	@Test
 	// file --p<TAB> => file --preventDuplicates=, file --pattern=
 	public void testUnfinishedOptionNameShouldComplete() {
-		assertThat(completionProvider.complete("basic --foo", 1), hasItems(Proposals.proposalThat(is("basic --fooble="))));
+		MatcherAssert.assertThat(completionProvider.complete("basic --foo", 1), hasItems(Proposals.proposalThat(is("basic --fooble="))));
 	}
 
 	@Test
 	// file | counter --name=<TAB> => nothing
 	public void testInGenericOptionValueCantProposeAnything() {
-		assertThat(completionProvider.complete("basic --expression=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("basic --expression=", 1), empty());
 	}
 
 	@Test
 	// plum --use-ssl=<TAB> => propose true|false
 	public void testValueHintForBooleans() {
-		assertThat(completionProvider.complete("plum --use-ssl=", 1),
+		MatcherAssert.assertThat(completionProvider.complete("plum --use-ssl=", 1),
 				hasItems(Proposals.proposalThat(is("plum --use-ssl=true")), Proposals.proposalThat(is("plum --use-ssl=false"))));
 	}
 
 	@Test
 	// basic --enum-value=<TAB> => propose enum values
 	public void testValueHintForEnums() {
-		assertThat(completionProvider.complete("basic --expresso=", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic --expresso=", 1),
 				hasItems(Proposals.proposalThat(is("basic --expresso=SINGLE")), Proposals.proposalThat(is("basic --expresso=DOUBLE"))));
 	}
 
 	@Test
 	public void testUnrecognizedPrefixesDontBlowUp() {
-		assertThat(completionProvider.complete("foo", 1), empty());
-		assertThat(completionProvider.complete("foo --", 1), empty());
-		assertThat(completionProvider.complete("http --notavalidoption", 1), empty());
-		assertThat(completionProvider.complete("http --notavalidoption=", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option=", 1), empty());
-		assertThat(completionProvider.complete("foo --some-option=prefix", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http --notavalidoption", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("http --notavalidoption=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option=", 1), empty());
+		MatcherAssert.assertThat(completionProvider.complete("foo --some-option=prefix", 1), empty());
 	}
 
 	/*
@@ -135,7 +132,7 @@ public class TaskCompletionProviderTests {
 	 */
 	@Test
 	public void testClosedSetValuesShouldBeExclusive() {
-		assertThat(completionProvider.complete("basic --expresso=s", 1),
+		MatcherAssert.assertThat(completionProvider.complete("basic --expresso=s", 1),
 				not(hasItems(Proposals.proposalThat(startsWith("basic --expresso=s --fooble")))));
 	}
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfigurationTest.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +43,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Christian Tzolov
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = ApplicationConfigurationMetadataResolverAutoConfigurationTest.TestConfig.class)
 @TestPropertySource(properties = {
 		".dockerconfigjson={\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}" +

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -24,8 +24,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -40,7 +41,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,7 +57,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 
 	private ApplicationConfigurationMetadataResolver resolver;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		MockitoAnnotations.initMocks(this);
 		resolver = new BootApplicationConfigurationMetadataResolver(containerImageMetadataResolver);
@@ -68,7 +68,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(new HashMap<>());
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new DockerResource("test/test:latest"));
-		assertThat(properties.size(), is(0));
+		MatcherAssert.assertThat(properties.size(), is(0));
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class BootApplicationConfigurationMetadataResolverTests {
 						new String(bytes)));
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new DockerResource("test/test:latest"));
-		assertThat(properties.size(), is(3));
+		MatcherAssert.assertThat(properties.size(), is(3));
 	}
 
 	@Test
@@ -94,23 +94,23 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		when(containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(result);
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new DockerResource("test/test:latest"));
-		assertThat(properties.size(), is(0));
+		MatcherAssert.assertThat(properties.size(), is(0));
 	}
 
 	@Test
 	public void appSpecificVisiblePropsShouldBeVisible() {
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new ClassPathResource("apps/filter-processor", getClass()));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
 	}
 
 	@Test
 	public void appSpecificVisibleLegacyPropsShouldBeVisible() {
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new ClassPathResource("apps/filter-processor-legacy", getClass()));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
 	}
 
 	@Test
@@ -120,18 +120,18 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		// expresso2 from old format doesn't get read.
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new ClassPathResource("apps/filter-processor-both", getClass()));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso3")));
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("filter.expression")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso3")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("some.other.property.included.prefix.expresso2")));
 	}
 
 	@Test
 	public void otherPropertiesShouldOnlyBeVisibleInExtensiveCall() {
 		List<ConfigurationMetadataProperty> properties = resolver
 				.listProperties(new ClassPathResource("apps/filter-processor", getClass()));
-		assertThat(properties, not(hasItem(configPropertyIdentifiedAs("some.prefix.hidden.by.default.secret"))));
+		MatcherAssert.assertThat(properties, not(hasItem(configPropertyIdentifiedAs("some.prefix.hidden.by.default.secret"))));
 		properties = resolver.listProperties(new ClassPathResource("apps/filter-processor", getClass()), true);
-		assertThat(properties, hasItem(configPropertyIdentifiedAs("some.prefix.hidden.by.default.secret")));
+		MatcherAssert.assertThat(properties, hasItem(configPropertyIdentifiedAs("some.prefix.hidden.by.default.secret")));
 	}
 
 	@Test
@@ -140,8 +140,8 @@ public class BootApplicationConfigurationMetadataResolverTests {
 				.listProperties(new ClassPathResource("apps/no-visible-properties", getClass()));
 		List<ConfigurationMetadataProperty> full = resolver
 				.listProperties(new ClassPathResource("apps/no-visible-properties", getClass()), true);
-		assertThat(properties.size(), is(0));
-		assertThat(full.size(), is(3));
+		MatcherAssert.assertThat(properties.size(), is(0));
+		MatcherAssert.assertThat(full.size(), is(3));
 	}
 
 	@Test
@@ -150,18 +150,18 @@ public class BootApplicationConfigurationMetadataResolverTests {
 				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()));
 		List<ConfigurationMetadataProperty> full = resolver
 				.listProperties(new ClassPathResource("apps/deprecated-error", getClass()), true);
-		assertThat(properties.size(), is(0));
-		assertThat(full.size(), is(2));
+		MatcherAssert.assertThat(properties.size(), is(0));
+		MatcherAssert.assertThat(full.size(), is(2));
 	}
 
 	@Test
 	public void shouldReturnPortMappingProperties() {
 		Map<String, Set<String>> portNames = resolver.listPortNames(new ClassPathResource("apps/filter-processor", getClass()));
-		assertThat(portNames.size(), is(2));
-		assertThat(portNames.get("inbound").size(), is(3));
-		assertThat(portNames.get("inbound"), containsInAnyOrder("in1", "in2", "in3"));
-		assertThat(portNames.get("outbound").size(), is(2));
-		assertThat(portNames.get("outbound"), containsInAnyOrder("out1", "out2"));
+		MatcherAssert.assertThat(portNames.size(), is(2));
+		MatcherAssert.assertThat(portNames.get("inbound").size(), is(3));
+		MatcherAssert.assertThat(portNames.get("inbound"), containsInAnyOrder("in1", "in2", "in3"));
+		MatcherAssert.assertThat(portNames.get("outbound").size(), is(2));
+		MatcherAssert.assertThat(portNames.get("outbound"), containsInAnyOrder("out1", "out2"));
 	}
 
 	@Test
@@ -171,11 +171,11 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		result.put("configuration-properties.outbound-ports", "output1, output2");
 		when(this.containerImageMetadataResolver.getImageLabels("test/test:latest")).thenReturn(result);
 		Map<String, Set<String>> portNames = this.resolver.listPortNames(new DockerResource("test/test:latest"));
-		assertThat(portNames.size(), is(2));
-		assertThat(portNames.get("inbound").size(), is(3));
-		assertThat(portNames.get("inbound"), containsInAnyOrder("input1", "input2", "input3"));
-		assertThat(portNames.get("outbound").size(), is(2));
-		assertThat(portNames.get("outbound"), containsInAnyOrder("output1", "output2"));
+		MatcherAssert.assertThat(portNames.size(), is(2));
+		MatcherAssert.assertThat(portNames.get("inbound").size(), is(3));
+		MatcherAssert.assertThat(portNames.get("inbound"), containsInAnyOrder("input1", "input2", "input3"));
+		MatcherAssert.assertThat(portNames.get("outbound").size(), is(2));
+		MatcherAssert.assertThat(portNames.get("outbound"), containsInAnyOrder("output1", "output2"));
 	}
 
 	private Matcher<ConfigurationMetadataProperty> configPropertyIdentifiedAs(String name) {

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/DefaultContainerImageMetadataResolverTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/DefaultContainerImageMetadataResolverTest.java
@@ -23,8 +23,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -41,7 +42,7 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,7 +65,7 @@ public class DefaultContainerImageMetadataResolverTest {
 
 	private ContainerRegistryService containerRegistryService;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		MockitoAnnotations.initMocks(this);
 
@@ -91,10 +92,12 @@ public class DefaultContainerImageMetadataResolverTest {
 				new ContainerImageParser(), registryConfigurationMap, Arrays.asList(registryAuthorizer));
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsInvalidImageName() {
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
-		resolver.getImageLabels(null);
+		assertThrows(ContainerRegistryException.class, () -> {
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
+			resolver.getImageLabels(null);
+		});
 	}
 
 	@Test
@@ -109,8 +112,8 @@ public class DefaultContainerImageMetadataResolverTest {
 				"registry-1.docker.io", null, "test/image", "123");
 
 		Map<String, String> labels = resolver.getImageLabels("test/image:latest");
-		assertThat(labels.size(), is(1));
-		assertThat(labels.get("boza"), is("koza"));
+		MatcherAssert.assertThat(labels.size(), is(1));
+		MatcherAssert.assertThat(labels.get("boza"), is("koza"));
 	}
 
 	@Test
@@ -125,61 +128,71 @@ public class DefaultContainerImageMetadataResolverTest {
 				"my-private-repository.com", "5000", "test/image", "123");
 
 		Map<String, String> labels = resolver.getImageLabels("my-private-repository.com:5000/test/image:latest");
-		assertThat(labels.size(), is(1));
-		assertThat(labels.get("boza"), is("koza"));
+		MatcherAssert.assertThat(labels.size(), is(1));
+		MatcherAssert.assertThat(labels.get("boza"), is("koza"));
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsMissingRegistryConfiguration() {
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
-		resolver.getImageLabels("somehost:8083/test/image:latest");
+		assertThrows(ContainerRegistryException.class, () -> {
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
+			resolver.getImageLabels("somehost:8083/test/image:latest");
+		});
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsMissingRegistryAuthorizer() {
+		assertThrows(ContainerRegistryException.class, () -> {
 
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
-				new ContainerRegistryService(containerImageRestTemplateFactory,
-						new ContainerImageParser(), registryConfigurationMap, Collections.emptyList()));
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+					new ContainerRegistryService(containerImageRestTemplateFactory,
+							new ContainerImageParser(), registryConfigurationMap, Collections.emptyList()));
 
-		resolver.getImageLabels("test/image:latest");
+			resolver.getImageLabels("test/image:latest");
+		});
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsMissingAuthorizationHeader() {
-		RegistryAuthorizer registryAuthorizer = mock(RegistryAuthorizer.class);
+		assertThrows(ContainerRegistryException.class, () -> {
+			RegistryAuthorizer registryAuthorizer = mock(RegistryAuthorizer.class);
 
-		when(registryAuthorizer.getType()).thenReturn(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2);
-		when(registryAuthorizer.getAuthorizationHeaders(any(ContainerImage.class), any())).thenReturn(null);
+			when(registryAuthorizer.getType()).thenReturn(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2);
+			when(registryAuthorizer.getAuthorizationHeaders(any(ContainerImage.class), any())).thenReturn(null);
 
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
-				new ContainerRegistryService(containerImageRestTemplateFactory, new ContainerImageParser(), registryConfigurationMap, Arrays.asList(registryAuthorizer)));
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(
+					new ContainerRegistryService(containerImageRestTemplateFactory, new ContainerImageParser(), registryConfigurationMap, Arrays.asList(registryAuthorizer)));
 
-		resolver.getImageLabels("test/image:latest");
+			resolver.getImageLabels("test/image:latest");
+		});
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsInvalidManifestResponse() {
+		assertThrows(ContainerRegistryException.class, () -> {
 
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
 
-		Map<String, Object> manifestResponseWithoutConfig = Collections.emptyMap();
-		mockManifestRestTemplateCall(manifestResponseWithoutConfig, "registry-1.docker.io",
-				null, "test/image", "latest");
+			Map<String, Object> manifestResponseWithoutConfig = Collections.emptyMap();
+			mockManifestRestTemplateCall(manifestResponseWithoutConfig, "registry-1.docker.io",
+					null, "test/image", "latest");
 
-		resolver.getImageLabels("test/image:latest");
+			resolver.getImageLabels("test/image:latest");
+		});
 	}
 
-	@Test(expected = ContainerRegistryException.class)
+	@Test
 	public void getImageLabelsInvalidDigest() {
-		DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
+		assertThrows(ContainerRegistryException.class, () -> {
+			DefaultContainerImageMetadataResolver resolver = new MockedDefaultContainerImageMetadataResolver(this.containerRegistryService);
 
-		String emptyDigest = "";
-		Map<String, Object> manifestResponse = Collections.singletonMap("config", Collections.singletonMap("digest", emptyDigest));
-		mockManifestRestTemplateCall(manifestResponse, "registry-1.docker.io", null,
-				"test/image", "latest");
+			String emptyDigest = "";
+			Map<String, Object> manifestResponse = Collections.singletonMap("config", Collections.singletonMap("digest", emptyDigest));
+			mockManifestRestTemplateCall(manifestResponse, "registry-1.docker.io", null,
+					"test/image", "latest");
 
-		resolver.getImageLabels("test/image:latest");
+			resolver.getImageLabels("test/image:latest");
+		});
 	}
 
 	@Test
@@ -195,7 +208,7 @@ public class DefaultContainerImageMetadataResolverTest {
 				"registry-1.docker.io", null, "test/image", "123");
 
 		Map<String, String> labels = resolver.getImageLabels("test/image:latest");
-		assertThat(labels.size(), is(0));
+		MatcherAssert.assertThat(labels.size(), is(0));
 	}
 
 	private void mockManifestRestTemplateCall(Map<String, Object> mapToReturn, String registryHost,

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToRegistryConfigurationConverterTest.java
@@ -21,8 +21,9 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -39,7 +40,6 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,7 +58,7 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 
 	private DockerConfigJsonSecretToRegistryConfigurationConverter converter;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		MockitoAnnotations.initMocks(this);
 		when(containerImageRestTemplateFactory.getContainerRestTemplate(anyBoolean(), anyBoolean())).thenReturn(mockRestTemplate);
@@ -75,15 +75,15 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 		String b = "{\"auths\":{\"demo.repository.io\":{}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), nullValue());
-		assertThat(registryConfiguration.getSecret(), nullValue());
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.anonymous));
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), nullValue());
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), nullValue());
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.anonymous));
 	}
 
 	@Test
@@ -96,15 +96,15 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 		String b = "{\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), is("testuser"));
-		assertThat(registryConfiguration.getSecret(), is("testpassword"));
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.basicauth));
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), is("testuser"));
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), is("testpassword"));
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.basicauth));
 	}
 
 	@Test
@@ -121,16 +121,16 @@ public class DockerConfigJsonSecretToRegistryConfigurationConverterTest {
 		String b = "{\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), is("testuser"));
-		assertThat(registryConfiguration.getSecret(), is("testpassword"));
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2));
-		assertThat(registryConfiguration.getExtra().get("registryAuthUri"),
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), is("testuser"));
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), is("testpassword"));
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2));
+		MatcherAssert.assertThat(registryConfiguration.getExtra().get("registryAuthUri"),
 				is("https://demo.repository.io/service/token?service=demo-registry&scope=repository:{repository}:pull"));
 
 	}

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.container.registry.authorization;
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolverAutoConfiguration;
@@ -48,7 +48,7 @@ public class DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void clean() {
 		if (context != null) {
 			context.close();

--- a/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryConfigurationPropertiesTest.java
+++ b/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryConfigurationPropertiesTest.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.dataflow.container.registry;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest.java
+++ b/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest.java
@@ -21,8 +21,9 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -39,7 +40,6 @@ import org.springframework.web.client.RestTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,7 +58,7 @@ public class DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest
 
 	private DockerConfigJsonSecretToRegistryConfigurationConverter converter;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		MockitoAnnotations.initMocks(this);
 		when(containerImageRestTemplateFactory.getContainerRestTemplate(anyBoolean(), anyBoolean())).thenReturn(mockRestTemplate);
@@ -75,15 +75,15 @@ public class DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest
 		String b = "{\"auths\":{\"demo.repository.io\":{}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), nullValue());
-		assertThat(registryConfiguration.getSecret(), nullValue());
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.anonymous));
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), nullValue());
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), nullValue());
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.anonymous));
 	}
 
 	@Test
@@ -96,15 +96,15 @@ public class DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest
 		String b = "{\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), is("testuser"));
-		assertThat(registryConfiguration.getSecret(), is("testpassword"));
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.basicauth));
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), is("testuser"));
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), is("testpassword"));
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.basicauth));
 	}
 
 	@Test
@@ -121,16 +121,16 @@ public class DockerConfigJsonSecretToContainerRegistryConfigurationConverterTest
 		String b = "{\"auths\":{\"demo.repository.io\":{\"username\":\"testuser\",\"password\":\"testpassword\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}}}";
 		Map<String, ContainerRegistryConfiguration> result = converter.convert(b);
 
-		assertThat(result.size(), is(1));
+		MatcherAssert.assertThat(result.size(), is(1));
 		assertThat(result.containsKey("demo.repository.io")).isTrue();
 
 		ContainerRegistryConfiguration registryConfiguration = result.get("demo.repository.io");
 
-		assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
-		assertThat(registryConfiguration.getUser(), is("testuser"));
-		assertThat(registryConfiguration.getSecret(), is("testpassword"));
-		assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2));
-		assertThat(registryConfiguration.getExtra().get("registryAuthUri"),
+		MatcherAssert.assertThat(registryConfiguration.getRegistryHost(), is("demo.repository.io"));
+		MatcherAssert.assertThat(registryConfiguration.getUser(), is("testuser"));
+		MatcherAssert.assertThat(registryConfiguration.getSecret(), is("testpassword"));
+		MatcherAssert.assertThat(registryConfiguration.getAuthorizationType(), is(ContainerRegistryConfiguration.AuthorizationType.dockeroauth2));
+		MatcherAssert.assertThat(registryConfiguration.getExtra().get("registryAuthUri"),
 				is("https://demo.repository.io/service/token?service=demo-registry&scope=repository:{repository}:pull"));
 
 	}

--- a/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/NodeTests.java
+++ b/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/NodeTests.java
@@ -17,9 +17,9 @@ package org.springframework.cloud.dataflow.core.dsl;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Oleg Zhurakousky

--- a/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -22,19 +22,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.dsl.graph.Graph;
 import org.springframework.cloud.dataflow.core.dsl.graph.Link;
 import org.springframework.cloud.dataflow.core.dsl.graph.Node;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the parser and visitor infrastructure. Check it accepts expected data and
@@ -704,7 +704,7 @@ public class TaskParserTests {
 				+ "[0-1][1-2][2-3][3-4][fail:1-9][fail2:2-9][9-10][10-4]", spec);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void transitionToSplit() {
 		String spec = "aa 'foo'->:split && bb && split: <cc || dd> && ee";
@@ -1624,8 +1624,7 @@ public class TaskParserTests {
 	}
 
 	private void assertApps(List<TaskApp> taskApps, String... expectedTaskAppNames) {
-		assertEquals("Expected " + expectedTaskAppNames.length + " but was " + taskApps.size() + ": " + taskApps,
-				expectedTaskAppNames.length, taskApps.size());
+		assertEquals(expectedTaskAppNames.length, taskApps.size(), "Expected " + expectedTaskAppNames.length + " but was " + taskApps.size() + ": " + taskApps);
 		Set<String> set2 = new HashSet<String>();
 		for (TaskApp taskApp : taskApps) {
 			StringBuilder s = new StringBuilder();

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/AppRegistrationTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/AppRegistrationTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.core;
 
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/ArgumentSanitizerTest.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.core;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Christian Tzolov
@@ -34,7 +34,7 @@ public class ArgumentSanitizerTest {
 	private static final String[] keys = { "password", "secret", "key", "token", ".*credentials.*",
 			"vcap_services", "url" };
 
-	@Before
+	@BeforeEach
 	public void before() {
 		sanitizer = new ArgumentSanitizer();
 	}
@@ -42,8 +42,8 @@ public class ArgumentSanitizerTest {
 	@Test
 	public void testSanitizeProperties() {
 		for (String key : keys) {
-			Assert.assertEquals("--" + key + "=******", sanitizer.sanitize("--" + key + "=foo"));
-			Assert.assertEquals("******", sanitizer.sanitize(key, "bar"));
+			Assertions.assertEquals("--" + key + "=******", sanitizer.sanitize("--" + key + "=foo"));
+			Assertions.assertEquals("******", sanitizer.sanitize(key, "bar"));
 		}
 	}
 
@@ -57,11 +57,11 @@ public class ArgumentSanitizerTest {
 
 		final List<String> sanitizedArguments = sanitizer.sanitizeArguments(arguments);
 
-		Assert.assertEquals(keys.length, sanitizedArguments.size());
+		Assertions.assertEquals(keys.length, sanitizedArguments.size());
 
 		int order = 0;
 		for(String sanitizedString : sanitizedArguments) {
-			Assert.assertEquals("--" + keys[order] + "=******", sanitizedString);
+			Assertions.assertEquals("--" + keys[order] + "=******", sanitizedString);
 			order++;
 		}
 	}
@@ -69,9 +69,9 @@ public class ArgumentSanitizerTest {
 
 	@Test
 	public void testMultipartProperty() {
-		Assert.assertEquals("--password=******", sanitizer.sanitize("--password=boza"));
-		Assert.assertEquals("--one.two.password=******", sanitizer.sanitize("--one.two.password=boza"));
-		Assert.assertEquals("--one_two_password=******", sanitizer.sanitize("--one_two_password=boza"));
+		Assertions.assertEquals("--password=******", sanitizer.sanitize("--password=boza"));
+		Assertions.assertEquals("--one.two.password=******", sanitizer.sanitize("--one.two.password=boza"));
+		Assertions.assertEquals("--one_two_password=******", sanitizer.sanitize("--one_two_password=boza"));
 	}
 
 //	@Test

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamApplicationDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamApplicationDefinitionTests.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.dataflow.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Patrick Peralta

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionServiceUtilsTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionServiceUtilsTests.java
@@ -20,10 +20,10 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Christian Tzolov
@@ -38,7 +38,7 @@ public class StreamDefinitionServiceUtilsTests {
 		reverseDslTest("time | log", 2);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void quotesInParams() {
 		reverseDslTest("foo --bar='payload.matches(''hello'')' | file", 2);
@@ -59,13 +59,13 @@ public class StreamDefinitionServiceUtilsTests {
 		reverseDslTest("time | filter | log", 3);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testXD2416_1() {
 		reverseDslTest("http | transform --expression='payload.replace(\"abc\", \"\")' | log", 3);
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void testXD2416_2() {
 		reverseDslTest("http | transform --expression='payload.replace(\"abc\", '''')' | log", 3);

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionTests.java
@@ -19,17 +19,17 @@ package org.springframework.cloud.dataflow.core;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.dsl.ParseException;
 import org.springframework.cloud.dataflow.core.dsl.StreamParser;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mark Fisher
@@ -198,17 +198,17 @@ public class StreamDefinitionTests {
 			new StreamDefinition("test", ":foo > boot");
 		}
 		catch (ParseException expected) {
-			assertThat(expected.getMessage(),
+			MatcherAssert.assertThat(expected.getMessage(),
 					containsString("A destination is not supported in this kind of definition"));
-			assertThat(expected.getPosition(), is(0));
+			MatcherAssert.assertThat(expected.getPosition(), is(0));
 		}
 		try {
 			new StreamDefinition("test", "bart | goo > :foo");
 		}
 		catch (ParseException expected) {
-			assertThat(expected.getMessage(),
+			MatcherAssert.assertThat(expected.getMessage(),
 					containsString("A destination is not supported in this kind of definition"));
-			assertThat(expected.getPosition(), is(13));
+			MatcherAssert.assertThat(expected.getPosition(), is(13));
 		}
 	}
 

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/TaskDefinitionTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/TaskDefinitionTests.java
@@ -20,11 +20,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Thomas Risberg
@@ -75,8 +75,8 @@ public class TaskDefinitionTests {
 		TaskDefinition definitionOne = new TaskDefinition("test", "timestamp");
 		TaskDefinition definitionTwo = new TaskDefinition("test", "timestamp");
 
-		assertTrue("TaskDefinitions were expected to be equal.", definitionOne.equals(definitionTwo));
-		assertTrue("TaskDefinitions were expected to be equal.", definitionOne.equals(definitionOne));
+		assertTrue(definitionOne.equals(definitionTwo), "TaskDefinitions were expected to be equal.");
+		assertTrue(definitionOne.equals(definitionOne), "TaskDefinitions were expected to be equal.");
 
 	}
 
@@ -85,9 +85,9 @@ public class TaskDefinitionTests {
 		TaskDefinition definitionOne = new TaskDefinition("test", "timestamp");
 		TaskDefinition definitionFoo = new TaskDefinition("test", "foo");
 
-		assertFalse("TaskDefinitions were not expected to be equal.", definitionOne.equals(definitionFoo));
-		assertFalse("TaskDefinitions were not expected to be equal.", definitionOne.equals(null));
-		assertFalse("TaskDefinitions were not expected to be equal.", definitionOne.equals("HI"));
+		assertFalse(definitionOne.equals(definitionFoo), "TaskDefinitions were not expected to be equal.");
+		assertFalse(definitionOne.equals(null), "TaskDefinitions were not expected to be equal.");
+		assertFalse(definitionOne.equals("HI"), "TaskDefinitions were not expected to be equal.");
 	}
 	@Test
 	public void testHashCode() {
@@ -95,8 +95,8 @@ public class TaskDefinitionTests {
 		TaskDefinition definitionTwo = new TaskDefinition("test", "timestamp");
 		TaskDefinition definitionFoo = new TaskDefinition("test", "foo");
 
-		assertTrue("TaskDefinitions' hashcodes were expected to be equal.", definitionOne.hashCode() == definitionTwo.hashCode());
-		assertFalse("TaskDefinitions' hashcodes were not expected to be equal.", definitionOne.hashCode() == definitionFoo.hashCode());
+		assertTrue(definitionOne.hashCode() == definitionTwo.hashCode(), "TaskDefinitions' hashcodes were expected to be equal.");
+		assertFalse(definitionOne.hashCode() == definitionFoo.hashCode(), "TaskDefinitions' hashcodes were not expected to be equal.");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/TaskDefinitionToDslConverterTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/TaskDefinitionToDslConverterTests.java
@@ -19,9 +19,10 @@ package org.springframework.cloud.dataflow.core;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Christian Tzolov
@@ -86,10 +87,12 @@ public class TaskDefinitionToDslConverterTests {
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void compositeTaskDsl() {
-		TaskDefinition taskDefinition = new TaskDefinition("composedTaskName", "foo && bar");
-		new TaskDefinitionToDslConverter().toDsl(taskDefinition);
+		assertThrows(IllegalArgumentException.class, () -> {
+			TaskDefinition taskDefinition = new TaskDefinition("composedTaskName", "foo && bar");
+			new TaskDefinitionToDslConverter().toDsl(taskDefinition);
+		});
 	}
 
 }

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryPlatformPropertiesTests.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryPlatformPropertiesTests.java
@@ -18,15 +18,13 @@ package org.springframework.cloud.dataflow.server.config.cloudfoundry;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Donovan Muller
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = CloudFoundryPlatformPropertiesTests.TestConfig.class)
 @ActiveProfiles("cloudfoundry-platform-properties")
 public class CloudFoundryPlatformPropertiesTests {

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactoryTests.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/CloudFoundryTaskPlatformFactoryTests.java
@@ -33,8 +33,8 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.reactor.TokenProvider;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.dataflow.core.Launcher;
@@ -77,7 +77,7 @@ public class CloudFoundryTaskPlatformFactoryTests {
 
 	private CloudFoundryDeploymentProperties deploymentProperties;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		when(this.cloudFoundryClient.info())
 				.thenReturn(getInfoRequest -> Mono.just(GetInfoResponse.builder().apiVersion("0.0.0").build()));

--- a/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesPlatformPropertiesTests.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesPlatformPropertiesTests.java
@@ -18,8 +18,7 @@ package org.springframework.cloud.dataflow.server.config.kubernetes;
 import java.util.Map;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -30,14 +29,12 @@ import org.springframework.cloud.deployer.spi.kubernetes.KubernetesClientFactory
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Donovan Muller
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = KubernetesPlatformPropertiesTests.TestConfig.class)
 @ActiveProfiles("kubernetes-platform-properties")
 public class KubernetesPlatformPropertiesTests {

--- a/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactoryTests.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesTaskPlatformFactoryTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.server.config.kubernetes;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskPlatform;

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryServiceTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryServiceTests.java
@@ -22,8 +22,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.dataflow.audit.service.DefaultAuditRecordService;
@@ -46,10 +47,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -77,7 +77,7 @@ public class DefaultAppRegistryServiceTests {
 	@Test
 	public void testNotFound() {
 		AppRegistration registration = appRegistryService.find("foo", ApplicationType.source);
-		assertThat(registration, Matchers.nullValue());
+		MatcherAssert.assertThat(registration, Matchers.nullValue());
 	}
 
 	@Test
@@ -87,8 +87,8 @@ public class DefaultAppRegistryServiceTests {
 				eq(registration.getName()), eq(registration.getType()))).thenReturn(registration);
 
 		AppRegistration registration2 = appRegistryService.find("foo", ApplicationType.source);
-		assertThat(registration2.getName(), is("foo"));
-		assertThat(registration2.getType(), is(ApplicationType.source));
+		MatcherAssert.assertThat(registration2.getName(), is("foo"));
+		MatcherAssert.assertThat(registration2.getType(), is(ApplicationType.source));
 	}
 
 	@Test
@@ -100,7 +100,7 @@ public class DefaultAppRegistryServiceTests {
 		AppRegistration registration2 = appRegistryService.find("foo", ApplicationType.source);
 		Resource appMetadataResource = appRegistryService.getAppMetadataResource(registration2);
 
-		assertThat(appMetadataResource.getFilename(), is("foo-source-metadata"));
+		MatcherAssert.assertThat(appMetadataResource.getFilename(), is("foo-source-metadata"));
 	}
 
 	@Test
@@ -113,7 +113,7 @@ public class DefaultAppRegistryServiceTests {
 		AppRegistration registration2 = appRegistryService.find("foo", ApplicationType.source);
 		Resource appMetadataResource = appRegistryService.getAppMetadataResource(registration2);
 
-		assertThat(appMetadataResource.getFilename(), is("foo-source"));
+		MatcherAssert.assertThat(appMetadataResource.getFilename(), is("foo-source"));
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistryService.findAll();
 
-		assertThat(registrations, containsInAnyOrder(
+		MatcherAssert.assertThat(registrations, containsInAnyOrder(
 				allOf(
 						hasProperty("name", is("foo")),
 						hasProperty("uri", is(URI.create("classpath:/foo-source"))),
@@ -226,7 +226,7 @@ public class DefaultAppRegistryServiceTests {
 				eq("foo"), eq(ApplicationType.source), eq("1.0"))).thenReturn(appRegistration());
 		when(appRegistrationRepository.findAppRegistrationByNameAndTypeAndVersion(
 				eq("bar"), eq(ApplicationType.sink), eq("1.0"))).thenReturn(appRegistration());
-		assertThat(appRegistryService.importAll(false,
+		MatcherAssert.assertThat(appRegistryService.importAll(false,
 				new ClassPathResource("AppRegistryTests-importAllOverwrite.properties", getClass())).size(), equalTo(0));
 	}
 
@@ -238,12 +238,12 @@ public class DefaultAppRegistryServiceTests {
 		verify(appRegistrationRepository, times(1)).save(appRegistrationCaptor.capture());
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 		AppRegistration appRegistration = registrations.get(0);
-		assertThat(appRegistration, hasProperty("name", is("cassandra")));
-		assertThat(appRegistration, hasProperty("uri",
+		MatcherAssert.assertThat(appRegistration, hasProperty("name", is("cassandra")));
+		MatcherAssert.assertThat(appRegistration, hasProperty("uri",
 				is(URI.create("http://repo.spring.io/release/org/springframework/cloud/stream/app/cassandra-sink-rabbit/2.1.0.RELEASE/cassandra-sink-rabbit-2.1.0.RELEASE.jar"))));
-		assertThat(appRegistration, hasProperty("metadataUri",
+		MatcherAssert.assertThat(appRegistration, hasProperty("metadataUri",
 				is(URI.create("http://repo.spring.io/release/org/springframework/cloud/stream/app/cassandra-sink-rabbit/2.1.0.RELEASE/cassandra-sink-rabbit-2.1.0.RELEASE-metadata.jar"))));
-		assertThat(appRegistration,	hasProperty("type", is(ApplicationType.sink)));
+		MatcherAssert.assertThat(appRegistration,	hasProperty("type", is(ApplicationType.sink)));
 	}
 
 	@Test
@@ -262,7 +262,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("bar")),
@@ -287,7 +287,7 @@ public class DefaultAppRegistryServiceTests {
 
 		registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("foo")),
@@ -323,7 +323,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("time")),
@@ -365,7 +365,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("time")),
@@ -406,7 +406,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("time")),
@@ -447,7 +447,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("time")),
@@ -488,7 +488,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("time")),
@@ -518,7 +518,7 @@ public class DefaultAppRegistryServiceTests {
 
 		List<AppRegistration> registrations = appRegistrationCaptor.getAllValues();
 
-		assertThat(registrations,
+		MatcherAssert.assertThat(registrations,
 				containsInAnyOrder(
 						allOf(
 								hasProperty("name", is("foo")),

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.registry.support;
 import java.net.MalformedURLException;
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
@@ -30,7 +30,8 @@ import org.springframework.core.io.UrlResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -45,10 +46,12 @@ public class AppResourceCommonTests {
 	private ResourceLoader resourceLoader = mock(ResourceLoader.class);
 	private AppResourceCommon appResourceCommon = new AppResourceCommon(new MavenProperties(), resourceLoader);
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testBadNamedJars() throws Exception {
-		UrlResource urlResource = new UrlResource("https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit.jar");
-		appResourceCommon.getUrlResourceVersion(urlResource);
+		assertThrows(IllegalArgumentException.class, () -> {
+			UrlResource urlResource = new UrlResource("https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit.jar");
+			appResourceCommon.getUrlResourceVersion(urlResource);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/DockerImageTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/DockerImageTests.java
@@ -22,37 +22,35 @@ package org.springframework.cloud.dataflow.registry.support;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for DockerImage parsing methods Code from https://github.com/vmware/admiral
  */
-@RunWith(Parameterized.class)
 public class DockerImageTests {
-	private final String description;
+	private String description;
 
-	private final String fullImageName;
+	private String fullImageName;
 
-	private final String expectedHost;
+	private String expectedHost;
 
-	private final String expectedNamespace;
+	private String expectedNamespace;
 
-	private final String expectedRepo;
+	private String expectedRepo;
 
-	private final String expectedNamespaceAndRepo;
+	private String expectedNamespaceAndRepo;
 
-	private final String expectedTag;
+	private String expectedTag;
 
 	/**
 	 * @param expectedHost
 	 * @param expectedNamespace
 	 * @param expectedRepo
 	 */
-	public DockerImageTests(String description, String fullImageName, String expectedHost,
+	public void initDockerImageTests(String description, String fullImageName, String expectedHost,
 			String expectedNamespace,
 			String expectedRepo,
 			String expectedNamespaceAndRepo,
@@ -67,7 +65,6 @@ public class DockerImageTests {
 		this.expectedTag = expectedTag;
 	}
 
-	@Parameterized.Parameters
 	public static List<String[]> data() {
 		List<String[]> data = new ArrayList<>();
 		data.add(new String[] { "all sections", "myhost:300/namespace/repo:tag", "myhost:300",
@@ -120,15 +117,19 @@ public class DockerImageTests {
 		return data;
 	}
 
-	@Test
-	public void testDockerImageParsing() {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void testDockerImageParsing(String description, String fullImageName, String expectedHost, String expectedNamespace, String expectedRepo, String expectedNamespaceAndRepo, String expectedTag) {
+
+		initDockerImageTests(description, fullImageName, expectedHost, expectedNamespace, expectedRepo, expectedNamespaceAndRepo, expectedTag);
 
 		DockerImage dockerImage = DockerImage.fromImageName(fullImageName);
-		assertEquals(description + ": host", expectedHost, dockerImage.getHost());
-		assertEquals(description + ": namespace", expectedNamespace, dockerImage.getNamespace());
-		assertEquals(description + ": repository", expectedRepo, dockerImage.getRepository());
-		assertEquals(description + ": namespace and repo", expectedNamespaceAndRepo,
-				dockerImage.getNamespaceAndRepo());
-		assertEquals(description + ": tag", expectedTag, dockerImage.getTag());
+		assertEquals(expectedHost, dockerImage.getHost(), description + ": host");
+		assertEquals(expectedNamespace, dockerImage.getNamespace(), description + ": namespace");
+		assertEquals(expectedRepo, dockerImage.getRepository(), description + ": repository");
+		assertEquals(expectedNamespaceAndRepo,
+				dockerImage.getNamespaceAndRepo(),
+				description + ": namespace and repo");
+		assertEquals(expectedTag, dockerImage.getTag(), description + ": tag");
 	}
 }

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataFlowClientAutoConfigurationTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataFlowClientAutoConfigurationTests.java
@@ -17,8 +17,8 @@ package org.springframework.cloud.dataflow.rest.client;
 
 import java.util.Collections;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.boot.SpringApplication;
@@ -41,8 +41,8 @@ public class DataFlowClientAutoConfigurationTests {
 		ConfigurableApplicationContext applicationContext = SpringApplication.run(TestApplication.class,
 				"--spring.cloud.dataflow.client.enableDsl=true",
 				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration,org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration");
-		Assert.assertNotNull(applicationContext.getBean(DataFlowTemplate.class));
-		Assert.assertNotNull(applicationContext.getBean(StreamBuilder.class));
+		Assertions.assertNotNull(applicationContext.getBean(DataFlowTemplate.class));
+		Assertions.assertNotNull(applicationContext.getBean(StreamBuilder.class));
 		RestTemplate template = applicationContext.getBean(RestTemplate.class);
 		//No auth
 		Mockito.verify(template, Mockito.times(0)).setRequestFactory(Mockito.any());
@@ -55,14 +55,14 @@ public class DataFlowClientAutoConfigurationTests {
 				"--spring.cloud.dataflow.client.authentication.basic.username=foo",
 				"--spring.cloud.dataflow.client.authentication.basic.password=bar",
 				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration,org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration");
-		Assert.assertNotNull(applicationContext.getBean(DataFlowTemplate.class));
-		Assert.assertNotNull(applicationContext.getBean(StreamBuilder.class));
+		Assertions.assertNotNull(applicationContext.getBean(DataFlowTemplate.class));
+		Assertions.assertNotNull(applicationContext.getBean(StreamBuilder.class));
 
 		RestTemplate template = applicationContext.getBean(RestTemplate.class);
 		DataFlowClientProperties properties = applicationContext.getBean(DataFlowClientProperties.class);
-		Assert.assertNotNull(properties.getAuthentication());
-		Assert.assertEquals("foo", properties.getAuthentication().getBasic().getUsername());
-		Assert.assertEquals("bar", properties.getAuthentication().getBasic().getPassword());
+		Assertions.assertNotNull(properties.getAuthentication());
+		Assertions.assertEquals("foo", properties.getAuthentication().getBasic().getUsername());
+		Assertions.assertEquals("bar", properties.getAuthentication().getBasic().getPassword());
 		Mockito.verify(template, Mockito.times(1)).setRequestFactory(Mockito.any());
 		applicationContext.close();
 	}

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowClientExceptionTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowClientExceptionTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.cloud.dataflow.rest.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.mediatype.vnderrors.VndErrors;
 import org.springframework.hateoas.mediatype.vnderrors.VndErrors.VndError;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
@@ -44,11 +44,12 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -60,12 +61,12 @@ import static org.mockito.Mockito.when;
  */
 public class DataflowTemplateTests {
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(100));
 	}
 
-	@After
+	@AfterEach
 	public void shutdown() {
 		System.clearProperty("sun.net.client.defaultConnectTimeout");
 	}
@@ -84,9 +85,11 @@ public class DataflowTemplateTests {
 		fail("Expected an IllegalArgumentException to be thrown.");
 	}
 
-	@Test(expected = ResourceAccessException.class)
+	@Test
 	public void testDataFlowTemplateContructorWithNonExistingUri() throws URISyntaxException {
-		new DataFlowTemplate(new URI("https://doesnotexist:1234"));
+		assertThrows(ResourceAccessException.class, () -> {
+			new DataFlowTemplate(new URI("https://doesnotexist:1234"));
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/ExecutionContextDeserializationTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/ExecutionContextDeserializationTests.java
@@ -21,17 +21,17 @@ import java.io.InputStream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.util.StreamUtils;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gunnar Hillert
@@ -107,7 +107,7 @@ public class ExecutionContextDeserializationTests {
 			fail("Expected a ClassCastException to be thrown.");
 		}
 		catch (ClassCastException ce) {
-			assertThat(ce.getMessage(), containsString("key=[barNumber] is not of type: [class java.lang.Long], it is [(class java.lang.Integer)"));
+			MatcherAssert.assertThat(ce.getMessage(), containsString("key=[barNumber] is not of type: [class java.lang.Long], it is [(class java.lang.Integer)"));
 		}
 
 		try {
@@ -115,7 +115,7 @@ public class ExecutionContextDeserializationTests {
 			fail("Expected a ClassCastException to be thrown.");
 		}
 		catch (ClassCastException ce) {
-			assertThat(ce.getMessage(), containsString("key=[barNumber] is not of type: [class java.lang.Double], it is [(class java.lang.Integer)"));
+			MatcherAssert.assertThat(ce.getMessage(), containsString("key=[barNumber] is not of type: [class java.lang.Double], it is [(class java.lang.Integer)"));
 		}
 
 		assertEquals(22222222222L, executionContext.getLong("longNumber"));
@@ -125,7 +125,7 @@ public class ExecutionContextDeserializationTests {
 			fail("Expected a ClassCastException to be thrown.");
 		}
 		catch (ClassCastException ce) {
-			assertThat(ce.getMessage(), containsString("key=[longNumber] is not of type: [class java.lang.Integer], it is [(class java.lang.Long)"));
+			MatcherAssert.assertThat(ce.getMessage(), containsString("key=[longNumber] is not of type: [class java.lang.Integer], it is [(class java.lang.Long)"));
 		}
 
 		assertEquals("true", executionContext.get("fooBoolean"));

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/ExecutionContextSerializationTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/ExecutionContextSerializationTests.java
@@ -19,11 +19,11 @@ package org.springframework.cloud.dataflow.rest.client;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.item.ExecutionContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/JobExecutionDeserializationTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/JobExecutionDeserializationTests.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
@@ -30,8 +30,8 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.util.StreamUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Gunnar Hillert
@@ -53,7 +53,7 @@ public class JobExecutionDeserializationTests {
 				new TypeReference<PagedModel<EntityModel<JobExecutionResource>>>() {
 				});
 		final JobExecutionResource jobExecutionResource = paged.getContent().iterator().next().getContent();
-		assertEquals("Expect 1 JobExecutionInfoResource", 6, paged.getContent().size());
+		assertEquals(6, paged.getContent().size(), "Expect 1 JobExecutionInfoResource");
 		assertEquals(Long.valueOf(6), jobExecutionResource.getJobId());
 		assertEquals("job200616815", jobExecutionResource.getName());
 		assertEquals("COMPLETED", jobExecutionResource.getJobExecution().getStatus().name());

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/SchedulerTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/SchedulerTemplateTests.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.cloud.dataflow.rest.resource.RootResource;
@@ -49,7 +49,7 @@ public class SchedulerTemplateTests {
 	private RestTemplate restTemplate;
 	private SchedulerTemplate template;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		rootResource = mock(RootResource.class);
 		when(rootResource.getLink(SCHEDULES_RELATION)).thenReturn(Optional.of(new Link(SCHEDULES_RELATION)));

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -20,9 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.RepresentationModel;
@@ -41,7 +41,7 @@ public class TaskTemplateTests {
 
 	private RestTemplate restTemplate;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		restTemplate = mock(RestTemplate.class);
 
@@ -68,13 +68,13 @@ public class TaskTemplateTests {
 	private void validateExecutionLinkPresent(String dataFlowVersion) {
 		TestResource testResource = new TestResource();
 		new TaskTemplate(this.restTemplate, testResource, dataFlowVersion);
-		Assert.assertTrue(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
+		Assertions.assertTrue(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
 	}
 
 	private void validateExecutionLinkNotPresent(String version) {
 		TestResource testResource = new TestResource();
 		new TaskTemplate(this.restTemplate, testResource, version);
-		Assert.assertFalse(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
+		Assertions.assertFalse(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK));
 	}
 
 	public static class TestResource extends RepresentationModel {

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/VersionUtilsTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/VersionUtilsTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.dataflow.rest.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.rest.client.support.VersionUtils;
 

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/dsl/StreamDslTests.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,6 +41,7 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
@@ -74,7 +75,7 @@ public class StreamDslTests {
 
 	private StreamApplication logApplication = new StreamApplication("log");
 
-	@Before
+	@BeforeEach
 	public void init() {
 		MockitoAnnotations.initMocks(this);
 		when(client.streamOperations()).thenReturn(this.streamOperations);
@@ -233,11 +234,13 @@ public class StreamDslTests {
 				eq(false));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testDuplicateNameNoLabel() {
-		Stream.builder(client).name("test").source(timeApplication)
-				.processor(filterApplication).processor(filterApplication)
-				.sink(logApplication).create();
+		assertThrows(IllegalStateException.class, () -> {
+			Stream.builder(client).name("test").source(timeApplication)
+					.processor(filterApplication).processor(filterApplication)
+					.sink(logApplication).create();
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/JobUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/job/support/JobUtilsTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.cloud.dataflow.rest.job.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/DeploymentStateResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/DeploymentStateResourceTests.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Gunnar Hillert
@@ -40,9 +40,9 @@ public class DeploymentStateResourceTests {
 
 		final DocumentContext documentContext = JsonPath.parse(result);
 
-		assertThat(documentContext.read("$.key"), is("deployed"));
-		assertThat(documentContext.read("$.displayName"), is("Deployed"));
-		assertThat(documentContext.read("$.description"), is("The stream has been successfully deployed"));
+		MatcherAssert.assertThat(documentContext.read("$.key"), is("deployed"));
+		MatcherAssert.assertThat(documentContext.read("$.displayName"), is("Deployed"));
+		MatcherAssert.assertThat(documentContext.read("$.description"), is("The stream has been successfully deployed"));
 
 	}
 

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
@@ -23,12 +23,14 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.rest.util.CheckableResource;
 import org.springframework.cloud.dataflow.rest.util.HttpClientConfigurer;
 import org.springframework.cloud.dataflow.rest.util.ResourceBasedAuthorizationInterceptor;
 import org.springframework.core.io.ByteArrayResource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mike Heath
@@ -57,48 +59,52 @@ public class HttpClientTest {
 		}
 	}
 
-	@Test(expected = Passed.class)
+	@Test
 	public void resourceBasedAuthorizationHeader() throws Exception {
-		final String credentials = "Super Secret Credentials";
+		assertThrows(Passed.class, () -> {
+			final String credentials = "Super Secret Credentials";
 
-		final CheckableResource resource = new ByteArrayCheckableResource(credentials.getBytes(), null);
+			final CheckableResource resource = new ByteArrayCheckableResource(credentials.getBytes(), null);
 
-		final URI targetHost = new URI("http://test.com");
-		try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
-				.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
-				.addInterceptor((request, context) -> {
-					final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
-					Assertions.assertThat(authorization).isEqualTo(credentials);
+			final URI targetHost = new URI("http://test.com");
+			try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
+					.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
+					.addInterceptor((request, context) -> {
+						final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
+						Assertions.assertThat(authorization).isEqualTo(credentials);
 
-					// Throw an exception to short-circuit making an HTTP request
-					throw new Passed();
-				})
-				.buildHttpClient()) {
-			client.execute(new HttpGet(targetHost));
-		}
+						// Throw an exception to short-circuit making an HTTP request
+						throw new Passed();
+					})
+					.buildHttpClient()) {
+				client.execute(new HttpGet(targetHost));
+			}
+		});
 	}
 
 	static final class Passed extends RuntimeException {
 	}
 
-	@Test(expected = TestException.class)
+	@Test
 	public void resourceBasedAuthorizationHeaderResourceCheck() throws Exception {
-		final String credentials = "Super Secret Credentials";
+		assertThrows(TestException.class, () -> {
+			final String credentials = "Super Secret Credentials";
 
-		final CheckableResource resource = new ByteArrayCheckableResource(credentials.getBytes(), new TestException());
+			final CheckableResource resource = new ByteArrayCheckableResource(credentials.getBytes(), new TestException());
 
-		final URI targetHost = new URI("http://test.com");
-		try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
-				.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
-				.addInterceptor((request, context) -> {
-					final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
-					Assertions.assertThat(authorization).isEqualTo(credentials);
+			final URI targetHost = new URI("http://test.com");
+			try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
+					.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
+					.addInterceptor((request, context) -> {
+						final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
+						Assertions.assertThat(authorization).isEqualTo(credentials);
 
-					// Throw an exception to short-circuit making an HTTP request
-					throw new Passed();
-				})
-				.buildHttpClient()) {
-			client.execute(new HttpGet(targetHost));
-		}
+						// Throw an exception to short-circuit making an HTTP request
+						throw new Passed();
+					})
+					.buildHttpClient()) {
+				client.execute(new HttpGet(targetHost));
+			}
+		});
 	}
 }

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
@@ -32,8 +32,8 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.core.io.UrlResource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Provides tests for the {@link TaskExecutionResourceTests} class.

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/StepExecutionJacksonMixInTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/StepExecutionJacksonMixInTests.java
@@ -19,7 +19,8 @@ package org.springframework.cloud.dataflow.rest.support.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepExecution;
@@ -27,7 +28,7 @@ import org.springframework.batch.item.ExecutionContext;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests that the {@link ExecutionContextJacksonMixIn} works as expected.
@@ -42,15 +43,17 @@ public class StepExecutionJacksonMixInTests {
 	 *
 	 * @throws JsonProcessingException if a Json generation error occurs.
 	 */
-	@Test(expected = JsonMappingException.class)
+	@Test
 	public void testSerializationOfSingleStepExecutionWithoutMixin() throws JsonProcessingException {
+		assertThrows(JsonMappingException.class, () -> {
 
-		final ObjectMapper objectMapper = new ObjectMapper();
+			final ObjectMapper objectMapper = new ObjectMapper();
 
-		final StepExecution stepExecution = getStepExecution();
-		final String result = objectMapper.writeValueAsString(stepExecution);
+			final StepExecution stepExecution = getStepExecution();
+			final String result = objectMapper.writeValueAsString(stepExecution);
 
-		assertThat(result, containsString("\"executionContext\":{\"dirty\":true,\"empty\":false}"));
+			MatcherAssert.assertThat(result, containsString("\"executionContext\":{\"dirty\":true,\"empty\":false}"));
+		});
 	}
 
 	/**
@@ -70,15 +73,15 @@ public class StepExecutionJacksonMixInTests {
 		final StepExecution stepExecution = getStepExecution();
 		final String result = objectMapper.writeValueAsString(stepExecution);
 
-		assertThat(result, not(containsString("\"executionContext\":{\"dirty\":true,\"empty\":false}")));
-		assertThat(result, containsString("\"executionContext\":{\"dirty\":true,\"empty\":false,\"values\":[{"));
+		MatcherAssert.assertThat(result, not(containsString("\"executionContext\":{\"dirty\":true,\"empty\":false}")));
+		MatcherAssert.assertThat(result, containsString("\"executionContext\":{\"dirty\":true,\"empty\":false,\"values\":[{"));
 
-		assertThat(result, containsString("{\"counter\":1234}"));
-		assertThat(result, containsString("{\"myDouble\":1.123456}"));
-		assertThat(result, containsString("{\"Josh\":4444444444}"));
-		assertThat(result, containsString("{\"awesomeString\":\"Yep\"}"));
-		assertThat(result, containsString("{\"hello\":\"world\""));
-		assertThat(result, containsString("{\"counter2\":9999}"));
+		MatcherAssert.assertThat(result, containsString("{\"counter\":1234}"));
+		MatcherAssert.assertThat(result, containsString("{\"myDouble\":1.123456}"));
+		MatcherAssert.assertThat(result, containsString("{\"Josh\":4444444444}"));
+		MatcherAssert.assertThat(result, containsString("{\"awesomeString\":\"Yep\"}"));
+		MatcherAssert.assertThat(result, containsString("{\"hello\":\"world\""));
+		MatcherAssert.assertThat(result, containsString("{\"counter2\":9999}"));
 	}
 
 	private StepExecution getStepExecution() {

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
@@ -25,7 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.util.FileCopyUtils;
 
@@ -34,9 +35,8 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link DeploymentPropertiesUtils}.
@@ -49,41 +49,41 @@ public class DeploymentPropertiesUtilsTests {
 
 	private static void assertArrays(String[] left, String[] right) {
 		ArrayList<String> params = new ArrayList<>(Arrays.asList(left));
-		assertThat(DeploymentPropertiesUtils.removeQuoting(params), containsInAnyOrder(right));
+		MatcherAssert.assertThat(DeploymentPropertiesUtils.removeQuoting(params), containsInAnyOrder(right));
 	}
 
 	@Test
 	public void testDeploymentPropertiesParsing() {
 		Map<String, String> props = DeploymentPropertiesUtils.parse("app.foo.bar=v, app.foo.wizz=v2  , deployer.foo"
 				+ ".pot=fern, app.other.key = value  , deployer.other.cow = meww, scheduler.other.key = baz");
-		assertThat(props, hasEntry("app.foo.bar", "v"));
-		assertThat(props, hasEntry("app.other.key", "value"));
-		assertThat(props, hasEntry("app.foo.wizz", "v2"));
-		assertThat(props, hasEntry("deployer.foo.pot", "fern"));
-		assertThat(props, hasEntry("deployer.other.cow", "meww"));
-		assertThat(props, hasEntry("scheduler.other.key", "baz"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar", "v"));
+		MatcherAssert.assertThat(props, hasEntry("app.other.key", "value"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.wizz", "v2"));
+		MatcherAssert.assertThat(props, hasEntry("deployer.foo.pot", "fern"));
+		MatcherAssert.assertThat(props, hasEntry("deployer.other.cow", "meww"));
+		MatcherAssert.assertThat(props, hasEntry("scheduler.other.key", "baz"));
 
 		props = DeploymentPropertiesUtils.parse("app.f=v");
-		assertThat(props, hasEntry("app.f", "v"));
+		MatcherAssert.assertThat(props, hasEntry("app.f", "v"));
 
 		props = DeploymentPropertiesUtils.parse("app.foo1=bar1,app.foo2=bar2,app.foo3=bar3,xxx3");
-		assertThat(props, hasEntry("app.foo1", "bar1"));
-		assertThat(props, hasEntry("app.foo2", "bar2"));
-		assertThat(props, hasEntry("app.foo3", "bar3,xxx3"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo1", "bar1"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo2", "bar2"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo3", "bar3,xxx3"));
 
 		props = DeploymentPropertiesUtils.parse("deployer.foo1 = bar1 , app.foo2= bar2,  deployer.foo3  = bar3,xxx3");
-		assertThat(props, hasEntry("deployer.foo1", "bar1"));
-		assertThat(props, hasEntry("app.foo2", "bar2"));
-		assertThat(props, hasEntry("deployer.foo3", "bar3,xxx3"));
+		MatcherAssert.assertThat(props, hasEntry("deployer.foo1", "bar1"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo2", "bar2"));
+		MatcherAssert.assertThat(props, hasEntry("deployer.foo3", "bar3,xxx3"));
 
 		props = DeploymentPropertiesUtils.parse("app.*.count=1");
-		assertThat(props, hasEntry("app.*.count", "1"));
+		MatcherAssert.assertThat(props, hasEntry("app.*.count", "1"));
 
 		props = DeploymentPropertiesUtils.parse("app.*.my-count=1");
-		assertThat(props, hasEntry("app.*.my-count", "1"));
+		MatcherAssert.assertThat(props, hasEntry("app.*.my-count", "1"));
 
 		props = DeploymentPropertiesUtils.parse("app.transform.producer.partitionKeyExpression=fakeExpression('xxx')");
-		assertThat(props, hasEntry("app.transform.producer.partitionKeyExpression", "fakeExpression('xxx')"));
+		MatcherAssert.assertThat(props, hasEntry("app.transform.producer.partitionKeyExpression", "fakeExpression('xxx')"));
 
 		try {
 			DeploymentPropertiesUtils.parse("invalidkeyvalue");
@@ -94,20 +94,20 @@ public class DeploymentPropertiesUtilsTests {
 		}
 
 		props = DeploymentPropertiesUtils.parse("deployer.foo=bar,invalidkeyvalue2");
-		assertThat(props.size(), is(1));
-		assertThat(props, hasEntry("deployer.foo", "bar,invalidkeyvalue2"));
+		MatcherAssert.assertThat(props.size(), is(1));
+		MatcherAssert.assertThat(props, hasEntry("deployer.foo", "bar,invalidkeyvalue2"));
 
 		props = DeploymentPropertiesUtils.parse("app.foo.bar1=jee1,jee2,jee3,deployer.foo.bar2=jee4,jee5,jee6");
-		assertThat(props, hasEntry("app.foo.bar1", "jee1,jee2,jee3"));
-		assertThat(props, hasEntry("deployer.foo.bar2", "jee4,jee5,jee6"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar1", "jee1,jee2,jee3"));
+		MatcherAssert.assertThat(props, hasEntry("deployer.foo.bar2", "jee4,jee5,jee6"));
 
 		props = DeploymentPropertiesUtils.parse("app.foo.bar1=xxx=1,app.foo.bar2=xxx=2");
-		assertThat(props, hasEntry("app.foo.bar1", "xxx=1"));
-		assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar1", "xxx=1"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
 
 		props = DeploymentPropertiesUtils.parse("app.foo.bar1=xxx=1,test=value,app.foo.bar2=xxx=2");
-		assertThat(props, hasEntry("app.foo.bar1", "xxx=1,test=value"));
-		assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar1", "xxx=1,test=value"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar2", "xxx=2"));
 	}
 
 
@@ -161,9 +161,9 @@ public class DeploymentPropertiesUtilsTests {
 	public void testLongDeploymentPropertyValues() {
 		Map<String, String> props = DeploymentPropertiesUtils
 				.parse("app.foo.bar=FoooooooooooooooooooooBar,app.foo" + ".bar2=FoooooooooooooooooooooBar");
-		assertThat(props, hasEntry("app.foo.bar", "FoooooooooooooooooooooBar"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar", "FoooooooooooooooooooooBar"));
 		props = DeploymentPropertiesUtils.parse("app.foo.bar=FooooooooooooooooooooooooooooooooooooooooooooooooooooBar");
-		assertThat(props, hasEntry("app.foo.bar", "FooooooooooooooooooooooooooooooooooooooooooooooooooooBar"));
+		MatcherAssert.assertThat(props, hasEntry("app.foo.bar", "FooooooooooooooooooooooooooooooooooooooooooooooooooooBar"));
 	}
 
 	@Test
@@ -177,10 +177,10 @@ public class DeploymentPropertiesUtilsTests {
 		props.put("deployer.myapp.precedence", "app");
 		Map<String, String> result = DeploymentPropertiesUtils.extractAndQualifyDeployerProperties(props, "myapp");
 
-		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
-		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
-		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
-		assertThat(result, not(hasKey("app.myapp.foo")));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
+		MatcherAssert.assertThat(result, not(hasKey("app.myapp.foo")));
 	}
 
 	@Test
@@ -194,10 +194,10 @@ public class DeploymentPropertiesUtilsTests {
 		props.put("deployer.myapp.precedence", "app");
 		Map<String, String> result = DeploymentPropertiesUtils.qualifyDeployerProperties(props, "myapp");
 
-		assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
-		assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
-		assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
-		assertThat(result, hasKey("app.myapp.foo"));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.count", "2"));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.foo", "bar"));
+		MatcherAssert.assertThat(result, hasEntry("spring.cloud.deployer.precedence", "app"));
+		MatcherAssert.assertThat(result, hasKey("app.myapp.foo"));
 	}
 
 	@Test
@@ -225,11 +225,11 @@ public class DeploymentPropertiesUtilsTests {
 		FileCopyUtils.copy("app.foo1:\n  bar1: spam".getBytes(), file);
 
 		Map<String, String> props = DeploymentPropertiesUtils.parseDeploymentProperties("app.foo2=bar2", file, 0);
-		assertThat(props.size(), is(1));
-		assertThat(props.get("app.foo2"), is("bar2"));
+		MatcherAssert.assertThat(props.size(), is(1));
+		MatcherAssert.assertThat(props.get("app.foo2"), is("bar2"));
 
 		props = DeploymentPropertiesUtils.parseDeploymentProperties("foo2=bar2", file, 1);
-		assertThat(props.size(), is(1));
-		assertThat(props.get("app.foo1.bar1"), is("spam"));
+		MatcherAssert.assertThat(props.size(), is(1));
+		MatcherAssert.assertThat(props.get("app.foo1.bar1"), is("spam"));
 	}
 }

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
@@ -21,12 +21,12 @@ import java.net.URI;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.util.ReflectionUtils;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gunnar Hillert
@@ -70,7 +70,7 @@ public class HttpClientConfigurerTests {
 			builder.withProxyCredentials(URI.create("spring"), "spring", "cloud");
 		}
 		catch (IllegalArgumentException e) {
-			Assert.assertEquals("The scheme component of the proxyUri must not be empty.", e.getMessage());
+			Assertions.assertEquals("The scheme component of the proxyUri must not be empty.", e.getMessage());
 			return;
 		}
 		fail("Expected an IllegalArgumentException to be thrown.");
@@ -88,7 +88,7 @@ public class HttpClientConfigurerTests {
 			builder.withProxyCredentials(null, null, null);
 		}
 		catch (IllegalArgumentException e) {
-			Assert.assertEquals("The proxyUri must not be null.", e.getMessage());
+			Assertions.assertEquals("The proxyUri must not be null.", e.getMessage());
 			return;
 		}
 		fail("Expected an IllegalArgumentException to be thrown.");
@@ -107,8 +107,8 @@ public class HttpClientConfigurerTests {
 		final Field credentialsProviderField = ReflectionUtils.findField(HttpClientConfigurer.class, "credentialsProvider");
 		ReflectionUtils.makeAccessible(credentialsProviderField);
 		CredentialsProvider credentialsProvider = (CredentialsProvider) credentialsProviderField.get(builder);
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
-		Assert.assertNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
+		Assertions.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
+		Assertions.assertNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
 	}
 
 	/**
@@ -124,7 +124,7 @@ public class HttpClientConfigurerTests {
 		final Field credentialsProviderField = ReflectionUtils.findField(HttpClientConfigurer.class, "credentialsProvider");
 		ReflectionUtils.makeAccessible(credentialsProviderField);
 		CredentialsProvider credentialsProvider = (CredentialsProvider) credentialsProviderField.get(builder);
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
+		Assertions.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
+		Assertions.assertNotNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/completion/TabOnTapCompletionProviderTests.java
@@ -23,9 +23,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.hamcrest.FeatureMatcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -51,18 +51,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResourceLoader;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -87,7 +84,7 @@ public class TabOnTapCompletionProviderTests {
 		};
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		this.streamDefinitionRepository.save(new StreamDefinition("foo", "time | transform | log"));
 		this.streamDefinitionRepository.save(new StreamDefinition("bar", "time | log"));
@@ -98,21 +95,21 @@ public class TabOnTapCompletionProviderTests {
 	@Test
 	// :foo ==> add appropriate app names
 	public void testAppNamesAfterStreamName() {
-		assertThat(completionProvider.complete(":foo", 1),
+		MatcherAssert.assertThat(completionProvider.complete(":foo", 1),
 				hasItems(proposalThat(is(":foo.time")), proposalThat(is(":foo.transform"))));
 	}
 
 	@Test
 	// :foo. ==> add appropriate app names
 	public void testAppNamesAfterStreamNameWithDotAfterStreamName() {
-		assertThat(completionProvider.complete(":foo.", 1),
+		MatcherAssert.assertThat(completionProvider.complete(":foo.", 1),
 				hasItems(proposalThat(is(":foo.time")), proposalThat(is(":foo.transform"))));
 	}
 
 	@Test
 	// : ==> add stream name
 	public void testStreamNameAfterColon() {
-		assertThat(completionProvider.complete(":", 1), hasItems(proposalThat(is(":foo")), proposalThat(is(":bar"))));
+		MatcherAssert.assertThat(completionProvider.complete(":", 1), hasItems(proposalThat(is(":foo")), proposalThat(is(":bar"))));
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfigurationTests.java
@@ -20,10 +20,10 @@ import java.net.ConnectException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
@@ -60,9 +60,10 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.security.authentication.AuthenticationManager;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -78,7 +79,7 @@ public class DataFlowServerConfigurationTests {
 
 	private MutablePropertySources propertySources;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = new AnnotationConfigApplicationContext();
 		context.setId("testDataFlowConfig");
@@ -93,7 +94,7 @@ public class DataFlowServerConfigurationTests {
 		propertySources = environment.getPropertySources();
 	}
 
-	@After
+	@AfterEach
 	public void teardown() {
 		if (context != null) {
 			context.close();
@@ -104,7 +105,7 @@ public class DataFlowServerConfigurationTests {
 	 * Verify that embedded server starts if h2 url is specified with default properties.
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void testStartEmbeddedH2Server() {
 		Map<String, Object> myMap = new HashMap<>();
 		myMap.put("spring.datasource.url", "jdbc:h2:tcp://localhost:19092/mem:dataflow");
@@ -122,23 +123,25 @@ public class DataFlowServerConfigurationTests {
 	 *
 	 * @throws Throwable if any error occurs and should be handled by the caller.
 	 */
-	@Test(expected = ConnectException.class)
+	@Test
 	public void testDoNotStartEmbeddedH2Server() throws Throwable {
-		Throwable exceptionResult = null;
-		Map<String, Object> myMap = new HashMap<>();
-		myMap.put("spring.datasource.url", "jdbc:h2:tcp://localhost:19092/mem:dataflow");
-		myMap.put("spring.dataflow.embedded.database.enabled", "false");
-		myMap.put("spring.jpa.database", "H2");
-		propertySources.addFirst(new MapPropertySource("EnvironmentTestPropsource", myMap));
-		context.setEnvironment(environment);
-		try {
-			context.refresh();
-		}
-		catch (BeanCreationException exception) {
-			exceptionResult = exception.getRootCause();
-		}
-		assertNotNull(exceptionResult);
-		throw exceptionResult;
+		assertThrows(ConnectException.class, () -> {
+			Throwable exceptionResult = null;
+			Map<String, Object> myMap = new HashMap<>();
+			myMap.put("spring.datasource.url", "jdbc:h2:tcp://localhost:19092/mem:dataflow");
+			myMap.put("spring.dataflow.embedded.database.enabled", "false");
+			myMap.put("spring.jpa.database", "H2");
+			propertySources.addFirst(new MapPropertySource("EnvironmentTestPropsource", myMap));
+			context.setEnvironment(environment);
+			try {
+				context.refresh();
+			}
+			catch (BeanCreationException exception) {
+				exceptionResult = exception.getRootCause();
+			}
+			assertNotNull(exceptionResult);
+			throw exceptionResult;
+		});
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
@@ -41,8 +41,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.AuthenticationManager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/LocalPlatformTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/LocalPlatformTests.java
@@ -18,8 +18,8 @@ package org.springframework.cloud.dataflow.server.config;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.Banner;
 import org.springframework.boot.WebApplicationType;
@@ -43,7 +43,7 @@ public class LocalPlatformTests {
 
 	private ConfigurableApplicationContext context;
 
-	@After
+	@AfterEach
 	public void cleanup() {
 		if (this.context != null) {
 			this.context.close();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalPlatformPropertiesTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalPlatformPropertiesTests.java
@@ -17,8 +17,7 @@ package org.springframework.cloud.dataflow.server.config.features;
 
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -26,14 +25,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Mark Pollack
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = LocalPlatformPropertiesTests.TestConfig.class)
 @ActiveProfiles("local-platform-properties")
 public class LocalPlatformPropertiesTests {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactoryTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/features/LocalTaskPlatformFactoryTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.server.config.features;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +31,6 @@ import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -51,7 +49,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @TestPropertySource(properties = {
@@ -76,7 +73,7 @@ public class AboutControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -106,7 +103,6 @@ public class AboutControllerTests {
 				.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", not(isEmptyOrNullString())));
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -126,7 +122,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -144,7 +140,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -163,7 +158,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -181,7 +176,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -200,7 +194,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -219,7 +213,6 @@ public class AboutControllerTests {
 	}
 
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -238,7 +231,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -256,7 +249,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -272,7 +264,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -290,7 +282,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -309,7 +300,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -327,7 +318,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -348,7 +338,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -365,7 +355,6 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -397,7 +386,7 @@ public class AboutControllerTests {
 		@Autowired
 		private SkipperClient skipperClient;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -20,9 +20,9 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -50,7 +50,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -63,7 +62,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
@@ -81,7 +79,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  * @author Chris Schaefer
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @Transactional
@@ -108,7 +105,7 @@ public class AppRegistryControllerTests {
 	@Autowired
 	private StreamDefinitionRepository streamDefinitionRepository;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -123,7 +120,7 @@ public class AppRegistryControllerTests {
 	public void testRegisterVersionedApp() throws Exception {
 		mockMvc.perform(post("/apps/sink/log1/1.2.0.RELEASE").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());
-		assertThat(this.appRegistryService.find("log1", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
+		MatcherAssert.assertThat(this.appRegistryService.find("log1", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
 	}
 
 	@Test
@@ -152,7 +149,7 @@ public class AppRegistryControllerTests {
 	public void testRegisterApp() throws Exception {
 		mockMvc.perform(post("/apps/sink/log1").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());
-		assertThat(this.appRegistryService.find("log1", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
+		MatcherAssert.assertThat(this.appRegistryService.find("log1", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
 	}
 
 	@Test
@@ -253,39 +250,39 @@ public class AppRegistryControllerTests {
 	public void testRegisterAll() throws Exception {
 		mockMvc.perform(post("/apps").param("apps", "sink.foo=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());
-		assertThat(this.appRegistryService.find("foo", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
+		MatcherAssert.assertThat(this.appRegistryService.find("foo", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
 	}
 
 	@Test
 	public void testRegisterAllFromFile() throws Exception {
 		mockMvc.perform(post("/apps").param("uri", "classpath:/register-all.txt").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());
-		assertThat(this.appRegistryService.find("foo", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
+		MatcherAssert.assertThat(this.appRegistryService.find("foo", ApplicationType.sink).getUri().toString(), is("maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE"));
 	}
 
 	@Test
 	public void testRegisterAllWithoutForce() throws Exception {
 		this.appRegistryService.importAll(false, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
-		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
 				is("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT"));
 	}
 
 	@Test
 	public void testRegisterAllWithForce() throws Exception {
 		this.appRegistryService.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
-		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
 				is("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT"));
-		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
+		MatcherAssert.assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
 				is("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT"));
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -19,10 +19,9 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +45,6 @@ import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -55,7 +53,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -70,7 +68,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Daniel Serleg
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -102,7 +99,7 @@ public class AuditRecordControllerTests {
 
 	private ZonedDateTime endDate;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() throws Exception {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -133,7 +130,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		appRegistrationRepository.deleteAll();
 		streamDefinitionRepository.deleteAll();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CompletionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/CompletionControllerTests.java
@@ -15,9 +15,8 @@
  */
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -26,7 +25,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -41,7 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Vinicius Carvalho
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -52,7 +49,7 @@ public class CompletionControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -18,10 +18,9 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.util.Date;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
@@ -41,7 +40,6 @@ import org.springframework.cloud.task.batch.listener.TaskBatchDao;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.context.WebApplicationContext;
@@ -50,6 +48,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -61,7 +60,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Glenn Renfro
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
@@ -86,15 +84,17 @@ public class JobExecutionControllerTests {
 	@Autowired
 	private RequestMappingHandlerAdapter adapter;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = JobExecutionUtils.createBaseJobExecutionMockMvc(jobRepository, taskBatchDao,
 				dao, wac, adapter);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testJobExecutionControllerConstructorMissingRepository() {
-		new JobExecutionController(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new JobExecutionController(null);
+		});
 	}
 
 	@Test
@@ -135,9 +135,9 @@ public class JobExecutionControllerTests {
 
 		final JobExecution jobExecution = jobRepository.getLastJobExecution(JobExecutionUtils.JOB_NAME_STARTED,
 				new JobParameters());
-		Assert.assertNotNull(jobExecution);
-		Assert.assertEquals(Long.valueOf(6), jobExecution.getId());
-		Assert.assertEquals(BatchStatus.STOPPING, jobExecution.getStatus());
+		Assertions.assertNotNull(jobExecution);
+		Assertions.assertEquals(Long.valueOf(6), jobExecution.getId());
+		Assertions.assertEquals(BatchStatus.STOPPING, jobExecution.getStatus());
 
 		mockMvc.perform(put("/jobs/executions/6").accept(MediaType.APPLICATION_JSON).param("stop", "true"))
 				.andExpect(status().isOk());
@@ -150,9 +150,9 @@ public class JobExecutionControllerTests {
 
 		final JobExecution jobExecution = jobRepository.getLastJobExecution(JobExecutionUtils.JOB_NAME_STOPPED,
 				new JobParameters());
-		Assert.assertNotNull(jobExecution);
-		Assert.assertEquals(Long.valueOf(7), jobExecution.getId());
-		Assert.assertEquals(BatchStatus.STOPPED, jobExecution.getStatus());
+		Assertions.assertNotNull(jobExecution);
+		Assertions.assertEquals(Long.valueOf(7), jobExecution.getId());
+		Assertions.assertEquals(BatchStatus.STOPPED, jobExecution.getStatus());
 
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
@@ -20,9 +20,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.commons.lang3.time.DateUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +38,6 @@ import org.springframework.cloud.task.batch.listener.TaskBatchDao;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
@@ -47,6 +45,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -55,7 +54,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
@@ -80,15 +78,17 @@ public class JobExecutionThinControllerTests {
 	@Autowired
 	private RequestMappingHandlerAdapter adapter;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = JobExecutionUtils.createBaseJobExecutionMockMvc(jobRepository, taskBatchDao,
 				dao, wac, adapter);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testJobExecutionThinControllerConstructorMissingRepository() {
-		new JobExecutionThinController(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new JobExecutionThinController(null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
@@ -19,9 +19,8 @@ package org.springframework.cloud.dataflow.server.controller;
 import java.util.ArrayList;
 import java.util.Date;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -41,13 +40,13 @@ import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -57,7 +56,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
@@ -89,7 +87,7 @@ public class JobInstanceControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -101,9 +99,11 @@ public class JobInstanceControllerTests {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testJobInstanceControllerConstructorMissingRepository() {
-		new JobInstanceController(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new JobInstanceController(null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobStepExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobStepExecutionControllerTests.java
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.Date;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -48,7 +47,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -56,6 +54,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -65,7 +64,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
@@ -108,7 +106,7 @@ public class JobStepExecutionControllerTests {
 	@Autowired
 	private RequestMappingHandlerAdapter adapter;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -127,9 +125,11 @@ public class JobStepExecutionControllerTests {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testJobStepExecutionControllerConstructorMissingRepository() {
-		new JobStepExecutionController(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new JobStepExecutionController(null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RootControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RootControllerTests.java
@@ -18,10 +18,9 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -30,7 +29,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.StreamUtils;
@@ -43,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TestDependencies.class })
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 public class RootControllerTests {
@@ -53,7 +50,7 @@ public class RootControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -68,6 +65,6 @@ public class RootControllerTests {
 				new DefaultResourceLoader().getResource("classpath:/root-controller-result.json").getInputStream(),
 				StandardCharsets.UTF_8);
 
-		Assert.assertEquals(expectedResult.replace("\n", ""), mvcResult);
+		Assertions.assertEquals(expectedResult.replace("\n", ""), mvcResult);
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeAppsControllerTests.java
@@ -22,9 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -45,7 +44,6 @@ import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -64,7 +62,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -84,7 +81,7 @@ public class RuntimeAppsControllerTests {
 	@Autowired
 	private SkipperClient skipperClient;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/RuntimeStreamsControllerTests.java
@@ -24,9 +24,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -48,7 +47,6 @@ import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -70,7 +68,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Daniel Serleg
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -90,7 +87,7 @@ public class RuntimeStreamsControllerTests {
 	@Autowired
 	private SkipperClient skipperClient;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() throws Exception {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -29,10 +29,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +72,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.client.RestClientException;
@@ -83,6 +81,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -109,7 +108,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Christian Tzolov
  * @author Daniel Serleg
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -137,7 +135,7 @@ public class StreamControllerTests {
 	@Autowired
 	private StreamDefinitionService streamDefinitionService;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -155,7 +153,7 @@ public class StreamControllerTests {
 		when(skipperClient.search(anyString(), eq(false))).thenReturn(new ArrayList<PackageMetadata>());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		repository.deleteAll();
 		auditRecordRepository.deleteAll();
@@ -163,9 +161,11 @@ public class StreamControllerTests {
 		assertThat(auditRecordRepository.count()).isZero();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testConstructorMissingStreamService() {
-		new StreamDefinitionController(null, null, null, null, null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new StreamDefinitionController(null, null, null, null, null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -24,11 +24,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -70,9 +68,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class StreamDeploymentControllerTests {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	private StreamDeploymentController controller;
 
 	@Mock
@@ -87,7 +82,7 @@ public class StreamDeploymentControllerTests {
 	@Mock
 	private Deployer deployer;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
@@ -101,7 +96,7 @@ public class StreamDeploymentControllerTests {
 		ArgumentCaptor<String> argumentCaptor1 = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<Map> argumentCaptor2 = ArgumentCaptor.forClass(Map.class);
 		verify(streamService).deployStream(argumentCaptor1.capture(), argumentCaptor2.capture());
-		Assert.assertEquals(argumentCaptor1.getValue(), "test");
+		Assertions.assertEquals(argumentCaptor1.getValue(), "test");
 	}
 
 	@Test
@@ -129,7 +124,7 @@ public class StreamDeploymentControllerTests {
 		this.controller.update("ticktock", updateStreamRequest);
 		ArgumentCaptor<UpdateStreamRequest> argumentCaptor1 = ArgumentCaptor.forClass(UpdateStreamRequest.class);
 		verify(streamService).updateStream(eq("ticktock"), argumentCaptor1.capture());
-		Assert.assertEquals(updateStreamRequest, argumentCaptor1.getValue());
+		Assertions.assertEquals(updateStreamRequest, argumentCaptor1.getValue());
 	}
 
 	@Test
@@ -150,8 +145,8 @@ public class StreamDeploymentControllerTests {
 		ArgumentCaptor<String> argumentCaptor1 = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<Integer> argumentCaptor2 = ArgumentCaptor.forClass(Integer.class);
 		verify(streamService).rollbackStream(argumentCaptor1.capture(), argumentCaptor2.capture());
-		Assert.assertEquals(argumentCaptor1.getValue(), "test1");
-		Assert.assertEquals("Rollback version is incorrect", 2, (int) argumentCaptor2.getValue());
+		Assertions.assertEquals(argumentCaptor1.getValue(), "test1");
+		Assertions.assertEquals(2, (int) argumentCaptor2.getValue(), "Rollback version is incorrect");
 	}
 
 	@Test
@@ -191,11 +186,11 @@ public class StreamDeploymentControllerTests {
 		when(this.streamDefinitionService.redactDsl(any())).thenReturn("time | log");
 
 		StreamDeploymentResource streamDeploymentResource = this.controller.info(streamDefinition.getName(), false);
-		Assert.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
-		Assert.assertEquals(streamDeploymentResource.getDslText(), streamDefinition.getDslText());
-		Assert.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
-		Assert.assertEquals("{\"log\":{\"test2\":\"value2\"},\"time\":{\"test1\":\"value1\"}}", streamDeploymentResource.getDeploymentProperties());
-		Assert.assertEquals(streamDeploymentResource.getStatus(), DeploymentState.deployed.name());
+		Assertions.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
+		Assertions.assertEquals(streamDeploymentResource.getDslText(), streamDefinition.getDslText());
+		Assertions.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
+		Assertions.assertEquals("{\"log\":{\"test2\":\"value2\"},\"time\":{\"test1\":\"value1\"}}", streamDeploymentResource.getDeploymentProperties());
+		Assertions.assertEquals(streamDeploymentResource.getStatus(), DeploymentState.deployed.name());
 	}
 
 	@Test
@@ -219,11 +214,11 @@ public class StreamDeploymentControllerTests {
 		when(this.streamDefinitionService.redactDsl(any())).thenReturn("time | log");
 
 		StreamDeploymentResource streamDeploymentResource = this.controller.info(streamDefinition.getName(), true);
-		Assert.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
-		Assert.assertEquals(streamDeploymentResource.getDslText(), streamDefinition.getDslText());
-		Assert.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
-		Assert.assertEquals("{\"log\":{\"test2\":\"value2\"},\"time\":{\"test1\":\"value1\"}}", streamDeploymentResource.getDeploymentProperties());
-		Assert.assertEquals(streamDeploymentResource.getStatus(), DeploymentState.undeployed.name());
+		Assertions.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
+		Assertions.assertEquals(streamDeploymentResource.getDslText(), streamDefinition.getDslText());
+		Assertions.assertEquals(streamDeploymentResource.getStreamName(), streamDefinition.getName());
+		Assertions.assertEquals("{\"log\":{\"test2\":\"value2\"},\"time\":{\"test1\":\"value1\"}}", streamDeploymentResource.getDeploymentProperties());
+		Assertions.assertEquals(streamDeploymentResource.getStatus(), DeploymentState.undeployed.name());
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamLogsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamLogsControllerTests.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -36,7 +35,6 @@ import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -49,7 +47,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -69,7 +66,7 @@ public class StreamLogsControllerTests {
 	@Autowired
 	private SkipperClient skipperClient;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -29,9 +29,8 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -63,7 +62,6 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -76,7 +74,8 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
@@ -98,7 +97,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -148,7 +146,7 @@ public class TaskControllerTests {
 
 	private static List<String> SAMPLE_CLEANSED_ARGUMENT_LIST;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -196,14 +194,18 @@ public class TaskControllerTests {
 		this.dataflowTaskExecutionMetadataDao.save(taskExecutionComplete, taskManifest);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskDefinitionControllerConstructorMissingRepository() {
-		new TaskDefinitionController(mock(TaskExplorer.class), null, taskSaveService, taskDeleteService, taskDefinitionAssemblerProvider);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskDefinitionController(mock(TaskExplorer.class), null, taskSaveService, taskDeleteService, taskDefinitionAssemblerProvider);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskDefinitionControllerConstructorMissingTaskExplorer() {
-		new TaskDefinitionController(null, mock(TaskDefinitionRepository.class), taskSaveService, taskDeleteService, taskDefinitionAssemblerProvider);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskDefinitionController(null, mock(TaskDefinitionRepository.class), taskSaveService, taskDeleteService, taskDefinitionAssemblerProvider);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.server.controller;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +31,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.dataflow.configuration.metadata.ApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -48,7 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Janne Valkealahti
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 public class TaskCtrControllerTests {
@@ -61,7 +58,7 @@ public class TaskCtrControllerTests {
 	@MockBean
 	private ApplicationConfigurationMetadataResolver metadataResolver;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -22,9 +22,8 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -57,7 +56,6 @@ import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -68,6 +66,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -83,7 +82,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author David Turanski
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class, PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -148,7 +146,7 @@ public class TaskExecutionControllerTests {
 	@Autowired
 	private TaskJobService taskJobService;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		Launcher launcher = new Launcher("default", "local", taskLauncher);
 		launcherRepository.save(launcher);
@@ -197,40 +195,52 @@ public class TaskExecutionControllerTests {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingExplorer() {
-		new TaskExecutionController(null, taskExecutionService, taskDefinitionRepository, taskExecutionInfoService,
-				taskDeleteService, taskJobService);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(null, taskExecutionService, taskDefinitionRepository, taskExecutionInfoService,
+					taskDeleteService, taskJobService);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingTaskService() {
-		new TaskExecutionController(taskExplorer, null, taskDefinitionRepository, taskExecutionInfoService,
-				taskDeleteService, taskJobService);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(taskExplorer, null, taskDefinitionRepository, taskExecutionInfoService,
+					taskDeleteService, taskJobService);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingTaskDefinitionRepository() {
-		new TaskExecutionController(taskExplorer, taskExecutionService, null, taskExecutionInfoService,
-				taskDeleteService, taskJobService);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(taskExplorer, taskExecutionService, null, taskExecutionInfoService,
+					taskDeleteService, taskJobService);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingTaskDefinitionRetriever() {
-		new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository, null,
-				taskDeleteService, taskJobService);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository, null,
+					taskDeleteService, taskJobService);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingDeleteTaskService() {
-		new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository,
-				taskExecutionInfoService, null, taskJobService);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository,
+					taskExecutionInfoService, null, taskJobService);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskExecutionControllerConstructorMissingDeleteTaskJobService() {
-		new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository,
-				taskExecutionInfoService, taskDeleteService, null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskExecutionController(taskExplorer, taskExecutionService, taskDefinitionRepository,
+					taskExecutionInfoService, taskDeleteService, null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskLogsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskLogsControllerTests.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
@@ -37,7 +36,6 @@ import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -49,7 +47,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { JobDependencies.class, PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -70,7 +67,7 @@ public class TaskLogsControllerTests {
 	@Autowired
 	private TaskPlatform taskPlatform;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		Launcher launcher = new Launcher("default", "local", taskLauncher);
 		launcherRepository.save(launcher);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskPlatformControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskPlatformControllerTests.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
@@ -35,12 +34,11 @@ import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -49,7 +47,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = {  JobDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class, BatchProperties.class })
 @EnableConfigurationProperties({ CommonApplicationProperties.class })
@@ -68,7 +65,7 @@ public class TaskPlatformControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -22,9 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -49,7 +48,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -57,7 +55,8 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -72,7 +71,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Glenn Renfro
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -99,15 +97,17 @@ public class TaskSchedulerControllerTests {
 
 	private MockMvc mockMvc;
 
-	@Before
+	@BeforeEach
 	public void setupMockMVC() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTaskSchedulerControllerConstructorMissingService() {
-		new TaskSchedulerController(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			new TaskSchedulerController(null);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TasksInfoControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TasksInfoControllerTests.java
@@ -22,9 +22,8 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
@@ -52,7 +51,6 @@ import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -65,7 +63,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = {JobDependencies.class, PropertyPlaceholderAutoConfiguration.class, BatchProperties.class})
 @EnableConfigurationProperties({CommonApplicationProperties.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -115,7 +112,7 @@ public class TasksInfoControllerTests {
     @Autowired
     private TaskDeploymentRepository taskDeploymentRepository;
 
-    @Before
+    @BeforeEach
     public void setupMockMVC() {
         Launcher launcher = new Launcher("default", "local", taskLauncher);
         launcherRepository.save(launcher);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/ToolsControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/ToolsControllerTests.java
@@ -15,9 +15,8 @@
  */
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -26,7 +25,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -40,7 +38,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Andy Clement
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)
@@ -51,7 +48,7 @@ public class ToolsControllerTests {
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/AbstractTaskDefinitionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/AbstractTaskDefinitionTests.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.TaskDefinition;
 import org.springframework.data.domain.Page;
@@ -28,9 +28,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Provides the tests required for exercising a TaskDefinitionRepository impl.
@@ -79,19 +80,23 @@ public abstract class AbstractTaskDefinitionTests {
 		assertEquals(page.getContent().size(), 3);
 	}
 
-	@Test(expected = DuplicateTaskException.class)
+	@Test
 	public void testSaveDuplicate() {
-		repository.save(new TaskDefinition("task1", "myTask"));
-		repository.save(new TaskDefinition("task1", "myTask"));
+		assertThrows(DuplicateTaskException.class, () -> {
+			repository.save(new TaskDefinition("task1", "myTask"));
+			repository.save(new TaskDefinition("task1", "myTask"));
+		});
 	}
 
-	@Test(expected = DuplicateTaskException.class)
+	@Test
 	public void testSaveAllDuplicate() {
-		List<TaskDefinition> definitions = new ArrayList<>();
-		definitions.add(new TaskDefinition("task1", "myTask"));
+		assertThrows(DuplicateTaskException.class, () -> {
+			List<TaskDefinition> definitions = new ArrayList<>();
+			definitions.add(new TaskDefinition("task1", "myTask"));
 
-		repository.save(new TaskDefinition("task1", "myTask"));
-		repository.saveAll(definitions);
+			repository.save(new TaskDefinition("task1", "myTask"));
+			repository.saveAll(definitions);
+		});
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDaoTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/JdbcDataflowTaskExecutionDaoTests.java
@@ -22,8 +22,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -32,11 +31,9 @@ import org.springframework.cloud.dataflow.server.configuration.TaskServiceDepend
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/SchemaGenerationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/SchemaGenerationTests.java
@@ -29,8 +29,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,12 +42,10 @@ import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = {
 		EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class
 })

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/TaskExecutionExplorerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/TaskExecutionExplorerTests.java
@@ -23,9 +23,8 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -38,14 +37,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -60,7 +57,7 @@ public class TaskExecutionExplorerTests {
 
 	private JdbcTemplate template;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		template = new JdbcTemplate(dataSource);
 		template.execute("DELETE FROM task_execution");
@@ -69,9 +66,9 @@ public class TaskExecutionExplorerTests {
 	@Test
 	public void testInitializer() throws Exception {
 		int actual = template.queryForObject("SELECT COUNT(*) from TASK_EXECUTION", Integer.class);
-		assertEquals("expected 0 entries returned from task_execution", 0, actual);
+		assertEquals(0, actual, "expected 0 entries returned from task_execution");
 		actual = template.queryForObject("SELECT COUNT(*) from TASK_EXECUTION_PARAMS", Integer.class);
-		assertEquals("expected 0 entries returned from task_execution_params", 0, actual);
+		assertEquals(0, actual, "expected 0 entries returned from task_execution_params");
 	}
 
 	@Test
@@ -83,8 +80,9 @@ public class TaskExecutionExplorerTests {
 		insertTestExecutionDataIntoRepo(template, 0L, "foo");
 
 		List<TaskExecution> resultList = explorer.findAll(PageRequest.of(0, 10)).getContent();
-		assertEquals(String.format("expected %s entries returned from task_execution", ENTRY_COUNT), ENTRY_COUNT,
-				resultList.size());
+		assertEquals(ENTRY_COUNT,
+				resultList.size(),
+				String.format("expected %s entries returned from task_execution", ENTRY_COUNT));
 		Map<Long, TaskExecution> actual = new HashMap<>();
 		for (int executionId = 0; executionId < ENTRY_COUNT; executionId++) {
 			TaskExecution taskExecution = resultList.get(executionId);
@@ -92,8 +90,8 @@ public class TaskExecutionExplorerTests {
 		}
 		for (long executionId = 0; executionId < ENTRY_COUNT; executionId++) {
 			TaskExecution taskExecution = actual.get(executionId);
-			assertEquals("expected execution id does not match actual", executionId, taskExecution.getExecutionId());
-			assertEquals("expected taskName does not match actual", "foo", taskExecution.getTaskName());
+			assertEquals(executionId, taskExecution.getExecutionId(), "expected execution id does not match actual");
+			assertEquals("foo", taskExecution.getTaskName(), "expected taskName does not match actual");
 		}
 
 	}
@@ -106,10 +104,10 @@ public class TaskExecutionExplorerTests {
 		insertTestExecutionDataIntoRepo(template, 0L, "fee");
 
 		List<TaskExecution> resultList = explorer.findTaskExecutionsByName("fee", PageRequest.of(0, 10)).getContent();
-		assertEquals("expected 1 entries returned from task_execution", 1, resultList.size());
+		assertEquals(1, resultList.size(), "expected 1 entries returned from task_execution");
 		TaskExecution taskExecution = resultList.get(0);
-		assertEquals("expected execution id does not match actual", 0, taskExecution.getExecutionId());
-		assertEquals("expected taskName does not match actual", "fee", taskExecution.getTaskName());
+		assertEquals(0, taskExecution.getExecutionId(), "expected execution id does not match actual");
+		assertEquals("fee", taskExecution.getTaskName(), "expected taskName does not match actual");
 	}
 
 	private void insertTestExecutionDataIntoRepo(JdbcTemplate template, long id, String taskName) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageableTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/support/SearchPageableTests.java
@@ -16,7 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.repository.support;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.data.domain.PageRequest;
 
@@ -24,10 +25,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Gunnar Hillert
@@ -128,14 +128,14 @@ public class SearchPageableTests {
 		final PageRequest pageable = PageRequest.of(1, 5);
 		final SearchPageable searchPageable = new SearchPageable(pageable, "findByTaskNameContains query");
 
-		assertThat(searchPageable.getColumns(), is(empty()));
+		MatcherAssert.assertThat(searchPageable.getColumns(), is(empty()));
 		assertNotNull(searchPageable.getPageable());
 		assertEquals(searchPageable.getSearchQuery(), "findByTaskNameContains query");
 
 		searchPageable.addColumns("c1", "c2");
 
-		assertThat(searchPageable.getColumns(), hasSize(2));
-		assertThat(searchPageable.getColumns(), contains("c1", "c2"));
+		MatcherAssert.assertThat(searchPageable.getColumns(), hasSize(2));
+		MatcherAssert.assertThat(searchPageable.getColumns(), contains("c1", "c2"));
 
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreatorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/AppDeploymentRequestCreatorTests.java
@@ -18,12 +18,11 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.util.HashMap;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsMapContaining;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.cloud.dataflow.configuration.metadata.BootApplicationConfigurationMetadataResolver;
 import org.springframework.cloud.dataflow.configuration.metadata.container.ContainerImageMetadataResolver;
@@ -35,24 +34,23 @@ import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationPr
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Ilayaperumal Gopinathan
  * @author Eric Bottard
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class AppDeploymentRequestCreatorTests {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	private AppDeploymentRequestCreator appDeploymentRequestCreator;
 
-	@Before
+	@BeforeEach
 	public void setupMock() {
 		this.appDeploymentRequestCreator = new AppDeploymentRequestCreator(mock(AppRegistryService.class),
 				mock(CommonApplicationProperties.class),
@@ -70,8 +68,8 @@ public class AppDeploymentRequestCreatorTests {
 		AppDefinition modified = this.appDeploymentRequestCreator.mergeAndExpandAppProperties(appDefinition, app,
 				new HashMap<>());
 
-		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.timezone", "GMT+2"));
-		org.junit.Assert.assertThat(modified.getProperties(), not(IsMapContaining.hasKey("timezone")));
+		MatcherAssert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.timezone", "GMT+2"));
+		MatcherAssert.assertThat(modified.getProperties(), not(IsMapContaining.hasKey("timezone")));
 	}
 
 	@Test
@@ -84,24 +82,22 @@ public class AppDeploymentRequestCreatorTests {
 		AppDefinition modified = this.appDeploymentRequestCreator.mergeAndExpandAppProperties(appDefinition, app,
 				new HashMap<>());
 
-		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.format", "yy"));
-		org.junit.Assert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("time.format", "hh"));
+		MatcherAssert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("date.format", "yy"));
+		MatcherAssert.assertThat(modified.getProperties(), IsMapContaining.hasEntry("time.format", "hh"));
 	}
 
 	@Test
 	public void testSameNamePropertiesKOWhenShorthand() {
-		StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
-				.setApplicationType(ApplicationType.app)
-				.setProperty("format", "hh").build("streamname");
+		Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+			StreamAppDefinition appDefinition = new StreamAppDefinition.Builder().setRegisteredAppName("my-app")
+					.setApplicationType(ApplicationType.app)
+					.setProperty("format", "hh").build("streamname");
 
-		Resource app = new ClassPathResource("/apps/included-source");
+			Resource app = new ClassPathResource("/apps/included-source");
 
-		thrown.expect(IllegalArgumentException.class);
-		thrown.expectMessage("Ambiguous short form property 'format'");
-		thrown.expectMessage("date.format");
-		thrown.expectMessage("time.format");
-
-		this.appDeploymentRequestCreator.mergeAndExpandAppProperties(appDefinition, app, new HashMap<>());
+			this.appDeploymentRequestCreator.mergeAndExpandAppProperties(appDefinition, app, new HashMap<>());
+		});
+		assertTrue(exception.getMessage().contains("time.format"));
 	}
 
 	@Test
@@ -115,7 +111,7 @@ public class AppDeploymentRequestCreatorTests {
 		AppDefinition modified = this.appDeploymentRequestCreator.mergeAndExpandAppProperties(appDefinition, app,
 				new HashMap<>());
 
-		org.junit.Assert.assertThat(modified.getProperties(),
+		MatcherAssert.assertThat(modified.getProperties(),
 				IsMapContaining.hasEntry("date.some-long-property", "yy"));
 
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceMultiplatformTests.java
@@ -26,10 +26,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -67,18 +66,17 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class,
 		DefaultSchedulerServiceMultiplatformTests.MultiplatformTaskConfiguration.class,
 		PropertyPlaceholderAutoConfiguration.class }, properties = {
@@ -147,7 +145,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 
 	List<String> commandLineArgs;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception{
 		this.appRegistry.save("demo", ApplicationType.task, "1.0.0.", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
 		this.appRegistry.save("demo2", ApplicationType.task, "1.0.0", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
@@ -165,7 +163,7 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		this.commandLineArgs = new ArrayList<>();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		((SimpleTestScheduler)simpleTestScheduler).getSchedules().clear();
 	}
@@ -176,11 +174,13 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
-		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
-				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
-				this.commandLineArgs, null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
+					"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
+					this.commandLineArgs, null);
+		});
 	}
 
 	@Test
@@ -218,12 +218,14 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME));
 	}
 
-	@Test(expected = CreateScheduleException.class)
+	@Test
 	public void testDuplicate(){
-		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
-		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+		assertThrows(CreateScheduleException.class, () -> {
+			schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
+					this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+			schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
+					this.testProperties, this.commandLineArgs, KUBERNETES_PLATFORM);
+		});
 	}
 
 	@Test
@@ -328,14 +330,18 @@ public class DefaultSchedulerServiceMultiplatformTests {
 		assertThat(schedules.size()).isEqualTo(MAX_COUNT);
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testListPaginated() {
-		schedulerService.list(PageRequest.of(0, 1), null);
+		assertThrows(UnsupportedOperationException.class, () -> {
+			schedulerService.list(PageRequest.of(0, 1), null);
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testListWithParamsPaginated() {
-		schedulerService.list(PageRequest.of(0, 1), BASE_DEFINITION_NAME);
+		assertThrows(UnsupportedOperationException.class, () -> {
+			schedulerService.list(PageRequest.of(0, 1), BASE_DEFINITION_NAME);
+		});
 	}
 
 	@Test
@@ -366,18 +372,18 @@ public class DefaultSchedulerServiceMultiplatformTests {
 	public void testScheduleWithCommandLineArguments() throws Exception{
 		List<String> commandLineArguments = getCommandLineArguments(Arrays.asList("--myArg1", "--myArg2"));
 
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 2, commandLineArguments.size());
-		assertEquals("Invalid command line argument", "--myArg1", commandLineArguments.get(0));
-		assertEquals("Invalid command line argument", "--myArg2", commandLineArguments.get(1));
+		assertNotNull(commandLineArguments, "Command line arguments should not be null");
+		assertEquals(2, commandLineArguments.size(), "Invalid number of command line arguments");
+		assertEquals("--myArg1", commandLineArguments.get(0), "Invalid command line argument");
+		assertEquals("--myArg2", commandLineArguments.get(1), "Invalid command line argument");
 	}
 
 	@Test
 	public void testScheduleWithoutCommandLineArguments() throws Exception {
 		List<String> commandLineArguments = getCommandLineArguments(new ArrayList<>());
 
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 0, commandLineArguments.size());
+		assertNotNull(commandLineArguments, "Command line arguments should not be null");
+		assertEquals(0, commandLineArguments.size(), "Invalid number of command line arguments");
 	}
 
 	private List<String> getCommandLineArguments(List<String> commandLineArguments) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -26,10 +26,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -66,18 +65,17 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class,
 		PropertyPlaceholderAutoConfiguration.class }, properties = {
 		"spring.cloud.dataflow.applicationProperties.task.globalkey=globalvalue",
@@ -143,7 +141,7 @@ public class DefaultSchedulerServiceTests {
 
 	List<String> commandLineArgs;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception{
 		this.appRegistry.save("demo", ApplicationType.task, "1.0.0.", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
 		this.appRegistry.save("demo2", ApplicationType.task, "1.0.0", new URI("file:src/test/resources/apps/foo-task"), new URI("file:src/test/resources/apps/foo-task"));
@@ -161,7 +159,7 @@ public class DefaultSchedulerServiceTests {
 		this.commandLineArgs = new ArrayList<>();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		((SimpleTestScheduler)simpleTestScheduler).getSchedules().clear();
 	}
@@ -172,11 +170,13 @@ public class DefaultSchedulerServiceTests {
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testScheduleWithLongNameOnKuberenetesPlatform() {
-		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
-				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
-				this.commandLineArgs, null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
+					"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
+					this.commandLineArgs, null);
+		});
 	}
 
 	@Test
@@ -214,12 +214,14 @@ public class DefaultSchedulerServiceTests {
 		verifyScheduleExistsInScheduler(createScheduleInfo(BASE_SCHEDULE_NAME, CTR_DEFINITION_NAME));
 	}
 
-	@Test(expected = CreateScheduleException.class)
+	@Test
 	public void testDuplicate(){
-		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs);
-		schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
-				this.testProperties, this.commandLineArgs);
+		assertThrows(CreateScheduleException.class, () -> {
+			schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
+					this.testProperties, this.commandLineArgs);
+			schedulerService.schedule(BASE_SCHEDULE_NAME + 1, BASE_DEFINITION_NAME,
+					this.testProperties, this.commandLineArgs);
+		});
 	}
 
 	@Test
@@ -325,14 +327,18 @@ public class DefaultSchedulerServiceTests {
 		assertThat(schedules.size()).isEqualTo(MAX_COUNT);
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testListPaginated() {
-		schedulerService.list(PageRequest.of(0, 1));
+		assertThrows(UnsupportedOperationException.class, () -> {
+			schedulerService.list(PageRequest.of(0, 1));
+		});
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testListWithParamsPaginated() {
-		schedulerService.list(PageRequest.of(0, 1), BASE_DEFINITION_NAME);
+		assertThrows(UnsupportedOperationException.class, () -> {
+			schedulerService.list(PageRequest.of(0, 1), BASE_DEFINITION_NAME);
+		});
 	}
 
 	@Test
@@ -363,18 +369,18 @@ public class DefaultSchedulerServiceTests {
 	public void testScheduleWithCommandLineArguments() throws Exception{
 		List<String> commandLineArguments = getCommandLineArguments(Arrays.asList("--myArg1", "--myArg2"));
 
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 2, commandLineArguments.size());
-		assertEquals("Invalid command line argument", "--myArg1", commandLineArguments.get(0));
-		assertEquals("Invalid command line argument", "--myArg2", commandLineArguments.get(1));
+		assertNotNull(commandLineArguments, "Command line arguments should not be null");
+		assertEquals(2, commandLineArguments.size(), "Invalid number of command line arguments");
+		assertEquals("--myArg1", commandLineArguments.get(0), "Invalid command line argument");
+		assertEquals("--myArg2", commandLineArguments.get(1), "Invalid command line argument");
 	}
 
 	@Test
 	public void testScheduleWithoutCommandLineArguments() throws Exception {
 		List<String> commandLineArguments = getCommandLineArguments(new ArrayList<>());
 
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 0, commandLineArguments.size());
+		assertNotNull(commandLineArguments, "Command line arguments should not be null");
+		assertEquals(0, commandLineArguments.size(), "Invalid number of command line arguments");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests.java
@@ -23,10 +23,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -61,11 +60,10 @@ import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -78,7 +76,6 @@ import static org.mockito.Mockito.when;
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @TestPropertySource(properties = { "spring.main.banner-mode=off"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -97,13 +94,13 @@ public class DefaultStreamServiceIntegrationTests {
 	@MockBean
 	private SkipperClient skipperClient;
 
-	@Before
+	@BeforeEach
 	public void before() throws URISyntaxException {
 		createTickTock();
 		this.skipperClient = MockUtils.configureMock(this.skipperClient);
 	}
 
-	@After
+	@AfterEach
 	public void destroyStream() {
 		when(this.skipperClient.search(anyString(), anyBoolean())).thenReturn(Arrays.asList(new PackageMetadata()));
 		streamService.undeployStream("ticktock");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -22,8 +22,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -43,7 +42,6 @@ import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.support.PlatformUtils;
 import org.springframework.cloud.dataflow.server.support.TestResourceUtils;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +53,6 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Ilayaperumal Gopinathan
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpgradeStreamTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpgradeStreamTests.java
@@ -17,8 +17,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -34,7 +33,6 @@ import org.springframework.cloud.dataflow.server.service.StreamService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.support.PlatformUtils;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,7 +43,6 @@ import static org.mockito.Mockito.when;
  * @author Mark Pollack
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase(replace = Replace.ANY)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTransactionTests.java
@@ -25,11 +25,8 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -66,9 +63,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -78,15 +74,11 @@ import static org.mockito.Mockito.when;
  * @author Glenn Renfro
  * @author Gunnar Hillert
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 @AutoConfigureTestDatabase(replace = Replace.ANY)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class DefaultTaskExecutionServiceTransactionTests {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	private final static String BASE_TASK_NAME = "myTask";
 
@@ -139,7 +131,7 @@ public class DefaultTaskExecutionServiceTransactionTests {
 
 	private TaskExecutionService transactionTaskService;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.launcherRepository.save(new Launcher("default", "local", new TaskLauncherStub(dataSource)));
 		this.taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -27,9 +27,8 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.batch.core.BatchStatus;
@@ -61,10 +60,9 @@ import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.core.io.FileUrlResource;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
@@ -72,7 +70,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = {TaskServiceDependencies.class, JobDependencies.class, BatchProperties.class}, properties = {
 		"spring.main.allow-bean-definition-overriding=true"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
@@ -116,7 +113,7 @@ public class DefaultTaskJobServiceTests {
 
 	private JobParameters jobParameters;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		Map<String, JobParameter> jobParameterMap = new HashMap<>();
 		jobParameterMap.put("identifying.param", new JobParameter("testparam"));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
@@ -21,9 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.cloud.dataflow.core.TaskDefinition;
@@ -35,10 +33,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
@@ -49,9 +47,6 @@ import static org.mockito.Mockito.mock;
  */
 public class TaskServiceUtilsTests {
 	public static final String BASE_GRAPH = "AAA && BBB";
-
-	@Rule
-	public ExpectedException expectedException;
 
 	@Test
 	public void testCreateComposedTaskDefinition() {
@@ -210,26 +205,26 @@ public class TaskServiceUtilsTests {
 		Map<String, String> appDeploymentProperties = new HashMap<>();
 		TaskServiceUtils.updateDataFlowUriIfNeeded(DATA_FLOW_SERVICE_URI, appDeploymentProperties, cmdLineArgs);
 		assertTrue(appDeploymentProperties.containsKey("dataflowServerUri"));
-		assertTrue("dataflowServerUri is expected to be in the app deployment properties",
-				appDeploymentProperties.get("dataflowServerUri").equals("https://myserver:9191"));
+		assertTrue(appDeploymentProperties.get("dataflowServerUri").equals("https://myserver:9191"),
+				"dataflowServerUri is expected to be in the app deployment properties");
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("dataflow-server-uri", "http://localhost:8080");
 		TaskServiceUtils.updateDataFlowUriIfNeeded(DATA_FLOW_SERVICE_URI, appDeploymentProperties, cmdLineArgs);
 		assertTrue(!appDeploymentProperties.containsKey("dataflowServerUri"));
-		assertTrue("dataflowServerUri is incorrect",
-				appDeploymentProperties.get("dataflow-server-uri").equals("http://localhost:8080"));
+		assertTrue(appDeploymentProperties.get("dataflow-server-uri").equals("http://localhost:8080"),
+				"dataflowServerUri is incorrect");
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("dataflowServerUri", "http://localhost:8191");
 		TaskServiceUtils.updateDataFlowUriIfNeeded(DATA_FLOW_SERVICE_URI, appDeploymentProperties, cmdLineArgs);
 		assertTrue(appDeploymentProperties.containsKey("dataflowServerUri"));
-		assertTrue("dataflowServerUri is incorrect",
-				appDeploymentProperties.get("dataflowServerUri").equals("http://localhost:8191"));
+		assertTrue(appDeploymentProperties.get("dataflowServerUri").equals("http://localhost:8191"),
+				"dataflowServerUri is incorrect");
 		appDeploymentProperties.clear();
 		appDeploymentProperties.put("DATAFLOW_SERVER_URI", "http://localhost:9000");
 		TaskServiceUtils.updateDataFlowUriIfNeeded(DATA_FLOW_SERVICE_URI, appDeploymentProperties, cmdLineArgs);
 		assertTrue(!appDeploymentProperties.containsKey("dataflowServerUri"));
-		assertTrue("dataflowServerUri is incorrect",
-				appDeploymentProperties.get("DATAFLOW_SERVER_URI").equals("http://localhost:9000"));
+		assertTrue(appDeploymentProperties.get("DATAFLOW_SERVER_URI").equals("http://localhost:9000"),
+				"dataflowServerUri is incorrect");
 		appDeploymentProperties.clear();
 		cmdLineArgs.add("--dataflowServerUri=http://localhost:8383");
 		TaskServiceUtils.updateDataFlowUriIfNeeded(DATA_FLOW_SERVICE_URI, appDeploymentProperties, cmdLineArgs);
@@ -253,10 +248,10 @@ public class TaskServiceUtilsTests {
 
 		String imagePullSecretPropertyKey = "deployer.composed-task-runner.kubernetes.imagePullSecret";
 
-		assertTrue("Task deployment properties are missing composed task runner imagePullSecret",
-				taskDeploymentProperties.containsKey(imagePullSecretPropertyKey));
+		assertTrue(taskDeploymentProperties.containsKey(imagePullSecretPropertyKey),
+				"Task deployment properties are missing composed task runner imagePullSecret");
 
-		assertEquals("Invalid imagePullSecret", "regcred", taskDeploymentProperties.get(imagePullSecretPropertyKey));
+		assertEquals("regcred", taskDeploymentProperties.get(imagePullSecretPropertyKey), "Invalid imagePullSecret");
 	}
 
 	@Test
@@ -270,7 +265,7 @@ public class TaskServiceUtilsTests {
 		String uri = TaskServiceUtils.getComposedTaskLauncherUri(taskConfigurationProperties,
 				composedTaskRunnerConfigurationProperties);
 
-		assertEquals("Invalid task runner URI string", "docker://something", uri);
+		assertEquals("docker://something", uri, "Invalid task runner URI string");
 	}
 
 	@Test
@@ -282,7 +277,7 @@ public class TaskServiceUtilsTests {
 		String uri = TaskServiceUtils.getComposedTaskLauncherUri(new TaskConfigurationProperties(),
 				composedTaskRunnerConfigurationProperties);
 
-		assertEquals("Invalid task runner URI string", "docker://something", uri);
+		assertEquals("docker://something", uri, "Invalid task runner URI string");
 	}
 
 	@Test
@@ -298,15 +293,15 @@ public class TaskServiceUtilsTests {
 		String uri = TaskServiceUtils.getComposedTaskLauncherUri(taskConfigurationProperties,
 				composedTaskRunnerConfigurationProperties);
 
-		assertEquals("Invalid task runner URI string", "gcr.io://something", uri);
+		assertEquals("gcr.io://something", uri, "Invalid task runner URI string");
 	}
 
 	@Test
 	public void testImagePullSecretNullCTRProperties() {
 		Map<String, String> taskDeploymentProperties = new HashMap<>();
 		TaskServiceUtils.addImagePullSecretProperty(taskDeploymentProperties, null);
-		assertFalse("Task deployment properties should not contain imagePullSecret",
-				taskDeploymentProperties.containsKey("deployer.composed-task-runner.kubernetes.imagePullSecret"));
+		assertFalse(taskDeploymentProperties.containsKey("deployer.composed-task-runner.kubernetes.imagePullSecret"),
+				"Task deployment properties should not contain imagePullSecret");
 	}
 
 	@Test
@@ -317,7 +312,7 @@ public class TaskServiceUtilsTests {
 
 		boolean result = TaskServiceUtils.isUseUserAccessToken(null, composedTaskRunnerConfigurationProperties);
 
-		assertTrue("Use user access token should be true", result);
+		assertTrue(result, "Use user access token should be true");
 	}
 
 	@Test
@@ -328,7 +323,7 @@ public class TaskServiceUtilsTests {
 
 		boolean result = TaskServiceUtils.isUseUserAccessToken(null, composedTaskRunnerConfigurationProperties);
 
-		assertFalse("Use user access token should be false", result);
+		assertFalse(result, "Use user access token should be false");
 	}
 
 	@Test
@@ -338,7 +333,7 @@ public class TaskServiceUtilsTests {
 
 		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
 
-		assertFalse("Use user access token should be false", result);
+		assertFalse(result, "Use user access token should be false");
 	}
 
 	@Test
@@ -349,7 +344,7 @@ public class TaskServiceUtilsTests {
 
 		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
 
-		assertTrue("Use user access token should be true", result);
+		assertTrue(result, "Use user access token should be true");
 	}
 
 	@Test
@@ -359,7 +354,7 @@ public class TaskServiceUtilsTests {
 
 		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
 
-		assertFalse("Use user access token should be false", result);
+		assertFalse(result, "Use user access token should be false");
 	}
 
 	private TaskNode parse(String dsltext) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiffTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/PropertiesDiffTests.java
@@ -19,7 +19,7 @@ package org.springframework.cloud.dataflow.server.service.impl.diff;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.server.service.impl.diff.PropertiesDiff.PropertyChange;
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/diff/TaskAnalyzerTests.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.TaskManifest;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/validation/DefaultAppValidationServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/validation/DefaultAppValidationServiceTests.java
@@ -21,8 +21,8 @@ import java.net.URI;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -43,17 +43,15 @@ import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class }, properties = {
 		"spring.main.allow-bean-definition-overriding=true" })
 @EnableConfigurationProperties({ CommonApplicationProperties.class, TaskConfigurationProperties.class,
@@ -97,7 +95,7 @@ public class DefaultAppValidationServiceTests {
 	@Test
 	@DirtiesContext
 	public void validateDockerTest() {
-		org.junit.Assume.assumeTrue(dockerCheck());
+		Assumptions.assumeTrue(dockerCheck());
 		initializeDockerRegistry(appRegistry, "springcloudstream/log-sink-rabbit:latest");
 		assertTrue(appValidationService.validate("AAA", ApplicationType.task));
 	}
@@ -105,7 +103,7 @@ public class DefaultAppValidationServiceTests {
 	@Test
 	@DirtiesContext
 	public void validateDockerMultiPageTest() {
-		org.junit.Assume.assumeTrue(dockerCheck());
+		Assumptions.assumeTrue(dockerCheck());
 		initializeDockerRegistry(appRegistry, "springcloudstream/log-sink-rabbit:1.3.1.RELEASE");
 		assertTrue(appValidationService.validate("AAA", ApplicationType.task));
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/ResourceUtilsTests.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.dataflow.server.stream;
 
 import java.net.MalformedURLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.registry.support.AppResourceCommon;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -27,6 +27,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mark Pollack
@@ -64,10 +65,12 @@ public class ResourceUtilsTests {
 		assertThat(appResourceService.getResourceVersion(dockerResource)).isEqualTo("current");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidDockerResourceProcessing() {
-		DockerResource dockerResource = new DockerResource("springcloudstream:file-source-kafka-10:1.2.0.RELEASE");
-		appResourceService.getResourceWithoutVersion(dockerResource);
+		assertThrows(IllegalArgumentException.class, () -> {
+			DockerResource dockerResource = new DockerResource("springcloudstream:file-source-kafka-10:1.2.0.RELEASE");
+			appResourceService.getResourceWithoutVersion(dockerResource);
+		});
 	}
 
 	@Test
@@ -85,9 +88,11 @@ public class ResourceUtilsTests {
 		assertThat(appResourceService.getResourceVersion(resource)).isEqualTo("1.2.0.RELEASE");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testFileResourceWithoutVersion() throws MalformedURLException {
-		Resource resource = new UrlResource("https://springcloudstream/filesourcekafkacrap.jar");
-		assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("https://springcloudstream/filesourcekafkacrap.jar");
+		assertThrows(IllegalArgumentException.class, () -> {
+			Resource resource = new UrlResource("https://springcloudstream/filesourcekafkacrap.jar");
+			assertThat(appResourceService.getResourceWithoutVersion(resource)).isEqualTo("https://springcloudstream/filesourcekafkacrap.jar");
+		});
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/stream/SkipperStreamDeployerTests.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
@@ -62,8 +62,9 @@ import org.springframework.cloud.skipper.domain.VersionInfo;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.util.StreamUtils;
 
-import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -238,16 +239,18 @@ public class SkipperStreamDeployerTests {
 		verify(appRegistryService, times(1)).appExist(eq("log"), eq(ApplicationType.sink), eq("1.2.0.RELEASE"));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testDeployWithNotRegisteredApps() {
-		AppRegistryService appRegistryService = mock(AppRegistryService.class);
+		assertThrows(IllegalStateException.class, () -> {
+			AppRegistryService appRegistryService = mock(AppRegistryService.class);
 
-		when(appRegistryService.appExist(eq("time"), eq(ApplicationType.source), eq("1.2.0.RELEASE")))
-				.thenReturn(true);
-		when(appRegistryService.appExist(eq("log"), eq(ApplicationType.sink), eq("1.2.0.RELEASE")))
-				.thenReturn(false);
+			when(appRegistryService.appExist(eq("time"), eq(ApplicationType.source), eq("1.2.0.RELEASE")))
+					.thenReturn(true);
+			when(appRegistryService.appExist(eq("log"), eq(ApplicationType.sink), eq("1.2.0.RELEASE")))
+					.thenReturn(false);
 
-		testAppRegisteredOnStreamDeploy(appRegistryService);
+			testAppRegisteredOnStreamDeploy(appRegistryService);
+		});
 	}
 
 	private void testAppRegisteredOnStreamDeploy(AppRegistryService appRegistryService) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
@@ -22,9 +22,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
@@ -42,7 +42,7 @@ public class ArgumentSanitizerTest {
 	private static final String[] keys = { "password", "secret", "key", "token", ".*credentials.*",
 			"vcap_services", "url" };
 
-	@Before
+	@BeforeEach
 	public void before() {
 		sanitizer = new ArgumentSanitizer();
 	}
@@ -50,8 +50,8 @@ public class ArgumentSanitizerTest {
 	@Test
 	public void testSanitizeProperties() {
 		for (String key : keys) {
-			Assert.assertEquals("--" + key + "=******", sanitizer.sanitize("--" + key + "=foo"));
-			Assert.assertEquals("******", sanitizer.sanitize(key, "bar"));
+			Assertions.assertEquals("--" + key + "=******", sanitizer.sanitize("--" + key + "=foo"));
+			Assertions.assertEquals("******", sanitizer.sanitize(key, "bar"));
 		}
 	}
 
@@ -74,19 +74,19 @@ public class ArgumentSanitizerTest {
 		JobParameters sanitizedJobParameters = this.sanitizer.sanitizeJobParameters(jobParameters);
 		for(Map.Entry<String, JobParameter> entry : sanitizedJobParameters.getParameters().entrySet()) {
 			if (entry.getKey().equals("username") || entry.getKey().equals("password")) {
-				Assert.assertEquals("******", entry.getValue().getValue());
+				Assertions.assertEquals("******", entry.getValue().getValue());
 			}
 			else if (entry.getKey().equals("name")) {
-				Assert.assertEquals("baz", entry.getValue().getValue());
+				Assertions.assertEquals("baz", entry.getValue().getValue());
 			}
 			else if (entry.getKey().equals("C")) {
-				Assert.assertEquals(1L, entry.getValue().getValue());
+				Assertions.assertEquals(1L, entry.getValue().getValue());
 			}
 			else if (entry.getKey().equals("D")) {
-				Assert.assertEquals(1D, entry.getValue().getValue());
+				Assertions.assertEquals(1D, entry.getValue().getValue());
 			}
 			else if (entry.getKey().equals("E")) {
-				Assert.assertEquals(testDate, entry.getValue().getValue());
+				Assertions.assertEquals(testDate, entry.getValue().getValue());
 			}
 		}
 	}
@@ -94,21 +94,21 @@ public class ArgumentSanitizerTest {
 	@Test
 	public void testSanitizeTaskDefinition() {
 		TaskDefinition taskDefinition = new TaskDefinition("mytask", "task1 --some.password=foobar --another-secret=kenny");
-		Assert.assertEquals("task1 --some.password='******' --another-secret='******'", this.sanitizer.sanitizeTaskDsl(taskDefinition));
+		Assertions.assertEquals("task1 --some.password='******' --another-secret='******'", this.sanitizer.sanitizeTaskDsl(taskDefinition));
 	}
 
 
 	@Test
 	public void testSanitizeComposedTaskDefinition() {
 		TaskDefinition taskDefinition = new TaskDefinition("mytask", "task1 --some.password=foobar && task2 --some.password=woof");
-		Assert.assertEquals("task1 --some.password='******' && task2 --some.password='******'", this.sanitizer.sanitizeTaskDsl(taskDefinition));
+		Assertions.assertEquals("task1 --some.password='******' && task2 --some.password='******'", this.sanitizer.sanitizeTaskDsl(taskDefinition));
 	}
 
 	@Test
 	public void testSanitizeComposedTaskSplitDefinition() {
 		TaskDefinition taskDefinition = new TaskDefinition(
 				"mytask", "<task1 --some.password=foobar || task2 --some.password=woof> && task3  --some.password=foobar");
-		Assert.assertEquals(
+		Assertions.assertEquals(
 				"<task1 --some.password='******' || task2 --some.password='******'> && task3 --some.password='******'",
 				this.sanitizer.sanitizeTaskDsl(taskDefinition));
 	}
@@ -123,11 +123,11 @@ public class ArgumentSanitizerTest {
 
 		final List<String> sanitizedArguments = sanitizer.sanitizeArguments(arguments);
 
-		Assert.assertEquals(keys.length, sanitizedArguments.size());
+		Assertions.assertEquals(keys.length, sanitizedArguments.size());
 
 		int order = 0;
 		for(String sanitizedString : sanitizedArguments) {
-			Assert.assertEquals("--" + keys[order] + "=******", sanitizedString);
+			Assertions.assertEquals("--" + keys[order] + "=******", sanitizedString);
 			order++;
 		}
 	}
@@ -135,9 +135,9 @@ public class ArgumentSanitizerTest {
 
 	@Test
 	public void testMultipartProperty() {
-		Assert.assertEquals("--password=******", sanitizer.sanitize("--password=boza"));
-		Assert.assertEquals("--one.two.password=******", sanitizer.sanitize("--one.two.password=boza"));
-		Assert.assertEquals("--one_two_password=******", sanitizer.sanitize("--one_two_password=boza"));
+		Assertions.assertEquals("--password=******", sanitizer.sanitize("--password=boza"));
+		Assertions.assertEquals("--one.two.password=******", sanitizer.sanitize("--one.two.password=boza"));
+		Assertions.assertEquals("--one_two_password=******", sanitizer.sanitize("--one_two_password=boza"));
 	}
 
 //	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TaskSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/TaskSanitizerTest.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.core.TaskManifest;
 import org.springframework.cloud.dataflow.rest.util.TaskSanitizer;
@@ -48,8 +48,8 @@ public class TaskSanitizerTest {
 		taskExecution.setTaskName("a1");
 		taskExecution.setArguments(Arrays.asList("--username=test", "--password=testing"));
 		TaskExecution sanitizedTaskExecution = this.taskSanitizer.sanitizeTaskExecutionArguments(taskExecution);
-		Assert.assertEquals("--username=******", sanitizedTaskExecution.getArguments().get(0));
-		Assert.assertEquals("--password=******", sanitizedTaskExecution.getArguments().get(1));
+		Assertions.assertEquals("--username=******", sanitizedTaskExecution.getArguments().get(0));
+		Assertions.assertEquals("--password=******", sanitizedTaskExecution.getArguments().get(1));
 	}
 
 	@Test
@@ -69,13 +69,13 @@ public class TaskSanitizerTest {
 		taskManifest.setTaskDeploymentRequest(appDeploymentRequest);
 		TaskManifest sanitizedTaskManifest = this.taskSanitizer.sanitizeTaskManifest(taskManifest);
 		List<String> commandLineArgs = sanitizedTaskManifest.getTaskDeploymentRequest().getCommandlineArguments();
-		Assert.assertEquals("--username=******", commandLineArgs.get(0));
-		Assert.assertEquals("--password=******", commandLineArgs.get(1));
+		Assertions.assertEquals("--username=******", commandLineArgs.get(0));
+		Assertions.assertEquals("--password=******", commandLineArgs.get(1));
 		Map<String, String> deploymentProps = sanitizedTaskManifest.getTaskDeploymentRequest().getDeploymentProperties();
-		Assert.assertEquals("******", sanitizedTaskManifest.getTaskDeploymentRequest().getDefinition().getProperties().get("secret"));
-		Assert.assertEquals("******", sanitizedTaskManifest.getTaskDeploymentRequest().getDefinition().getProperties().get("user.key"));
-		Assert.assertEquals("******", deploymentProps.get("secret"));
-		Assert.assertEquals("******", deploymentProps.get("user.key"));
+		Assertions.assertEquals("******", sanitizedTaskManifest.getTaskDeploymentRequest().getDefinition().getProperties().get("secret"));
+		Assertions.assertEquals("******", sanitizedTaskManifest.getTaskDeploymentRequest().getDefinition().getProperties().get("user.key"));
+		Assertions.assertEquals("******", deploymentProps.get("secret"));
+		Assertions.assertEquals("******", deploymentProps.get("user.key"));
 
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
@@ -30,8 +30,7 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.reactor.TokenProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +44,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +66,6 @@ import static org.mockito.Mockito.when;
 	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.space=space",
 	"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].deployment.schedulerurl=https://localhost"
 	})
-@RunWith(SpringRunner.class)
 public class CloudFoundrySchedulerTests {
 
 	@Autowired

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultLocalTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultLocalTests.java
@@ -16,18 +16,15 @@
 
 package org.springframework.cloud.dataflow.server.single;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author David Turanski
  **/
 @SpringBootTest(classes = {
 		DataFlowServerApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@RunWith(SpringRunner.class)
 public class DefaultLocalTests {
 
 	@Test

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultSchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/DefaultSchedulerTests.java
@@ -18,14 +18,12 @@ package org.springframework.cloud.dataflow.server.single;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 					{
 						"spring.cloud.dataflow.features.schedules-enabled=true"
 					})
-@RunWith(SpringRunner.class)
 public class DefaultSchedulerTests {
 
 	@Autowired

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/KubernetesSchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/KubernetesSchedulerTests.java
@@ -18,15 +18,13 @@ package org.springframework.cloud.dataflow.server.single;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"kubernetes_service_host=foo",
 		"spring.cloud.dataflow.features.schedules-enabled=true"
 	})
-@RunWith(SpringRunner.class)
 public class KubernetesSchedulerTests {
 
 	@Autowired

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/MultiplePlatformTypeTests.java
@@ -29,8 +29,7 @@ import org.cloudfoundry.client.v2.spaces.ListSpacesResponse;
 import org.cloudfoundry.client.v2.spaces.SpaceResource;
 import org.cloudfoundry.client.v2.spaces.Spaces;
 import org.cloudfoundry.reactor.TokenProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +43,6 @@ import org.springframework.cloud.deployer.spi.local.LocalTaskLauncher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,7 +64,6 @@ import static org.mockito.Mockito.when;
 		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.space=space",
 		"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].deployment.scheduler-url=https://localhost"
 	})
-@RunWith(SpringRunner.class)
 public class MultiplePlatformTypeTests {
 
 	@Autowired

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.dataflow.shell;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +104,7 @@ public abstract class AbstractShellIntegrationTest {
 	@Rule
 	public TestName name = new TestName();
 
-	@BeforeClass
+	@BeforeAll
 	public static void startUp() {
 		if (applicationContext == null) {
 			if (System.getProperty(SHUTDOWN_AFTER_RUN) != null) {
@@ -135,7 +135,7 @@ public abstract class AbstractShellIntegrationTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void shutdown() {
 		if (shutdownAfterRun) {
 			logger.info("Stopping Data Flow Shell");

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandsTests.java
@@ -24,10 +24,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.Banner;
 import org.springframework.boot.WebApplicationType;
@@ -43,8 +44,7 @@ import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoC
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.ResourceUtils;
 
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for {@link org.springframework.cloud.dataflow.shell.ShellCommandLineRunner}.
@@ -53,8 +53,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ShellCommandsTests extends AbstractShellIntegrationTest {
 
-	@After
-	@Before
+	@AfterEach
+	@BeforeEach
 	public void unregisterAll() {
 		AppRegistryService registry = applicationContext.getBean(AppRegistryService.class);
 		for (AppRegistration appReg : registry.findAll()) {
@@ -78,7 +78,7 @@ public class ShellCommandsTests extends AbstractShellIntegrationTest {
 				"commands/stream_all_delete.txt,commands/registerTask_timestamp.txt,commands/unregisterTask_timestamp.txt,commands/registerSink_log.txt,commands/unregisterSink_log.txt");
 		assertTrue(runShell(commandFiles));
 
-		assertThat("Registry should be empty", AbstractShellIntegrationTest.applicationContext.getBean(AppRegistryService.class).findAll(),
+		MatcherAssert.assertThat("Registry should be empty", AbstractShellIntegrationTest.applicationContext.getBean(AppRegistryService.class).findAll(),
 				Matchers.empty());
 	}
 
@@ -93,7 +93,7 @@ public class ShellCommandsTests extends AbstractShellIntegrationTest {
 
 	private void assertAppExists(String name, ApplicationType type) {
 		AppRegistryService registry = AbstractShellIntegrationTest.applicationContext.getBean(AppRegistryService.class);
-		assertTrue(String.format("'%s' application should be registered", name), registry.appExist(name, type));
+		assertTrue(registry.appExist(name, type), String.format("'%s' application should be registered", name));
 	}
 
 	/**

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AssertionsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AssertionsTests.java
@@ -16,9 +16,10 @@
 
 package org.springframework.cloud.dataflow.shell.command;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Mark Fisher
@@ -35,24 +36,32 @@ public class AssertionsTests {
 		Assertions.atMostOneOf("foo", "x", "bar", null);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void atMostOneWithTwo() {
-		Assertions.atMostOneOf("foo", "x", "bar", "y");
+		assertThrows(IllegalStateException.class, () -> {
+			Assertions.atMostOneOf("foo", "x", "bar", "y");
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void atMostOneWithOddArgs() {
-		Assertions.atMostOneOf("foo", "x", "bar", null, "oops");
+		assertThrows(IllegalArgumentException.class, () -> {
+			Assertions.atMostOneOf("foo", "x", "bar", null, "oops");
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void atMostOneWithNonStringKey() {
-		assertEquals(1, Assertions.atMostOneOf("foo", null, 99, "y"));
+		assertThrows(IllegalArgumentException.class, () -> {
+			assertEquals(1, Assertions.atMostOneOf("foo", null, 99, "y"));
+		});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void exactlyOneWithNone() {
-		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", null, "baz", null));
+		assertThrows(IllegalStateException.class, () -> {
+			assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", null, "baz", null));
+		});
 	}
 
 	@Test
@@ -60,18 +69,24 @@ public class AssertionsTests {
 		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", "y", "baz", null));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void exactlyOneWithTwo() {
-		assertEquals(1, Assertions.exactlyOneOf("foo", "x", "bar", "y", "baz", null));
+		assertThrows(IllegalStateException.class, () -> {
+			assertEquals(1, Assertions.exactlyOneOf("foo", "x", "bar", "y", "baz", null));
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void exactlyOneWithOddArgs() {
-		assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", "y", "oops"));
+		assertThrows(IllegalArgumentException.class, () -> {
+			assertEquals(1, Assertions.exactlyOneOf("foo", null, "bar", "y", "oops"));
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void exactlyOneWithNonStringKey() {
-		assertEquals(1, Assertions.exactlyOneOf("foo", null, 99, "y"));
+		assertThrows(IllegalArgumentException.class, () -> {
+			assertEquals(1, Assertions.exactlyOneOf("foo", null, 99, "y"));
+		});
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/ConfigCommandTests.java
@@ -22,8 +22,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -48,7 +49,6 @@ import org.springframework.web.client.RestTemplate;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,7 +68,7 @@ public class ConfigCommandTests {
 	@Mock
 	private RestTemplate restTemplate;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 
@@ -118,7 +118,7 @@ public class ConfigCommandTests {
 			final Table infoResult = (Table) configCommands.info().get(0);
 			String expectedOutput = FileCopyUtils.copyToString(new InputStreamReader(
 					getClass().getResourceAsStream(ConfigCommandTests.class.getSimpleName() + "-testInfo.txt"), "UTF-8"));
-			assertThat(infoResult.render(80), is(expectedOutput));
+			MatcherAssert.assertThat(infoResult.render(80), is(expectedOutput));
 		}
 	}
 
@@ -129,7 +129,7 @@ public class ConfigCommandTests {
 		when(restTemplate.getForObject(Mockito.any(URI.class), Mockito.eq(RootResource.class))).thenReturn(value);
 
 		final String targetResult = configCommands.target("http://localhost:9393", null, null, null, null, false, null, null, null);
-		assertThat(targetResult, containsString("Incompatible version of Data Flow server detected"));
+		MatcherAssert.assertThat(targetResult, containsString("Incompatible version of Data Flow server detected"));
 	}
 
 	@Test
@@ -165,6 +165,6 @@ public class ConfigCommandTests {
 
 		System.out.println(targetResult);
 
-		assertThat(targetResult, is(expectedTargetMessage));
+		MatcherAssert.assertThat(targetResult, is(expectedTargetMessage));
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
@@ -24,9 +24,9 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +48,8 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.shell.core.CommandResult;
 import org.springframework.shell.table.Table;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Glenn Renfro
@@ -76,7 +76,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 
 	private static List<Long> taskExecutionIds = new ArrayList<>(3);
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws Exception {
 		Thread.sleep(2000);
 		DataSource dataSource = applicationContext.getBean(DataSource.class);
@@ -92,7 +92,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		taskExecutionIds.add(createSampleJob(JOB_NAME_FOOBAR, 2));
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() {
 		JdbcTemplate template = new JdbcTemplate(applicationContext.getBean(DataSource.class));
 		template.afterPropertiesSet();
@@ -155,8 +155,9 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 
 		Table table = getTable(job().executionDisplay(getFirstJobExecutionIdFromTable()));
 		verifyColumnNumber(table, 2);
-		assertEquals("Number of expected rows returned from the table is incorrect", 18,
-				table.getModel().getRowCount());
+		assertEquals(18,
+				table.getModel().getRowCount(),
+				"Number of expected rows returned from the table is incorrect");
 		int rowNumber = 0;
 		checkCell(table, rowNumber++, 0, "Key ");
 		checkCell(table, rowNumber++, 0, "Job Execution Id ");
@@ -183,7 +184,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 						&& table.getModel().getValue(paramRowTwo, 0).equals("foo(STRING) "))) {
 			jobParamsPresent = true;
 		}
-		assertTrue("the table did not contain the correct job parameters ", jobParamsPresent);
+		assertTrue(jobParamsPresent, "the table did not contain the correct job parameters ");
 	}
 
 	@Test
@@ -202,7 +203,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 				|| table.getModel().getValue(1, 4).equals("-bar=BAR,foo=FOO")) {
 			isValidCell = true;
 		}
-		assertTrue("Job Parameters does match expected.", isValidCell);
+		assertTrue(isValidCell, "Job Parameters does match expected.");
 	}
 
 	@Test
@@ -269,17 +270,18 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 	}
 
 	private void checkCell(Table table, int row, int column, Object expectedValue) {
-		assertEquals(String.format("Cell %d,%d's value should be %s", row, column, expectedValue), expectedValue,
-				table.getModel().getValue(row, column));
+		assertEquals(expectedValue,
+				table.getModel().getValue(row, column),
+				String.format("Cell %d,%d's value should be %s", row, column, expectedValue));
 	}
 
 	private Table getTable(CommandResult cr) {
-		assertTrue("Command must be successful", cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Command must be successful");
 		return (Table) cr.getResult();
 	}
 
 	private void verifyColumnNumber(Table table, int columnCount) {
-		assertEquals("Number of columns returned was not expected", columnCount, table.getModel().getColumnCount());
+		assertEquals(columnCount, table.getModel().getColumnCount(), "Number of columns returned was not expected");
 	}
 
 	private long getFirstJobExecutionIdFromTable() {

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/RuntimeCommandsTests.java
@@ -22,9 +22,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,8 +37,7 @@ import org.springframework.cloud.dataflow.shell.config.DataFlowShell;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.shell.table.TableModel;
 
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -61,7 +61,7 @@ public class RuntimeCommandsTests {
 
 	private AppStatusResource appStatusResource3;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		when(dataFlowOperations.runtimeOperations()).thenReturn(runtimeOperations);
@@ -119,7 +119,7 @@ public class RuntimeCommandsTests {
 		TableModel model = runtimeCommands.list(true, null).getModel();
 		for (int row = 0; row < expected.length; row++) {
 			for (int col = 0; col < expected[row].length; col++) {
-				assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
+				MatcherAssert.assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
 			}
 		}
 	}
@@ -137,7 +137,7 @@ public class RuntimeCommandsTests {
 		TableModel model = runtimeCommands.list(false, null).getModel();
 		for (int row = 0; row < expected.length; row++) {
 			for (int col = 0; col < expected[row].length; col++) {
-				assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
+				MatcherAssert.assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
 			}
 		}
 	}
@@ -150,7 +150,7 @@ public class RuntimeCommandsTests {
 		assertTrue(model.getRowCount() == 4);
 		for (int row = 0; row < expected.length; row++) {
 			for (int col = 0; col < expected[row].length; col++) {
-				assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
+				MatcherAssert.assertThat(String.valueOf(model.getValue(row + 1, col)), Matchers.is(expected[row][col]));
 			}
 		}
 	}

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTemplate.java
@@ -27,9 +27,9 @@ import org.springframework.shell.core.JLineShellComponent;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableModel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Helper methods for stream commands to execute in the shell.
@@ -118,7 +118,7 @@ public class StreamCommandTemplate {
 	public void deploy(String streamname) {
 		CommandResult cr = shell.executeCommand("stream deploy --name " + streamname);
 		// stateVerifier.waitForDeploy(streamname);
-		assertTrue("Failure.  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure.  CommandResult = " + cr.toString());
 		assertEquals("Deployed stream '" + streamname + "'", cr.getResult());
 	}
 
@@ -129,7 +129,7 @@ public class StreamCommandTemplate {
 	 */
 	public CommandResult validate(String streamName) {
 		CommandResult cr = shell.executeCommand("stream validate --name " + streamName);
-		assertTrue("Failure.  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure.  CommandResult = " + cr.toString());
 		return cr;
 	}
 
@@ -142,8 +142,8 @@ public class StreamCommandTemplate {
 			String streamname = streams.get(s);
 			CommandResult cr = shell.executeCommand("stream destroy --name " + streamname);
 			// stateVerifier.waitForDestroy(streamname);
-			assertTrue("Failure to destroy stream " + streamname + ".  CommandResult = " + cr.toString(),
-					cr.isSuccess());
+			assertTrue(cr.isSuccess(),
+					"Failure to destroy stream " + streamname + ".  CommandResult = " + cr.toString());
 		}
 	}
 
@@ -155,7 +155,7 @@ public class StreamCommandTemplate {
 	public void destroyStream(String stream) {
 		CommandResult cr = shell.executeCommand("stream destroy --name " + stream);
 		// stateVerifier.waitForDestroy(stream);
-		assertTrue("Failure to destroy stream " + stream + ".  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure to destroy stream " + stream + ".  CommandResult = " + cr.toString());
 		streams.remove(stream);
 	}
 
@@ -179,7 +179,7 @@ public class StreamCommandTemplate {
 	 */
 	public void verifyExists(String streamName, String definition, boolean deployed) {
 		CommandResult cr = shell.executeCommand("stream list");
-		assertTrue("Failure.  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure.  CommandResult = " + cr.toString());
 
 		Table table = (org.springframework.shell.table.Table) cr.getResult();
 		TableModel model = table.getModel();

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.shell.command;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +37,8 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.shell.core.CommandResult;
 import org.springframework.shell.table.Table;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -52,13 +52,13 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(StreamCommandTests.class);
 
-	@Before
+	@BeforeEach
 	public void registerApps() {
 		AppRegistryService registry = applicationContext.getBean(AppRegistryService.class);
 		registry.importAll(true, new ClassPathResource(APPS_URI));
 	}
 
-	@After
+	@AfterEach
 	public void destroyStreams() {
 		stream().destroyCreatedStreams();
 	}
@@ -100,26 +100,26 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 		stream().createDontDeploy(streamName, "time | log");
 
 		CommandResult cr = stream().validate(streamName);
-		assertTrue("task validate status command must be successful", cr.isSuccess());
+		assertTrue(cr.isSuccess(), "task validate status command must be successful");
 		List results = (List) cr.getResult();
 		Table table = (Table)results.get(0);
-		assertEquals("Number of columns returned was not expected", 2, table.getModel().getColumnCount());
-		assertEquals("First Row First Value should be: Stream Name", "Stream Name", table.getModel().getValue(0, 0));
-		assertEquals("First Row Second Value should be: Stream Definition", "Stream Definition", table.getModel().getValue(0, 1));
-		assertEquals("Second Row First Value should be: " + streamName, streamName, table.getModel().getValue(1, 0));
-		assertEquals("Second Row Second Value should be: time | log", "time | log", table.getModel().getValue(1, 1));
+		assertEquals(2, table.getModel().getColumnCount(), "Number of columns returned was not expected");
+		assertEquals("Stream Name", table.getModel().getValue(0, 0), "First Row First Value should be: Stream Name");
+		assertEquals("Stream Definition", table.getModel().getValue(0, 1), "First Row Second Value should be: Stream Definition");
+		assertEquals(streamName, table.getModel().getValue(1, 0), "Second Row First Value should be: " + streamName);
+		assertEquals("time | log", table.getModel().getValue(1, 1), "Second Row Second Value should be: time | log");
 
 		String message = String.format("\n%s is a valid stream.", streamName);
-		assertEquals(String.format("Notification should be: %s",message ), message, results.get(1));
+		assertEquals(message, results.get(1), String.format("Notification should be: %s",message ));
 
 		table = (Table)results.get(2);
-		assertEquals("Number of columns returned was not expected", 2, table.getModel().getColumnCount());
-		assertEquals("First Row First Value should be: App Name", "App Name", table.getModel().getValue(0, 0));
-		assertEquals("First Row Second Value should be: Validation Status", "Validation Status", table.getModel().getValue(0, 1));
-		assertEquals("Second Row First Value should be: source:time", "source:time" , table.getModel().getValue(1, 0));
-		assertEquals("Second Row Second Value should be: valid", "valid", table.getModel().getValue(1, 1));
-		assertEquals("Third Row First Value should be: sink:log", "sink:log" , table.getModel().getValue(2, 0));
-		assertEquals("Third Row Second Value should be: valid", "valid", table.getModel().getValue(2, 1));
+		assertEquals(2, table.getModel().getColumnCount(), "Number of columns returned was not expected");
+		assertEquals("App Name", table.getModel().getValue(0, 0), "First Row First Value should be: App Name");
+		assertEquals("Validation Status", table.getModel().getValue(0, 1), "First Row Second Value should be: Validation Status");
+		assertEquals("source:time" , table.getModel().getValue(1, 0), "Second Row First Value should be: source:time");
+		assertEquals("valid", table.getModel().getValue(1, 1), "Second Row Second Value should be: valid");
+		assertEquals("sink:log" , table.getModel().getValue(2, 0), "Third Row First Value should be: sink:log");
+		assertEquals("valid", table.getModel().getValue(2, 1), "Third Row Second Value should be: valid");
 	}
 
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTemplate.java
@@ -24,9 +24,9 @@ import org.springframework.shell.core.JLineShellComponent;
 import org.springframework.shell.table.Table;
 import org.springframework.shell.table.TableModel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Helper methods for task commands to execute in the shell.
@@ -118,7 +118,7 @@ public class TaskCommandTemplate {
 		Thread.sleep(5000);
 		CommandResult cr = shell.executeCommand("task execution log --id " + id);
 
-		assertTrue("Task execution log = " + cr.toString(), cr.toString().contains("Starting"));
+		assertTrue(cr.toString().contains("Starting"), "Task execution log = " + cr.toString());
 
 		return cr.toString();
 	}
@@ -261,7 +261,7 @@ public class TaskCommandTemplate {
 			String taskname = tasks.get(s);
 			CommandResult cr = shell.executeCommand("task destroy --name " + taskname);
 			// stateVerifier.waitForDestroy(taskname);
-			assertTrue("Failure to destroy task " + taskname + ".  CommandResult = " + cr.toString(), cr.isSuccess());
+			assertTrue(cr.isSuccess(), "Failure to destroy task " + taskname + ".  CommandResult = " + cr.toString());
 		}
 	}
 
@@ -273,7 +273,7 @@ public class TaskCommandTemplate {
 	public void destroyTask(String task) {
 		CommandResult cr = shell.executeCommand("task destroy --name " + task);
 		// stateVerifier.waitForDestroy(task);
-		assertTrue("Failure to destroy task " + task + ".  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure to destroy task " + task + ".  CommandResult = " + cr.toString());
 		tasks.remove(task);
 	}
 
@@ -286,7 +286,7 @@ public class TaskCommandTemplate {
 	public void destroyTask(String task, boolean cleanup) {
 		String cleanupString = (cleanup) ? "--cleanup" : "";
 		CommandResult cr = shell.executeCommand("task destroy --name " + task + " " + cleanupString);
-		assertTrue("Failure to destroy task " + task + ".  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure to destroy task " + task + ".  CommandResult = " + cr.toString());
 		tasks.remove(task);
 	}
 
@@ -297,7 +297,7 @@ public class TaskCommandTemplate {
 	public void destroyAllTasks() {
 		CommandResult cr = shell.executeCommand("task all destroy --force");
 		// stateVerifier.waitForDestroy(task);
-		assertTrue("Failure to destroy all tasks. CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure to destroy all tasks. CommandResult = " + cr.toString());
 		tasks.clear();
 	}
 
@@ -309,7 +309,7 @@ public class TaskCommandTemplate {
 	 */
 	public void verifyExists(String taskName, String definition) {
 		CommandResult cr = shell.executeCommand("task list");
-		assertTrue("Failure.  CommandResult = " + cr.toString(), cr.isSuccess());
+		assertTrue(cr.isSuccess(), "Failure.  CommandResult = " + cr.toString());
 		Table table = (Table) cr.getResult();
 		TableModel model = table.getModel();
 		for (int row = 0; row < model.getRowCount(); row++) {

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandTemplate.java
@@ -37,7 +37,7 @@ import org.springframework.shell.core.CommandResult;
 import org.springframework.shell.core.JLineShellComponent;
 import org.springframework.shell.table.Table;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandsTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandsTest.java
@@ -17,9 +17,9 @@ package org.springframework.cloud.dataflow.shell.command;
 
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
 
@@ -28,7 +28,7 @@ import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
  */
 public class TaskScheduleCommandsTest extends AbstractShellIntegrationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws InterruptedException {
 		Thread.sleep(2000);
 	}
@@ -45,8 +45,9 @@ public class TaskScheduleCommandsTest extends AbstractShellIntegrationTest {
 
 	@Test
 	public void tryScheduleWithPropertiesAndPropertiesFile() throws IOException {
-		Assert.assertThrows("You cannot specify both 'properties' and 'propertiesFile'", IllegalArgumentException.class,
-				() -> schedule().createWithPropertiesAndPropertiesFile("schedName", "def", "* * * * *","app.tmp2.foo=bar",  "./src/test/resources/taskSchedulerWithPropertiesFile.properties", ""));
+		Assertions.assertThrows(IllegalArgumentException.class,
+				() -> schedule().createWithPropertiesAndPropertiesFile("schedName", "def", "* * * * *","app.tmp2.foo=bar",  "./src/test/resources/taskSchedulerWithPropertiesFile.properties", ""),
+				"You cannot specify both 'properties' and 'propertiesFile'");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/support/RoleTypeTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/support/RoleTypeTests.java
@@ -16,10 +16,10 @@
 package org.springframework.cloud.dataflow.shell.command.support;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/config/DataFlowShellTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/config/DataFlowShellTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.cloud.dataflow.shell.config;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
@@ -36,7 +36,7 @@ public class DataFlowShellTests {
 		final DataFlowShell dataFlowShell = new DataFlowShell();
 		dataFlowShell.setDataFlowOperations(null);
 
-		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 
 	}
 
@@ -45,7 +45,7 @@ public class DataFlowShellTests {
 		final Target target = new Target("https://myUri");
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 
 	}
 
@@ -54,7 +54,7 @@ public class DataFlowShellTests {
 		final Target target = new Target("https://myUri");
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertTrue(dataFlowShell.hasAccess(null, OpsType.STREAM));
+		Assertions.assertTrue(dataFlowShell.hasAccess(null, OpsType.STREAM));
 
 	}
 
@@ -64,7 +64,7 @@ public class DataFlowShellTests {
 		target.setAuthenticationEnabled(true);
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 
 	}
 
@@ -76,7 +76,7 @@ public class DataFlowShellTests {
 		target.setAuthenticated(true);
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertTrue(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class DataFlowShellTests {
 		target.setAuthenticationEnabled(true);
 		target.setAuthenticated(true);
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class DataFlowShellTests {
 		target.setAuthenticated(true);
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
+		Assertions.assertFalse(dataFlowShell.hasAccess(RoleType.VIEW, OpsType.STREAM));
 	}
 
 	@Test
@@ -110,7 +110,7 @@ public class DataFlowShellTests {
 		target.setAuthenticated(true);
 
 		final DataFlowShell dataFlowShell = prepareDataFlowShellWithStreamOperations(target);
-		Assert.assertTrue(dataFlowShell.hasAccess(null, OpsType.STREAM));
+		Assertions.assertTrue(dataFlowShell.hasAccess(null, OpsType.STREAM));
 	}
 
 	private DataFlowShell prepareDataFlowShellWithStreamOperations(Target target) {

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
@@ -20,7 +20,6 @@ import java.io.FileOutputStream;
 import java.util.UUID;
 
 import org.junit.rules.ExternalResource;
-import org.junit.rules.TemporaryFolder;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.ldap.server.ApacheDSContainer;
@@ -50,7 +49,7 @@ public class LdapServerResource extends ExternalResource {
 
 	private ApacheDSContainer apacheDSContainer;
 
-	private TemporaryFolder temporaryFolder = new TemporaryFolder();
+	private File temporaryFolder = new File("fixme");
 
 	private File workingDir;
 
@@ -77,8 +76,6 @@ public class LdapServerResource extends ExternalResource {
 	protected void before() throws Throwable {
 
 		originalLdapPort = System.getProperty(LDAP_PORT_PROPERTY);
-
-		temporaryFolder.create();
 		apacheDSContainer = new ApacheDSContainer("dc=springframework,dc=org",
 				"classpath:org/springframework/cloud/dataflow/server/local/security/" + this.ldapFileName);
 		int ldapPort = SocketUtils.findAvailableTcpPort();
@@ -86,8 +83,8 @@ public class LdapServerResource extends ExternalResource {
 
 			apacheDSContainer.setLdapOverSslEnabled(true);
 
-			final File temporaryKeyStoreFile = new File(temporaryFolder.getRoot(), "dataflow.keystore");
-			final File temporaryTrustStoreFile = new File(temporaryFolder.getRoot(), "dataflow.truststore");
+			final File temporaryKeyStoreFile = new File(temporaryFolder, "dataflow.keystore");
+			final File temporaryTrustStoreFile = new File(temporaryFolder, "dataflow.truststore");
 
 			FileCopyUtils.copy(keyStoreResource.getInputStream(), new FileOutputStream(temporaryKeyStoreFile));
 			FileCopyUtils.copy(trustStoreResource.getInputStream(), new FileOutputStream(temporaryTrustStoreFile));
@@ -105,7 +102,7 @@ public class LdapServerResource extends ExternalResource {
 
 		apacheDSContainer.setPort(ldapPort);
 		apacheDSContainer.afterPropertiesSet();
-		workingDir = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+		workingDir = new File(temporaryFolder, UUID.randomUUID().toString());
 		apacheDSContainer.setWorkingDirectory(workingDir);
 		apacheDSContainer.start();
 		System.setProperty(LDAP_PORT_PROPERTY, Integer.toString(ldapPort));

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSearchAndBindSslTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSearchAndBindSslTests.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.dataflow.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Marius Bogoevici
  * @author Gunnar Hillert
  */
-@Ignore("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
+@Disabled("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class LocalServerSecurityWithLdapSearchAndBindSslTests {
 

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSearchAndBindTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSearchAndBindTests.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.dataflow.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Marius Bogoevici
  * @author Gunnar Hillert
  */
-@Ignore("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
+@Disabled("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
 public class LocalServerSecurityWithLdapSearchAndBindTests {
 
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindAndDefaultManagementTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindAndDefaultManagementTests.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.dataflow.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Marius Bogoevici
  * @author Gunnar Hillert
  */
-@Ignore("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
+@Disabled("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
 public class LocalServerSecurityWithLdapSimpleBindAndDefaultManagementTests {
 
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindGroupMappingTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindGroupMappingTests.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.dataflow.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  */
-@Ignore("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
+@Disabled("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
 public class LocalServerSecurityWithLdapSimpleBindGroupMappingTests {
 
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LocalServerSecurityWithLdapSimpleBindTests.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.dataflow.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Marius Bogoevici
  * @author Gunnar Hillert
  */
-@Ignore("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
+@Disabled("Ignored until proper UAA integration exists") //FIXME see https://github.com/spring-cloud/spring-cloud-dataflow/issues/2580
 public class LocalServerSecurityWithLdapSimpleBindTests {
 
 	private final static LocalDataflowResource localDataflowResource = new LocalDataflowResource(

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
@@ -18,9 +18,10 @@ package org.springframework.cloud.dataflow.server.single;
 
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.SpringApplication;
@@ -41,9 +42,8 @@ import org.springframework.util.SocketUtils;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link LocalTestDataFlowServer}.
@@ -53,12 +53,12 @@ import static org.junit.Assert.fail;
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
  */
-@Ignore
+@Disabled
 public class LocalConfigurationTests {
 
 	private ConfigurableApplicationContext context;
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (context != null) {
 			context.close();
@@ -84,9 +84,9 @@ public class LocalConfigurationTests {
 		// LocalDataFlowServerAutoConfiguration also adds docker and maven resource loaders.
 		DelegatingResourceLoader delegatingResourceLoader = context.getBean(DelegatingResourceLoader.class);
 		Map<String, ResourceLoader> loaders = TestUtils.readField("loaders", delegatingResourceLoader);
-		assertThat(loaders.size(), is(2));
-		assertThat(loaders.get("maven"), notNullValue());
-		assertThat(loaders.get("docker"), notNullValue());
+		MatcherAssert.assertThat(loaders.size(), is(2));
+		MatcherAssert.assertThat(loaders.get("maven"), notNullValue());
+		MatcherAssert.assertThat(loaders.get("docker"), notNullValue());
 	}
 
 	@Test
@@ -125,6 +125,6 @@ public class LocalConfigurationTests {
 	public void testNoDataflowConfig() {
 		SpringApplication app = new SpringApplication(LocalTestNoDataFlowServer.class);
 		context = app.run(new String[] { "--spring.cloud.kubernetes.enabled=false", "--server.port=0", "--spring.jpa.database=H2", "--spring.flyway.enabled=false" });
-		assertThat(context.containsBean("appRegistry"), is(false));
+		MatcherAssert.assertThat(context.containsBean("appRegistry"), is(false));
 	}
 }

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/DataFlowClientAutoConfigurationAgaintstServerTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/DataFlowClientAutoConfigurationAgaintstServerTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.cloud.dataflow.server.single.security;
 
-import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -35,8 +35,8 @@ import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Gunnar Hillert
@@ -50,7 +50,7 @@ public class DataFlowClientAutoConfigurationAgaintstServerTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void clean() {
 		if (context != null) {
 			context.close();

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2AndExternalAuthoritiesTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2AndExternalAuthoritiesTests.java
@@ -20,9 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -35,7 +36,6 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -64,7 +64,7 @@ public class LocalServerSecurityWithOAuth2AndExternalAuthoritiesTests {
 	@Test
 	public void testAuthoritiesMapperBean() throws Exception {
 		final AuthoritiesMapper authoritiesMapper = localDataflowResource.getWebApplicationContext().getBean(AuthoritiesMapper.class);
-		Assert.assertTrue(authoritiesMapper instanceof ExternalOauth2ResourceAuthoritiesMapper);
+		Assertions.assertTrue(authoritiesMapper instanceof ExternalOauth2ResourceAuthoritiesMapper);
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class LocalServerSecurityWithOAuth2AndExternalAuthoritiesTests {
 		resourceDetails
 				.setAccessTokenUri("http://localhost:" + oAuth2ServerResource.getOauth2ServerPort() + "/oauth/token");
 
-		Assert.assertEquals(0, externalAuthoritiesServer.getRequestCount());
+		Assertions.assertEquals(0, externalAuthoritiesServer.getRequestCount());
 
 		final OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(resourceDetails);
 		final OAuth2AccessToken accessToken = oAuth2RestTemplate.getAccessToken();
@@ -97,8 +97,8 @@ public class LocalServerSecurityWithOAuth2AndExternalAuthoritiesTests {
 				.andExpect(jsonPath("$.authenticationEnabled", is(Boolean.TRUE)))
 				.andExpect(jsonPath("$.roles", hasSize(3)));
 
-		assertThat(externalAuthoritiesServer.getRequestCount(), is(1));
+		MatcherAssert.assertThat(externalAuthoritiesServer.getRequestCount(), is(1));
 		final RecordedRequest recordedRequest = externalAuthoritiesServer.takeRequest();
-		assertThat(recordedRequest.getHeader("Authorization"), is("Bearer " + accessTokenAsString));
+		MatcherAssert.assertThat(recordedRequest.getHeader("Authorization"), is("Bearer " + accessTokenAsString));
 	}
 }

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2BasicAuthAndExternalAuthoritiesTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2BasicAuthAndExternalAuthoritiesTests.java
@@ -20,8 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.hamcrest.MatcherAssert;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -31,7 +32,6 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.springframework.cloud.dataflow.server.single.security.SecurityTestUtils.basicAuthorizationHeader;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -74,8 +74,8 @@ public class LocalServerSecurityWithOAuth2BasicAuthAndExternalAuthoritiesTests {
 				.andExpect(jsonPath("$.authenticationEnabled", is(Boolean.TRUE)))
 				.andExpect(jsonPath("$.roles", hasSize(3)));
 
-		assertThat(externalAuthoritiesServer.getRequestCount(), is(1));
+		MatcherAssert.assertThat(externalAuthoritiesServer.getRequestCount(), is(1));
 		final RecordedRequest recordedRequest = externalAuthoritiesServer.takeRequest();
-		assertThat(recordedRequest.getHeader("Authorization"), is(not(emptyString())));
+		MatcherAssert.assertThat(recordedRequest.getHeader("Authorization"), is(not(emptyString())));
 	}
 }

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithOAuth2Tests.java
@@ -16,9 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.single.security;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -31,7 +31,7 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.cloud.dataflow.server.single.security.SecurityTestUtils.basicAuthorizationHeader;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -269,7 +269,7 @@ public class LocalServerSecurityWithOAuth2Tests {
 
 		assertTrue(Boolean.valueOf(oAuthServerResponse));
 
-		Assert.assertThrows(AuthenticationServiceException.class, () -> {
+		Assertions.assertThrows(AuthenticationServiceException.class, () -> {
 			localDataflowResource.getMockMvc()
 				.perform(get("/security/info").header("Authorization", "bearer " + accessTokenAsString)).andDo(print())
 				.andExpect(status().isUnauthorized());
@@ -279,7 +279,7 @@ public class LocalServerSecurityWithOAuth2Tests {
 			.perform(get("/logout").header("Authorization", "bearer " + accessTokenAsString)).andDo(print())
 			.andExpect(status().isFound());
 
-		Assert.assertThrows(AuthenticationServiceException.class, () -> {
+		Assertions.assertThrows(AuthenticationServiceException.class, () -> {
 			localDataflowResource.getMockMvc()
 				.perform(get("/security/info").header("Authorization", "bearer " + accessTokenAsString)).andDo(print())
 				.andExpect(status().isUnauthorized());
@@ -289,7 +289,7 @@ public class LocalServerSecurityWithOAuth2Tests {
 	@Test
 	public void testAccessRootUrlWithWrongOAuth2AccessToken() throws Exception {
 		// https://github.com/spring-projects/spring-security/issues/10038
-		Assert.assertThrows(AuthenticationServiceException.class, () -> {
+		Assertions.assertThrows(AuthenticationServiceException.class, () -> {
 			localDataflowResource.getMockMvc().perform(get("/").header("Authorization", "bearer 123456")).andDo(print())
 					.andExpect(status().isUnauthorized());
 		});

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithUsersFileTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/security/LocalServerSecurityWithUsersFileTests.java
@@ -19,15 +19,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +51,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(Parameterized.class)
 public class LocalServerSecurityWithUsersFileTests {
 
 	private final static Logger logger = LoggerFactory.getLogger(LocalServerSecurityWithUsersFileTests.class);
@@ -73,563 +69,555 @@ public class LocalServerSecurityWithUsersFileTests {
 	private static UserCredentials manageOnlyUser = new UserCredentials("alice", "alicepwd");
 
 	private static UserCredentials createOnlyUser = new UserCredentials("cartman", "cartmanpwd");
-
-	@Parameter(0)
 	public HttpMethod httpMethod;
-
-	@Parameter(1)
 	public HttpStatus expectedHttpStatus;
-
-	@Parameter(2)
 	public String url;
-
-	@Parameter(3)
 	public UserCredentials userCredentials;
-
-	@Parameter(4)
 	public Map<String, String> urlParameters;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		localDataflowResource.mockSkipperAboutInfo();
 	}
 
-	@Parameters(name = "Authentication Test {index} - {0} {2} - Returns: {1}")
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] {
+		return Arrays.asList(new Object[][]{
 
-				{ HttpMethod.GET, HttpStatus.OK, "/", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/", null, null },
+				{HttpMethod.GET, HttpStatus.OK, "/", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/", null, null},
 
 				/* AppRegistryController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/apps", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/apps", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/apps", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/apps", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/apps/task/taskname", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps/task/taskname", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/apps/task/taskname", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/apps/task/taskname", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/apps/task/taskname", createOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.CREATED, "/apps/task/taskname", createOnlyUser,
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.BAD_REQUEST, "/apps/task/taskname", createOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.CREATED, "/apps/task/taskname", createOnlyUser,
 						TestUtils.toImmutableMap("uri", "maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
-								"force", "false") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
+								"force", "false")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null},
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.OK, "/apps/task/taskname", createOnlyUser, null }, // Should be 404 - See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/apps/task/taskname", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/apps/task/taskname", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.OK, "/apps/task/taskname", createOnlyUser, null}, // Should be 404 - See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/apps/task/taskname", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", manageOnlyUser,
-						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", viewOnlyUser,
-						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
-				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", manageOnlyUser,
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/apps", viewOnlyUser,
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true")},
+				{HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
 						TestUtils.toImmutableMap("uri", "https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-rabbit-maven", "apps",
-								"app=is_ignored", "force", "false") },
+								"app=is_ignored", "force", "false")},
 				// Should be 400 -
 				// See https://github.com/spring-cloud/spring-cloud-dataflow/issues/1071
-				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
+				{HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
 						TestUtils.toImmutableMap("uri", "https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/spring-cloud-stream-app-descriptor/Celsius.SR1/spring-cloud-stream-app-descriptor-Celsius.SR1.stream-apps-rabbit-maven", "force",
-								"false") },
-				{ HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/apps", createOnlyUser,
+								"false")},
+				{HttpMethod.POST, HttpStatus.INTERNAL_SERVER_ERROR, "/apps", createOnlyUser,
 						TestUtils.toImmutableMap("apps",
 								"appTypeMissing=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
-								"force", "false") }, // Should be 400 - See https://github
+								"force", "false")}, // Should be 400 - See https://github
 				// .com/spring-cloud/spring-cloud-dataflow/issues/1071
-				{ HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
+				{HttpMethod.POST, HttpStatus.CREATED, "/apps", createOnlyUser,
 						TestUtils.toImmutableMap("apps",
 								"task" + ".myCoolApp=maven://io.spring.cloud:scdf-sample-app:jar:1.0.0.BUILD-SNAPSHOT",
-								"force", "false") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps", null,
-						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true") },
+								"force", "false")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/apps", null,
+						TestUtils.toImmutableMap("uri", "???", "apps", "??", "force", "true")},
 
 				/* AuditController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/audit-records", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/audit-records", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/1", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/audit-records/1", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/1", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/1", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/1", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/audit-records/1", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/1", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/1", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-action-types", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/audit-records/audit-action-types", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-action-types", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/audit-action-types", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-action-types", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/audit-records/audit-action-types", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-action-types", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/audit-action-types", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-operation-types", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/audit-records/audit-operation-types", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-operation-types", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/audit-operation-types", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-operation-types", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/audit-records/audit-operation-types", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/audit-records/audit-operation-types", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/audit-records/audit-operation-types", null, null},
 
 				/* CompletionController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", viewOnlyUser, TestUtils.toImmutableMap("start", "2") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/completions/stream", viewOnlyUser, TestUtils.toImmutableMap("start", "2")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", viewOnlyUser, TestUtils.toImmutableMap("start", "2") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/completions/task", viewOnlyUser, TestUtils.toImmutableMap("start", "2")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2","start", "0") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", createOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2","start", "0") },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/stream", viewOnlyUser,
-						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", viewOnlyUser,
-						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null,
-						TestUtils.toImmutableMap("detailLevel", "2") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", manageOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2", "start", "0")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/stream", createOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2", "start", "0")},
+				{HttpMethod.GET, HttpStatus.OK, "/completions/stream", viewOnlyUser,
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/stream", viewOnlyUser,
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/stream", null,
+						TestUtils.toImmutableMap("detailLevel", "2")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", createOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.OK, "/completions/task", viewOnlyUser,
-						TestUtils.toImmutableMap("start", "2", "detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", viewOnlyUser,
-						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null,
-						TestUtils.toImmutableMap("detailLevel", "2") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", manageOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/completions/task", createOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.OK, "/completions/task", viewOnlyUser,
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/completions/task", viewOnlyUser,
+						TestUtils.toImmutableMap("start", "2", "detailLevel", "-123")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/completions/task", null,
+						TestUtils.toImmutableMap("detailLevel", "2")},
 
 				/* ToolsController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", manageOnlyUser,
-						TestUtils.toImmutableMap("definition", "fooApp") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", createOnlyUser,
-						TestUtils.toImmutableMap("definition", "fooApp") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null,
-						TestUtils.toImmutableMap("definition", "fooApp") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", manageOnlyUser,
+						TestUtils.toImmutableMap("definition", "fooApp")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/parseTaskTextToGraph", createOnlyUser,
+						TestUtils.toImmutableMap("definition", "fooApp")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/parseTaskTextToGraph", null,
+						TestUtils.toImmutableMap("definition", "fooApp")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", manageOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", createOnlyUser,
-						TestUtils.toImmutableMap("detailLevel", "2") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null,
-						TestUtils.toImmutableMap("detailLevel", "2") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", manageOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tools/convertTaskGraphToText", createOnlyUser,
+						TestUtils.toImmutableMap("detailLevel", "2")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tools/convertTaskGraphToText", null,
+						TestUtils.toImmutableMap("detailLevel", "2")},
 
 				/* JobExecutionController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/jobs/executions", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/jobs/executions", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.OK, "/jobs/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.OK, "/jobs/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						TestUtils.toImmutableMap("name", "myname") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
+						TestUtils.toImmutableMap("name", "myname")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions", null,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null, null},
 
-				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
-						TestUtils.toImmutableMap("stop", "true") },
-				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						TestUtils.toImmutableMap("stop", "true") },
-				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						TestUtils.toImmutableMap("stop", "true") },
-				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						TestUtils.toImmutableMap("stop", "true") },
+				{HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
+						TestUtils.toImmutableMap("stop", "true")},
+				{HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
+						TestUtils.toImmutableMap("stop", "true")},
+				{HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
+						TestUtils.toImmutableMap("stop", "true")},
+				{HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
+						TestUtils.toImmutableMap("stop", "true")},
 
-				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
-						TestUtils.toImmutableMap("restart", "true") },
-				{ HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
-						TestUtils.toImmutableMap("restart", "true") },
-				{ HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
-						TestUtils.toImmutableMap("restart", "true") },
-				{ HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
-						TestUtils.toImmutableMap("restart", "true") },
+				{HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", manageOnlyUser,
+						TestUtils.toImmutableMap("restart", "true")},
+				{HttpMethod.PUT, HttpStatus.FORBIDDEN, "/jobs/executions/123", viewOnlyUser,
+						TestUtils.toImmutableMap("restart", "true")},
+				{HttpMethod.PUT, HttpStatus.NOT_FOUND, "/jobs/executions/123", createOnlyUser,
+						TestUtils.toImmutableMap("restart", "true")},
+				{HttpMethod.PUT, HttpStatus.UNAUTHORIZED, "/jobs/executions/123", null,
+						TestUtils.toImmutableMap("restart", "true")},
 
 				/* JobExecutionThinController */
 
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/jobs/thinexecutions", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/jobs/thinexecutions", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.OK, "/jobs/thinexecutions", viewOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.OK, "/jobs/thinexecutions", viewOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/thinexecutions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
-						TestUtils.toImmutableMap("name", "myname") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/thinexecutions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
+						TestUtils.toImmutableMap("name", "myname")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/thinexecutions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
-						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/thinexecutions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/thinexecutions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/thinexecutions", null,
+						TestUtils.toImmutableMap("name", "myname", "page", "0", "size", "10")},
 
 				/* JobInstanceController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						TestUtils.toImmutableMap("name", "my-job-name") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
+						TestUtils.toImmutableMap("name", "my-job-name")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/instances", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/instances", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances/123", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances/123", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances/123", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances/123", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances/123", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/instances/123", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/instances/123", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/instances/123", null, null},
 
 				/* JobStepExecutionController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/abc/steps", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/executions/abc/steps", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/abc/steps", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/abc/steps", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/abc/steps", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/jobs/executions/abc/steps", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/abc/steps", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/abc/steps", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null,
-						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps", null,
+						TestUtils.toImmutableMap("name", "my-job-name", "page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps/1", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps/1", null, null},
 
 				/* JobStepExecutionProgressController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1/progress", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1/progress", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1/progress", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps/1/progress", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1/progress", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/jobs/executions/123/steps/1/progress", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/jobs/executions/123/steps/1/progress", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/jobs/executions/123/steps/1/progress", null, null},
 
 				/* RuntimeAppsController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/runtime/apps", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/runtime/apps", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123/instances", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123/instances", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123/instances", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123/instances", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances/456", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123/instances/456", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances/456", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123/instances/456", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances/456", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/runtime/apps/123/instances/456", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/runtime/apps/123/instances/456", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/runtime/apps/123/instances/456", null, null},
 
 				/* StreamDefinitionController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch") },
-				{ HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch")},
+				{HttpMethod.GET, HttpStatus.OK, "/streams/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
+						TestUtils.toImmutableMap("findByTaskNameContains", "mysearch")},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
-				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar") },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar")},
+				{HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
+						TestUtils.toImmutableMap("name", "myname", "definition", "fooo | baaar")},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "myname") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
-						TestUtils.toImmutableMap("name", "myname") },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.POST, HttpStatus.BAD_REQUEST, "/streams/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "myname")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/definitions", null,
+						TestUtils.toImmutableMap("name", "myname")},
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/streams/definitions/delete-me", createOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/definitions/delete-me", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions/delete-me", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/streams/definitions/delete-me", createOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/definitions/delete-me", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", manageOnlyUser,
-						null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream/related", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
-						null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", manageOnlyUser,
+						null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream/related", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
+						null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", manageOnlyUser,
-						TestUtils.toImmutableMap("nested", "wrong-param") },
-				{ HttpMethod.GET, HttpStatus.BAD_REQUEST, "/streams/definitions/my-stream/related", viewOnlyUser,
-						TestUtils.toImmutableMap("nested", "wrong-param") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
-						TestUtils.toImmutableMap("nested", "wrong-param") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null,
-						TestUtils.toImmutableMap("nested", "wrong-param") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", manageOnlyUser,
+						TestUtils.toImmutableMap("nested", "wrong-param")},
+				{HttpMethod.GET, HttpStatus.BAD_REQUEST, "/streams/definitions/my-stream/related", viewOnlyUser,
+						TestUtils.toImmutableMap("nested", "wrong-param")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream/related", createOnlyUser,
+						TestUtils.toImmutableMap("nested", "wrong-param")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream/related", null,
+						TestUtils.toImmutableMap("nested", "wrong-param")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/streams/definitions/my-stream", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/streams/definitions/my-stream", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/definitions/my-stream", null, null},
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.OK, "/streams/definitions", createOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/definitions", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.OK, "/streams/definitions", createOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/definitions", null, null},
 
 				/* SkipperStreamDeploymentController */
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.OK, "/streams/deployments", createOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/deployments", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.OK, "/streams/deployments", createOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/deployments", null, null},
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", createOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", createOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", manageOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", viewOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", createOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", manageOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/streams/deployments/my-stream", viewOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.NOT_FOUND, "/streams/deployments/my-stream", createOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/streams/deployments/my-stream", null, null},
 
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/history/my-stream/2", null, null },
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/history/my-stream/2", null, null},
 
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/manifest/my-stream/2", null, null },
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/manifest/my-stream/2", null, null},
 
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/platform/list", null, null },
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/streams/deployments/platform/list", null, null},
 
 				/* TaskPlatformController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/tasks/platforms", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/platforms", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/tasks/platforms", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/platforms", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/platforms", null, null},
 
 				/* TaskDefinitionController */
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name") },
-				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						TestUtils.toImmutableMap("name", "my-name") },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name")},
+				{HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
+						TestUtils.toImmutableMap("name", "my-name")},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
-				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
-						TestUtils.toImmutableMap("name", "my-name", "definition", "foo") },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/definitions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo")},
+				{HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/definitions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/definitions", null,
+						TestUtils.toImmutableMap("name", "my-name", "definition", "foo")},
 
 				/* TaskExecutionController */
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/tasks/executions", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/tasks/executions", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.OK, "/tasks/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						TestUtils.toImmutableMap("page", "0", "size", "10") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.OK, "/tasks/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
+						TestUtils.toImmutableMap("page", "0", "size", "10")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						TestUtils.toImmutableMap("name", "my-task-name") },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
+						TestUtils.toImmutableMap("name", "my-task-name")},
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions/123", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/tasks/executions/123", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/tasks/executions/123", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null},
 
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/tasks/executions/123", viewOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/tasks/executions/123", createOnlyUser, null },
-				{ HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null },
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.FORBIDDEN, "/tasks/executions/123", viewOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.NOT_FOUND, "/tasks/executions/123", createOnlyUser, null},
+				{HttpMethod.DELETE, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/executions", createOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.BAD_REQUEST, "/tasks/executions", createOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions/123", viewOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions/123", createOnlyUser, null },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions/123", manageOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions/123", viewOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions/123", createOnlyUser, null},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions/123", null, null},
 
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions", createOnlyUser,
-						TestUtils.toImmutableMap("name", "my-task-name") },
-				{ HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
-						TestUtils.toImmutableMap("name", "my-task-name") },
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", manageOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.POST, HttpStatus.FORBIDDEN, "/tasks/executions", viewOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.POST, HttpStatus.NOT_FOUND, "/tasks/executions", createOnlyUser,
+						TestUtils.toImmutableMap("name", "my-task-name")},
+				{HttpMethod.POST, HttpStatus.UNAUTHORIZED, "/tasks/executions", null,
+						TestUtils.toImmutableMap("name", "my-task-name")},
 
 				/* UiController */
 
-				{ HttpMethod.GET, HttpStatus.FOUND, "/dashboard", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FOUND, "/dashboard", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FOUND, "/dashboard", createOnlyUser, null },
+				{HttpMethod.GET, HttpStatus.FOUND, "/dashboard", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FOUND, "/dashboard", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FOUND, "/dashboard", createOnlyUser, null},
 
 				// FIXME
 				// { HttpMethod.GET, HttpStatus.FOUND, "/dashboard", null, null },
 
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/about", manageOnlyUser, null },
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/about", manageOnlyUser, null},
 
-				{ HttpMethod.GET, HttpStatus.OK, "/about", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/about", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/about", null, null },
+				{HttpMethod.GET, HttpStatus.OK, "/about", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/about", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/about", null, null},
 
-				{ HttpMethod.GET, HttpStatus.OK, "/management", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/management", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/management", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/management", null, null },
+				{HttpMethod.GET, HttpStatus.OK, "/management", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/management", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/management", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/management", null, null},
 
-				{ HttpMethod.GET, HttpStatus.OK, "/management/info", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/management/info", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/management/info", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/management/info", null, null },
+				{HttpMethod.GET, HttpStatus.OK, "/management/info", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/management/info", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/management/info", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/management/info", null, null},
 
-				{ HttpMethod.GET, HttpStatus.NOT_FOUND, "/management/does-not-exist", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/management/does-not-exist", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.FORBIDDEN, "/management/does-not-exist", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/management/does-not-exist", null, null },
+				{HttpMethod.GET, HttpStatus.NOT_FOUND, "/management/does-not-exist", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/management/does-not-exist", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.FORBIDDEN, "/management/does-not-exist", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.UNAUTHORIZED, "/management/does-not-exist", null, null},
 
 				/* SecurityController */
 
-				{ HttpMethod.GET, HttpStatus.OK, "/security/info", manageOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/security/info", viewOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/security/info", createOnlyUser, null },
-				{ HttpMethod.GET, HttpStatus.OK, "/security/info", null, null }
+				{HttpMethod.GET, HttpStatus.OK, "/security/info", manageOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/security/info", viewOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/security/info", createOnlyUser, null},
+				{HttpMethod.GET, HttpStatus.OK, "/security/info", null, null}
 		});
 	}
 
-	@Test
-	public void testEndpointAuthentication() throws Exception {
+	@MethodSource("data")
+	@ParameterizedTest(name = "Authentication Test {index} - {0} {2} - Returns: {1}")
+	public void testEndpointAuthentication(HttpMethod httpMethod, HttpStatus expectedHttpStatus, String url, UserCredentials userCredentials, Map<String, String> urlParameters) throws Exception {
+
+		initLocalServerSecurityWithUsersFileTests(httpMethod, expectedHttpStatus, url, userCredentials, urlParameters);
 
 		logger.info(String.format(
 				"Using parameters - httpMethod: %s, " + "URL: %s, URL parameters: %s, user credentials: %s",
@@ -638,20 +626,20 @@ public class LocalServerSecurityWithUsersFileTests {
 		final MockHttpServletRequestBuilder rb;
 
 		switch (httpMethod) {
-		case GET:
-			rb = get(url);
-			break;
-		case POST:
-			rb = post(url);
-			break;
-		case PUT:
-			rb = put(url);
-			break;
-		case DELETE:
-			rb = delete(url);
-			break;
-		default:
-			throw new IllegalArgumentException("Unsupported Method: " + httpMethod);
+			case GET:
+				rb = get(url);
+				break;
+			case POST:
+				rb = post(url);
+				break;
+			case PUT:
+				rb = put(url);
+				break;
+			case DELETE:
+				rb = delete(url);
+				break;
+			default:
+				throw new IllegalArgumentException("Unsupported Method: " + httpMethod);
 		}
 
 		if (this.userCredentials != null) {
@@ -668,32 +656,32 @@ public class LocalServerSecurityWithUsersFileTests {
 		final ResultMatcher statusResultMatcher;
 
 		switch (expectedHttpStatus) {
-		case UNAUTHORIZED:
-			statusResultMatcher = status().isUnauthorized();
-			break;
-		case FORBIDDEN:
-			statusResultMatcher = status().isForbidden();
-			break;
-		case FOUND:
-			statusResultMatcher = status().isFound();
-			break;
-		case NOT_FOUND:
-			statusResultMatcher = status().isNotFound();
-			break;
-		case OK:
-			statusResultMatcher = status().isOk();
-			break;
-		case CREATED:
-			statusResultMatcher = status().isCreated();
-			break;
-		case BAD_REQUEST:
-			statusResultMatcher = status().isBadRequest();
-			break;
-		case INTERNAL_SERVER_ERROR:
-			statusResultMatcher = status().isInternalServerError();
-			break;
-		default:
-			throw new IllegalArgumentException("Unsupported Status: " + expectedHttpStatus);
+			case UNAUTHORIZED:
+				statusResultMatcher = status().isUnauthorized();
+				break;
+			case FORBIDDEN:
+				statusResultMatcher = status().isForbidden();
+				break;
+			case FOUND:
+				statusResultMatcher = status().isFound();
+				break;
+			case NOT_FOUND:
+				statusResultMatcher = status().isNotFound();
+				break;
+			case OK:
+				statusResultMatcher = status().isOk();
+				break;
+			case CREATED:
+				statusResultMatcher = status().isCreated();
+				break;
+			case BAD_REQUEST:
+				statusResultMatcher = status().isBadRequest();
+				break;
+			case INTERNAL_SERVER_ERROR:
+				statusResultMatcher = status().isInternalServerError();
+				break;
+			default:
+				throw new IllegalArgumentException("Unsupported Status: " + expectedHttpStatus);
 		}
 
 		try {
@@ -729,6 +717,13 @@ public class LocalServerSecurityWithUsersFileTests {
 		public String toString() {
 			return String.format("UserCredentials: %s/%s.", this.username, this.password);
 		}
+	}
 
+	public void initLocalServerSecurityWithUsersFileTests(HttpMethod httpMethod, HttpStatus expectedHttpStatus, String url, UserCredentials userCredentials, Map<String, String> urlParameters) {
+		this.httpMethod = httpMethod;
+		this.expectedHttpStatus = expectedHttpStatus;
+		this.url = url;
+		this.userCredentials = userCredentials;
+		this.urlParameters = urlParameters;
 	}
 }


### PR DESCRIPTION
Hi @jvalkeal. This is a continuation of our effort to lift you up to JUnit 5. I'd like to make a few notes about this one though. 

* There are still two JUnit 4 `ExternalResource` implementations left in the code that will need to be migrated to JUnit 5. That should be all you have to do. The tests won't pass completely until these are migrated.
* We can generate this patch off of the latest main commit at any time with very little effort. So if you don't want to do this in the next couple days, just ping me when you're ready and we can regenerate a fresh commit off of the latest head, leaving you with just the `ExternalResource` migrations. Mainly I want you to see that the bulk of the heavy lifting is done, and you just have a couple things left to do.
* I've intentionally left the assertions as JUnit assertions to limit the scope of change somewhat. As soon as we get this merged, I can follow it up immediately with a PR to migrate to AssertJ. Hopefully this plan makes sense.

See https://github.com/spring-cloud/spring-cloud-dataflow/issues/4436.

cc / @cppwfs As promised last week ;)

Co-authored-by: Moderne <team@moderne.io>