### PR TITLE
fix: Spelling mistake for process

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -395,7 +395,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 			deploymentProperties, launcher.getType(), previousTaskDeploymentProperties);
 
 
-		// pre prosess command-line args
+		// pre process command-line args
 		// moving things like app.<label> = arg
 		// into deployment properties if ctr and removing
 		// prefix if simple task.


### PR DESCRIPTION
Updated spelling mistake from prosess to process

fix #5455 