### PR TITLE
Set the db for mariadb to mysql

### DIFF
--- a/src/kubernetes/server/server-config.yaml
+++ b/src/kubernetes/server/server-config.yaml
@@ -28,7 +28,7 @@ data:
                     limits:
                       memory: 1024Mi
       datasource:
-        url: jdbc:mariadb://${MARIADB_SERVICE_HOST}:${MARIADB_SERVICE_PORT}/mariadb
+        url: jdbc:mariadb://${MARIADB_SERVICE_HOST}:${MARIADB_SERVICE_PORT}/mysql
         username: root
         password: ${mariadb-root-password}
         driverClassName: org.mariadb.jdbc.Driver

--- a/src/templates/kubernetes/server/server-config.yaml
+++ b/src/templates/kubernetes/server/server-config.yaml
@@ -28,7 +28,7 @@ data:
                     limits:
                       memory: 1024Mi
       datasource:
-        url: jdbc:mariadb://${MARIADB_SERVICE_HOST}:${MARIADB_SERVICE_PORT}/mariadb
+        url: jdbc:mariadb://${MARIADB_SERVICE_HOST}:${MARIADB_SERVICE_PORT}/mysql
         username: root
         password: ${mariadb-root-password}
         driverClassName: org.mariadb.jdbc.Driver


### PR DESCRIPTION
Mysql is still the default db for mariadb