### PR TITLE
Springdoc integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 		<wavefront-spring-boot-bom.version>2.2.0</wavefront-spring-boot-bom.version>
 		<spring-cloud-dataflow-apps-docs-plugin.version>1.0.4</spring-cloud-dataflow-apps-docs-plugin.version>
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.4</spring-cloud-dataflow-apps-metadata-plugin.version>
+		<springdoc-openapi-ui.version>1.6.6</springdoc-openapi-ui.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-dataflow-container-registry</module>
@@ -237,6 +238,11 @@
 				<groupId>com.amazonaws</groupId>
 				<artifactId>aws-java-sdk-ecr</artifactId>
 				<version>${aws-java-sdk-ecr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springdoc</groupId>
+				<artifactId>springdoc-openapi-ui</artifactId>
+				<version>${springdoc-openapi-ui.version}</version>
 			</dependency>
 			<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
 			<dependency>

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -2962,3 +2962,34 @@ include::{snippets}/task-logs-documentation/get-logs-by-task-id/curl-request.ado
 ===== Response Structure
 
 include::{snippets}/task-logs-documentation/get-logs-by-task-id/http-response.adoc[]
+
+[[api-guide-openapi]]
+== OpenAPI
+
+The https://springdoc.org/#Introduction[Springdoc] library is integrated with the server in an opt-in fashion. Once enabled, it provides OpenAPI3 documentation and a Swagger UI.
+
+To enable, set the following properties in your `application.yml` prior to launching the server:
+```yaml
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+```
+The properties can also be set on the command line:
+```shell
+-Dspringdoc.api-docs.enabled=true -Dspringdoc.swagger-ui.enabled=true
+```
+or as environment variables:
+```shell
+SPRINGDOC_APIDOCS_ENABLED=true
+SPRINGDOC_SWAGGERUI_ENABLED=true
+```
+
+Once enabled, the OpenAPI3 docs and Swagger UI are available at the `/v3/api-docs` and `/swagger-ui/index.html` URIs, respectively (eg. http://localhost:9393/v3/api-docs).
+
+TIP: The Swagger UI will be initially be blank. Type in "/v3/api-docs/" in the "Explore" bar and click "Explore".
+
+TIP: If you try out the API's in the Swagger UI and get errors related to `"No property string found for type"` try replacing the **pageable** parameter with `{ }` or removing its `"sort"` attribute.
+
+There are a plethora of available https://springdoc.org/#properties[OpenAPI] and https://springdoc.org/#swagger-ui-properties[Swagger UI] properties to configure the feature.

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -40,6 +40,10 @@
 			<artifactId>HikariCP</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataflowOAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataflowOAuthSecurityConfiguration.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.dataflow.server.config;
 
 import org.springframework.cloud.common.security.OAuthSecurityConfiguration;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
@@ -16,11 +16,19 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import org.springdoc.core.SpringDocConfigProperties;
-import org.springdoc.core.SwaggerUiConfigProperties;
+import javax.annotation.PostConstruct;
 
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springdoc.core.SpringDocConfiguration;
+import org.springdoc.core.SwaggerUiConfigProperties;
+import org.springdoc.webmvc.ui.SwaggerConfig;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cloud.dataflow.server.support.SpringDocJsonDecodeFilter;
 import org.springframework.context.annotation.Bean;
@@ -35,83 +43,91 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
  * @author Tobias Soloschenko
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ SpringDocConfigProperties.class, SwaggerUiConfigProperties.class })
 @ConditionalOnBean({ SpringDocConfigProperties.class, SwaggerUiConfigProperties.class })
+@AutoConfigureAfter({ SpringDocConfiguration.class, SwaggerConfig.class })
 public class SpringDocAutoConfiguration {
 
-    public static final String SWAGGER_UI_CONTEXT = "/swagger-ui/**";
+	private static final Logger logger = LoggerFactory.getLogger(SpringDocAutoConfiguration.class);
 
-    private final SpringDocConfigProperties springDocConfigProperties;
+	private final SpringDocConfigProperties springDocConfigProperties;
 
-    private final SwaggerUiConfigProperties swaggerUiConfigProperties;
+	private final SwaggerUiConfigProperties swaggerUiConfigProperties;
 
-    /**
-     * Creates the SpringDocConfiguration with the given properties.
-     *
-     * @param springDocConfigProperties the spring doc config properties
-     * @param swaggerUiConfigProperties the swagger ui config properties
-     */
-    public SpringDocAutoConfiguration(SpringDocConfigProperties springDocConfigProperties, SwaggerUiConfigProperties swaggerUiConfigProperties) {
-        this.springDocConfigProperties = springDocConfigProperties;
-        this.swaggerUiConfigProperties = swaggerUiConfigProperties;
-    }
+	/**
+	 * Creates the SpringDocConfiguration with the given properties.
+	 *
+	 * @param springDocConfigProperties the spring doc config properties
+	 * @param swaggerUiConfigProperties the swagger ui config properties
+	 */
+	public SpringDocAutoConfiguration(SpringDocConfigProperties springDocConfigProperties,
+			SwaggerUiConfigProperties swaggerUiConfigProperties) {
+		this.springDocConfigProperties = springDocConfigProperties;
+		this.swaggerUiConfigProperties = swaggerUiConfigProperties;
+	}
 
-    /**
-     * Creates a web security customizer for the spring security which makes the SpringDoc frontend public available.
-     *
-     * @return a web security customizer with security settings for SpringDoc
-     */
-    @Bean("springDocWebSecurityCustomizer")
-    public WebSecurityCustomizer springDocCustomizer() {
-        return (webSecurity -> webSecurity.ignoring().antMatchers(
-                SWAGGER_UI_CONTEXT,
-                getApiDocsPathContext() + "/**",
-                swaggerUiConfigProperties.getPath(),
-                swaggerUiConfigProperties.getConfigUrl(),
-                swaggerUiConfigProperties.getValidatorUrl(),
-                swaggerUiConfigProperties.getOauth2RedirectUrl(),
-                springDocConfigProperties.getWebjars().getPrefix(),
-                springDocConfigProperties.getWebjars().getPrefix() + "/**"));
-    }
+	@PostConstruct
+	void init() {
+		logger.info("SpringDoc enabled");
+	}
 
-    /**
-     * Applies {@link SpringDocJsonDecodeFilter} to the filter chain which decodes the JSON of ApiDocs and SwaggerUi so that the SpringDoc frontend is able
-     * to read it. Spring Cloud Data Flow however requires the JSON to be escaped and wrapped into quotes, because the
-     * Angular Ui frontend is using it that way.
-     *
-     * @return a filter registration bean which unescapes the content of the JSON endpoints of SpringDoc before it is returned.
-     */
-    @Bean
-    public FilterRegistrationBean<SpringDocJsonDecodeFilter> springDocJsonDecodeFilterRegistration() {
-        String apiDocsPathContext = getApiDocsPathContext();
-        String swaggerUiConfigContext = getSwaggerUiConfigContext();
+	/**
+	 * Creates a web security customizer for the spring security which makes the SpringDoc frontend public available.
+	 *
+	 * @return a web security customizer with security settings for SpringDoc
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public WebSecurityCustomizer springDocWebSecurityCustomizer() {
+		return (webSecurity -> webSecurity.ignoring().antMatchers(
+				"/swagger-ui/**",
+				getApiDocsPathContext() + "/**",
+				swaggerUiConfigProperties.getPath(),
+				swaggerUiConfigProperties.getConfigUrl(),
+				swaggerUiConfigProperties.getValidatorUrl(),
+				swaggerUiConfigProperties.getOauth2RedirectUrl(),
+				springDocConfigProperties.getWebjars().getPrefix(),
+				springDocConfigProperties.getWebjars().getPrefix() + "/**"));
+	}
 
-        FilterRegistrationBean<SpringDocJsonDecodeFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new SpringDocJsonDecodeFilter());
-        registrationBean.addUrlPatterns(apiDocsPathContext, apiDocsPathContext + "/*", swaggerUiConfigContext,
-                swaggerUiConfigContext + "/*");
+	/**
+	 * Applies {@link SpringDocJsonDecodeFilter} to the filter chain which decodes the JSON of ApiDocs and SwaggerUi so that the SpringDoc frontend is able
+	 * to read it. Spring Cloud Data Flow however requires the JSON to be escaped and wrapped into quotes, because the
+	 * Angular Ui frontend is using it that way.
+	 *
+	 * @return a filter registration bean which unescapes the content of the JSON endpoints of SpringDoc before it is returned.
+	 */
+	@Bean
+	@ConditionalOnMissingBean(name = "springDocJsonDecodeFilterRegistration")
+	public FilterRegistrationBean<SpringDocJsonDecodeFilter> springDocJsonDecodeFilterRegistration() {
+		String apiDocsPathContext = getApiDocsPathContext();
+		String swaggerUiConfigContext = getSwaggerUiConfigContext();
+		FilterRegistrationBean<SpringDocJsonDecodeFilter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(new SpringDocJsonDecodeFilter());
+		registrationBean.addUrlPatterns(apiDocsPathContext, apiDocsPathContext + "/*", swaggerUiConfigContext,
+				swaggerUiConfigContext + "/*");
+		return registrationBean;
+	}
 
-        return registrationBean;
-    }
+	/**
+	 * Gets the SwaggerUi config context. For example the default configuration for the SwaggerUi config is /v3/api-docs/swagger-config
+	 * which results in a context of /v3/api-docs.
+	 *
+	 * @return the SwaggerUi config path context
+	 */
+	private String getSwaggerUiConfigContext() {
+		String swaggerUiConfigUrl = swaggerUiConfigProperties.getConfigUrl();
+		return swaggerUiConfigUrl.substring(0, swaggerUiConfigUrl.lastIndexOf("/"));
+	}
 
-    /**
-     * Gets the SwaggerUi config context. For example the default configuration for the SwaggerUi config is /v3/api-docs/swagger-config
-     * which results in a context of /v3/api-docs.
-     *
-     * @return the SwaggerUi config path context
-     */
-    private String getSwaggerUiConfigContext() {
-        String swaggerUiConfigUrl = swaggerUiConfigProperties.getConfigUrl();
-        return swaggerUiConfigUrl.substring(0, swaggerUiConfigUrl.lastIndexOf("/"));
-    }
-
-    /**
-     * Gets the ApiDocs context path. For example the default configuration for the ApiDocs path is /v3/api-docs
-     * which results in a context of /v3.
-     *
-     * @return the api docs path context
-     */
-    private String getApiDocsPathContext() {
-        String apiDocsPath = springDocConfigProperties.getApiDocs().getPath();
-        return apiDocsPath.substring(0, apiDocsPath.lastIndexOf("/"));
-    }
+	/**
+	 * Gets the ApiDocs context path. For example the default configuration for the ApiDocs path is /v3/api-docs
+	 * which results in a context of /v3.
+	 *
+	 * @return the api docs path context
+	 */
+	private String getApiDocsPathContext() {
+		String apiDocsPath = springDocConfigProperties.getApiDocs().getPath();
+		return apiDocsPath.substring(0, apiDocsPath.lastIndexOf("/"));
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.config;
+
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springdoc.core.SwaggerUiConfigProperties;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.dataflow.server.support.SpringDocJsonDecodeFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+
+/**
+ * Makes SpringDoc public available without any authentication required by initializing a {@link WebSecurityCustomizer} and
+ * applying all path of SpringDoc to be ignored. Also applies a filter registration bean to unescape JSON content for the
+ * SpringDoc frontend.
+ *
+ * @author Tobias Soloschenko
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnBean({ SpringDocConfigProperties.class, SwaggerUiConfigProperties.class })
+public class SpringDocAutoConfiguration {
+
+    public static final String SWAGGER_UI_CONTEXT = "/swagger-ui/**";
+
+    private final SpringDocConfigProperties springDocConfigProperties;
+
+    private final SwaggerUiConfigProperties swaggerUiConfigProperties;
+
+    /**
+     * Creates the SpringDocConfiguration with the given properties.
+     *
+     * @param springDocConfigProperties the spring doc config properties
+     * @param swaggerUiConfigProperties the swagger ui config properties
+     */
+    public SpringDocAutoConfiguration(SpringDocConfigProperties springDocConfigProperties, SwaggerUiConfigProperties swaggerUiConfigProperties) {
+        this.springDocConfigProperties = springDocConfigProperties;
+        this.swaggerUiConfigProperties = swaggerUiConfigProperties;
+    }
+
+    /**
+     * Creates a web security customizer for the spring security which makes the SpringDoc frontend public available.
+     *
+     * @return a web security customizer with security settings for SpringDoc
+     */
+    @Bean("springDocWebSecurityCustomizer")
+    public WebSecurityCustomizer springDocCustomizer() {
+        return (webSecurity -> webSecurity.ignoring().antMatchers(
+                SWAGGER_UI_CONTEXT,
+                getApiDocsPathContext() + "/**",
+                swaggerUiConfigProperties.getPath(),
+                swaggerUiConfigProperties.getConfigUrl(),
+                swaggerUiConfigProperties.getValidatorUrl(),
+                swaggerUiConfigProperties.getOauth2RedirectUrl(),
+                springDocConfigProperties.getWebjars().getPrefix(),
+                springDocConfigProperties.getWebjars().getPrefix() + "/**"));
+    }
+
+    /**
+     * Applies {@link SpringDocJsonDecodeFilter} to the filter chain which decodes the JSON of ApiDocs and SwaggerUi so that the SpringDoc frontend is able
+     * to read it. Spring Cloud Data Flow however requires the JSON to be escaped and wrapped into quotes, because the
+     * Angular Ui frontend is using it that way.
+     *
+     * @return a filter registration bean which unescapes the content of the JSON endpoints of SpringDoc before it is returned.
+     */
+    @Bean
+    public FilterRegistrationBean<SpringDocJsonDecodeFilter> springDocJsonDecodeFilterRegistration() {
+        String apiDocsPathContext = getApiDocsPathContext();
+        String swaggerUiConfigContext = getSwaggerUiConfigContext();
+
+        FilterRegistrationBean<SpringDocJsonDecodeFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new SpringDocJsonDecodeFilter());
+        registrationBean.addUrlPatterns(apiDocsPathContext, apiDocsPathContext + "/*", swaggerUiConfigContext,
+                swaggerUiConfigContext + "/*");
+
+        return registrationBean;
+    }
+
+    /**
+     * Gets the SwaggerUi config context. For example the default configuration for the SwaggerUi config is /v3/api-docs/swagger-config
+     * which results in a context of /v3/api-docs.
+     *
+     * @return the SwaggerUi config path context
+     */
+    private String getSwaggerUiConfigContext() {
+        String swaggerUiConfigUrl = swaggerUiConfigProperties.getConfigUrl();
+        return swaggerUiConfigUrl.substring(0, swaggerUiConfigUrl.lastIndexOf("/"));
+    }
+
+    /**
+     * Gets the ApiDocs context path. For example the default configuration for the ApiDocs path is /v3/api-docs
+     * which results in a context of /v3.
+     *
+     * @return the api docs path context
+     */
+    private String getApiDocsPathContext() {
+        String apiDocsPath = springDocConfigProperties.getApiDocs().getPath();
+        return apiDocsPath.substring(0, apiDocsPath.lastIndexOf("/"));
+    }
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilter.java
@@ -33,6 +33,7 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 /**
@@ -60,7 +61,9 @@ public class SpringDocJsonDecodeFilter implements Filter {
         // Replaces all escaped quotes
         content = StringEscapeUtils.unescapeJson(content);
         // Replaces first and last quote
-        content = content.substring(1, content.length() - 1);
+		if (StringUtils.hasText(content)) {
+			content = content.substring(1, content.length() - 1);
+		}
         if (LOG.isTraceEnabled()) {
             LOG.trace("Using decoded JSON for serving api-docs: {}", content);
         }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.support;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * Sets up a filter that unescapes the JSON content of the API endpoints of OpenApi and Swagger.
+ * This is similar to the issue mentioned here: https://github.com/springdoc/springdoc-openapi/issues/624
+ * Spring Cloud Data Flow however needs the escaped JSON to show task logs in the UI.
+ *
+ * @author Tobias Soloschenko
+ */
+public class SpringDocJsonDecodeFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringDocJsonDecodeFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        final HttpServletRequestWrapper httpServletRequestWrapper = new HttpServletRequestWrapper((HttpServletRequest) request);
+        final ContentCachingResponseWrapper httpServletResponseWrapper = new ContentCachingResponseWrapper((HttpServletResponse) response);
+
+        chain.doFilter(httpServletRequestWrapper, httpServletResponseWrapper);
+
+        ServletOutputStream outputStream = httpServletResponseWrapper.getResponse().getOutputStream();
+
+        LOG.debug("Request for Swagger api-docs detected - unescaping json content.");
+        String content = new String(httpServletResponseWrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
+        // Replaces all escaped quotes
+        content = StringEscapeUtils.unescapeJson(content);
+        // Replaces first and last quote
+        content = content.substring(1, content.length() - 1);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Using decoded JSON for serving api-docs: {}", content);
+        }
+        outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+
+    }
+}

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -243,3 +243,8 @@ spring:
             # Tools
 
             - POST   /tools/**                       => hasRole('ROLE_VIEW')
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -243,8 +243,16 @@ spring:
             # Tools
 
             - POST   /tools/**                       => hasRole('ROLE_VIEW')
+
+# Defaults for Springdoc (taken from https://springdoc.org/properties.html)
 springdoc:
   api-docs:
     enabled: false
+    path: /v3/api-docs
   swagger-ui:
     enabled: false
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    config-url: /v3/api-docs/swagger-config
+    validator-url: https://validator.swagger.io/validator
+    oauth2-redirect-url: /swagger-ui/oauth2-redirect.html

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.boot.env.EnvironmentPostProcessor=\
   org.springframework.cloud.dataflow.server.config.MetricsReplicationEnvironmentPostProcessor
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.dataflow.server.config.DataFlowServerAutoConfiguration,\
-  org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration
+  org.springframework.cloud.dataflow.server.config.DataFlowControllerAutoConfiguration, \
+  org.springframework.cloud.dataflow.server.config.SpringDocAutoConfiguration

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/EmptyDefaultTestApplication.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/EmptyDefaultTestApplication.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.config;
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.cloud.common.security.core.support.OAuth2TokenUtilsService;
+import org.springframework.cloud.dataflow.core.StreamDefinitionService;
+import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.cloud.dataflow.server.service.SchedulerService;
+import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
+import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskExecutionService;
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.task.repository.TaskRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * A configuration that can be used to bring up an empty Dataflow server with defaults.
+ *
+ * @author Chris Bono
+ */
+@Configuration
+@EnableAutoConfiguration(exclude = {
+		SessionAutoConfiguration.class,
+		FlywayAutoConfiguration.class,
+		SecurityAutoConfiguration.class,
+		SecurityFilterAutoConfiguration.class,
+		ManagementWebSecurityAutoConfiguration.class })
+@EnableDataFlowServer
+public class EmptyDefaultTestApplication {
+
+	@Bean
+	public AppDeployer appDeployer() {
+		return mock(AppDeployer.class);
+	}
+
+	@Bean
+	public TaskLauncher taskLauncher() {
+		return mock(TaskLauncher.class);
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager() {
+		return mock(AuthenticationManager.class);
+	}
+
+	@Bean
+	public TaskExecutionService taskService() {
+		return mock(DefaultTaskExecutionService.class);
+	}
+
+	@Bean
+	public TaskRepository taskRepository() {
+		return mock(TaskRepository.class);
+	}
+
+	@Bean
+	public SchedulerService schedulerService() {
+		return mock(SchedulerService.class);
+	}
+
+	@Bean
+	public Scheduler scheduler() {
+		return mock(Scheduler.class);
+	}
+
+	@Bean
+	public OAuth2TokenUtilsService oauth2TokenUtilsService() {
+		return mock(OAuth2TokenUtilsService.class);
+	}
+
+	@Bean
+	public StreamDefinitionService streamDefinitionService() {
+		return mock(StreamDefinitionService.class);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.config;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.springdoc.core.Constants;
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springdoc.core.SpringDocConfiguration;
+import org.springdoc.core.SwaggerUiConfigProperties;
+import org.springdoc.core.SwaggerUiOAuthProperties;
+import org.springdoc.webmvc.ui.SwaggerConfig;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.dataflow.server.support.SpringDocJsonDecodeFilter;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.util.AntPathMatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Lightweight integration tests for {@link SpringDocAutoConfiguration}.
+ *
+ * @author Chris Bono
+ */
+public class SpringDocAutoConfigurationTests {
+
+	// The base web context runner does the following:
+	//   - loads default props via config data additional location
+	//	 - loads the config props auto-config to ensure config props beans get bound to the env
+	//	 - loads all auto-configs that are loaded by Springdoc
+	//   - loads custom Springdoc auto-config
+	private WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withPropertyValues("spring.config.additional-location=classpath:/META-INF/dataflow-server-defaults.yml")
+			.withInitializer(new ConfigDataApplicationContextInitializer())
+			.withConfiguration(AutoConfigurations.of(
+					ConfigurationPropertiesAutoConfiguration.class,
+					SpringDocConfiguration.class,
+					SpringDocConfigProperties.class,
+					SwaggerConfig.class,
+					SwaggerUiConfigProperties.class,
+					SwaggerUiOAuthProperties.class,
+					SpringDocAutoConfiguration.class));
+
+	private WebApplicationContextRunner contextRunnerWithSpringDocEnabled() {
+		return contextRunner.withPropertyValues("springdoc.api-docs.enabled=true", "springdoc.swagger-ui.enabled=true");
+	}
+
+	@Test
+	void enabledWithDefaultSpringDocSettings() {
+		contextRunnerWithSpringDocEnabled()
+				.run((context) -> {
+					assertThat(context)
+							.hasSingleBean(SpringDocAutoConfiguration.class)
+							.hasBean("springDocWebSecurityCustomizer")
+							.hasBean("springDocJsonDecodeFilterRegistration");
+					verfiyFilterHasUrlPatterns(context,"/v3", "/v3/*", "/v3/api-docs", "/v3/api-docs/*");
+					verifyCustomizerHasIgnorePatterns(context, "/swagger-ui/**",
+							"/v3/**",
+							"/swagger-ui.html",
+							"/v3/api-docs/swagger-config",
+							"https://validator.swagger.io/validator",
+							"/swagger-ui/oauth2-redirect.html",
+							"/webjars",
+							"/webjars/**"
+					);
+				});
+	}
+
+	@Test
+	void enabledWithCustomSpringDocSettings() {
+		contextRunnerWithSpringDocEnabled()
+				.withPropertyValues(
+						"springdoc.api-docs.path=/v4/foo/api-docs",
+						"springdoc.swagger-ui.config-url=/v4/bar/swagger-config")
+				.run((context) -> {
+					assertThat(context)
+							.hasSingleBean(SpringDocAutoConfiguration.class)
+							.hasBean("springDocWebSecurityCustomizer")
+							.hasBean("springDocJsonDecodeFilterRegistration");
+					verfiyFilterHasUrlPatterns(context,"/v4/foo", "/v4/foo/*", "/v4/bar", "/v4/bar/*");
+					verifyCustomizerHasIgnorePatterns(context, "/swagger-ui/**",
+							"/v4/foo/**",
+							"/swagger-ui.html",
+							"/v4/bar/swagger-config",
+							"https://validator.swagger.io/validator",
+							"/swagger-ui/oauth2-redirect.html",
+							"/webjars",
+							"/webjars/**"
+					);
+				});
+	}
+
+	private void verfiyFilterHasUrlPatterns(AssertableWebApplicationContext context, String... expected) {
+		FilterRegistrationBean<SpringDocJsonDecodeFilter> filterRegistration =
+				context.getBean("springDocJsonDecodeFilterRegistration", FilterRegistrationBean.class);
+		assertThat(filterRegistration.getUrlPatterns()).containsExactlyInAnyOrder(expected);
+	}
+
+	private void verifyCustomizerHasIgnorePatterns(AssertableWebApplicationContext context, String... expected) {
+		WebSecurityCustomizer customizer = context.getBean("springDocWebSecurityCustomizer", WebSecurityCustomizer.class);
+		WebSecurity webSecurity = mock(WebSecurity.class, Answers.RETURNS_DEEP_STUBS);
+		customizer.customize(webSecurity);
+		ArgumentCaptor<String> antMatchersCaptor = ArgumentCaptor.forClass(String.class);
+		verify(webSecurity.ignoring()).antMatchers(antMatchersCaptor.capture());
+		assertThat(antMatchersCaptor.getAllValues()).containsExactly(expected);
+	}
+
+	@Test
+	void defaultsAreInSyncWithSpringdoc() {
+		contextRunnerWithSpringDocEnabled()
+				.run((context) -> {
+					SpringDocConfigProperties springDocConfigProps = context.getBean(SpringDocConfigProperties.class);
+					SwaggerUiConfigProperties swaggerUiConfigProps = context.getBean(SwaggerUiConfigProperties.class);
+					assertThat(springDocConfigProps.getApiDocs().getPath()).isEqualTo(Constants.DEFAULT_API_DOCS_URL);
+					assertThat(swaggerUiConfigProps.getPath()).isEqualTo(Constants.DEFAULT_SWAGGER_UI_PATH);
+					assertThat(swaggerUiConfigProps.getConfigUrl()).isEqualTo(
+							Constants.DEFAULT_API_DOCS_URL + AntPathMatcher.DEFAULT_PATH_SEPARATOR + Constants.SWAGGGER_CONFIG_FILE);
+					assertThat(swaggerUiConfigProps.getValidatorUrl()).isEqualTo("https://validator.swagger.io/validator");
+					assertThat(swaggerUiConfigProps.getOauth2RedirectUrl()).isEqualTo(Constants.SWAGGER_UI_OAUTH_REDIRECT_URL);
+				});
+	}
+
+	@Test
+	void customWebSecurityCustomizerIsRespected() {
+		WebSecurityCustomizer customizer = mock(WebSecurityCustomizer.class);
+		contextRunnerWithSpringDocEnabled()
+				.withBean("springDocWebSecurityCustomizer", WebSecurityCustomizer.class, () -> customizer)
+				.run((context) -> assertThat(context).getBean("springDocWebSecurityCustomizer").isSameAs(customizer));
+	}
+
+	@Test
+	void customFilterRegistrationIsRespected() {
+		FilterRegistrationBean<SpringDocJsonDecodeFilter> filterRegistrationBean = mock(FilterRegistrationBean.class);
+		contextRunnerWithSpringDocEnabled()
+				.withBean("springDocJsonDecodeFilterRegistration", FilterRegistrationBean.class, () -> filterRegistrationBean)
+				.run((context) -> assertThat(context).getBean("springDocJsonDecodeFilterRegistration").isSameAs(filterRegistrationBean));
+	}
+
+	@Test
+	void disabledByDefault() {
+		contextRunner.run((context) ->
+				assertThat(context).hasNotFailed().doesNotHaveBean(SpringDocAutoConfiguration.class));
+	}
+
+	@Test
+	void disabledWhenOnlySpringDocsEnabled() {
+		contextRunner.withPropertyValues("springdoc.api-docs.enabled=true").run((context) ->
+				assertThat(context).hasNotFailed().doesNotHaveBean(SpringDocAutoConfiguration.class));
+	}
+
+	@Test
+	void disabledWhenOnlySwaggerUiEnabled() {
+		contextRunner.withPropertyValues("springdoc.swagger-ui.enabled=true").run((context) ->
+				assertThat(context).hasNotFailed().doesNotHaveBean(SpringDocAutoConfiguration.class));
+	}
+
+	@Test
+	void disabledWhenSpringDocConfigPropsClassNotAvailable() {
+		contextRunnerWithSpringDocEnabled()
+				.withClassLoader(new FilteredClassLoader(SpringDocConfigProperties.class))
+				.run((context) -> assertThat(context).hasNotFailed().doesNotHaveBean(SpringDocAutoConfiguration.class));
+	}
+
+	@Test
+	void disabledWhenSwaggerUiConfigPropsClassNotAvailable() {
+		contextRunnerWithSpringDocEnabled()
+				.withClassLoader(new FilteredClassLoader(SwaggerUiConfigProperties.class))
+				.run((context) -> assertThat(context).hasNotFailed().doesNotHaveBean(SpringDocAutoConfiguration.class));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocIntegrationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocIntegrationTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.config;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test that does a few coarse-grained sanity checks for the {@link SpringDocAutoConfiguration Springdoc
+ * integration} with a running Spring Cloud Dataflow server.
+ *
+ * @author Chris Bono
+ */
+public class SpringDocIntegrationTests {
+
+	@Test
+	public void disabledByDefault() {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(EmptyDefaultTestApplication.class,
+				"--server.port=0",
+				"--spring.main.allow-bean-definition-overriding=true",
+				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration" +
+						",org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration")) {
+			assertThat(ctx.containsBean("springDocWebSecurityCustomizer")).isFalse();
+			assertThat(ctx.containsBean("springDocJsonDecodeFilterRegistration")).isFalse();
+		}
+	}
+
+	@Test
+	public void disabledSpringDocAutoConfiguration() {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(EmptyDefaultTestApplication.class,
+				"--server.port=0",
+				"--springdoc.api-docs.enabled=true",
+				"--springdoc.swagger-ui.enabled=true",
+				"--spring.main.allow-bean-definition-overriding=true",
+				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration" +
+						",org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration" +
+						",org.springframework.cloud.dataflow.server.config.SpringDocAutoConfiguration")) {
+			assertThat(ctx.containsBean("springDocWebSecurityCustomizer")).isFalse();
+			assertThat(ctx.containsBean("springDocJsonDecodeFilterRegistration")).isFalse();
+		}
+	}
+
+	@Test
+	public void enabledWithDefaults() {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(EmptyDefaultTestApplication.class,
+				"--server.port=0",
+				"--springdoc.api-docs.enabled=true",
+				"--springdoc.swagger-ui.enabled=true",
+				"--spring.main.allow-bean-definition-overriding=true",
+				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration" +
+						",org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration")) {
+			assertThat(ctx.containsBean("springDocWebSecurityCustomizer")).isTrue();
+			assertThat(ctx.containsBean("springDocJsonDecodeFilterRegistration")).isTrue();
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilterTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/SpringDocJsonDecodeFilterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.support;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is a test for {@link SpringDocJsonDecodeFilter} to check if the json content is decoded correctly.
+ * @author Tobias Soloschenko
+ */
+public class SpringDocJsonDecodeFilterTest {
+
+    private static final String OPENAPI_JSON_ESCAPED_CONTENT = "\"{\\\"openapi:\\\"3.0.1\\\",\\\"info\\\":{\\\"title\\\":\\\"OpenAPI definition\\\",\\\"version\\\":\\\"v0\\\"}}\"";
+
+    private static final String OPENAPI_JSON_UNESCAPED_CONTENT = "{\"openapi:\"3.0.1\",\"info\":{\"title\":\"OpenAPI definition\",\"version\":\"v0\"}}";
+
+    @Test
+    public void doFilterTest() throws ServletException, IOException {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+        MockFilterChain mockFilterChain = new MockFilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+                response.getOutputStream().write(OPENAPI_JSON_ESCAPED_CONTENT.getBytes(StandardCharsets.UTF_8));
+                super.doFilter(request, response);
+            }
+        };
+        new SpringDocJsonDecodeFilter().doFilter(mockHttpServletRequest, mockHttpServletResponse, mockFilterChain);
+        assertThat(mockHttpServletResponse.getContentAsString()).isEqualTo(OPENAPI_JSON_UNESCAPED_CONTENT);
+    }
+
+}

--- a/spring-cloud-dataflow-server-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/spring-cloud-dataflow-server-core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This is a continuation of @klopfdreh original PR [here](https://github.com/spring-cloud/spring-cloud-dataflow/pull/4836). 

@klopfdreh I squased/rebased your PR on 2.9.x and then cherry-picked to a userbranch off of main. I will close your original PR that is in 2.9.x and we can continue to work from here. 

I think we are good on testing now. 

**Here is what is remaining:**
- [x] code review my recent commit
- [x] add lightweight docs on "How to Use Springdoc" (including enabling/disabling/config options (point to springdoc docs) 
- [x] why is default api now showing up? 

@klopfdreh if you can do the above that would be great. Otherwise I will get around to it next weekend. 

**Steps to see enable**
1. Start SCDF server with Springdoc enabled properties
  ```shell
  -Dspringdoc.api-docs.enabled=true -Dspringdoc.swagger-ui.enabled=true
  ```
  OR
  ```yaml
  springdoc:
    api-docs:
      enabled: true
    swagger-ui:
      enabled: true
  ```
2. Navigate to http://localhost:9393/v3/api-docs (you will see the openapi definition)
3. Navigate to  http://localhost:9393/swagger-ui/index.html
  > ⚠️ the Swagger UI will be empty as the "Explore" bar is empty. 
4. Type in "/v3/api-docs/" and click "Explore"
5. Start exploring the APIs

NOTE: I set `springdoc.swagger-ui.disable-swagger-default-url: true` as that was loading the Swagger Petstore in the Swagger UI. I then tried to set `springdoc.swagger-ui.url: /v3/api-docs/` but it does not see