### PR TITLE
Expose ssbj option groups

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,8 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 						subsectionWithPath("options").description("The options of the application (Array)"),
 						fieldWithPath("shortDescription").description("The description of the application"),
 						fieldWithPath("inboundPortNames").description("Inbound port names of the application"),
-						fieldWithPath("outboundPortNames").description("Outbound port names of the application")
+						fieldWithPath("outboundPortNames").description("Outbound port names of the application"),
+						fieldWithPath("optionGroups").description("Option groups of the application")
 					)
 				)
 			);

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,4 +63,14 @@ public abstract class ApplicationConfigurationMetadataResolver {
 	public abstract List<ConfigurationMetadataProperty> listProperties(Resource metadataResource, boolean exhaustive);
 
 	public abstract Map<String, Set<String>> listPortNames(Resource metadataResource);
+
+	/**
+	 * Return information about option grouping which is coming from an additional
+	 * metadata files meant to provide more details which options belong together.
+	 * Keys in a map are arbitrary id's and values a full options id's.
+	 *
+	 * @param metadataResource the metadata resource
+	 * @return map of option groups
+	 */
+	public abstract Map<String, Set<String>> listOptionGroups(Resource metadataResource);
 }

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,8 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 
 	private static final String PORT_MAPPING_PROPERTIES = "classpath*:/META-INF/dataflow-configuration-port-mapping.properties";
 
+	private static final String OPTION_GROUPS_PROPERTIES = "classpath*:/META-INF/dataflow-configuration-option-groups.properties";
+
 	private static final String CONFIGURATION_PROPERTIES_CLASSES = "configuration-properties.classes";
 
 	private static final String CONFIGURATION_PROPERTIES_NAMES = "configuration-properties.names";
@@ -91,6 +93,8 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 	private static final String CONFIGURATION_PROPERTIES_INBOUND_PORTS = "configuration-properties.inbound-ports";
 
 	private static final String CONFIGURATION_PROPERTIES_OUTBOUND_PORTS = "configuration-properties.outbound-ports";
+
+	private static final String CONFIGURATION_PROPERTIES_OPTION_GROUPS = "org.springframework.cloud.dataflow.configuration-properties.option-groups";
 
 	private static final String CONTAINER_IMAGE_CONFIGURATION_METADATA_LABEL_NAME = "org.springframework.cloud.dataflow.spring-configuration-metadata.json";
 
@@ -141,8 +145,9 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 		}
 
 		Resource[] portMappingResources = resourcePatternResolver.getResources(PORT_MAPPING_PROPERTIES);
+		Resource[] groupingResources = resourcePatternResolver.getResources(OPTION_GROUPS_PROPERTIES);
 		return concatArrays(configurationResources, deprecatedSpringConfigurationResources,
-				deprecatedDataflowConfigurationResources, portMappingResources);
+				deprecatedDataflowConfigurationResources, portMappingResources, groupingResources);
 
 	}
 
@@ -193,6 +198,31 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 				else {
 					Archive archive = resolveAsArchive(app);
 					return listPortNames(archive);
+				}
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Failed to retrieve port names for resource {} because of {}",
+					app, ExceptionUtils.getRootCauseMessage(e));
+			if (logger.isDebugEnabled()) {
+				logger.debug("(Details) for failed to retrieve port names for resource:" + app, e);
+			}
+			return Collections.emptyMap();
+		}
+
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public Map<String, Set<String>> listOptionGroups(Resource app) {
+		try {
+			if (app != null) {
+				if (isDockerSchema(app.getURI())) {
+					return resolveOptionGroupsFromContainerImage(app.getURI());
+				}
+				else {
+					Archive archive = resolveAsArchive(app);
+					return listOptionGroups(archive);
 				}
 			}
 		}
@@ -263,6 +293,22 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			portsMap.put("outbound", outboundPorts);
 		}
 		return portsMap;
+	}
+
+	private Map<String, Set<String>> resolveOptionGroupsFromContainerImage(URI imageUri) {
+		String imageName = imageUri.getSchemeSpecificPart();
+		Map<String, String> labels = this.containerImageMetadataResolver.getImageLabels(imageName);
+		if (CollectionUtils.isEmpty(labels)) {
+			return Collections.emptyMap();
+		}
+		Map<String, Set<String>> groupingsMap = new HashMap<>();
+		labels.entrySet().stream()
+			.filter(e -> e.getKey().startsWith(CONFIGURATION_PROPERTIES_OPTION_GROUPS))
+			.forEach(e -> {
+				String gKey = e.getKey().substring(CONFIGURATION_PROPERTIES_OPTION_GROUPS.length() + 1);
+				groupingsMap.put(gKey, new HashSet<>(Arrays.asList(StringUtils.delimitedListToStringArray(e.getValue(), ",", " "))));
+			});
+		return groupingsMap;
 	}
 
 	public List<ConfigurationMetadataProperty> listProperties(Archive archive, boolean exhaustive) {
@@ -339,6 +385,28 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			throw new AppMetadataResolutionException(
 					"Exception trying to list configuration properties for application " + archive,
 					e);
+		}
+	}
+
+	private Map<String, Set<String>> listOptionGroups(Archive archive) {
+		try (URLClassLoader moduleClassLoader = new BootClassLoaderFactory(archive, parent).createClassLoader()) {
+			Map<String, Set<String>> groupingsMap = new HashMap<>();
+			for (Resource resource : visibleConfigurationMetadataResources(moduleClassLoader)) {
+				Properties properties = new Properties();
+				properties.load(resource.getInputStream());
+				for(String key : properties.stringPropertyNames()) {
+					if (key.startsWith(CONFIGURATION_PROPERTIES_OPTION_GROUPS)) {
+						String value = properties.getProperty(key);
+						String gKey = key.substring(CONFIGURATION_PROPERTIES_OPTION_GROUPS.length() + 1);
+						groupingsMap.put(gKey, new HashSet<>(Arrays.asList(StringUtils.delimitedListToStringArray(value, ",", " "))));
+					}
+				}
+			}
+			return groupingsMap;
+		}
+		catch (Exception e) {
+			throw new AppMetadataResolutionException(
+					"Exception trying to list configuration properties option groups for application " + archive, e);
 		}
 	}
 

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,6 +162,19 @@ public class BootApplicationConfigurationMetadataResolverTests {
 		assertThat(portNames.get("inbound"), containsInAnyOrder("in1", "in2", "in3"));
 		assertThat(portNames.get("outbound").size(), is(2));
 		assertThat(portNames.get("outbound"), containsInAnyOrder("out1", "out2"));
+	}
+
+	@Test
+	public void shouldReturnOptionGroupsProperties() {
+		Map<String, Set<String>> optionGroups = resolver.listOptionGroups(new ClassPathResource("apps/filter-processor", getClass()));
+		assertThat(optionGroups.size(), is(4));
+		assertThat(optionGroups.get("g1").size(), is(3));
+		assertThat(optionGroups.get("g1"), containsInAnyOrder("foo1.bar1", "foo1.bar2", "foo1.bar3"));
+		assertThat(optionGroups.get("g2").size(), is(0));
+		assertThat(optionGroups.get("g1.sb1").size(), is(1));
+		assertThat(optionGroups.get("g1.sb1"), containsInAnyOrder("foo2.bar1"));
+		assertThat(optionGroups.get("g1.sb2").size(), is(2));
+		assertThat(optionGroups.get("g1.sb2"), containsInAnyOrder("foo3.bar1", "foo3.bar2"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-configuration-metadata/src/test/resources/org/springframework/cloud/dataflow/configuration/metadata/apps/filter-processor/META-INF/dataflow-configuration-option-groups.properties
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/resources/org/springframework/cloud/dataflow/configuration/metadata/apps/filter-processor/META-INF/dataflow-configuration-option-groups.properties
@@ -1,0 +1,7 @@
+org.springframework.cloud.dataflow.configuration-properties.option-groups.g1=foo1.bar1,\
+  foo1.bar2,\
+  foo1.bar3
+org.springframework.cloud.dataflow.configuration-properties.option-groups.g2=
+org.springframework.cloud.dataflow.configuration-properties.option-groups.g1.sb1=foo2.bar1
+org.springframework.cloud.dataflow.configuration-properties.option-groups.g1.sb2=foo3.bar1,\
+  foo3.bar2

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/DetailedAppRegistrationResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/DetailedAppRegistrationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 package org.springframework.cloud.dataflow.rest.resource;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
@@ -54,6 +56,11 @@ public class DetailedAppRegistrationResource extends AppRegistrationResource {
 	 * Outbound port names configured for the app.
 	 */
 	private final Set<String> outboundPortNames = new HashSet<>();
+
+	/**
+	 * Option groups configured for the app.
+	 */
+	private final Map<String, Set<String>> optionGroups = new HashMap<>();
 
 	/**
 	 * Default constructor for serialization frameworks.
@@ -148,6 +155,15 @@ public class DetailedAppRegistrationResource extends AppRegistrationResource {
 	 */
 	public String getShortDescription() {
 		return shortDescription;
+	}
+
+	/**
+	 * Return an option groups.
+	 *
+	 * @return the option groups
+	 */
+	public Map<String, Set<String>> getOptionGroups() {
+		return optionGroups;
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,6 +209,9 @@ public class AppRegistryController {
 				}
 			}
 		}
+		Map<String, Set<String>> groupingsMap = this.metadataResolver
+				.listOptionGroups(this.appRegistryService.getAppMetadataResource(registration));
+		result.getOptionGroups().putAll(groupingsMap);
 		return result;
 	}
 

--- a/spring-cloud-dataflow-single-step-batch-job/src/main/resources/META-INF/dataflow-configuration-option-groups.properties
+++ b/spring-cloud-dataflow-single-step-batch-job/src/main/resources/META-INF/dataflow-configuration-option-groups.properties
@@ -1,0 +1,65 @@
+org.springframework.cloud.dataflow.configuration-properties.option-groups.common=spring.batch.job.job-name,\
+  spring.batch.job.step-name,\
+  spring.batch.job.chunk-size,\
+  spring.batch.job.names
+org.springframework.cloud.dataflow.configuration-properties.option-groups.readers.amqpitemreader=spring.batch.job.amqpitemreader.enabled,\
+  spring.batch.job.amqpitemreader.json-converter-enabled
+org.springframework.cloud.dataflow.configuration-properties.option-groups.readers.flatfileitemreader=spring.batch.job.flatfileitemreader.comments,\
+  spring.batch.job.flatfileitemreader.current-item-count,\
+  spring.batch.job.flatfileitemreader.delimited,\
+  spring.batch.job.flatfileitemreader.delimiter,\
+  spring.batch.job.flatfileitemreader.encoding,\
+  spring.batch.job.flatfileitemreader.fixed-length,\
+  spring.batch.job.flatfileitemreader.included-fields,\
+  spring.batch.job.flatfileitemreader.lines-to-skip,\
+  spring.batch.job.flatfileitemreader.max-item-count,\
+  spring.batch.job.flatfileitemreader.name,\
+  spring.batch.job.flatfileitemreader.names,\
+  spring.batch.job.flatfileitemreader.parsing-strict,\
+  spring.batch.job.flatfileitemreader.quote-character,\
+  spring.batch.job.flatfileitemreader.ranges,\
+  spring.batch.job.flatfileitemreader.resource,\
+  spring.batch.job.flatfileitemreader.save-state,\
+  spring.batch.job.flatfileitemreader.strict
+org.springframework.cloud.dataflow.configuration-properties.option-groups.readers.jdbccursoritemreader=spring.batch.job.jdbccursoritemreader.current-item-count,\
+  spring.batch.job.jdbccursoritemreader.driver-supports-absolute,\
+  spring.batch.job.jdbccursoritemreader.fetch-size,\
+  spring.batch.job.jdbccursoritemreader.ignore-warnings,\
+  spring.batch.job.jdbccursoritemreader.max-item-count,\
+  spring.batch.job.jdbccursoritemreader.max-rows,\
+  spring.batch.job.jdbccursoritemreader.name,\
+  spring.batch.job.jdbccursoritemreader.query-timeout,\
+  spring.batch.job.jdbccursoritemreader.save-state,\
+  spring.batch.job.jdbccursoritemreader.sql,\
+  spring.batch.job.jdbccursoritemreader.use-shared-extended-connection,\
+  spring.batch.job.jdbccursoritemreader.verify-cursor-position
+org.springframework.cloud.dataflow.configuration-properties.option-groups.readers.kafkaitemreader=spring.batch.job.kafkaitemreader.name,\
+  spring.batch.job.kafkaitemreader.partitions,\
+  spring.batch.job.kafkaitemreader.poll-time-out-in-seconds,\
+  spring.batch.job.kafkaitemreader.save-state,\
+  spring.batch.job.kafkaitemreader.topic,\
+  spring.batch.job.kafkaitemwriter.delete,\
+  spring.batch.job.kafkaitemwriter.topic
+org.springframework.cloud.dataflow.configuration-properties.option-groups.writers.amqpitemwriter=
+org.springframework.cloud.dataflow.configuration-properties.option-groups.writers.flatfileitemwriter=spring.batch.job.flatfileitemwriter.append,\
+  spring.batch.job.flatfileitemwriter.delimited,\
+  spring.batch.job.flatfileitemwriter.delimiter,\
+  spring.batch.job.flatfileitemwriter.encoding,\
+  spring.batch.job.flatfileitemwriter.force-sync,\
+  spring.batch.job.flatfileitemwriter.format,\
+  spring.batch.job.flatfileitemwriter.formatted,\
+  spring.batch.job.flatfileitemwriter.line-separator,\
+  spring.batch.job.flatfileitemwriter.locale,\
+  spring.batch.job.flatfileitemwriter.maximum-length,\
+  spring.batch.job.flatfileitemwriter.minimum-length,\
+  spring.batch.job.flatfileitemwriter.name,\
+  spring.batch.job.flatfileitemwriter.names,\
+  spring.batch.job.flatfileitemwriter.resource,\
+  spring.batch.job.flatfileitemwriter.save-state,\
+  spring.batch.job.flatfileitemwriter.should-delete-if-empty,\
+  spring.batch.job.flatfileitemwriter.should-delete-if-exists,\
+  spring.batch.job.flatfileitemwriter.transactional
+org.springframework.cloud.dataflow.configuration-properties.option-groups.writers.jdbcbatchitemwriter=spring.batch.job.jdbcbatchitemwriter.assert-updates,\
+  spring.batch.job.jdbcbatchitemwriter.name,\
+  spring.batch.job.jdbcbatchitemwriter.sql
+org.springframework.cloud.dataflow.configuration-properties.option-groups.writers.kafkaitemwriter=


### PR DESCRIPTION
- single step batch job is a monolith task app having set of readers/writers
  where combination of valid options depends on what reader and writer is
  "enabled" at any given time. order to "hint" UI we need to expose
  these set of options.
- Using same idea how app can define inbount/outbound port names
  by properties file in META-INF, define a set of properties which
  maps into arbitrary grouping id with set of options in it.
- File name is `dataflow-configuration-option-groups.properties` which can contain
  sections named `org.springframework.cloud.dataflow.configuration-properties.option-groups.<xxx>.<ddd>`
  where `<xxx>.<ddd>` becomes grouping id and value of it is a delimited list of options.
- Fixes #4670

For docker needed labels can be added with pack using something like:
```
pack build \
  --path spring-cloud-dataflow-single-step-batch-job/target/spring-cloud-dataflow-single-step-batch-job-2.9.0-SNAPSHOT.jar \
  --builder gcr.io/paketo-buildpacks/builder:base \
  --env BP_JVM_VERSION=16 ghcr.io/jvalkeal/springcloud/spring-cloud-dataflow-single-step-batch-job:2.9.0-SNAPSHOT \
  --env BP_IMAGE_LABELS="$(unzip -p spring-cloud-dataflow-single-step-batch-job/target/spring-cloud-dataflow-single-step-batch-job-2.9.0-SNAPSHOT.jar META-INF/dataflow-configuration-option-groups.properties | sed -e ':a' -e 'N' -e '$!ba' -e 's/\\\n//g' -e 's/ //g' -e 's/\n/ /')"
```