### PR TITLE
Task list shell command will now work properly.

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/DeploymentPropertiesUtilsTests.java
@@ -87,7 +87,7 @@ public class DeploymentPropertiesUtilsTests {
 			fail("Illegal Argument Exception expected.");
 		}
 		catch (Exception e) {
-			assertTrue(e.getMessage().equals("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed."));
+			assertThat(e.getMessage()).isEqualTo("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed. Not invalidkeyvalue");
 		}
 
 		props = DeploymentPropertiesUtils.parse("deployer.foo=bar,invalidkeyvalue2");
@@ -124,7 +124,7 @@ public class DeploymentPropertiesUtilsTests {
 			fail("Illegal Argument Exception expected.");
 		}
 		catch (Exception e) {
-			assertTrue(e.getMessage().equals("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed."));
+			assertThat(e.getMessage()).isEqualTo("Only deployment property keys starting with 'app.' or 'scheduler' or 'deployer.'  or 'version.' allowed. Not a=b");
 		}
 
 		props = DeploymentPropertiesUtils.parseArgumentList("a=b c=d", " ");

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -151,7 +151,6 @@ public class TaskCommands {
 		headers.put("dslText", "Task Definition");
 		headers.put("description", "description");
 		headers.put("status", "Task Status");
-		headers.put("schemaTarget", "Schema Target");
 		final TableBuilder builder = new TableBuilder(new BeanListTableModel<>(tasks, headers));
 		return DataFlowTables.applyStyle(builder).build();
 	}


### PR DESCRIPTION
Execute the following steps in SCDF Shel to reproduce the issue.
```
app register --bootVersion 3 --name timestamp3 --uri maven://io.spring:timestamp-task:3.0.0 --type task 
task create --name ts3 --definition timestamp3
task list
```
**Bug** 
This steps above caused the shell to crash with no exception. 

**Cause**
An additional header of `schemaType` was added to task definitions.  

**Additional fix**
* Also fixed tests in the DeployerPropertiesUtilTests.

