### PR TITLE
Validate K8s specific stream deployment/task launch

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamService.java
@@ -168,6 +168,12 @@ public class DefaultStreamService implements StreamService {
 				.findFirst()
 				.orElse("unknown");
 
+
+		if (platformType.equals("kubernetes") && !STREAM_NAME_PATTERN.matcher(streamDefinition.getName()).matches()) {
+			throw new InvalidStreamDefinitionException(String.format("Stream name %s is invalid. %s",
+					streamDefinition.getName(), STREAM_NAME_VALIDATION_MSG));
+		}
+
 		List<AppDeploymentRequest> appDeploymentRequests = this.appDeploymentRequestCreator
 				.createRequests(streamDefinition, deploymentPropertiesToUse, platformType);
 
@@ -407,10 +413,6 @@ public class DefaultStreamService implements StreamService {
 						String.format("Application name '%s' with type '%s' does not exist in the app registry.",
 								appName, applicationType));
 			}
-		}
-
-		if (!STREAM_NAME_PATTERN.matcher(streamName).matches()) {
-			errorMessages.add(STREAM_NAME_VALIDATION_MSG);
 		}
 
 		if (!errorMessages.isEmpty()) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -64,6 +65,7 @@ import org.springframework.cloud.dataflow.server.service.impl.diff.TaskAnalyzer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.task.listener.TaskException;
 import org.springframework.cloud.task.listener.TaskExecutionException;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.TaskExplorer;
@@ -145,6 +147,11 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	private TaskConfigurationProperties taskConfigurationProperties;
 
 	private ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties;
+
+	private static final Pattern TASK_NAME_PATTERN = Pattern.compile("[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?");
+	private static final String TASK_NAME_VALIDATION_MSG = "Task name must consist of alphanumeric characters " +
+			"or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name', " +
+			"or 'abc-123')";
 
 	/**
 	 * Initializes the {@link DefaultTaskExecutionService}.
@@ -257,7 +264,14 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	public long executeTask(String taskName, Map<String, String> taskDeploymentProperties, List<String> commandLineArgs) {
 		// Get platform name and fallback to 'default'
 		String platformName = getPlatform(taskDeploymentProperties);
-
+		String platformType = StreamSupport.stream(launcherRepository.findAll().spliterator(), true)
+				.filter(deployer -> deployer.getName().equalsIgnoreCase(platformName))
+				.map(Launcher::getType)
+				.findFirst()
+				.orElse("unknown");
+		if (platformType.equals(TaskPlatformFactory.KUBERNETES_PLATFORM_TYPE) && !TASK_NAME_PATTERN.matcher(taskName).matches()) {
+			throw new TaskException(String.format("Task name %s is invalid. %s", taskName, TASK_NAME_VALIDATION_MSG));
+		}
 		// Naive local state to prevent parallel launches to break things up
 		if(this.tasksBeingUpgraded.containsKey(taskName)) {
 			List<String> platforms = this.tasksBeingUpgraded.get(taskName);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskSaveService.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.server.service.impl;
 
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springframework.cloud.dataflow.audit.service.AuditRecordService;
@@ -33,7 +32,6 @@ import org.springframework.cloud.dataflow.rest.util.ArgumentSanitizer;
 import org.springframework.cloud.dataflow.server.repository.DuplicateTaskException;
 import org.springframework.cloud.dataflow.server.repository.TaskDefinitionRepository;
 import org.springframework.cloud.dataflow.server.service.TaskSaveService;
-import org.springframework.cloud.task.listener.TaskException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -56,9 +54,6 @@ import org.springframework.util.StringUtils;
  * @author Chris Schaefer
  */
 public class DefaultTaskSaveService implements TaskSaveService {
-	private static final Pattern TASK_NAME_PATTERN = Pattern.compile("[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?");
-	private static final String TASK_NAME_VALIDATION_MSG = "Task name must consist of alphanumeric characters or '-', " +
-			"start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123')";
 
 	private final TaskDefinitionRepository taskDefinitionRepository;
 
@@ -85,10 +80,6 @@ public class DefaultTaskSaveService implements TaskSaveService {
 	@Override
 	@Transactional
 	public void saveTaskDefinition(TaskDefinition taskDefinition) {
-		if (!TASK_NAME_PATTERN.matcher(taskDefinition.getTaskName()).matches()) {
-			throw new TaskException(TASK_NAME_VALIDATION_MSG);
-		}
-
 		TaskParser taskParser = new TaskParser(taskDefinition.getTaskName(), taskDefinition.getDslText(), true, true);
 		TaskNode taskNode = taskParser.parse();
 		if (taskDefinitionRepository.existsById(taskDefinition.getTaskName())) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -62,6 +62,7 @@ import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.task.listener.TaskException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.PageRequest;
@@ -178,6 +179,16 @@ public class DefaultSchedulerServiceTests {
 				"1234567789012345612345678901234567890123", BASE_DEFINITION_NAME, this.testProperties,
 				this.commandLineArgs, null);
 	}
+
+	@Test(expected = TaskException.class)
+	public void testScheduleWithInvalidTaskNameOnKuberenetesPlatform() {
+		String taskName = "test_a1";
+		taskDefinitionRepository.save(new TaskDefinition(taskName, "demo"));
+		getMockedKubernetesSchedulerService().schedule(BASE_SCHEDULE_NAME +
+						"test1", taskName, this.testProperties,
+				this.commandLineArgs, "default");
+	}
+
 
 	@Test
 	public void testScheduleWithCapitalizeNameOnKuberenetesPlatform() {


### PR DESCRIPTION
 - Instead of restricting the stream creation for all the platforms, restrict the invalid stream/task name only after when they are about to be deployed/launched.
   Since SCDF is aware of the underlying platform only at the time of deployment, we go with this approach of validation

 - Also, to provide compatibility with the previous deployments on local and CF, we don't enforce this validation on non K8s environments

Resolves #4640