### PR TITLE
fix: also possible to use only non-key-value argument(s)

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtils.java
@@ -149,7 +149,7 @@ public final class DeploymentPropertiesUtils {
 	 */
 	public static List<String> parseArgumentList(String s, String delimiter) {
 		ArrayList<String> pairs = new ArrayList<>();
-		if (s != null && s.contains("=")) {
+		if (s != null) {
 			// get raw candidates as simple comma split
 			String[] candidates = StringUtils.delimitedListToStringArray(s, delimiter);
 			for (int i = 0; i < candidates.length; i++) {

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
@@ -140,6 +140,13 @@ public class DeploymentPropertiesUtilsTests {
 		assertTrue(props.contains("foo1=bar1"));
 		assertTrue(props.contains("foo2=bar2"));
 		assertTrue(props.contains("foo3=bar3 xxx3"));
+
+		props = DeploymentPropertiesUtils.parseArgumentList("xxx3", " ");
+		assertTrue(props.contains("xxx3"));
+
+		props = DeploymentPropertiesUtils.parseArgumentList("xxx3 foo=bar", " ");
+		assertTrue(props.contains("xxx3"));
+		assertTrue(props.contains("foo=bar"));
 	}
 
 	@Test


### PR DESCRIPTION
ex) `--testArgument`