### PR TITLE
Adjust `maven.remoteRepositories` for Artifactory cutover

### DIFF
--- a/spring-cloud-starter-dataflow-server/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-starter-dataflow-server/src/main/resources/dataflow-server.yml
@@ -8,8 +8,10 @@ info:
 
 maven:
   remoteRepositories:
+    mavenCentral:
+      url: https://repo.maven.apache.org/maven2
     springRepo:
-      url: https://repo.spring.io/libs-snapshot
+      url: https://repo.spring.io/snapshot
 
 spring:
   application:


### PR DESCRIPTION
- Add `mavenCentral` remote rep
- Edit `springRepo` (`libs-snapshot` -> `/snapshot`)

See #5321


### Verification
**Prove its broken**
- Switch to `/snapshot`
- Clear my local m2 cache for `org/springframework/cloud/stream/app`
- Run SCDF + Skipper locally
- Register bulk kafka/maven apps from SCDF UI
- Create `time | log` stream def
- Deploy `time | log` stream def
- 💥 

**Fix**
- Add mavenCentral remote repo
- Redo the above steps and see that the 💥 goes away 
