### PR TITLE
Added startup probe

### DIFF
--- a/src/carvel/config/dataflow-deployment.yml
+++ b/src/carvel/config/dataflow-deployment.yml
@@ -43,16 +43,24 @@ spec:
           readOnly: true
         ports:
         - containerPort: 80
+        startupProbe:
+          httpGet:
+            port: 9393
+            path: #@ dataflow_liveness_path()
+          failureThreshold: 40
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 5
         livenessProbe:
           httpGet:
             path: #@ dataflow_liveness_path()
             port: 9393
-          initialDelaySeconds: 45
+          initialDelaySeconds: 5
         readinessProbe:
           httpGet:
             path: #@ dataflow_readiness_path()
             port: 9393
-          initialDelaySeconds: 45
+          initialDelaySeconds: 10
         resources:
           limits:
             cpu: #@ data.values.scdf.server.resources.limits.cpu

--- a/src/carvel/config/skipper-deployment.yml
+++ b/src/carvel/config/skipper-deployment.yml
@@ -42,16 +42,24 @@ spec:
         #@ end
         ports:
         - containerPort: 80
+        startupProbe:
+          httpGet:
+            port: 7577
+            path: /actuator
+          failureThreshold: 40
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 5
         livenessProbe:
           httpGet:
             path: /actuator/health
             port: 7577
-          initialDelaySeconds: 45
+          initialDelaySeconds: 5
         readinessProbe:
           httpGet:
             path: /actuator/info
             port: 7577
-          initialDelaySeconds: 45
+          initialDelaySeconds: 10
         resources:
           limits:
             cpu: #@ data.values.scdf.skipper.resources.limits.cpu


### PR DESCRIPTION
Adding a startup probe can reduce the time it takes for application to register live/healthy. 
The initial time of live and healthy only start when startup probe reports success.