### PR TITLE
Make dataflow server uri a test property

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -839,7 +839,8 @@ public class DataFlowIT {
 			try (Stream stream = Stream.builder(dataFlowOperations).name("tasklauncher-test")
 					.definition("http | " + dataflowTaskLauncherAppName
 							+ " --trigger.initialDelay=100 --trigger.maxPeriod=1000 " +
-							"--spring.cloud.dataflow.client.serverUri=http://dataflow-server:9393")
+							"--spring.cloud.dataflow.client.serverUri=" + testProperties.getPlatform()
+							.getConnection().getDataflowServerUri())
 					.create()
 					.deploy(testDeploymentProperties())) {
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -69,6 +69,7 @@ import org.springframework.cloud.dataflow.integration.test.util.RuntimeApplicati
 import org.springframework.cloud.dataflow.rest.client.AppRegistryOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowClientException;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
+import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientProperties;
 import org.springframework.cloud.dataflow.rest.client.dsl.DeploymentPropertiesBuilder;
 import org.springframework.cloud.dataflow.rest.client.dsl.Stream;
 import org.springframework.cloud.dataflow.rest.client.dsl.StreamApplication;
@@ -202,6 +203,9 @@ public class DataFlowIT {
 
 	@Autowired
 	protected RuntimeApplicationHelper runtimeApps;
+
+	@Autowired
+	protected DataFlowClientProperties dataFlowClientProperties;
 
 	/**
 	 * Folder that collects the external docker-compose YAML files such as coming from
@@ -839,8 +843,7 @@ public class DataFlowIT {
 			try (Stream stream = Stream.builder(dataFlowOperations).name("tasklauncher-test")
 					.definition("http | " + dataflowTaskLauncherAppName
 							+ " --trigger.initialDelay=100 --trigger.maxPeriod=1000 " +
-							"--spring.cloud.dataflow.client.serverUri=" + testProperties.getPlatform()
-							.getConnection().getDataflowServerUri())
+							"--spring.cloud.dataflow.client.serverUri=" + dataFlowClientProperties.getServerUri())
 					.create()
 					.deploy(testDeploymentProperties())) {
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -1053,9 +1053,9 @@ public class DataFlowIT {
 
 	public static final int EXIT_CODE_ERROR = 1;
 
-	public static final String TEST_VERSION_NUMBER = "2.1.0.RELEASE";
+	public static final String TEST_VERSION_NUMBER = "2.0.2";
 
-	public static final String CURRENT_VERSION_NUMBER = "2.1.1.RELEASE";
+	public static final String CURRENT_VERSION_NUMBER = "2.0.1";
 
 	private List<String> composedTaskLaunchArguments(String... additionalArguments) {
 		// the dataflow-server-use-user-access-token=true argument is required COMPOSED tasks in

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Christian Tzolov
+ * @author David Turanski
  */
 @ConfigurationProperties(prefix = "test")
 public class IntegrationTestProperties {
@@ -152,6 +153,11 @@ public class IntegrationTestProperties {
 		private String influxUrl = "http://localhost:8086";
 
 		/**
+		 * Dataflow server URI
+		 */
+		private String dataflowServerUri = "http://localhost:9393";
+
+		/**
 		 * Streaming applications are behind HTTPS.
 		 */
 		private boolean applicationOverHttps;
@@ -186,6 +192,14 @@ public class IntegrationTestProperties {
 
 		public void setApplicationOverHttps(boolean applicationOverHttps) {
 			this.applicationOverHttps = applicationOverHttps;
+		}
+
+		String getDataflowServerUri() {
+			return dataflowServerUri;
+		}
+
+		void setDataflowServerUri(String dataflowServerUri) {
+			this.dataflowServerUri = dataflowServerUri;
 		}
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/IntegrationTestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Christian Tzolov
- * @author David Turanski
  */
 @ConfigurationProperties(prefix = "test")
 public class IntegrationTestProperties {
@@ -153,11 +152,6 @@ public class IntegrationTestProperties {
 		private String influxUrl = "http://localhost:8086";
 
 		/**
-		 * Dataflow server URI
-		 */
-		private String dataflowServerUri = "http://localhost:9393";
-
-		/**
 		 * Streaming applications are behind HTTPS.
 		 */
 		private boolean applicationOverHttps;
@@ -192,14 +186,6 @@ public class IntegrationTestProperties {
 
 		public void setApplicationOverHttps(boolean applicationOverHttps) {
 			this.applicationOverHttps = applicationOverHttps;
-		}
-
-		String getDataflowServerUri() {
-			return dataflowServerUri;
-		}
-
-		void setDataflowServerUri(String dataflowServerUri) {
-			this.dataflowServerUri = dataflowServerUri;
 		}
 	}
 }


### PR DESCRIPTION
tasklauncher test fails on CF now that I fixed the tasklauncher-sink app registration issue 