### PR TITLE
Update tests to use 3.2.0 version of artifacts 

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -267,26 +267,26 @@ public class AppRegistryControllerTests {
 	public void testRegisterAllWithoutForce() throws Exception {
 		this.appRegistryService.importAll(false, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
 		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:3.2.0"));
 		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:3.2.0"));
 		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
-				is("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:3.2.0"));
 		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.task.app:timestamp-task:3.2.0"));
 	}
 
 	@Test
 	public void testRegisterAllWithForce() throws Exception {
 		this.appRegistryService.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
 		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:3.2.0"));
 		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:3.2.0"));
 		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString(),
-				is("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:3.2.0"));
 		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString(),
-				is("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT"));
+				is("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:3.2.0"));
 	}
 
 	@Test
@@ -368,7 +368,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(6)));
+				.andExpect(jsonPath("$.options[*]", hasSize(1)));
 	}
 
 	@Test
@@ -376,7 +376,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(905)));
+				.andExpect(jsonPath("$.options[*]", hasSize(2001)));
 	}
 
 	@Test
@@ -425,11 +425,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isConflict());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/1.0.0.BUILD-SNAPSHOT").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/3.2.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/1.0.0.BUILD-SNAPSHOT").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/3.2.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -567,11 +567,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isOk());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/1.0.0.BUILD-SNAPSHOT").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/3.2.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/1.0.0.BUILD-SNAPSHOT").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/3.2.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -671,17 +671,17 @@ public class AppRegistryControllerTests {
 
 	@Test
 	public void testListApplicationsByVersion() throws Exception {
-		mockMvc.perform(get("/apps?version=1.0.0.BUILD-SNAPSHOT").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/apps?version=3.2.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(4)));
 	}
 
 	@Test
 	public void testListApplicationsByVersionAndSearch() throws Exception {
-		mockMvc.perform(get("/apps?version=1.0.0.BUILD-SNAPSHOT&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=3.2.0&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(2)));
-		mockMvc.perform(get("/apps?version=1.0.0.BUILD-SNAPSHOT&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=3.2.0&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(1)));
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -339,7 +339,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(9)));
 
-		appRegistryService.delete("filter", ApplicationType.processor, "1.0.0.BUILD-SNAPSHOT");
+		appRegistryService.delete("filter", ApplicationType.processor, "3.2.0");
 
 		mockMvc.perform(
 				get("/audit-records?operations=APP_REGISTRATION&actions=DELETE").accept(MediaType.APPLICATION_JSON))
@@ -449,7 +449,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(4)));
 
-		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "1.0.0.BUILD-SNAPSHOT");
+		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "3.2.0");
 		appRegistryService.save(filter);
 
 		mockMvc.perform(

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -860,8 +860,7 @@ public class StreamControllerTests {
 		assertThat(logSpec.getApplicationProperties().get("level")).isNull();
 
 		SpringCloudDeployerApplicationSpec timeSpec = parseSpec(timePackage.getConfigValues().getRaw());
-		assertThat(timeSpec.getApplicationProperties().get("trigger.fixed-delay")).isEqualTo("2");
-		assertThat(timeSpec.getApplicationProperties().get("fixed-delay")).isNull();
+		assertThat(timeSpec.getApplicationProperties().get("fixed-delay")).isEqualTo("2");
 	}
 
 	@Test
@@ -894,7 +893,7 @@ public class StreamControllerTests {
 		assertThat(logSpec.getDeploymentProperties().get(AppDeployer.INDEXED_PROPERTY_KEY)).isEqualTo("true");
 
 		SpringCloudDeployerApplicationSpec timeSpec = parseSpec(timePackage.getConfigValues().getRaw());
-		assertThat(timeSpec.getApplicationProperties().get("trigger.fixed-delay")).isEqualTo("4");
+		assertThat(timeSpec.getApplicationProperties().get("fixed-delay")).isEqualTo("4");
 	}
 
 	@Test
@@ -925,7 +924,7 @@ public class StreamControllerTests {
 		assertThat(logSpec.getApplicationProperties().get("log.level")).isEqualTo("ERROR");
 
 		SpringCloudDeployerApplicationSpec timeSpec = parseSpec(timePackage.getConfigValues().getRaw());
-		assertThat(timeSpec.getApplicationProperties().get("trigger.fixed-delay")).isEqualTo("4");
+		assertThat(timeSpec.getApplicationProperties().get("fixed-delay")).isEqualTo("4");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamDeploymentControllerTests.java
@@ -171,8 +171,8 @@ public class StreamDeploymentControllerTests {
 		streamDeploymentProperties.put("time", deploymentProperties1);
 		streamDeploymentProperties.put("log", deploymentProperties2);
 		Map<String, String> appVersions = new HashMap<>();
-		appVersions.put("time", "1.0.0.BUILD-SNAPSHOT");
-		appVersions.put("log", "1.0.0.BUILD-SNAPSHOT");
+		appVersions.put("time", "3.2.0");
+		appVersions.put("log", "3.2.0");
 		StreamDefinition streamDefinition = new StreamDefinition("testStream1", "time | log");
 		StreamDeployment streamDeployment = new StreamDeployment(streamDefinition.getName(),
 				new JSONObject(streamDeploymentProperties).toString());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -82,7 +82,7 @@ public class DefaultStreamServiceUpdateTests {
 	@Test
 	public void testCreateUpdateRequestsWithRegisteredApp() throws IOException {
 		this.appRegistryService.save("log", ApplicationType.sink, "1.1.1.RELEASE",
-				URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:1.0.0.BUILD-SNAPSHOT"),
+				URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:3.2.0"),
 				null);
 		testCreateUpdateRequests();
 	}

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
@@ -1,8 +1,8 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT
-source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-kafka:1.0.0.BUILD-SNAPSHOT
-processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT
-processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-kafka:1.0.0.BUILD-SNAPSHOT
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT
-sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-kafka:1.0.0.BUILD-SNAPSHOT
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT
-task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:1.0.0.BUILD-SNAPSHOT
+source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:3.2.0
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-kafka:3.2.0
+processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:3.2.0
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-kafka:3.2.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:3.2.0
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-kafka:3.2.0
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:3.2.0
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:3.2.0

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
@@ -1,8 +1,8 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT
-source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT
-processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT
-processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:1.0.0.BUILD-SNAPSHOT
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
-sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT
-task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.0
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.0
+processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:3.2.0
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:3.2.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.0
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.0
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:3.2.0
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-task:3.2.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-stream-apps.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-stream-apps.properties
@@ -1,2 +1,2 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:1.0.0.BUILD-SNAPSHOT
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
@@ -1,1 +1,1 @@
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:3.2.0
+task.timestamp=maven://io.spring:timestamp-task:2.0.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-task-apps.properties
@@ -1,1 +1,1 @@
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:1.0.0.BUILD-SNAPSHOT
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:3.2.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerSink_log.txt
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerSink_log.txt
@@ -1,1 +1,1 @@
-app register --type sink --force --name log --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.0.0.BUILD-SNAPSHOT
+app register --type sink --force --name log --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerTask_timestamp.txt
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerTask_timestamp.txt
@@ -1,1 +1,1 @@
-app register --type task --force --name timestamp --uri maven://org.springframework.cloud.task.app:task-timestamp:1.0.0.BUILD-SNAPSHOT
+app register --type task --force --name timestamp --uri maven://org.springframework.cloud.task.app:task-timestamp:3.2.0


### PR DESCRIPTION
The SCDF server core tests are broken as they rely on the `1.0.0.BUILD-SNAPSHOT` version of the stream apps which no longer exist in Artifactory.

Moves to the latest `3.2.0` artifacts and adjusts tests accordingly.