### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/actions/build-repository-bundle/action.yml
+++ b/.github/actions/build-repository-bundle/action.yml
@@ -35,6 +35,6 @@ runs:
       REPO_BUNDLE_GENERATED: ${{ runner.temp }}/generated/repobundle
     shell: bash
     run: |
-      echo "::set-output name=bundle-path::$REPO_BUNDLE_GENERATED"
+      echo "bundle-path=$REPO_BUNDLE_GENERATED" >> $GITHUB_OUTPUT
       SCDF_DIR="${{ inputs.project-directory || '.' }}"
       bash $SCDF_DIR/.github/actions/build-repository-bundle/build-repository-bundle.sh


### PR DESCRIPTION
## Description

Closes #5435 

Update `.github/actions/build-repository-bundle/action.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=bundle-path::$REPO_BUNDLE_GENERATED"
```

**TO-BE**

```yaml
echo "bundle-path=$REPO_BUNDLE_GENERATED" >> $GITHUB_OUTPUT
```

