### PR TITLE
Update location of the git-commit-id plugin

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -358,8 +358,8 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>pl.project13.maven</groupId>
-					<artifactId>git-commit-id-plugin</artifactId>
+					<groupId>io.github.git-commit-id</groupId>
+					<artifactId>git-commit-id-maven-plugin</artifactId>
 					<version>${git-commit-id-plugin.version}</version>
 					<executions>
 						<execution>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -367,8 +367,8 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>pl.project13.maven</groupId>
-					<artifactId>git-commit-id-plugin</artifactId>
+					<groupId>io.github.git-commit-id</groupId>
+					<artifactId>git-commit-id-maven-plugin</artifactId>
 					<version>${git-commit-id-plugin.version}</version>
 					<executions>
 						<execution>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -318,8 +318,8 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>pl.project13.maven</groupId>
-				<artifactId>git-commit-id-plugin</artifactId>
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The git-commit-id plugin was relocated from
`pl.project13.maven:git-commit-id-plugin:4.9.9` to `io.github.git-commit-id:git-commit-id-maven-plugin:4.9.9`.