### PR TITLE
Fix failure in Kubernetes tests

### DIFF
--- a/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
+++ b/spring-cloud-dataflow-autoconfigure/src/test/java/org/springframework/cloud/dataflow/autoconfigure/local/SchedulerPerPlatformTest.java
@@ -64,7 +64,7 @@ public class SchedulerPerPlatformTest {
 	}
 
 	@TestPropertySource(properties = { "spring.cloud.dataflow.features.schedules-enabled=true",
-			"kubernetes_service_host=dummy" })
+			"kubernetes_service_host=dummy", "spring.cloud.kubernetes.client.namespace=default" })
 	public static class KubernetesSchedulerActivatedTests extends AbstractSchedulerPerPlatformTest {
 
 		@Test

--- a/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesPlatformPropertiesTests.java
+++ b/spring-cloud-dataflow-platform-kubernetes/src/test/java/org/springframework/cloud/dataflow/server/config/kubernetes/KubernetesPlatformPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,9 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Donovan Muller
+ * @author Chris Bono
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = KubernetesPlatformPropertiesTests.TestConfig.class)
+@SpringBootTest(classes = KubernetesPlatformPropertiesTests.TestConfig.class,
+        properties = { "spring.cloud.kubernetes.client.namespace=default" })
 @ActiveProfiles("kubernetes-platform-properties")
 public class KubernetesPlatformPropertiesTests {
 

--- a/spring-cloud-dataflow-platform-kubernetes/src/test/resources/application-kubernetes-platform-properties.yml
+++ b/spring-cloud-dataflow-platform-kubernetes/src/test/resources/application-kubernetes-platform-properties.yml
@@ -8,7 +8,7 @@ spring:
               dev:
                 fabric8:
                   masterUrl: https://192.168.0.1:8443
-                  namespace: dev1
+                namespace: dev1
                 imagePullPolicy: Always
                 entryPointStyle: exec
                 limits:

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/CloudFoundrySchedulerTests.java
@@ -63,7 +63,8 @@ import static org.mockito.Mockito.when;
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = {
 				"spring.cloud.dataflow.features.schedules-enabled=true",
-				"VCAP_SERVICES=foo",
+                "spring.cloud.kubernetes.enabled=false",
+				"VCAP_SERVICES={}",
 				"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.url=https://localhost",
 				"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.org=org",
 				"spring.cloud.dataflow.task.platform.cloudfoundry.accounts[cf].connection.space=space",

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/KubernetesSchedulerTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/KubernetesSchedulerTests.java
@@ -35,13 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  **/
 @ActiveProfiles("kubernetes")
 @SpringBootTest(
-	classes = { DataFlowServerApplication.class },
-	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-	properties = {
-		"spring.cloud.dataflow.task.platform.kubernetes.accounts[k8s].namespace=default",
-		"kubernetes_service_host=foo",
-		"spring.cloud.dataflow.features.schedules-enabled=true"
-	})
+        classes = { DataFlowServerApplication.class },
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.cloud.dataflow.task.platform.kubernetes.accounts[k8s].namespace=default",
+                "spring.cloud.kubernetes.client.namespace=default",
+                "kubernetes_service_host=foo",
+                "spring.cloud.dataflow.features.schedules-enabled=true"
+        })
 @RunWith(SpringRunner.class)
 public class KubernetesSchedulerTests {
 


### PR DESCRIPTION
- Add 'spring.cloud.kubernetes.client.namespace' prop which is required in SCK 2021.0.5