### PR TITLE
Add support to retrieve metadata on task properties

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/dataflow-configuration-metadata.properties
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/dataflow-configuration-metadata.properties
@@ -1,1 +1,1 @@
-configuration-properties.classes=org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties
+configuration-properties.classes=org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties, org.springframework.cloud.task.configuration.TaskProperties

--- a/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/spring-configuration-metadata-whitelist.properties
@@ -1,1 +1,1 @@
-configuration-properties.classes=org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties
+configuration-properties.classes=org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties, org.springframework.cloud.task.configuration.TaskProperties

--- a/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -17,6 +17,12 @@
       "sourceType": "org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties",
       "sourceMethod": "getComposedTaskAppProperties()"
     }
+  ,
+    {
+      "name": "task-app-properties",
+      "type": "org.springframework.cloud.task.configuration.TaskProperties",
+      "sourceType": "org.springframework.cloud.task.configuration.TaskProperties"
+    }
   ],
   "properties": [
     {

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.common.security.CommonSecurityAutoConfiguration
 import org.springframework.cloud.dataflow.composedtaskrunner.configuration.DataFlowTestConfiguration;
 import org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
+import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -59,7 +60,7 @@ import static org.mockito.Mockito.verify;
 @TestPropertySource(properties = {"graph=ComposedTest-AAA && ComposedTest-BBB && ComposedTest-CCC","max-wait-time=1010",
 		"composed-task-properties=" + ComposedTaskRunnerConfigurationWithPropertiesTests.COMPOSED_TASK_PROPS ,
 		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo --AAA.foo=bar BBB.que=qui",
-		"transaction-isolation-level=ISOLATION_READ_COMMITTED",
+		"transaction-isolation-level=ISOLATION_READ_COMMITTED","spring.cloud.task.closecontext-enabled=true",
 		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
 @EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 public class ComposedTaskRunnerConfigurationWithPropertiesTests {
@@ -72,6 +73,9 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
 	@Autowired
 	private ComposedTaskProperties composedTaskProperties;
+
+	@Autowired
+	private TaskProperties taskProperties;
 
 	@Autowired
 	ApplicationContext context;
@@ -101,6 +105,7 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 		assertThat(composedTaskProperties.getIntervalTimeBetweenChecks()).isEqualTo(1100);
 		assertThat(composedTaskProperties.getDataflowServerUri().toASCIIString()).isEqualTo("https://bar");
 		assertThat(composedTaskProperties.getTransactionIsolationLevel()).isEqualTo("ISOLATION_READ_COMMITTED");
+		assertThat(taskProperties.getClosecontextEnabled()).isTrue();
 
 		List<String> args = new ArrayList<>(2);
 		args.add("--baz=boo --foo=bar");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskCtrControllerTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.controller;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -68,7 +69,12 @@ public class TaskCtrControllerTests {
 		ConfigurationMetadataProperty p = new ConfigurationMetadataProperty();
 		p.setId("oauth2-client-credentials-scopes");
 		p.setName("oauth2-client-credentials-scopes");
-		List<ConfigurationMetadataProperty> props = Arrays.asList(p);
+		List<ConfigurationMetadataProperty> props = new ArrayList<>();
+		props.add(p);
+		p = new ConfigurationMetadataProperty();
+		p.setId("spring.cloud.task.closecontext-enabled");
+		p.setName("false");
+		props.add(p);
 		Mockito.when(metadataResolver.listProperties(any())).thenReturn(props);
 	}
 
@@ -76,6 +82,7 @@ public class TaskCtrControllerTests {
 	public void testOptions() throws Exception {
 		mockMvc.perform(get("/tasks/ctr/options").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.[?(@.id == 'oauth2-client-credentials-scopes')].name", hasItems("oauth2-client-credentials-scopes")));
+			.andExpect(jsonPath("$.[?(@.id == 'oauth2-client-credentials-scopes')].name", hasItems("oauth2-client-credentials-scopes")))
+			.andExpect(jsonPath("$.[?(@.id == 'spring.cloud.task.closecontext-enabled')].name", hasItems("false")));
 	}
 }


### PR DESCRIPTION
Tested it locally but found an issue in UI deleting property when navigating between builder and freetext
where the task properties were not reconstituted on the UI.   

Resolves #5229