### PR TITLE
Increase deploy timeout

### DIFF
--- a/src/carvel/templates/bundle/repo/versions.yml
+++ b/src/carvel/templates/bundle/repo/versions.yml
@@ -4,7 +4,7 @@ package_repository:
   packageSpec:
     syncPeriod: 5m
     deploy:
-      kappWaitTimeout: 5m
+      kappWaitTimeout: 10m
   packageName: (@= data.values.package.name @).tanzu.vmware.com
   packages:
     - name: (@= data.values.package.name @)


### PR DESCRIPTION
kapp timeout of 5min is too short when deploying into mutiple namespaces at the same time.