### PR TITLE
TaskJobExecution was using jobExecutionId for the taskExecutionID

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcAggregateJobQueryDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcAggregateJobQueryDao.java
@@ -559,7 +559,7 @@ public class JdbcAggregateJobQueryDao implements AggregateJobQueryDao {
 	}
 
 	private TaskJobExecution createJobExecutionFromResultSet(ResultSet rs, int row, boolean readStepCount) throws SQLException {
-		long id = rs.getLong("JOB_EXECUTION_ID");
+		long id = rs.getLong("TASK_EXECUTION_ID");
 
 		JobExecution jobExecution;
 		String schemaTarget = rs.getString("SCHEMA_TARGET");


### PR DESCRIPTION
The DefaultTaskJobTests (integration) will now pass.