### PR TITLE
Make spring-cloud-dataflow-server jar executable

### DIFF
--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -135,6 +135,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<executable>true</executable>
+				</configuration>
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
ℹ️ I did not put this into a separate Maven profile. If we use a profile, the user will still need to build the application on their own as this is a build time option. 

The executable version of the jar works with both 

* `java -jar spring-cloud-dataflow-server-2.9.5-SNAPSHOT.jar`
* `./spring-cloud-dataflow-server-2.9.5-SNAPSHOT.jar`

I do not see a reason to not just make it executable by default. Also, none of the caveats listed in the [Boot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#deployment.installing) apply in our case.

If you run `less` on the generated jar you can see it is just a bash script in front of the binary jar contents. 


Fixes #4941