### PR TITLE
Add drop auth headers redirect strategy for Azure

### DIFF
--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -165,6 +165,22 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-image</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<imageName>
+						springcloud/${project.artifactId}:${project.version}
+					</imageName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -288,6 +288,41 @@ public class DataFlowIT {
 		dataFlowOperations.appRegistryOperations().unregister("docker-app-with-jar-metadata", ApplicationType.sink);
 	}
 
+	@Test
+	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	public void githubContainerRegistryTests() {
+		containerRegistryTests("github-log-sink",
+				"docker:ghcr.io/tzolov/log-sink-rabbit:3.1.0-SNAPSHOT");
+	}
+
+	@Test
+	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	public void azureContainerRegistryTests() {
+		containerRegistryTests("azure-log-sink",
+				"docker:scdftest.azurecr.io/springcloudstream/log-sink-rabbit:3.1.0-SNAPSHOT");
+	}
+
+	@Test
+	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	public void harborContainerRegistryTests() {
+		containerRegistryTests("harbor-log-sink",
+				"docker:projects.registry.vmware.com/scdf/scdftest/log-sink-rabbit:3.1.0-SNAPSHOT");
+	}
+
+	private void containerRegistryTests(String appName, String appUrl) {
+		logger.info("application-metadata-" + appName + "-container-registry-test");
+
+		// Docker app with container image metadata
+		dataFlowOperations.appRegistryOperations().register( appName, ApplicationType.sink,
+				appUrl, null, true);
+		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
+				.info(appName, ApplicationType.sink, false);
+		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(3);
+
+		// unregister the test apps
+		dataFlowOperations.appRegistryOperations().unregister(appName, ApplicationType.sink);
+	}
+
 	// -----------------------------------------------------------------------
 	//                          PLATFORM  TESTS
 	// -----------------------------------------------------------------------

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
@@ -289,21 +290,21 @@ public class DataFlowIT {
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	@EnabledIfEnvironmentVariable(named = "SCDF_CR_TEST", matches="true")
 	public void githubContainerRegistryTests() {
 		containerRegistryTests("github-log-sink",
 				"docker:ghcr.io/tzolov/log-sink-rabbit:3.1.0-SNAPSHOT");
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	@EnabledIfEnvironmentVariable(named = "SCDF_CR_TEST", matches="true")
 	public void azureContainerRegistryTests() {
 		containerRegistryTests("azure-log-sink",
 				"docker:scdftest.azurecr.io/springcloudstream/log-sink-rabbit:3.1.0-SNAPSHOT");
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = "SCDF_CR_TEST", matches="true")
+	@EnabledIfEnvironmentVariable(named = "SCDF_CR_TEST", matches="true")
 	public void harborContainerRegistryTests() {
 		containerRegistryTests("harbor-log-sink",
 				"docker:projects.registry.vmware.com/scdf/scdftest/log-sink-rabbit:3.1.0-SNAPSHOT");

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -110,6 +110,12 @@ public class DockerComposeFactory {
 			.withAdditionalEnvironmentVariable("METADATA_DEFAULT_DOCKERHUB_USER", DockerComposeFactoryProperties.get("METADATA_DEFAULT_DOCKERHUB_USER", ""))
 			.withAdditionalEnvironmentVariable("METADATA_DEFAULT_DOCKERHUB_PASSWORD", DockerComposeFactoryProperties.get("METADATA_DEFAULT_DOCKERHUB_PASSWORD", ""))
 			.withAdditionalEnvironmentVariable("COMPOSE_PROJECT_NAME", "scdf")
+			.withAdditionalEnvironmentVariable("CR_AZURE_USER", DockerComposeFactoryProperties.get("CR_AZURE_USER", ""))
+			.withAdditionalEnvironmentVariable("CR_AZURE_PASS", DockerComposeFactoryProperties.get("CR_AZURE_PASS", ""))
+			.withAdditionalEnvironmentVariable("CR_GITHUB_USER", DockerComposeFactoryProperties.get("CR_GITHUB_USER", ""))
+			.withAdditionalEnvironmentVariable("CR_GITHUB_PASS", DockerComposeFactoryProperties.get("CR_GITHUB_PASS", ""))
+			.withAdditionalEnvironmentVariable("CR_HARBOR_USER", DockerComposeFactoryProperties.get("CR_HARBOR_USER", ""))
+			.withAdditionalEnvironmentVariable("CR_HARBOR_PASS", DockerComposeFactoryProperties.get("CR_HARBOR_PASS", ""))
 			.build();
 
 	private static String[] addDockerComposeToPath(String[] dockerComposePaths, String additionalDockerCompose) {

--- a/spring-cloud-dataflow-server/src/test/resources/docker-compose-container-registry-it.yml
+++ b/spring-cloud-dataflow-server/src/test/resources/docker-compose-container-registry-it.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+
+  dataflow-server:
+    environment:
+# AZURE
+      - spring.cloud.dataflow.container.registry-configurations.azure-registry.registry-host=scdftest.azurecr.io
+      - spring.cloud.dataflow.container.registry-configurations.azure-registry.authorization-type=basicauth
+      - spring.cloud.dataflow.container.registry-configurations.azure-registry.user=${CR_AZURE_USER}
+      - spring.cloud.dataflow.container.registry-configurations.azure-registry.secret=${CR_AZURE_PASS}
+# HARBOR
+      - spring.cloud.dataflow.container.registry-configurations.harbor-registry.registry-host=projects.registry.vmware.com
+      - spring.cloud.dataflow.container.registry-configurations.harbor-registry.authorization-type=basicauth
+#      - spring.cloud.dataflow.container.registry-configurations.harbor-registry.authorization-type=dockeroauth2
+      - spring.cloud.dataflow.container.registry-configurations.harbor-registry.user=${CR_HARBOR_USER}
+      - spring.cloud.dataflow.container.registry-configurations.harbor-registry.secret=${CR_HARBOR_PASS}
+# GITHUB
+      - spring.cloud.dataflow.container.registry-configurations.github-registry.registry-host=ghcr.io
+      - spring.cloud.dataflow.container.registry-configurations.github-registry.authorization-type=dockeroauth2
+      - spring.cloud.dataflow.container.registry-configurations.github-registry.user=${CR_GITHUB_USER}
+      - spring.cloud.dataflow.container.registry-configurations.github-registry.secret=${CR_GITHUB_PASS}

--- a/src/docker-compose/docker-compose-debug-dataflow.yml
+++ b/src/docker-compose/docker-compose-debug-dataflow.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "5005:5005"
     environment:
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005

--- a/src/docker-compose/docker-compose-debug-skipper.yml
+++ b/src/docker-compose/docker-compose-debug-skipper.yml
@@ -6,4 +6,4 @@ services:
     ports:
       - "6006:6006"
     environment:
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:6006
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:6006


### PR DESCRIPTION
 - Drop Authorization headers only for Basic auth.
 - Add support for GitHub Container registry.
    - Jackson MessageConverter support for text/plain. The Github CR response's media-type is always text/plain although the content is in JSON
 - Normalize Azure redirect URI
 - Add Container Registries IT tests
 - Add SCDF image build configuration
 - Fix docker compose debug conf for build pack images

 Resolves #4412