### PR TITLE
Fix columns in BOOT3_BATCH_JOB_EXECUTION_PARAMS

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V9__Boot3_Batch5_Job_Execution_Params_Column_Fix.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V9__Boot3_Batch5_Job_Execution_Params_Column_Fix.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.migration.oracle;
+
+import java.util.Arrays;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import org.springframework.cloud.dataflow.common.flyway.SqlCommand;
+import org.springframework.cloud.dataflow.common.flyway.SqlCommandsRunner;
+
+/**
+ * Fixes the names of the {@code BOOT3_BATCH_JOB_EXECUTION_PARAMS} parameter columns.
+ *
+ * @author Chris Bono
+ */
+public class V9__Boot3_Batch5_Job_Execution_Params_Column_Fix extends BaseJavaMigration {
+
+	public final static String DROP_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE =
+			"ALTER TABLE BOOT3_BATCH_JOB_EXECUTION_PARAMS DROP (TYPE_CD, KEY_NAME, STRING_VAL, DATE_VAL, LONG_VAL, DOUBLE_VAL)";
+
+	public final static String ADD_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE =
+			"ALTER TABLE BOOT3_BATCH_JOB_EXECUTION_PARAMS ADD (\n" +
+					"    PARAMETER_NAME VARCHAR(100 char) NOT NULL,\n" +
+					"    PARAMETER_TYPE VARCHAR(100 char) NOT NULL,\n" +
+					"    PARAMETER_VALUE VARCHAR(2500 char)\n" +
+					")";
+
+	private final SqlCommandsRunner runner = new SqlCommandsRunner();
+
+	@Override
+	public void migrate(Context context) throws Exception {
+		runner.execute(context.getConnection(), Arrays.asList(
+				SqlCommand.from(DROP_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE),
+				SqlCommand.from(ADD_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE)));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V9__Boot3_Batch5_Job_Execution_Params_Column_Fix.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/db/migration/oracle/V9__Boot3_Batch5_Job_Execution_Params_Column_Fix.java
@@ -31,13 +31,15 @@ import org.springframework.cloud.dataflow.common.flyway.SqlCommandsRunner;
 public class V9__Boot3_Batch5_Job_Execution_Params_Column_Fix extends BaseJavaMigration {
 
 	public final static String DROP_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE =
-			"ALTER TABLE BOOT3_BATCH_JOB_EXECUTION_PARAMS DROP (TYPE_CD, KEY_NAME, STRING_VAL, DATE_VAL, LONG_VAL, DOUBLE_VAL)";
+			"ALTER TABLE BOOT3_BATCH_JOB_EXECUTION_PARAMS DROP (TYPE_CD, KEY_NAME, STRING_VAL, DATE_VAL, " +
+					"LONG_VAL, DOUBLE_VAL, IDENTIFYING)";
 
 	public final static String ADD_COLUMNS_BATCH_JOB_EXECUTION_PARAMS_TABLE =
 			"ALTER TABLE BOOT3_BATCH_JOB_EXECUTION_PARAMS ADD (\n" +
 					"    PARAMETER_NAME VARCHAR(100 char) NOT NULL,\n" +
 					"    PARAMETER_TYPE VARCHAR(100 char) NOT NULL,\n" +
-					"    PARAMETER_VALUE VARCHAR(2500 char)\n" +
+					"    PARAMETER_VALUE VARCHAR(2500 char),\n" +
+					"	 IDENTIFYING CHAR(1) NOT NULL\n" +
 					")";
 
 	private final SqlCommandsRunner runner = new SqlCommandsRunner();


### PR DESCRIPTION
This commit introduces an Oracle schema migration that updates the BOOT3_BATCH_JOB_EXECUTION_PARAMS table to use the newer Batch5 parameter columns.

I reproduced the bug locally against (with the help of the newly added https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64) and then fixed the issue and watched the bug go bye-bye.

Resolves #5534

ℹ️ I created #5545 to add test coverage for this use case.