### PR TITLE
fix: enable ctr for prometheus reporting

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -27,7 +27,7 @@
 		<commons-io.version>2.7</commons-io.version>
 		<commons-text.version>1.10.0</commons-text.version>
 		<postgresql.version>42.4.3</postgresql.version>
-		<prometheus-rsocket.version>1.5.0</prometheus-rsocket.version>
+		<prometheus-rsocket.version>1.5.1</prometheus-rsocket.version>
 		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<spring-cloud-services-starter-config-client.version>3.5.4</spring-cloud-services-starter-config-client.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -27,7 +27,7 @@
 		<commons-io.version>2.7</commons-io.version>
 		<commons-text.version>1.10.0</commons-text.version>
 		<postgresql.version>42.4.3</postgresql.version>
-		<prometheus-rsocket-spring.version>1.3.0</prometheus-rsocket-spring.version>
+		<prometheus-rsocket.version>1.5.0</prometheus-rsocket.version>
 		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<spring-cloud-services-starter-config-client.version>3.5.4</spring-cloud-services-starter-config-client.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>
@@ -93,7 +93,12 @@
 			<dependency>
 				<groupId>io.micrometer.prometheus</groupId>
 				<artifactId>prometheus-rsocket-spring</artifactId>
-				<version>${prometheus-rsocket-spring.version}</version>
+				<version>${prometheus-rsocket.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.micrometer.prometheus</groupId>
+				<artifactId>prometheus-rsocket-client</artifactId>
+				<version>${prometheus-rsocket.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.pivotal.cfenv</groupId>

--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -116,9 +116,16 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-spring</artifactId>
-			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer.prometheus</groupId>
+			<artifactId>prometheus-rsocket-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Currently the CTR does not report to prometheus-rsocket-proxy - even if the environment variables are given from the SCDF server. With this fix the CTR is reporting to the prometheus-rsocket-proxy like all other task applications