### PR TITLE
Feature: Configurable timeout for child task startup in CTR

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/StepBeanDefinitionRegistrar.java
@@ -208,6 +208,10 @@ public class StepBeanDefinitionRegistrar implements ImportBeanDefinitionRegistra
 		if (dataFlowUriString != null) {
 			properties.setDataflowServerUri(URI.create(dataFlowUriString));
 		}
+		String maxStartWaitTime = getPropertyValue("max-start-wait-time");
+		if (maxStartWaitTime != null) {
+			properties.setMaxStartWaitTime(Integer.parseInt(maxStartWaitTime));
+		}
 		String maxWaitTime = getPropertyValue("max-wait-time");
 		if (maxWaitTime != null) {
 			properties.setMaxWaitTime(Integer.parseInt(maxWaitTime));

--- a/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/main/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskProperties.java
@@ -35,6 +35,8 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 @ConfigurationProperties
 public class ComposedTaskProperties {
 
+	public static final int MAX_START_WAIT_TIME_DEFAULT = 0;
+
 	public static final int MAX_WAIT_TIME_DEFAULT = 0;
 
 	public static final int INTERVAL_TIME_BETWEEN_CHECKS_DEFAULT = 10000;
@@ -46,6 +48,12 @@ public class ComposedTaskProperties {
 	public static final int SPLIT_THREAD_MAX_POOL_SIZE_DEFAULT = Integer.MAX_VALUE;
 
 	public static final int SPLIT_THREAD_QUEUE_CAPACITY_DEFAULT = Integer.MAX_VALUE;
+
+	/**
+	 * The maximum amount of time in millis that the ComposedTaskRunner will wait for the
+	 * start_time of a steps taskExecution to be set before the execution of the Composed task is failed.
+	 */
+	private int maxStartWaitTime = MAX_START_WAIT_TIME_DEFAULT;
 
 	/**
 	 * The maximum amount of time in millis that a individual step can run before
@@ -219,6 +227,14 @@ public class ComposedTaskProperties {
 		catch (URISyntaxException e) {
 			throw new IllegalStateException("Invalid Spring Cloud Data Flow Server URI", e);
 		}
+	}
+
+	public int getMaxStartWaitTime() {
+		return this.maxStartWaitTime;
+	}
+
+	public void setMaxStartWaitTime(int maxStartWaitTime) {
+		this.maxStartWaitTime = maxStartWaitTime;
 	}
 
 	public int getMaxWaitTime() {

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/ComposedTaskRunnerConfigurationWithPropertiesTests.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.verify;
 		"composed-task-properties=" + ComposedTaskRunnerConfigurationWithPropertiesTests.COMPOSED_TASK_PROPS ,
 		"interval-time-between-checks=1100", "composed-task-arguments=--baz=boo --AAA.foo=bar BBB.que=qui",
 		"transaction-isolation-level=ISOLATION_READ_COMMITTED","spring.cloud.task.closecontext-enabled=true",
-		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest"})
+		"dataflow-server-uri=https://bar", "spring.cloud.task.name=ComposedTest","max-start-wait-time=1011"})
 @EnableAutoConfiguration(exclude = { CommonSecurityAutoConfiguration.class})
 public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 
@@ -102,6 +102,7 @@ public class ComposedTaskRunnerConfigurationWithPropertiesTests {
 		props.put("memory", "2048m");
 		assertThat(composedTaskProperties.getComposedTaskProperties()).isEqualTo(COMPOSED_TASK_PROPS);
 		assertThat(composedTaskProperties.getMaxWaitTime()).isEqualTo(1010);
+		assertThat(composedTaskProperties.getMaxStartWaitTime()).isEqualTo(1011);
 		assertThat(composedTaskProperties.getIntervalTimeBetweenChecks()).isEqualTo(1100);
 		assertThat(composedTaskProperties.getDataflowServerUri().toASCIIString()).isEqualTo("https://bar");
 		assertThat(composedTaskProperties.getTransactionIsolationLevel()).isEqualTo("ISOLATION_READ_COMMITTED");

--- a/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
+++ b/spring-cloud-dataflow-composed-task-runner/src/test/java/org/springframework/cloud/dataflow/composedtaskrunner/properties/ComposedTaskPropertiesTests.java
@@ -47,6 +47,7 @@ public class ComposedTaskPropertiesTests {
 		properties.setComposedTaskArguments("bbb");
 		properties.setIntervalTimeBetweenChecks(12345);
 		properties.setMaxWaitTime(6789);
+		properties.setMaxStartWaitTime(101112);
 		properties.setDataflowServerUri(new URI("http://test"));
 		properties.setGraph("ddd");
 		properties.setDataflowServerUsername("foo");
@@ -57,6 +58,7 @@ public class ComposedTaskPropertiesTests {
 		assertThat(properties.getComposedTaskArguments()).isEqualTo("bbb");
 		assertThat(properties.getIntervalTimeBetweenChecks()).isEqualTo(12345);
 		assertThat(properties.getMaxWaitTime()).isEqualTo(6789);
+		assertThat(properties.getMaxStartWaitTime()).isEqualTo(101112);
 		assertThat(properties.getDataflowServerUri().toString()).isEqualTo("http://test");
 		assertThat(properties.getGraph()).isEqualTo("ddd");
 		assertThat(properties.getDataflowServerUsername()).isEqualTo("foo");

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -584,6 +584,11 @@ Establish the transaction isolation level for the Composed Task Runner.
 A list of available transaction isolation levels can be found  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/TransactionDefinition.html[here].
 Default is `ISOLATION_REPEATABLE_READ`.
 
+* `max-start-wait-time`
+The maximum amount of time, in milliseconds, that the Composed Task Runner will wait for the
+`start_time` of a steps `taskExecution` to be set before the execution of the Composed task is failed (Integer, default: 0).
+Determines the maximum time each child task is allowed for application startup. The default of `0` indicates no timeout.
+
 * `max-wait-time`
 The maximum amount of time, in milliseconds, that an individual step can run before the execution of the Composed task is failed (Integer, default: 0).
 Determines the maximum time each child task is allowed to run before the CTR ends with a failure. The default of `0` indicates no timeout.


### PR DESCRIPTION
Allows the configuration of a timeout for the startup of child tasks (`max-start-wait-time`) in the Composed Task Runner that can be smaller than the timeout for task completion (`max-wait-time`).

To check whether a child task is still in startup, we check whether the start time of the `taskExecution` has been set:
```java
(taskExecution == null || taskExecution.getStartTime() == null)
```

This has been very helpful in our application, where we have some very long running tasks. By setting a `max-start-wait-time` that is significantly smaller than the `max-wait-time`, we can react a lot faster to tasks that fail on startup (for example, due to application context initialization failures).