### PR TITLE
Add actuator props to stream on deployment

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/application-stream-common-properties-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/application-stream-common-properties-defaults.yml
@@ -11,6 +11,10 @@ common:
 
         # Tags required to use the Wavefront Spring Boot tile.
         application: ${spring.cloud.dataflow.stream.name:unknown}-${spring.cloud.dataflow.stream.app.label:unknown}-${spring.cloud.dataflow.stream.app.type:unknown}
+    endpoints:
+      web:
+        exposure:
+          include: health,info,bindings
 
   # Properties required for Wavefront Tracing.
   wavefront.application.name: ${spring.cloud.dataflow.stream.name:unknown}
@@ -30,4 +34,3 @@ cloudfoundry:
         space.name: ${vcap.application.space_name:unknown}
         application.id: ${vcap.application.application_id:unknown}
         application.version: ${vcap.application.application_version:unknown}
-

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-install.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceIntegrationTests-install.yml
@@ -3,6 +3,7 @@
 "spec":
   "resource": "maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar"
   "applicationProperties":
+    "management.endpoints.web.exposure.include": "health,info,bindings"
     "spring.cloud.dataflow.stream.app.label": "log"
     "spring.cloud.dataflow.stream.name": "ticktock"
     "spring.cloud.dataflow.stream.app.type": "sink"


### PR DESCRIPTION
Adds actuator endpoint props in the common stream resource props which gives them to all deployed stream apps. 

- Verified manually in local stack. 
- Integration test added as well

Fixes #4753