### PR TITLE
Scheduler does not create schedule for CTR apps

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -232,7 +232,6 @@ public class DefaultSchedulerService implements SchedulerService {
 		if (taskNode.isComposed()) {
 			taskDefinition = new TaskDefinition(taskDefinition.getName(), TaskServiceUtils.createComposedTaskDefinition(taskNode.toExecutableDSL()));
 			Map<String, String> establishedComposedTaskProperties = TaskServiceUtils.establishComposedTaskProperties(taskDeploymentProperties, taskNode);
-			taskDeploymentProperties.clear();
 			taskDeploymentProperties.putAll(establishedComposedTaskProperties);
 			TaskServiceUtils.addImagePullSecretProperty(taskDeploymentProperties, this.composedTaskRunnerConfigurationProperties);
 			try {
@@ -310,6 +309,7 @@ public class DefaultSchedulerService implements SchedulerService {
 				commandLineArgs,
 				scheduleName,
 				getTaskResource(taskDefinitionName));
+
 		launcher.getScheduler().schedule(scheduleRequest);
 
 		this.auditRecordService.populateAndSaveAuditRecordUsingMapData(AuditOperationType.SCHEDULE, AuditActionType.CREATE,


### PR DESCRIPTION
There is a clear on the deploymentProperties that removes scheduling information as well as the properties for the composed task runner. Removing it allows those properties to be used and schedule to be created.

I did not see a side-effect but may have missed something.