### PR TITLE
Draft: Add docs for Kubernetes seccompProfile on PodSecurityContext.

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-kubernetes.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-kubernetes.adoc
@@ -250,7 +250,7 @@ These properties are also used when configuring the <<configuration-kubernetes-t
 |<none>
 
 |maximumConcurrentTasks
-|The maximum concurrent tasks allowed for this platform instance.
+|The maximum concurrent tasks allowed for this platform instance
 |20
 
 |podSecurityContext.runAsUser
@@ -258,7 +258,15 @@ These properties are also used when configuring the <<configuration-kubernetes-t
 |<none>
 
 |podSecurityContext.fsGroup
-|The numeric group ID to run pod container processes under
+|The numeric group ID for the volumes of the pod
+|<none>
+
+|podSecurityContext.supplementalGroups
+|The numeric group IDs applied to the pod container processes, in addition to the container's primary group ID
+|<none>
+
+|podSecurityContext.seccompProfile
+|The seccomp options to use for the pod containers expressed in YAML format.  e.g. ```{ seccompProfile: { type: 'Localhost', localhostProfile: 'my-profiles/profile-allow.json' }}```
 |<none>
 
 |affinity.nodeAffinity

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/getting-started-kubernetes.adoc
@@ -907,21 +907,25 @@ Replace the `envVarName`, `configMapName`, and `dataKey` attributes with the app
 
 ==== Pod Security Context
 
-You can confiure the pod security context to run processes under the specified UID (user ID) or GID (group ID).
-This is useful when you want to not run processes under the default `root` UID and GID.
-You can define either the `runAsUser` (UID) or `fsGroup` (GID), and you can configure them to work together.
-See the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] section of the Kubernetes reference for more information.
+The pod security context specifies security settings for a pod and its containers. The following options are configurable:
+
+* `runAsUser`: The numeric user ID to run pod container processes under
+* `fsGroup`: The numeric group ID for the volumes of the pod
+* `supplementalGroups`: The numeric group IDs applied to the pod container processes, in addition to the container's primary group ID
+* `seccompProfile`: The seccomp options to use for the pod containers
+
+See the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] section of the Kubernetes reference for more information on each of the above options.
 
 The following example shows how you can individually configure application pods:
 
 ====
 [source,options=nowrap]
 ----
-deployer.<application>.kubernetes.podSecurityContext={runAsUser: 65534, fsGroup: 65534}
+deployer.<application>.kubernetes.podSecurityContext={runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: 'RuntimeDefault' }}
 ----
 ====
 
-Replace `<application>` with the name of your application and the `runAsUser` and/or `fsGroup` attributes with the appropriate values for your container environment.
+Replace `<application>` with the name of your application and any attributes with the appropriate values for your container environment.
 
 You can configure the pod security context at the global server level as well.
 
@@ -943,6 +947,10 @@ data:
                     podSecurityContext:
                       runAsUser: 65534
                       fsGroup: 65534
+                      supplementalGroups: [65534,65535]
+                      seccompProfile:
+                        type: Localhost
+                        localhostProfile: my-profiles/profile-allow.json
 ----
 ====
 
@@ -964,10 +972,14 @@ data:
                     podSecurityContext:
                       runAsUser: 65534
                       fsGroup: 65534
+                      supplementalGroups: [65534,65535]
+                      seccompProfile:
+                        type: Localhost
+                        localhostProfile: my-profiles/profile-allow.json
 ----
 ====
 
-Replace the `runAsUser` and/or `fsGroup` attributes with the appropriate values for your container environment.
+Adjust the `podSecurityContext` attributes with the appropriate values for your container environment.
 
 ==== Service Ports
 


### PR DESCRIPTION
Documents changes made for gh-412

> ℹ️ Marked as "Draft" since there is a logical dependency on https://github.com/spring-cloud/spring-cloud-deployerkubernetes/pull/472
 