### PR TITLE
feature: UnexpectedTaskExecutionException

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/TaskLauncherTasklet.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/TaskLauncherTasklet.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.UnexpectedJobExecutionException;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.item.ExecutionContext;
@@ -40,6 +39,7 @@ import org.springframework.cloud.common.security.core.support.OAuth2AccessTokenP
 import org.springframework.cloud.dataflow.composedtaskrunner.properties.ComposedTaskProperties;
 import org.springframework.cloud.dataflow.composedtaskrunner.support.ComposedTaskException;
 import org.springframework.cloud.dataflow.composedtaskrunner.support.TaskExecutionTimeoutException;
+import org.springframework.cloud.dataflow.composedtaskrunner.support.UnexpectedTaskExecutionException;
 import org.springframework.cloud.dataflow.rest.client.DataFlowOperations;
 import org.springframework.cloud.dataflow.rest.client.DataFlowTemplate;
 import org.springframework.cloud.dataflow.rest.client.TaskOperations;
@@ -234,10 +234,12 @@ public class TaskLauncherTasklet implements Tasklet {
 			TaskExecution taskExecution = this.taskExplorer.getTaskExecution(this.executionId);
 			if (taskExecution != null && taskExecution.getEndTime() != null) {
 				if (taskExecution.getExitCode() == null) {
-					throw new UnexpectedJobExecutionException("Task returned a null exit code.");
-				} else if (taskExecution.getExitCode() != 0) {
-					throw new UnexpectedJobExecutionException("Task returned a non zero exit code.");
-				} else {
+					throw new UnexpectedTaskExecutionException("Task returned a null exit code.", taskExecution);
+				}
+				else if (taskExecution.getExitCode() != 0) {
+					throw new UnexpectedTaskExecutionException("Task returned a non zero exit code.", taskExecution);
+				}
+				else {
 					return RepeatStatus.FINISHED;
 				}
 			}

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.task.repository.TaskExecution;
 public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionException implements ExitCodeGenerator {
 
 	private static final long serialVersionUID = 1080992679855603656L;
+
 	/**
 	 * The unique id associated with the task execution.
 	 */

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
@@ -16,9 +16,7 @@
 
 package org.springframework.cloud.dataflow.composedtaskrunner.support;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import org.springframework.batch.core.UnexpectedJobExecutionException;
 import org.springframework.boot.ExitCodeGenerator;
@@ -32,8 +30,7 @@ import org.springframework.cloud.task.repository.TaskExecution;
  */
 public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionException implements ExitCodeGenerator {
 
-	private static final long serialVersionUID = 3494615323781500165L;
-
+	private static final long serialVersionUID = 1080992679855603656L;
 	/**
 	 * The unique id associated with the task execution.
 	 */
@@ -78,11 +75,6 @@ public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionExce
 	 * Error information available upon the failure of a task.
 	 */
 	private String errorMessage;
-
-	/**
-	 * The arguments that were used for this task execution.
-	 */
-	private ArrayList<String> arguments;
 
 	/**
 	 * Constructs an UnexpectedTaskExecutionException with the specified
@@ -146,7 +138,6 @@ public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionExce
 			externalExecutionId = taskExecution.getExternalExecutionId();
 			errorMessage = taskExecution.getErrorMessage();
 			exitMessage = taskExecution.getExitMessage();
-			arguments = new ArrayList<>(taskExecution.getArguments());
 		}
 	}
 
@@ -178,10 +169,6 @@ public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionExce
 
 	public String getExitMessage() {
 		return this.exitMessage;
-	}
-
-	public List<String> getArguments() {
-		return this.arguments;
 	}
 
 	public String getErrorMessage() {

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/support/UnexpectedTaskExecutionException.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.composedtaskrunner.support;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.batch.core.UnexpectedJobExecutionException;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.cloud.task.repository.TaskExecution;
+
+/**
+ * Creates a {@link UnexpectedTaskExecutionException} which extends {@link UnsupportedOperationException}, but
+ * also contains the exitCode as information.
+ *
+ * @author Tobias Soloschenko
+ */
+public class UnexpectedTaskExecutionException extends UnexpectedJobExecutionException implements ExitCodeGenerator {
+
+	private static final long serialVersionUID = 3494615323781500165L;
+
+	/**
+	 * The unique id associated with the task execution.
+	 */
+	private long executionId;
+
+	/**
+	 * The parent task execution id.
+	 */
+	private Long parentExecutionId;
+
+	/**
+	 * The recorded exit code for the task.
+	 */
+	private Integer exitCode = -1;
+
+	/**
+	 * User defined name for the task.
+	 */
+	private String taskName;
+
+	/**
+	 * Time of when the task was started.
+	 */
+	private Date startTime;
+
+	/**
+	 * Timestamp of when the task was completed/terminated.
+	 */
+	private Date endTime;
+
+	/**
+	 * Message returned from the task or stacktrace.
+	 */
+	private String exitMessage;
+
+	/**
+	 * Id assigned to the task by the platform.
+	 */
+	private String externalExecutionId;
+
+	/**
+	 * Error information available upon the failure of a task.
+	 */
+	private String errorMessage;
+
+	/**
+	 * The arguments that were used for this task execution.
+	 */
+	private ArrayList<String> arguments;
+
+	/**
+	 * Constructs an UnexpectedTaskExecutionException with the specified
+	 * detail message.
+	 *
+	 * @param message the detail message
+	 */
+	public UnexpectedTaskExecutionException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Constructs an UnexpectedTaskExecutionException with the specified
+	 * detail message, cause and exitCode.
+	 *
+	 * @param message the detail message
+	 * @param cause   the cause which leads to this exception
+	 */
+	public UnexpectedTaskExecutionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Constructs an UnexpectedTaskExecutionException with the specified
+	 * detail message and taskExecution.
+	 *
+	 * @param message       the detail message
+	 * @param taskExecution the taskExecution of the task
+	 */
+	public UnexpectedTaskExecutionException(String message, TaskExecution taskExecution) {
+		this(message);
+		assignTaskExecutionFields(taskExecution);
+	}
+
+	/**
+	 * Constructs an UnexpectedTaskExecutionException with the specified
+	 * detail message, cause and taskExecution.
+	 *
+	 * @param message       the detail message
+	 * @param cause         the cause which leads to this exception
+	 * @param taskExecution the taskExecution of the task
+	 */
+	public UnexpectedTaskExecutionException(String message, Throwable cause, TaskExecution taskExecution) {
+		this(message, cause);
+		assignTaskExecutionFields(taskExecution);
+	}
+
+	/**
+	 * Assigns the task execution fields to this exception.
+	 *
+	 * @param taskExecution the task execution of which the fields should be assigned to this exception
+	 */
+	private void assignTaskExecutionFields(TaskExecution taskExecution) {
+		if(taskExecution != null) {
+			executionId = taskExecution.getExecutionId();
+			parentExecutionId = taskExecution.getParentExecutionId();
+			exitCode = taskExecution.getExitCode();
+			taskName = taskExecution.getTaskName();
+			startTime = taskExecution.getStartTime();
+			endTime = taskExecution.getEndTime();
+			externalExecutionId = taskExecution.getExternalExecutionId();
+			errorMessage = taskExecution.getErrorMessage();
+			exitMessage = taskExecution.getExitMessage();
+			arguments = new ArrayList<>(taskExecution.getArguments());
+		}
+	}
+
+	public long getExecutionId() {
+		return this.executionId;
+	}
+
+	/**
+	 * Returns the exit code of the task.
+	 *
+	 * @return the exit code or -1 if the exit code couldn't be determined
+	 */
+	@Override
+	public int getExitCode() {
+		return this.exitCode;
+	}
+
+	public String getTaskName() {
+		return this.taskName;
+	}
+
+	public Date getStartTime() {
+		return (this.startTime != null) ? (Date) this.startTime.clone() : null;
+	}
+
+	public Date getEndTime() {
+		return (this.endTime != null) ? (Date) this.endTime.clone() : null;
+	}
+
+	public String getExitMessage() {
+		return this.exitMessage;
+	}
+
+	public List<String> getArguments() {
+		return this.arguments;
+	}
+
+	public String getErrorMessage() {
+		return this.errorMessage;
+	}
+
+	public String getExternalExecutionId() {
+		return this.externalExecutionId;
+	}
+
+	public Long getParentExecutionId() {
+		return this.parentExecutionId;
+	}
+
+}


### PR DESCRIPTION
It would be great if the CTR throws an `UnexpectedTaskExecutionException` in favor of `UnexpectedJobExecutionException` so that it is possible to create an `ApplicationListener` which can handle certain error causes.

Because the `TaskExecution` itself is not serializable, the fields are assigned to the `UnexpectedTaskExecutionException`.

If this code is fine for you it also needs to be merged into: https://github.com/spring-cloud/spring-cloud-dataflow/pull/5368

The `UnexpectedTaskExecutionException` also uses the `ExitCodeGenerator` interface so that the error code of a task which has failed is also forwarded through the CTR to its caller.

If the exit code is `null`, the `UnexpectedTaskExecutionException` returns `-1`