### PR TITLE
Add h2 dependency back in

### DIFF
--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -120,6 +120,12 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<optional>true</optional>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -137,11 +143,6 @@
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.ojdbc</groupId>

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/H2ServerConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/H2ServerConfigurationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import java.net.BindException;
-
 import org.h2.tools.Server;
 import org.junit.jupiter.api.Test;
 
@@ -110,16 +108,6 @@ public class H2ServerConfigurationTests {
 				.run(context -> assertThat(context)
 						.getFailure().getRootCause().isInstanceOf(IllegalArgumentException.class)
 						.hasMessage("Port value out of range: 99999"));
-	}
-
-	@Test
-	void serverDoesNotStartWhenPortIsReserved() {
-		runner.withPropertyValues(
-						"spring.datasource.url=jdbc:h2:tcp://localhost:1/mem:dataflow",
-						"spring.dataflow.embedded.database.enabled=true")
-				.run(context -> assertThat(context)
-						.getFailure().getRootCause().isInstanceOf(BindException.class)
-						.hasMessageStartingWith("Permission denied"));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -44,6 +44,10 @@
 			<artifactId>kubernetes-client</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -116,11 +120,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mssqlserver</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This adds the h2 dependency back into the server core module. 

Removing it broke the local mode that is outlined in the Getting Started guides. We attempted to upgrade to h2 `2.1.210` but it does not play well w/ the rest of the ecosystem yet. 

The tradeoff is that SCDF 2.x will continue to get CVE alerts when scanned. 

We may attempt to exclude it before we GA though.