### PR TITLE
Disable encryption for Mssql test container

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowCluster.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/container/DataflowCluster.java
@@ -295,6 +295,7 @@ public class DataflowCluster implements Startable {
 				databaseContainer.withExposedPorts(MSSQL_PORT);
 				databaseContainer.withNetworkAliases(databaseAlias);
 				databaseContainer.withNetwork(network);
+				databaseContainer.withUrlParam("encrypt", "false");
 				return databaseContainer;
 			} else if (clusterContainer.tag.startsWith(TagNames.ORACLE)) {
 				OracleContainer databaseContainer = new CustomOracleContainer(clusterContainer.image);


### PR DESCRIPTION
- Similar to the fix implemented in Testcontainers (
https://github.com/StefanHufschmidt/testcontainers-java/commit/45c207f045ae6aeff943e49dbacad302c1c84cdd) set `encypt=false`

Fixes #4978