### PR TITLE
Removed repo.spring.io/release usage from project

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -30,14 +30,6 @@
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>

--- a/.settings.xml
+++ b/.settings.xml
@@ -44,14 +44,6 @@
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -414,14 +414,6 @@
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.cloud.dataflow.registry.support;
 import java.net.MalformedURLException;
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
@@ -28,9 +28,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.UrlResource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -45,17 +43,17 @@ public class AppResourceCommonTests {
 	private ResourceLoader resourceLoader = mock(ResourceLoader.class);
 	private AppResourceCommon appResourceCommon = new AppResourceCommon(new MavenProperties(), resourceLoader);
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testBadNamedJars() throws Exception {
-		UrlResource urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit.jar");
-		appResourceCommon.getUrlResourceVersion(urlResource);
+		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit.jar");
+		assertThatIllegalArgumentException().isThrownBy( () -> appResourceCommon.getUrlResourceVersion(urlResource));
 	}
 
 	@Test
 	public void testInvalidUrlResourceWithoutVersion() throws Exception {
 		assertThat(appResourceCommon.getUrlResourceWithoutVersion(
-				new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar")))
-				.isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit");
+				new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar")))
+				.isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit");
 	}
 
 	@Test
@@ -87,39 +85,39 @@ public class AppResourceCommonTests {
 	public void testDefaultResource() {
 		String classpathUri = "classpath:AppRegistryTests-importAll.properties";
 		Resource resource = appResourceCommon.getResource(classpathUri);
-		assertTrue(resource instanceof ClassPathResource);
+		assertThat(resource instanceof ClassPathResource).isTrue();
 	}
 
 	@Test
 	public void testDockerUriString() throws Exception {
-		String dockerUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
+		String dockerUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
 		Resource resource = appResourceCommon.getResource(dockerUri);
-		assertTrue(resource instanceof DockerResource);
+		assertThat(resource instanceof DockerResource).isTrue();
 		assertThat(resource.getURI().toString().equals(dockerUri));
 	}
 
 	@Test
 	public void testJarMetadataUriDockerApp() throws Exception {
-		String appUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
-		String metadataUri = "https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar";
+		String appUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
+		String metadataUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), new URI(metadataUri));
 		verify(resourceLoader).getResource(eq(metadataUri));
 	}
 
 	@Test
 	public void testMetadataUriHttpApp() throws Exception {
-		String appUri = "https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/1.2.0.RELEASE/file-sink-rabbit-1.2.0.RELEASE.jar";
+		String appUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), null);
-		assertTrue(metadataResource instanceof UrlResource);
+		assertThat(metadataResource instanceof UrlResource).isTrue();
 		assertThat(metadataResource.getURI().toString().equals(appUri));
 	}
 
 	@Test
 	public void testMetadataUriDockerApp() throws Exception {
-		String appUri = "docker:springcloudstream/log-sink-rabbit:1.2.0.RELEASE";
+		String appUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), null);
 		assertThat(metadataResource).isNotNull();
-		assertTrue(metadataResource instanceof DockerResource);
+		assertThat(metadataResource instanceof DockerResource).isTrue();
 	}
 
 	@Test
@@ -149,73 +147,73 @@ public class AppResourceCommonTests {
 	@Test
 	public void testJars() throws MalformedURLException {
 		//Dashes in artifact name
-		UrlResource urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0.RELEASE.jar");
+		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1.jar");
 		String version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("1.2.0.RELEASE");
+		assertThat(version).isEqualTo("3.2.1");
 
 		String theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
-		assertThat(theRest).isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
+		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//No dashes in artfiact name - BUILD-SNAPSHOT
-		urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file/file-1.2.0.BUILD-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-3.2.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("1.2.0.BUILD-SNAPSHOT");
+		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
-		assertThat(theRest).isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file/file");
+		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
 		//No dashes in artfiact name - RELEASE
-		urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file/file-1.2.0.RELEASE.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-3.2.1.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("1.2.0.RELEASE");
+		assertThat(version).isEqualTo("3.2.1");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
-		assertThat(theRest).isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file/file");
+		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
 		//Spring style snapshots naming scheme
-		urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0.BUILD-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("1.2.0.BUILD-SNAPSHOT");
+		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
-		assertThat(theRest).isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
+		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//Standard maven style naming scheme
-		urlResource = new UrlResource("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-1.2.0-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("1.2.0-SNAPSHOT");
+		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
-		assertThat(theRest).isEqualTo("https://repo.spring.io/release/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
+		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 	}
 
 	@Test
 	public void testGetResourceWithoutVersion() {
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec:1.3.0.RELEASE")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec:3.2.1")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec");
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit::exec:1.3.0.RELEASE")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit::exec:3.2.1")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar:exec");
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar");
 	}
 
 	@Test
 	public void testGetResource() {
-		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1";
 		Resource resource = appResourceCommon.getResource(mavenUri);
 		assertThat(resource).isInstanceOf(MavenResource.class);
 	}
 
 	@Test
 	public void testGetResourceVersion() {
-		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:1.3.0.RELEASE";
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1";
 		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(mavenUri));
-		assertThat(version).isEqualTo("1.3.0.RELEASE");
+		assertThat(version).isEqualTo("3.2.1");
 	}
 
 	@Test
 	public void testGetMetadataResourceVersion() {
-		String httpUri = "http://repo.spring.io/release/org/springframework/cloud/stream/app/cassandra-sink-rabbit/2.1.0.BUILD-SNAPSHOT/cassandra-sink-rabbit-2.1.0.BUILD-SNAPSHOT-metadata.jar";
+		String httpUri = "http://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/cassandra-sink-rabbit/3.2.1-SNAPSHOT/cassandra-sink-rabbit-3.2.1-SNAPSHOT-metadata.jar";
 		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(httpUri));
-		assertThat(version).isEqualTo("2.1.0.BUILD-SNAPSHOT");
+		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -301,7 +301,6 @@ public class AboutController {
 	private String repoSelector(String version) {
 		final String REPO_SNAPSHOT_ROOT = "https://repo.spring.io/snapshot";
 		final String REPO_MILESTONE_ROOT = "https://repo.spring.io/milestone";
-		final String REPO_RELEASE_ROOT = "https://repo.spring.io/release";
 		final String MAVEN_ROOT = "https://repo.maven.apache.org/maven2";
 
 		String result = MAVEN_ROOT;
@@ -313,9 +312,6 @@ public class AboutController {
 		}
 		else if (version.contains(".RC")) {
 			result = REPO_MILESTONE_ROOT;
-		}
-		else if (version.contains(".RELEASE")) {
-			result = REPO_RELEASE_ROOT;
 		}
 		return result;
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AboutControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.dataflow.server.controller;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,12 +26,11 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.server.configuration.TestDependencies;
-import org.springframework.cloud.dataflow.server.support.LogTestNameRule;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -40,7 +38,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.reset;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Glenn Renfro
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestDependencies.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @TestPropertySource(properties = {
@@ -70,13 +68,10 @@ public class AboutControllerTests {
 
 	private MockMvc mockMvc;
 
-	@Rule
-	public LogTestNameRule logTestName = new LogTestNameRule();
-
 	@Autowired
 	private WebApplicationContext wac;
 
-	@Before
+	@BeforeEach
 	public void setupMocks() {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 				.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -99,14 +94,14 @@ public class AboutControllerTests {
 				.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist())
 				.andExpect(jsonPath("$.securityInfo.authenticationEnabled", is(false)))
 				.andExpect(jsonPath("$.securityInfo.authenticated", is(false)))
-				.andExpect(jsonPath("$.securityInfo.username", isEmptyOrNullString()))
+				.andExpect(jsonPath("$.securityInfo.username", is(emptyOrNullString())))
 				.andExpect(jsonPath("$.featureInfo.streamsEnabled", is(true)))
 				.andExpect(jsonPath("$.featureInfo.tasksEnabled", is(true)))
 				.andExpect(jsonPath("$.featureInfo.schedulesEnabled", is(false)))
-				.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", not(isEmptyOrNullString())));
+				.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", not(emptyOrNullString())));
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -120,13 +115,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -144,7 +136,7 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -157,13 +149,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -174,14 +163,14 @@ public class AboutControllerTests {
 			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
 			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(true)))
 					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
-					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/snapshot/org/springframework/cloud/spring-cloud-dataflow-shell/2.11.0-SNAPSHOT/spring-cloud-dataflow-shell-2.7.2-SNAPSHOT.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/snapshot/org/springframework/cloud/spring-cloud-dataflow-shell/2.11.0-SNAPSHOT/spring-cloud-dataflow-shell-2.11.0-SNAPSHOT.jar")))
 					.andExpect(jsonPath("$.versionInfo.shell.version", is("2.11.0-SNAPSHOT")))
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -194,13 +183,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -219,7 +205,7 @@ public class AboutControllerTests {
 	}
 
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -232,13 +218,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -256,7 +239,7 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -272,7 +255,7 @@ public class AboutControllerTests {
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -290,11 +273,11 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
-			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3.RELEASE",
+			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.version=1.2.3",
 			"spring.cloud.dataflow.version-info.dependency-fetch.enabled=false",
 			"spring.cloud.dataflow.version-info.dependencies.spring-cloud-dataflow-shell.checksum-sha1=ABCDEFG"
 	})
@@ -303,13 +286,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -320,14 +300,14 @@ public class AboutControllerTests {
 			ResultActions result = mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
 			result.andExpect(jsonPath("$.featureInfo.analyticsEnabled", is(true)))
 					.andExpect(jsonPath("$.versionInfo.shell.name", is("Spring Cloud Data Flow Shell")))
-					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.spring.io/release/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3.RELEASE/spring-cloud-dataflow-shell-1.2.3.RELEASE.jar")))
-					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3.RELEASE")))
+					.andExpect(jsonPath("$.versionInfo.shell.url", is("https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-dataflow-shell/1.2.3/spring-cloud-dataflow-shell-1.2.3.jar")))
+					.andExpect(jsonPath("$.versionInfo.shell.version", is("1.2.3")))
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha1").doesNotExist())
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist());
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -342,13 +322,10 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -365,7 +342,7 @@ public class AboutControllerTests {
 		}
 	}
 
-	@RunWith(SpringRunner.class)
+	@ExtendWith(SpringExtension.class)
 	@SpringBootTest(classes = TestDependencies.class)
 	@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 	@TestPropertySource(properties = {
@@ -388,16 +365,13 @@ public class AboutControllerTests {
 
 		private MockMvc mockMvc;
 
-		@Rule
-		public LogTestNameRule logTestName = new LogTestNameRule();
-
 		@Autowired
 		private WebApplicationContext wac;
 
 		@Autowired
 		private SkipperClient skipperClient;
 
-		@Before
+		@BeforeEach
 		public void setupMocks() {
 			this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
 					.defaultRequest(get("/").accept(MediaType.APPLICATION_JSON)).build();
@@ -420,7 +394,7 @@ public class AboutControllerTests {
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist())
 					.andExpect(jsonPath("$.securityInfo.authenticationEnabled", is(false)))
 					.andExpect(jsonPath("$.securityInfo.authenticated", is(false)))
-					.andExpect(jsonPath("$.securityInfo.username", isEmptyOrNullString()))
+					.andExpect(jsonPath("$.securityInfo.username", is(emptyOrNullString())))
 					.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", is("skipper server")))
 					.andExpect(jsonPath("$.monitoringDashboardInfo.url", is("http://localhost:3001")))
 					.andExpect(jsonPath("$.monitoringDashboardInfo.dashboardType", is("GRAFANA")))
@@ -449,8 +423,8 @@ public class AboutControllerTests {
 					.andExpect(jsonPath("$.versionInfo.shell.checksumSha256").doesNotExist())
 					.andExpect(jsonPath("$.securityInfo.authenticationEnabled", is(false)))
 					.andExpect(jsonPath("$.securityInfo.authenticated", is(false)))
-					.andExpect(jsonPath("$.securityInfo.username", isEmptyOrNullString()))
-					.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", isEmptyOrNullString())); // Connection to Skipper is lost!
+					.andExpect(jsonPath("$.securityInfo.username", is(emptyOrNullString())))
+					.andExpect(jsonPath("$.runtimeEnvironment.appDeployer.deployerName", is(emptyOrNullString()))); // Connection to Skipper is lost!
 		}
 	}
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-dependencies/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-dependencies/pom.xml
@@ -86,14 +86,6 @@
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>
-				<repository>
-					<id>spring-release</id>
-					<name>Spring Milestones</name>
-					<url>https://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
 			</repositories>
 			<pluginRepositories>
 				<pluginRepository>

--- a/spring-cloud-skipper/spring-cloud-skipper-docs/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-docs/pom.xml
@@ -35,14 +35,6 @@
 			<name>Spring Repository</name>
 			<url>https://repo.spring.io/milestone</url>
 		</repository>
-		<repository>
-			<id>spring-release</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/release</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
 	</repositories>
 
 	<dependencies>


### PR DESCRIPTION
This is an effort to remove all remaining usage of repo.spring.io/release from the project Changes include:
* Removal from settings, .settings, and pom.xmls because it should not be used as part of OSS build.
* Removal from tests
* Removed .RELEASE utilization from application tests
* Updated tests for application and aboutcontroller to use SNAPSHOT vs BUILD-SNAPSHOT
* Updated AboutController to only test for milestone, RC, snapshots and number ending suffixes.  No longer need to check for .RELEASE.