### PR TITLE
Deprecates attributes of the StepExecutionHistory

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -2769,6 +2769,7 @@ include::{snippets}/job-step-executions-documentation/step-progress/curl-request
 
 include::{snippets}/job-step-executions-documentation/step-progress/http-response.adoc[]
 
+NOTE: The following fields in the stepExecutionHistory are deprecated and will be removed in a future release: rollbackCount, readCount, writeCount, filterCount, readSkipCount, writeSkipCount, processSkipCount, durationPerRead.
 
 
 [[api-guide-resources-runtime-information-applications]]

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
@@ -21,6 +21,8 @@ import java.util.Date;
 import org.springframework.batch.core.StepExecution;
 
 /**
+ * Stores the cumulative information for a specific {@link StepExecution}'s history.
+ * }
  * @author Glenn Renfro
  */
 public class StepExecutionHistory {
@@ -79,46 +81,65 @@ public class StepExecutionHistory {
 		return stepName;
 	}
 
+	/**
+	 * Returns the number of {@link StepExecution}s are being used for history calculations.
+	 *
+	 * The id of an existing step execution for a specific job execution (required)
+	 * @return the number of {@link StepExecution}s.
+	 */
 	public int getCount() {
 		return count;
 	}
 
+	@Deprecated
 	public CumulativeHistory getCommitCount() {
 		return commitCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getRollbackCount() {
 		return rollbackCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getReadCount() {
 		return readCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getWriteCount() {
 		return writeCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getFilterCount() {
 		return filterCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getReadSkipCount() {
 		return readSkipCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getWriteSkipCount() {
 		return writeSkipCount;
 	}
 
+	@Deprecated
 	public CumulativeHistory getProcessSkipCount() {
 		return processSkipCount;
 	}
 
+	/**
+	 * Stores the cumulative history for a specified {@link StepExecution}'s duration.
+	 * @return {@link CumulativeHistory} for the duration of a specified {@link StepExecution}.
+	 */
 	public CumulativeHistory getDuration() {
 		return duration;
 	}
 
+	@Deprecated
 	public CumulativeHistory getDurationPerRead() {
 		return durationPerRead;
 	}


### PR DESCRIPTION
These attributes are not actively being used and cause confusion.

* The reason that the StepExecutionHistory was not deprecated as a whole is that duration and count are used in the percent complete feature for steps offered by the UI.
* Also added some documentation to the StepExecutionHistory class.
* Notifying folks of a deprecation via the RESTFul API has to be done through documentation for now.
* jThere was an option do so via the schema of the JSON however, based on my reading the plugin in Jackson that allows us to add a schema will soon no longer be supported.