### PR TITLE
Allow underscore in stream/task names on non-K8s environment

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -483,9 +483,11 @@ public class DataFlowControllerAutoConfiguration {
 				StreamDefinitionRepository streamDefinitionRepository,
 				SkipperStreamDeployer skipperStreamDeployer, AppDeploymentRequestCreator appDeploymentRequestCreator,
 				StreamValidationService streamValidationService,
-				AuditRecordService auditRecordService, StreamDefinitionService streamDefinitionService) {
+				AuditRecordService auditRecordService, StreamDefinitionService streamDefinitionService,
+				FeaturesProperties featuresProperties) {
 			return new DefaultStreamService(streamDefinitionRepository, skipperStreamDeployer,
-					appDeploymentRequestCreator, streamValidationService, auditRecordService, streamDefinitionService);
+					appDeploymentRequestCreator, streamValidationService, auditRecordService, streamDefinitionService,
+					featuresProperties);
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/FeaturesProperties.java
@@ -35,11 +35,15 @@ public class FeaturesProperties {
 
 	public static final String TASKS_ENABLED = "tasks-enabled";
 
+	public static final String UNDERSCORE_NAMES_ENABLED = "underscore-names-enabled";
+
 	private boolean streamsEnabled = true;
 
 	private boolean tasksEnabled = true;
 
 	private boolean schedulesEnabled = false;
+
+	private boolean underscoreNamesEnabled = false;
 
 	public boolean isStreamsEnabled() {
 		return this.streamsEnabled;
@@ -63,5 +67,13 @@ public class FeaturesProperties {
 
 	public void setSchedulesEnabled(boolean schedulesEnabled) {
 		this.schedulesEnabled = schedulesEnabled;
+	}
+
+	public boolean isUnderscoreNamesEnabled() {
+		return underscoreNamesEnabled;
+	}
+
+	public void setUnderscoreNamesEnabled(boolean underscoreNamesEnabled) {
+		this.underscoreNamesEnabled = underscoreNamesEnabled;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,8 +166,8 @@ public class TaskConfiguration {
 
 	@Bean
 	public TaskSaveService saveTaskService(TaskDefinitionRepository taskDefinitionRepository,
-			AuditRecordService auditRecordService, AppRegistryService registry) {
-		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry);
+			AuditRecordService auditRecordService, AppRegistryService registry, FeaturesProperties featuresProperties) {
+		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.springframework.cloud.dataflow.core.dsl.StreamNode;
 import org.springframework.cloud.dataflow.rest.SkipperStream;
 import org.springframework.cloud.dataflow.rest.UpdateStreamRequest;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployedException;
 import org.springframework.cloud.dataflow.server.controller.StreamAlreadyDeployingException;
 import org.springframework.cloud.dataflow.server.controller.support.InvalidStreamDefinitionException;
@@ -117,12 +118,15 @@ public class DefaultStreamService implements StreamService {
 
 	private final StreamDefinitionService streamDefinitionService;
 
+	private final FeaturesProperties featuresProperties;
+
 	public DefaultStreamService(StreamDefinitionRepository streamDefinitionRepository,
 			SkipperStreamDeployer skipperStreamDeployer,
 			AppDeploymentRequestCreator appDeploymentRequestCreator,
 			StreamValidationService streamValidationService,
 			AuditRecordService auditRecordService,
-			StreamDefinitionService streamDefinitionService) {
+			StreamDefinitionService streamDefinitionService,
+			FeaturesProperties featuresProperties) {
 
 		Assert.notNull(skipperStreamDeployer, "SkipperStreamDeployer must not be null");
 		Assert.notNull(appDeploymentRequestCreator, "AppDeploymentRequestCreator must not be null");
@@ -130,6 +134,7 @@ public class DefaultStreamService implements StreamService {
 		Assert.notNull(streamValidationService, "StreamValidationService must not be null");
 		Assert.notNull(auditRecordService, "AuditRecordService must not be null");
 		Assert.notNull(streamDefinitionService, "StreamDefinitionService must not be null");
+		Assert.notNull(featuresProperties, "FeaturesProperties must not be null");
 
 		this.skipperStreamDeployer = skipperStreamDeployer;
 		this.appDeploymentRequestCreator = appDeploymentRequestCreator;
@@ -138,7 +143,7 @@ public class DefaultStreamService implements StreamService {
 		this.auditRecordService = auditRecordService;
 		this.auditServiceUtils = new AuditServiceUtils();
 		this.streamDefinitionService = streamDefinitionService;
-
+		this.featuresProperties = featuresProperties;
 	}
 
 	/**
@@ -409,7 +414,7 @@ public class DefaultStreamService implements StreamService {
 			}
 		}
 
-		if (!STREAM_NAME_PATTERN.matcher(streamName).matches()) {
+		if (!this.featuresProperties.isUnderscoreNamesEnabled() && !STREAM_NAME_PATTERN.matcher(streamName).matches()) {
 			errorMessages.add(STREAM_NAME_VALIDATION_MSG);
 		}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.dataflow.core.dsl.TaskParser;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
 import org.springframework.cloud.dataflow.registry.support.NoSuchAppRegistrationException;
 import org.springframework.cloud.dataflow.rest.util.ArgumentSanitizer;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.repository.DuplicateTaskException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
@@ -71,21 +72,27 @@ public class DefaultTaskSaveService implements TaskSaveService {
 
 	private final ArgumentSanitizer argumentSanitizer = new ArgumentSanitizer();
 
+	private final FeaturesProperties featuresProperties;
+
 	public DefaultTaskSaveService(TaskDefinitionRepository taskDefinitionRepository,
-			AuditRecordService auditRecordService, AppRegistryService registry) {
+			AuditRecordService auditRecordService, AppRegistryService registry,
+			FeaturesProperties featuresProperties) {
 		Assert.notNull(taskDefinitionRepository, "TaskDefinitionRepository must not be null");
 		Assert.notNull(auditRecordService, "AuditRecordService must not be null");
 		Assert.notNull(registry, "AppRegistryService must not be null");
+		Assert.notNull(featuresProperties, "FeaturesProperties must not be null");
 
 		this.taskDefinitionRepository = taskDefinitionRepository;
 		this.auditRecordService = auditRecordService;
 		this.registry = registry;
+		this.featuresProperties = featuresProperties;
 	}
 
 	@Override
 	@Transactional
 	public void saveTaskDefinition(TaskDefinition taskDefinition) {
-		if (!TASK_NAME_PATTERN.matcher(taskDefinition.getTaskName()).matches()) {
+		if (!this.featuresProperties.isUnderscoreNamesEnabled() &&
+				!TASK_NAME_PATTERN.matcher(taskDefinition.getTaskName()).matches()) {
 			throw new TaskException(TASK_NAME_VALIDATION_MSG);
 		}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import org.springframework.cloud.dataflow.server.DockerValidatorProperties;
 import org.springframework.cloud.dataflow.server.batch.JobService;
 import org.springframework.cloud.dataflow.server.batch.SimpleJobServiceFactoryBean;
 import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.controller.JobExecutionController;
 import org.springframework.cloud.dataflow.server.controller.JobExecutionThinController;
 import org.springframework.cloud.dataflow.server.controller.JobInstanceController;
@@ -155,7 +156,7 @@ import static org.mockito.Mockito.mock;
 })
 @EnableJpaAuditing
 @EnableConfigurationProperties({ DockerValidatorProperties.class, TaskConfigurationProperties.class,
-		TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class})
+		TaskProperties.class, ComposedTaskRunnerConfigurationProperties.class, FeaturesProperties.class})
 @EnableMapRepositories(basePackages = "org.springframework.cloud.dataflow.server.job")
 public class JobDependencies {
 
@@ -267,8 +268,8 @@ public class JobDependencies {
 
 	@Bean
 	public TaskSaveService saveTaskService(TaskDefinitionRepository taskDefinitionRepository,
-			AuditRecordService auditRecordService, AppRegistryService registry) {
-		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry);
+			AuditRecordService auditRecordService, AppRegistryService registry, FeaturesProperties featuresProperties) {
+		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,6 +136,7 @@ import static org.mockito.Mockito.when;
 		TaskConfigurationProperties.class,
 		TaskProperties.class,
 		DockerValidatorProperties.class,
+		FeaturesProperties.class,
 		ComposedTaskRunnerConfigurationProperties.class })
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
@@ -262,11 +263,6 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public FeaturesProperties featuresProperties() {
-		return new FeaturesProperties();
-	}
-
-	@Bean
 	public SchedulerServiceProperties schedulerServiceProperties() {
 		return new SchedulerServiceProperties();
 	}
@@ -292,8 +288,8 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	public TaskSaveService saveTaskService(TaskDefinitionRepository taskDefinitionRepository,
-			AuditRecordService auditRecordService, AppRegistryService registry) {
-		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry);
+			AuditRecordService auditRecordService, AppRegistryService registry, FeaturesProperties featuresProperties) {
+		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -208,7 +208,8 @@ import static org.mockito.Mockito.when;
 		TaskProperties.class,
 		DockerValidatorProperties.class,
 		DataflowMetricsProperties.class,
-		ComposedTaskRunnerConfigurationProperties.class })
+		ComposedTaskRunnerConfigurationProperties.class,
+		FeaturesProperties.class })
 @EntityScan({
 		"org.springframework.cloud.dataflow.registry.domain",
 		"org.springframework.cloud.dataflow.core"
@@ -286,11 +287,6 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 	}
 
 	@Bean
-	public FeaturesProperties featuresProperties() {
-		return new FeaturesProperties();
-	}
-
-	@Bean
 	public StreamValidationService streamValidationService(AppRegistryService appRegistry,
 			DockerValidatorProperties dockerValidatorProperties,
 			StreamDefinitionRepository streamDefinitionRepository,
@@ -322,9 +318,11 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 			AppDeploymentRequestCreator appDeploymentRequestCreator,
 			StreamValidationService streamValidationService,
 			AuditRecordService auditRecordService,
-			StreamDefinitionService streamDefinitionService) {
+			StreamDefinitionService streamDefinitionService,
+			FeaturesProperties featuresProperties) {
 		return new DefaultStreamService(streamDefinitionRepository, skipperStreamDeployer,
-				appDeploymentRequestCreator, streamValidationService, auditRecordService, streamDefinitionService);
+				appDeploymentRequestCreator, streamValidationService, auditRecordService, streamDefinitionService,
+				featuresProperties);
 	}
 
 	@Bean
@@ -570,8 +568,8 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	public TaskSaveService saveTaskService(TaskDefinitionRepository taskDefinitionRepository,
-			AuditRecordService auditRecordService, AppRegistryService registry) {
-		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry);
+			AuditRecordService auditRecordService, AppRegistryService registry, FeaturesProperties featuresProperties) {
+		return new DefaultTaskSaveService(taskDefinitionRepository, auditRecordService, registry, featuresProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.DefaultStreamDefinitionService;
 import org.springframework.cloud.dataflow.core.StreamDefinition;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
 import org.springframework.cloud.dataflow.server.repository.StreamDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.StreamValidationService;
@@ -79,6 +80,9 @@ public class DefaultStreamServiceUpdateTests {
 	@Autowired
 	private StreamValidationService streamValidationService;
 
+	@Autowired
+	private FeaturesProperties featuresProperties;
+
 	@Test
 	public void testCreateUpdateRequestsWithRegisteredApp() throws IOException {
 		this.appRegistryService.save("log", ApplicationType.sink, "1.1.1.RELEASE",
@@ -103,7 +107,7 @@ public class DefaultStreamServiceUpdateTests {
 		DefaultStreamService streamService = new DefaultStreamService(streamDefinitionRepository,
 				skipperStreamDeployer,
 				appDeploymentRequestCreator, streamValidationService, auditRecordService,
-				new DefaultStreamDefinitionService());
+				new DefaultStreamDefinitionService(), featuresProperties);
 		StreamDefinition streamDefinition = new StreamDefinition("test", "time | log");
 		this.streamDefinitionRepository.save(streamDefinition);
 		Map<String, String> updateProperties = new HashMap<>();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -58,6 +58,7 @@ import org.springframework.cloud.dataflow.core.TaskManifest;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
 import org.springframework.cloud.dataflow.core.TaskPlatformFactory;
 import org.springframework.cloud.dataflow.registry.service.AppRegistryService;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
 import org.springframework.cloud.dataflow.server.configuration.TaskServiceDependencies;
 import org.springframework.cloud.dataflow.server.job.LauncherRepository;
 import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionDao;
@@ -1142,6 +1143,25 @@ public abstract class DefaultTaskExecutionServiceTests {
 					assertEquals(e.getMessage(), "Task name must consist of alphanumeric characters or '-', start " +
 							"with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name', " +
 							" or 'abc-123')");
+				}
+			}
+		}
+
+		@Test
+		@DirtiesContext
+		public void validateInvalidTaskNameWithUnderscoreNameAllowedTest() {
+			String[] taskNames = { "ta_sk" };
+
+			for (String taskName : taskNames) {
+				try {
+					initializeSuccessfulRegistry(appRegistry);
+					FeaturesProperties featuresProperties = mock(FeaturesProperties.class);
+					TaskSaveService taskSaveService = new DefaultTaskSaveService(taskDefinitionRepository,
+							auditRecordService, appRegistry, featuresProperties);
+					when(featuresProperties.isUnderscoreNamesEnabled()).thenReturn(true);
+					taskSaveService.saveTaskDefinition(new TaskDefinition(taskName, "AAA --foo=bar"));
+				} catch (Exception e) {
+					fail("Expected TaskException");
 				}
 			}
 		}


### PR DESCRIPTION
 - This is to add backwards compatibility support only on local and CF environments
 - Users need to specify `spring.cloud.dataflow.features.underscore-names-enabled" feature flag
   to enable underscore in the stream/task names
 - Add tests

Resolves #4640