### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/actions/build-package-bundle/action.yml
+++ b/.github/actions/build-package-bundle/action.yml
@@ -53,7 +53,7 @@ runs:
       IMGPKG_LOCK_GENERATED_OUT: ${{ runner.temp }}/generated/imgpkgout
     shell: bash
     run: |
-      echo "::set-output name=bundle-path::$PACKAGE_BUNDLE_GENERATED"
+      echo "bundle-path=$PACKAGE_BUNDLE_GENERATED" >> $GITHUB_OUTPUT
       ytt \
         -f $PACKAGE_BUNDLE_TEMPLATE \
         --output-files $PACKAGE_BUNDLE_GENERATED \


### PR DESCRIPTION
## Description

Fixes #5261

Update `.github/actions/build-package-bundle/action.yml` to use environment file instead of deprecated `set-output` command. 

For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/ -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=bundle-path::$PACKAGE_BUNDLE_GENERATED"
```

**TO-BE**

```yml
echo "bundle-path=$PACKAGE_BUNDLE_GENERATED" >> $GITHUB_OUTPUT
```
