### PR TITLE
Add support for running Oracle locally on Apple ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ stream or task and managing its lifecycle.
 
 Clone the repo and type 
 
-    $ ./mvnw -s settings.xml clean install 
+    $ ./mvnw -s .settings.xml clean install 
 
 Looking for more information? Follow this [link](https://github.com/spring-cloud/spring-cloud-dataflow/blob/master/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-building.adoc).
 
@@ -84,6 +84,19 @@ as this may lead to test failures under Windows.
 
 Therefore, please ensure that you set Git property `core.autocrlf` to `false`, e.g. using: `$ git config core.autocrlf false`.
 For more information please refer to the [Git documentation, Formatting and Whitespace](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration).
+
+----
+
+## Running Locally w/ Oracle 
+By default, the Dataflow server jar does not include the Oracle database driver dependency.
+If you want to use Oracle for development/testing when running locally, you can specify the `local-dev-oracle` Maven profile when building.
+The following command will include the Oracle driver dependency in the jar:
+```
+$ ./mvnw -s .settings.xml clean package -Plocal-dev-oracle
+```
+You can follow the steps in the [Oracle on Mac ARM64](https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64#run-container-in-docker) Wiki to run Oracle XE locally in Docker with Dataflow pointing at it.
+
+> **NOTE:** If you are not running Mac ARM64 just skip the steps related to Homebrew and Colima 
 
 ----
 

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -18,6 +18,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<oracle-driver-ojdbc8.version>21.9.0.0</oracle-driver-ojdbc8.version>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 		<checkstyle.config.location>../src/checkstyle/checkstyle.xml</checkstyle.config.location>
@@ -128,6 +129,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>uk.org.webcompere</groupId>
+			<artifactId>system-stubs-jupiter</artifactId>
+			<version>2.1.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
@@ -179,7 +185,7 @@
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc8</artifactId>
-			<version>21.9.0.0</version>
+			<version>${oracle-driver-ojdbc8.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -408,6 +414,16 @@
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>
+		</profile>
+		<profile>
+			<id>local-dev-oracle</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.oracle.database.jdbc</groupId>
+					<artifactId>ojdbc8</artifactId>
+					<version>${oracle-driver-ojdbc8.version}</version>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 </project>

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/OracleSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/OracleSmokeTest.java
@@ -15,22 +15,50 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
+import java.util.Locale;
+
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-
+import org.springframework.core.log.LogAccessor;
 
 /**
  * Basic database schema and JPA tests for Oracle XE.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
+@ExtendWith(SystemStubsExtension.class)
 public class OracleSmokeTest extends AbstractSmokeTest {
+
+	private static final LogAccessor LOG = new LogAccessor(OracleSmokeTest.class);
+
+	private static final String WIKI_LINK = "https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64";
+
+	@SystemStub
+	private static EnvironmentVariables ENV_VARS;
+
 	@BeforeAll
 	static void startContainer() {
-		container = new OracleContainer();
+		if (runningOnMacArm64()) {
+			LOG.warn(() -> "You are running on Mac ARM64. If this test fails, make sure Colima is running prior " +
+					"to test invocation. See " + WIKI_LINK + " for details");
+			ENV_VARS.set("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock");
+			ENV_VARS.set("DOCKER_HOST", String.format("unix://%s/.colima/docker.sock", System.getProperty("user.home")));
+		}
+		container = new OracleContainer(DockerImageName.parse("gvenzl/oracle-xe")
+				.withTag("18-slim-faststart"));
 		container.start();
+	}
+
+	private static boolean runningOnMacArm64() {
+		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		String osArchitecture = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
+		return osName.contains("mac") && osArchitecture.equals("aarch64");
 	}
 }


### PR DESCRIPTION
* Adds `local-dev-oracle` Maven profile that can be used to build a server jar that includes the Oracle database driver for local testing only.

* Introduces SystemStubsExtension for setting testcontainers required env vars when running tests on Mac M

* Decorates the OracleSmokeTest with the above which serves as an example of how to conditionally run an Oracle testcontainers test on Mac M.

* In tandem, a new page was added to thw Wiki https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64

Resolves #5539