### PR TITLE
[Do Not Merge] Validate the registered apps existence 

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolver.java
@@ -62,6 +62,18 @@ public abstract class ApplicationConfigurationMetadataResolver {
 	 */
 	public abstract List<ConfigurationMetadataProperty> listProperties(Resource metadataResource, boolean exhaustive);
 
+	/**
+	 * Verifies if the app metadata resource exists.
+	 * @param app application to check existence for.
+	 * @return Returns true if the app resource exists or false otherwise.
+	 */
+	public abstract boolean isMetadataResourceExists(Resource app);
+
+	/**
+	 * Retrieves port names (if any) from the provided metadata resources
+	 * @param metadataResource Metadata to retrieve the port names from.
+	 * @return Returns list of port names grouped into inbound and outbound groups.
+	 */
 	public abstract Map<String, Set<String>> listPortNames(Resource metadataResource);
 
 	/**

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/BootApplicationConfigurationMetadataResolver.java
@@ -167,13 +167,7 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 	public List<ConfigurationMetadataProperty> listProperties(Resource app, boolean exhaustive) {
 		try {
 			if (app != null) {
-				if (isDockerSchema(app.getURI())) {
-					return resolvePropertiesFromContainerImage(app.getURI());
-				}
-				else {
-					Archive archive = resolveAsArchive(app);
-					return listProperties(archive, exhaustive);
-				}
+				return listPropertiesOrThrowException(app, exhaustive);
 			}
 		}
 		catch (Exception e) {
@@ -182,10 +176,27 @@ public class BootApplicationConfigurationMetadataResolver extends ApplicationCon
 			if (logger.isDebugEnabled()) {
 				logger.debug("(Details) for failed to retrieve properties for resource:" + app, e);
 			}
-			return Collections.emptyList();
 		}
-
 		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean isMetadataResourceExists(Resource app) {
+		if (app == null) {
+			return false;
+		}
+		try {
+			return listPropertiesOrThrowException(app, true) != null;
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+	private List<ConfigurationMetadataProperty> listPropertiesOrThrowException(Resource app, boolean exhaustive) throws Exception {
+		return isDockerSchema(app.getURI()) ?
+				resolvePropertiesFromContainerImage(app.getURI()) :
+				listProperties(resolveAsArchive(app), exhaustive);
 	}
 
 	@Override

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryOperations.java
@@ -80,9 +80,10 @@ public interface AppRegistryOperations {
 	 * @param uri URI for the application artifact
 	 * @param metadataUri URI for the application metadata artifact
 	 * @param force if {@code true}, overwrites a pre-existing registration
+	 * @param artefactValidation if {@code true}, checks if the (metadata) URI refers a valid artefact.
 	 * @return the new app registration
 	 */
-	AppRegistrationResource register(String name, ApplicationType type, String uri, String metadataUri, boolean force);
+	AppRegistrationResource register(String name, ApplicationType type, String uri, String metadataUri, boolean force, boolean artefactValidation);
 
 	/**
 	 * Register an application name, type and version with its Maven coordinates.
@@ -93,10 +94,11 @@ public interface AppRegistryOperations {
 	 * @param uri URI for the application artifact
 	 * @param metadataUri URI for the application metadata artifact
 	 * @param force if {@code true}, overwrites a pre-existing registration
+	 * @param artefactValidation if {@code true}, checks if the (metadata) URI refers a valid aretefact.
 	 * @return the new app registration
 	 */
 	AppRegistrationResource register(String name, ApplicationType type, String version, String uri,
-			String metadataUri, boolean force);
+			String metadataUri, boolean force, boolean artefactValidation);
 
 	/**
 	 * Unregister an application name and type.
@@ -133,9 +135,10 @@ public interface AppRegistryOperations {
 	 *
 	 * @param uri URI for the properties file
 	 * @param force if {@code true}, overwrites any pre-existing registrations
+	 * @param artefactValidation if {@code true}, the existence of the app artifact is validated.
 	 * @return the paged list of new app registrations
 	 */
-	PagedModel<AppRegistrationResource> importFromResource(String uri, boolean force);
+	PagedModel<AppRegistrationResource> importFromResource(String uri, boolean force, boolean artefactValidation);
 
 
 	/**
@@ -143,8 +146,9 @@ public interface AppRegistryOperations {
 	 *
 	 * @param apps the apps as key/value pairs where key is "type.name" and value is a URI
 	 * @param force if {@code true}, overwrites any pre-existing registrations
+	 * @param artefactValidation if {@code true}, the existence of the app artifact is validated.
 	 * @return the paged list of new app registrations
 	 */
-	PagedModel<AppRegistrationResource> registerAll(Properties apps, boolean force);
+	PagedModel<AppRegistrationResource> registerAll(Properties apps, boolean force, boolean artefactValidation);
 
 }

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/AppRegistryTemplate.java
@@ -113,13 +113,14 @@ public class AppRegistryTemplate implements AppRegistryOperations {
 
 	@Override
 	public AppRegistrationResource register(String name, ApplicationType type, String uri, String metadataUri,
-			boolean force) {
+			boolean force, boolean artefactValidation) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("uri", uri);
 		if (metadataUri != null) {
 			values.add("metadata-uri", metadataUri);
 		}
 		values.add("force", Boolean.toString(force));
+		values.add("artefact-validation", Boolean.toString(artefactValidation));
 
 		return restTemplate.postForObject(appsLink.getHref() + "/{type}/{name}", values,
 				AppRegistrationResource.class, type, name);
@@ -127,28 +128,30 @@ public class AppRegistryTemplate implements AppRegistryOperations {
 
 	@Override
 	public AppRegistrationResource register(String name, ApplicationType type, String version, String uri,
-			String metadataUri, boolean force) {
+			String metadataUri, boolean force, boolean artefactValidation) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		values.add("uri", uri);
 		if (metadataUri != null) {
 			values.add("metadata-uri", metadataUri);
 		}
 		values.add("force", Boolean.toString(force));
+		values.add("artefact-validation", Boolean.toString(artefactValidation));
 
 		return restTemplate.postForObject(appsLink.getHref() + "/{type}/{name}/{version}", values,
 				AppRegistrationResource.class, type, name, version);
 	}
 
 	@Override
-	public PagedModel<AppRegistrationResource> importFromResource(String uri, boolean force) {
+	public PagedModel<AppRegistrationResource> importFromResource(String uri, boolean force, boolean artefactValidation) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		values.add("uri", uri);
 		values.add("force", Boolean.toString(force));
+		values.add("artefact-validation", Boolean.toString(artefactValidation));
 		return restTemplate.postForObject(appsLink.getHref(), values, AppRegistrationResource.Page.class);
 	}
 
 	@Override
-	public PagedModel<AppRegistrationResource> registerAll(Properties apps, boolean force) {
+	public PagedModel<AppRegistrationResource> registerAll(Properties apps, boolean force, boolean artefactValidation) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<>();
 		StringBuffer buffer = new StringBuffer();
 		for (String key : apps.stringPropertyNames()) {
@@ -156,6 +159,7 @@ public class AppRegistryTemplate implements AppRegistryOperations {
 		}
 		values.add("apps", buffer.toString());
 		values.add("force", Boolean.toString(force));
+		values.add("artefact-validation", Boolean.toString(artefactValidation));
 		return restTemplate.postForObject(appsLink.getHref(), values, AppRegistrationResource.Page.class);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/NonExistingApplicationArtefactException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/NonExistingApplicationArtefactException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.controller;
+
+import java.util.List;
+
+/**
+ * @author Christian Tzolov
+ */
+public class NonExistingApplicationArtefactException extends IllegalStateException {
+
+	private static final long serialVersionUID = 1L;
+	private final String uris;
+
+	public NonExistingApplicationArtefactException(String...uris) {
+		this.uris = String.join(",", uris);
+	}
+
+	public NonExistingApplicationArtefactException(List<String> uris) {
+		this.uris = String.join(",", uris);
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("Non existing application artifacts: %s'", uris);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RestControllerAdvice.java
@@ -93,14 +93,16 @@ public class RestControllerAdvice {
 	 * Log the exception message at warn level and stack trace as trace level. Return
 	 * response status HttpStatus.CONFLICT
 	 *
-	 * @param e one of the exceptions, {@link AppAlreadyRegisteredException},
+	 * @param e one of the exceptions, {@link NonExistingApplicationArtefactException},
+	 * {@link AppAlreadyRegisteredException},
 	 * {@link DuplicateStreamDefinitionException}, {@link DuplicateTaskException},
 	 * {@link StreamAlreadyDeployedException}, {@link StreamAlreadyDeployingException}, or
 	 * {@link StreamAlreadyDeployingException}
 	 * @return the error response in JSON format with media type
 	 * application/vnd.error+json
 	 */
-	@ExceptionHandler({ AppAlreadyRegisteredException.class, DuplicateStreamDefinitionException.class,
+	@ExceptionHandler({ NonExistingApplicationArtefactException.class,
+			AppAlreadyRegisteredException.class, DuplicateStreamDefinitionException.class,
 			DuplicateTaskException.class, StreamAlreadyDeployedException.class, StreamAlreadyDeployingException.class,
 			UnregisterAppException.class, InvalidCTRLaunchRequestException.class})
 	@ResponseStatus(HttpStatus.CONFLICT)

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -242,7 +242,7 @@ public class DataFlowIT {
 
 		// Maven app without metadata
 		dataFlowOperations.appRegistryOperations().register("maven-app-without-metadata", ApplicationType.sink,
-				"maven://org.springframework.cloud.stream.app:file-sink-kafka:3.0.1", null, true);
+				"maven://org.springframework.cloud.stream.app:file-sink-kafka:3.0.1", null, true, false);
 		DetailedAppRegistrationResource mavenAppWithoutMetadata = dataFlowOperations.appRegistryOperations()
 				.info("maven-app-without-metadata", ApplicationType.sink, false);
 		assertThat(mavenAppWithoutMetadata.getOptions()).hasSize(8);
@@ -258,21 +258,21 @@ public class DataFlowIT {
 
 		// Docker app with container image metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata", ApplicationType.source,
-				"docker:springcloudstream/time-source-kafka:2.1.4.RELEASE", null, true);
+				"docker:springcloudstream/time-source-kafka:2.1.4.RELEASE", null, true, false);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-container-metadata", ApplicationType.source, false);
 		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(6);
 
 		// Docker app with container image metadata with escape characters.
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-container-metadata-escape-chars", ApplicationType.source,
-				"docker:springcloudstream/http-source-rabbit:2.1.3.RELEASE", null, true);
+				"docker:springcloudstream/http-source-rabbit:2.1.3.RELEASE", null, true, false);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadataWithEscapeChars = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-container-metadata-escape-chars", ApplicationType.source, false);
 		assertThat(dockerAppWithContainerMetadataWithEscapeChars.getOptions()).hasSize(6);
 
 		// Docker app without metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-without-metadata", ApplicationType.sink,
-				"docker:springcloudstream/file-sink-kafka:2.1.1.RELEASE", null, true);
+				"docker:springcloudstream/file-sink-kafka:2.1.1.RELEASE", null, true, false);
 		DetailedAppRegistrationResource dockerAppWithoutMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-without-metadata", ApplicationType.sink, false);
 		assertThat(dockerAppWithoutMetadata.getOptions()).hasSize(0);
@@ -280,7 +280,7 @@ public class DataFlowIT {
 		// Docker app with jar metadata
 		dataFlowOperations.appRegistryOperations().register("docker-app-with-jar-metadata", ApplicationType.sink,
 				"docker:springcloudstream/file-sink-kafka:2.1.1.RELEASE",
-				"maven://org.springframework.cloud.stream.app:file-sink-kafka:jar:metadata:2.1.1.RELEASE", true);
+				"maven://org.springframework.cloud.stream.app:file-sink-kafka:jar:metadata:2.1.1.RELEASE", true, false);
 		DetailedAppRegistrationResource dockerAppWithJarMetadata = dataFlowOperations.appRegistryOperations()
 				.info("docker-app-with-jar-metadata", ApplicationType.sink, false);
 		assertThat(dockerAppWithJarMetadata.getOptions()).hasSize(8);
@@ -318,7 +318,7 @@ public class DataFlowIT {
 
 		// Docker app with container image metadata
 		dataFlowOperations.appRegistryOperations().register(appName, ApplicationType.sink,
-				appUrl, null, true);
+				appUrl, null, true, false);
 		DetailedAppRegistrationResource dockerAppWithContainerMetadata = dataFlowOperations.appRegistryOperations()
 				.info(appName, ApplicationType.sink, false);
 		assertThat(dockerAppWithContainerMetadata.getOptions()).hasSize(3);
@@ -1667,7 +1667,7 @@ public class DataFlowIT {
 				try {
 					appRegistryOperations.register("timestamp", ApplicationType.task,
 							"maven://org.springframework.cloud.task.app:timestamp-task:2.1.0.RELEASE",
-							"maven://org.springframework.cloud.task.app:timestamp-task:2.1.0.RELEASE", false);
+							"maven://org.springframework.cloud.task.app:timestamp-task:2.1.0.RELEASE", false, false);
 				}
 				catch (DataFlowClientException dfe) {
 					logger.info(dfe.getMessage(), dfe);
@@ -1677,7 +1677,7 @@ public class DataFlowIT {
 				try {
 					appRegistryOperations.register("timestamp", ApplicationType.task,
 							"docker:springcloudtask/timestamp-task:2.1.0.RELEASE",
-							null, false);
+							null, false, false);
 				}
 				catch (DataFlowClientException dfe) {
 					logger.info(dfe.getMessage(), dfe);

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommands.java
@@ -251,9 +251,10 @@ public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
 					"type" }, help = "the type for the registered application") ApplicationType type,
 			@CliOption(mandatory = true, key = { "uri" }, help = "URI for the application artifact") String uri,
 			@CliOption(key = { "metadata-uri" }, help = "Metadata URI for the application artifact") String metadataUri,
-			@CliOption(key = "force", help = "force update if application is already registered (only if not in use)", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean force) {
+			@CliOption(key = "force", help = "force update if application is already registered (only if not in use)", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean force,
+			@CliOption(key = "artefact-validation", help = "checks if the app URI represents an existing artefact", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean artefactValidation) {
 
-		appRegistryOperations().register(name, type, uri, metadataUri, force);
+		appRegistryOperations().register(name, type, uri, metadataUri, force, artefactValidation);
 
 		return String.format(("Successfully registered application '%s:%s'"), type, name);
 	}
@@ -335,14 +336,15 @@ public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
 	public String importFromResource(
 			@CliOption(mandatory = true, key = { "", "uri" }, help = "URI for the properties file") String uri,
 			@CliOption(key = "local", help = "whether to resolve the URI locally (as opposed to on the server)", specifiedDefaultValue = "true", unspecifiedDefaultValue = "true") boolean local,
-			@CliOption(key = "force", help = "force update if any module already exists (only if not in use)", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean force) {
+			@CliOption(key = "force", help = "force update if any module already exists (only if not in use)", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean force,
+			@CliOption(key = "artefact-validation", help = "checks if the app URI represents an existing artefact", specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean artefactValidation) {
 		if (local) {
 			try {
 				Resource resource = this.resourceLoader.getResource(uri);
 				Properties applications = PropertiesLoaderUtils.loadProperties(resource);
 				PagedModel<AppRegistrationResource> registered = null;
 				try {
-					registered = appRegistryOperations().registerAll(applications, force);
+					registered = appRegistryOperations().registerAll(applications, force, artefactValidation);
 				}
 				catch (Exception e) {
 					return "Error when registering applications from " + uri + ": " + e.getMessage();
@@ -358,7 +360,7 @@ public class AppRegistryCommands implements CommandMarker, ResourceLoaderAware {
 			}
 		}
 		else {
-			PagedModel<AppRegistrationResource> registered = appRegistryOperations().importFromResource(uri, force);
+			PagedModel<AppRegistrationResource> registered = appRegistryOperations().importFromResource(uri, force, artefactValidation);
 			return String.format("Successfully registered %d applications from '%s'",
 					registered.getMetadata().getTotalElements(), uri);
 		}


### PR DESCRIPTION
 - Add isMetadataResourceExists(Resource app) method to the App configuration metadata resolver APIs - later verifies that the metadata artifact being a metadata jar, application jar or docker image exists physically.

 - Extend the AppRegistryController #register and #registerAll methods with an optional, artefact-validation boolean flag. For backward compatibility the artefact-validation defaults to false.

 - The AppRegistryController#register() method with artefact-validation=true will fail with NonExistingApplicationArtefactException if the URIs are pointing to non-existing artefacts. The application registration is aborted.

 - The new NonExistingApplicationArtefactException exception is added to the RestControllerAdvice

 - The AppRegistryController#register() method with artefact-validation=true will store all valid registration but will remove those that faile to resovle their metadata URIs. The error message lists the failing app's URIs.

 - REST client's AppRegistryOperations#{register,registerimportFromResource,registerAll} methods are extended with an optional artefactValidation parameter.

 - Add some initial tests.

 Resolves #1497