### PR TITLE
Add segment creation immediate to all create-table for oracle

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V1-dataflow.sql
+++ b/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V1-dataflow.sql
@@ -10,7 +10,7 @@ create table app_registration (
   uri clob,
   version varchar2(255 char),
   primary key (id)
-);
+) segment creation immediate;
 
 create table task_deployment (
   id number(19,0) not null,
@@ -20,7 +20,7 @@ create table task_deployment (
   platform_name varchar2(255 char) not null,
   created_on timestamp,
   primary key (id)
-);
+) segment creation immediate;
 
 create table audit_records (
   id number(19,0) not null,
@@ -31,19 +31,19 @@ create table audit_records (
   created_by varchar2(255 char),
   created_on timestamp,
   primary key (id)
-);
+) segment creation immediate;
 
 create table stream_definitions (
   definition_name varchar2(255 char) not null,
   definition clob,
   primary key (definition_name)
-);
+) segment creation immediate;
 
 create table task_definitions (
   definition_name varchar2(255 char) not null,
   definition clob,
   primary key (definition_name)
-);
+) segment creation immediate;
 
 CREATE TABLE TASK_EXECUTION (
   TASK_EXECUTION_ID NUMBER NOT NULL PRIMARY KEY,
@@ -56,21 +56,21 @@ CREATE TABLE TASK_EXECUTION (
   LAST_UPDATED TIMESTAMP,
   EXTERNAL_EXECUTION_ID VARCHAR2(255),
   PARENT_EXECUTION_ID NUMBER
-);
+) segment creation immediate;
 
 CREATE TABLE TASK_EXECUTION_PARAMS (
   TASK_EXECUTION_ID NUMBER NOT NULL,
   TASK_PARAM VARCHAR2(2500),
   constraint TASK_EXEC_PARAMS_FK foreign key (TASK_EXECUTION_ID)
   references TASK_EXECUTION(TASK_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE TABLE TASK_TASK_BATCH (
   TASK_EXECUTION_ID NUMBER NOT NULL,
   JOB_EXECUTION_ID NUMBER NOT NULL,
   constraint TASK_EXEC_BATCH_FK foreign key (TASK_EXECUTION_ID)
   references TASK_EXECUTION(TASK_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE SEQUENCE TASK_SEQ START WITH 0 MINVALUE 0 MAXVALUE 9223372036854775807 NOCACHE NOCYCLE;
 
@@ -80,7 +80,7 @@ CREATE TABLE TASK_LOCK (
   CLIENT_ID CHAR(36),
   CREATED_DATE TIMESTAMP NOT NULL,
   constraint LOCK_PK primary key (LOCK_KEY, REGION)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_JOB_INSTANCE (
   JOB_INSTANCE_ID NUMBER(19,0) NOT NULL PRIMARY KEY,
@@ -88,7 +88,7 @@ CREATE TABLE BATCH_JOB_INSTANCE (
   JOB_NAME VARCHAR2(100 char) NOT NULL,
   JOB_KEY VARCHAR2(32 char) NOT NULL,
   constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_JOB_EXECUTION (
   JOB_EXECUTION_ID NUMBER(19,0) NOT NULL PRIMARY KEY,
@@ -104,7 +104,7 @@ CREATE TABLE BATCH_JOB_EXECUTION (
   JOB_CONFIGURATION_LOCATION VARCHAR(2500 char) NULL,
   constraint JOB_INST_EXEC_FK foreign key (JOB_INSTANCE_ID)
   references BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_JOB_EXECUTION_PARAMS (
   JOB_EXECUTION_ID NUMBER(19,0) NOT NULL,
@@ -117,7 +117,7 @@ CREATE TABLE BATCH_JOB_EXECUTION_PARAMS (
   IDENTIFYING CHAR(1) NOT NULL,
   constraint JOB_EXEC_PARAMS_FK foreign key (JOB_EXECUTION_ID)
   references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_STEP_EXECUTION (
   STEP_EXECUTION_ID NUMBER(19,0) NOT NULL PRIMARY KEY,
@@ -140,7 +140,7 @@ CREATE TABLE BATCH_STEP_EXECUTION (
   LAST_UPDATED TIMESTAMP,
   constraint JOB_EXEC_STEP_FK foreign key (JOB_EXECUTION_ID)
   references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT (
   STEP_EXECUTION_ID NUMBER(19,0) NOT NULL PRIMARY KEY,
@@ -148,7 +148,7 @@ CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT (
   SERIALIZED_CONTEXT CLOB,
   constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID)
   references BATCH_STEP_EXECUTION(STEP_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT (
   JOB_EXECUTION_ID NUMBER(19,0) NOT NULL PRIMARY KEY,
@@ -156,7 +156,7 @@ CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT (
   SERIALIZED_CONTEXT CLOB,
   constraint JOB_EXEC_CTX_FK foreign key (JOB_EXECUTION_ID)
   references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE SEQUENCE BATCH_STEP_EXECUTION_SEQ START WITH 0 MINVALUE 0 MAXVALUE 9223372036854775807 NOCYCLE;
 

--- a/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V1-skipper.sql
+++ b/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V1-skipper.sql
@@ -5,7 +5,7 @@ create table skipper_app_deployer_data (
   release_name varchar2(255 char),
   release_version number(10,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_info (
   id number(19,0) not null,
@@ -16,20 +16,20 @@ create table skipper_info (
   last_deployed timestamp,
   status_id number(19,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_manifest (
   id number(19,0) not null,
   object_version number(19,0),
   data clob,
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_package_file (
   id number(19,0) not null,
   package_bytes blob,
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_package_metadata (
   id number(19,0) not null,
@@ -51,7 +51,7 @@ create table skipper_package_metadata (
   version varchar2(255 char),
   packagefile_id number(19,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_release (
   id number(19,0) not null,
@@ -66,7 +66,7 @@ create table skipper_release (
   info_id number(19,0),
   manifest_id number(19,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_repository (
   id number(19,0) not null,
@@ -78,33 +78,33 @@ create table skipper_repository (
   source_url clob,
   url clob,
   primary key (id)
-);
+) segment creation immediate;
 
 create table skipper_status (
   id number(19,0) not null,
   platform_status clob,
   status_code varchar2(255 char),
   primary key (id)
-);
+) segment creation immediate;
 
 create table action (
   id number(19,0) not null,
   name varchar2(255 char),
   spel varchar2(255 char),
   primary key (id)
-);
+) segment creation immediate;
 
 create table deferred_events (
   jpa_repository_state_id number(19,0) not null,
   deferred_events varchar2(255 char)
-);
+) segment creation immediate;
 
 create table guard (
   id number(19,0) not null,
   name varchar2(255 char),
   spel varchar2(255 char),
   primary key (id)
-);
+) segment creation immediate;
 
 create table state (
   id number(19,0) not null,
@@ -117,32 +117,32 @@ create table state (
   initial_action_id number(19,0),
   parent_state_id number(19,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table state_entry_actions (
   jpa_repository_state_id number(19,0) not null,
   entry_actions_id number(19,0) not null,
   primary key (jpa_repository_state_id, entry_actions_id)
-);
+) segment creation immediate;
 
 create table state_exit_actions (
   jpa_repository_state_id number(19,0) not null,
   exit_actions_id number(19,0) not null,
   primary key (jpa_repository_state_id, exit_actions_id)
-);
+) segment creation immediate;
 
 create table state_state_actions (
   jpa_repository_state_id number(19,0) not null,
   state_actions_id number(19,0) not null,
   primary key (jpa_repository_state_id, state_actions_id)
-);
+) segment creation immediate;
 
 create table state_machine (
   machine_id varchar2(255 char) not null,
   state varchar2(255 char),
   state_machine_context blob,
   primary key (machine_id)
-);
+) segment creation immediate;
 
 create table transition (
   id number(19,0) not null,
@@ -153,13 +153,13 @@ create table transition (
   source_id number(19,0),
   target_id number(19,0),
   primary key (id)
-);
+) segment creation immediate;
 
 create table transition_actions (
   jpa_repository_transition_id number(19,0) not null,
   actions_id number(19,0) not null,
   primary key (jpa_repository_transition_id, actions_id)
-);
+) segment creation immediate;
 
 create index idx_pkg_name on skipper_package_metadata (name);
 

--- a/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V2-dataflow.sql
+++ b/spring-cloud-dataflow-server-core/src/main/resources/schemas/oracle/V2-dataflow.sql
@@ -11,6 +11,6 @@ CREATE TABLE task_execution_metadata (
   primary key (id),
   CONSTRAINT TASK_METADATA_FK FOREIGN KEY (task_execution_id)
   REFERENCES TASK_EXECUTION(TASK_EXECUTION_ID)
-);
+) segment creation immediate;
 
 CREATE SEQUENCE task_execution_metadata_seq START WITH 0 MINVALUE 0 MAXVALUE 9223372036854775807 NOCACHE NOCYCLE;


### PR DESCRIPTION
This avoids Oracle "Cannot serialize transaction" errors on startup. See https://oracle-base.com/articles/11g/segment-creation-on-demand-11gr2.  Not sure what this does on 10g.  Note that spring-batch 5.x does the same thing. 