### PR TITLE
Document the gitAndBuildInfo field returned from the AboutController 

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AboutDocumentation.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
+ * @author Chris Bono
  */
 @SuppressWarnings("NewClassNamingConvention")
 public class AboutDocumentation extends BaseDocumentation {
@@ -157,8 +158,32 @@ public class AboutDocumentation extends BaseDocumentation {
 						fieldWithPath("monitoringDashboardInfo.source").type(JsonFieldType.STRING).description(
 								"Unique DataFlow identifier within the monitoring system."),
 						fieldWithPath("monitoringDashboardInfo.refreshInterval").type(JsonFieldType.NUMBER).description(
-								"Provides the time interval (in seconds) for updating the monitoring dashboards.")
+								"Provides the time interval (in seconds) for updating the monitoring dashboards."),
 
+						fieldWithPath("gitAndBuildInfo").type(JsonFieldType.OBJECT).description(
+								"Provides the git and build info for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.git").type(JsonFieldType.OBJECT).description(
+								"Provides the git details for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.git.branch").type(JsonFieldType.STRING).description(
+								"Provides the git branch for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.git.commit").type(JsonFieldType.OBJECT).description(
+								"Provides the git commit info for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.git.commit.id").type(JsonFieldType.STRING).description(
+								"Provides the git commit id for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.git.commit.time").type(JsonFieldType.STRING).description(
+								"Provides the git commit time for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build").type(JsonFieldType.OBJECT).description(
+								"Provides the build details for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build.artifact").type(JsonFieldType.STRING).description(
+								"Provides the build artifact for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build.name").type(JsonFieldType.STRING).description(
+								"Provides the build name for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build.time").type(JsonFieldType.STRING).description(
+								"Provides the build time for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build.version").type(JsonFieldType.STRING).description(
+								"Provides the build version for the Dataflow server"),
+						fieldWithPath("gitAndBuildInfo.build.group").type(JsonFieldType.STRING).description(
+								"Provides the build group for the Dataflow server")
 				)));
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -1,7 +1,7 @@
 management:
   info:
     git:
-      mode: full
+      mode: simple
       enabled: true
   metrics:
     tags:


### PR DESCRIPTION
This switches to the `simple` mode of the git info contributor. Otherwise we would have to document every single field in the gigantic response returned from the `full` mode.

See #5507

⚠️ @felipeg48 you will need to update the code in the [UI PR counterpart](https://github.com/spring-cloud/spring-cloud-dataflow-ui/pull/1971) as the new path will be `gitAndBuildInfo.git.commit.id`.