### PR TITLE
Enable inherit logging for ITs (2)

### DIFF
--- a/spring-cloud-dataflow-server/src/test/resources/docker-compose-inherit-logging.yml
+++ b/spring-cloud-dataflow-server/src/test/resources/docker-compose-inherit-logging.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+# Enable inherit-logging for all stream and task applications. This allows the logs for those apps (including CRT)
+# to be inlined within the logs of the parent (e.g. Data Flow or Skipper) applications.
+# The parent logs are often preserved by the CI as build artefacts, this would allow collect and preserver
+# the apps logs as well.
+services:
+  dataflow-server:
+    environment:
+      - SPRING_CLOUD_DATAFLOW_TASK_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_INHERIT_LOGGING=true
+  skipper-server:
+    environment:
+      - SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_LOCAL_ACCOUNTS_DEFAULT_INHERIT_LOGGING=true


### PR DESCRIPTION
   Additional docker-compose file to set the inherit-logging on.
   One can use the -Dtest.docker.compose.paths to add it to the ITs list of docker-compose files.

   Resolves #4710