### PR TITLE
Test and Doc test cleanup

### DIFF
--- a/spring-cloud-dataflow-classic-docs/pom.xml
+++ b/spring-cloud-dataflow-classic-docs/pom.xml
@@ -88,7 +88,12 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -93,7 +92,6 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 				post("/streams/deployments/scale/{streamName}/{appName}/instances/{count}", "timelog", "log", 1)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(json))
-				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(pathParameters(
 						parameterWithName("streamName")
@@ -148,7 +146,6 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 				post("/streams/deployments/{timelog}", "timelog")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(json))
-				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("timelog")
@@ -163,13 +160,11 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 				post("/streams/deployments/{timelog1}", "timelog1")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(json))
-				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("timelog1")
 								.description("The name of an existing stream definition (required)"))
 				));
-		Thread.sleep(30000);
 		UpdateStreamRequest updateStreamRequest = new UpdateStreamRequest();
 		updateStreamRequest.setReleaseName("timelog1");
 		Map<String, String> updateProperties = new HashMap<>();
@@ -186,13 +181,11 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 				post("/streams/deployments/update/{timelog1}", "timelog1")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(convertObjectToJson(updateStreamRequest)))
-				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("timelog1")
 								.description("The name of an existing stream definition (required)"))
 				));
-		Thread.sleep(30000);
 	}
 
 	@Test
@@ -202,13 +195,11 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				post("/streams/deployments/rollback/{name}/{version}", "timelog1", 1)
 						.contentType(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("name")
 										.description("The name of an existing stream definition (required)"),
 								parameterWithName("version").description("The version to rollback to"))));
-		Thread.sleep(30000);
 	}
 
 	@Test
@@ -219,7 +210,6 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				get("/streams/deployments/history/{name}", "timelog1")
 						.contentType(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("name")
@@ -231,7 +221,6 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				get("/streams/deployments/manifest/{name}/{version}", "timelog1", 1)
 						.contentType(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("name")
@@ -244,7 +233,6 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				get("/streams/deployments/platform/list")
 						.contentType(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isOk());
 	}
 

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,16 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
+import org.awaitility.Awaitility;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.server.repository.TaskDeploymentRepository;
+import org.springframework.cloud.dataflow.server.service.TaskExecutionService;
+
+import java.time.Duration;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -34,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Documentation for the {@code /tasks/logs} endpoint.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Glenn Renfro
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TaskLogsDocumentation extends BaseDocumentation {
@@ -53,7 +58,9 @@ public class TaskLogsDocumentation extends BaseDocumentation {
 				.andExpect(status().isCreated());
 		TaskDeploymentRepository taskDeploymentRepository =
 				springDataflowServer.getWebApplicationContext().getBean(TaskDeploymentRepository.class);
-		Thread.sleep(30000);
+		TaskExecutionService service = this.springDataflowServer.getWebApplicationContext().getBean(TaskExecutionService.class);
+		Awaitility.await().atMost(Duration.ofMillis(30000)).until(() -> service.getLog("default",
+				taskDeploymentRepository.findTopByTaskDefinitionNameOrderByCreatedOnAsc(taskName).getTaskDeploymentId()).length() > 0);
 		this.mockMvc.perform(
 				get("/tasks/logs/"+taskDeploymentRepository.findTopByTaskDefinitionNameOrderByCreatedOnAsc(taskName)
 						.getTaskDeploymentId()).param("platformName", "default"))


### PR DESCRIPTION
* Updated TaskExecutionService tests to replaced deprecated code.
* Updated TaskLogsDocumentation to use Awaitility instead of a thread.sleep.
* Updated StreamDeploymentDocumentation to remove unnecessary prints that cluttered the log.
* Updated StreamDeploymentDocumentation to remove unnecessary thread.sleeps.