### PR TITLE
Update the version of commons-compress brought in by testcontainers

### DIFF
--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -32,6 +32,7 @@
 		<joda-time.version>2.10.6</joda-time.version>
 		<aws-java-sdk-ecr.version>1.12.513</aws-java-sdk-ecr.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
+		<commons-compress.version>1.24.0</commons-compress.version>
 		<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
 		<stream-applications.version>4.0.0-SNAPSHOT</stream-applications.version>
 		<wavefront-spring-boot-bom.version>2.3.4</wavefront-spring-boot-bom.version>
@@ -127,8 +128,19 @@
 				<groupId>org.testcontainers</groupId>
 				<artifactId>testcontainers-bom</artifactId>
 				<version>${testcontainers.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-compress</artifactId>
+					</exclusion>
+				</exclusions>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -40,7 +40,7 @@
 		<jmockit.version>1.24</jmockit.version>
 
 		<testcontainers.version>1.17.6</testcontainers.version>
-
+		<commons-compress.version>1.24.0</commons-compress.version>
 		<asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
 		<asciidoctorj.pdf.version>2.3.7</asciidoctorj.pdf.version>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
@@ -212,8 +212,19 @@
 				<groupId>org.testcontainers</groupId>
 				<artifactId>testcontainers-bom</artifactId>
 				<version>${testcontainers.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-compress</artifactId>
+					</exclusion>
+				</exclusions>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
The commons-compress has a CVE in version `1.22` which is fixed in version `1.24.0`. For some reason, testcontainers.jar brings in commons-compress at `api` configuration which in turn puts it on the classpath even though testcontainers is a 'test' configuration.