### PR TITLE
Resolves by labeled app properties are not resolved

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,7 +232,7 @@ public class TaskServiceUtils {
 	private static Map<String, String> extractPropertiesByPrefix(String type,
 			String name, String label, Map<String, String> taskDeploymentProperties) {
 		final String prefix1 = type + "." + name + ".";
-		final String prefix2 = StringUtils.hasText(label) ? type + "." + label + "." + name + "." : null;
+		final String prefix2 = StringUtils.hasText(label) ? type + "." + label + "." : null;
 
 		Map<String, String> props = taskDeploymentProperties.entrySet().stream()
 				.filter(kv -> kv.getKey().startsWith(prefix1))

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,6 +176,22 @@ public class TaskServiceUtilsTests {
 		taskDeploymentProperties.put("app.test.test", "baz");
 		taskDeploymentProperties.put("app.none.test", "boo");
 		Map<String, String> result = TaskServiceUtils.extractAppProperties("test",
+				taskDeploymentProperties);
+
+		assertThat(result.size()).isEqualTo(2);
+		assertThat(result.get("foo")).isEqualTo("bar");
+		assertThat(result.get("test")).isEqualTo("baz");
+	}
+
+	@Test
+	public void testExtractAppLabelProperties() {
+		Map<String, String> taskDeploymentProperties = new HashMap<>();
+		taskDeploymentProperties.put("app.mylabel.foo", "bar");
+		taskDeploymentProperties.put("test.none", "boo");
+		taskDeploymentProperties.put("app.test.test", "boo");
+		taskDeploymentProperties.put("app.mylabel.test", "baz");
+		taskDeploymentProperties.put("app.none.test", "boo");
+		Map<String, String> result = TaskServiceUtils.extractAppProperties("test", "mylabel",
 				taskDeploymentProperties);
 
 		assertThat(result.size()).isEqualTo(2);


### PR DESCRIPTION
resolves #5337

The code that handled identifying what properties should be moved from deployment properties
to app properties assumed the following format `app.label.taskname.key`.   But the format is actually `app.label.key`.