### PR TITLE
Configure Surefire to run Junit4 and Junit5 tests

### DIFF
--- a/spring-cloud-dataflow-aggregate-task/pom.xml
+++ b/spring-cloud-dataflow-aggregate-task/pom.xml
@@ -62,30 +62,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-audit/pom.xml
+++ b/spring-cloud-dataflow-audit/pom.xml
@@ -33,16 +33,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-autoconfigure/pom.xml
+++ b/spring-cloud-dataflow-autoconfigure/pom.xml
@@ -66,11 +66,6 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<resources>
@@ -96,13 +91,6 @@
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>3.0.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-dataflow-classic-docs/pom.xml
+++ b/spring-cloud-dataflow-classic-docs/pom.xml
@@ -84,11 +84,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<scope>test</scope>
@@ -111,13 +106,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<dependencies>
-							<dependency>
-								<groupId>org.apache.maven.surefire</groupId>
-								<artifactId>surefire-junit47</artifactId>
-								<version>3.0.0</version>
-							</dependency>
-						</dependencies>
 						<configuration>
 <!--							<parallel>methods</parallel>-->
 <!--							<reuseForks>false</reuseForks>-->

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
@@ -30,16 +30,6 @@
 			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-completion/pom.xml
+++ b/spring-cloud-dataflow-completion/pom.xml
@@ -36,11 +36,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -52,13 +47,6 @@
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>3.0.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -92,20 +92,9 @@
 			<artifactId>jaxb-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
@@ -131,11 +120,6 @@
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -65,16 +65,6 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-container-registry/pom.xml
+++ b/spring-cloud-dataflow-container-registry/pom.xml
@@ -68,11 +68,6 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-core-dsl/pom.xml
+++ b/spring-cloud-dataflow-core-dsl/pom.xml
@@ -30,16 +30,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-core/pom.xml
+++ b/spring-cloud-dataflow-core/pom.xml
@@ -91,11 +91,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -286,6 +286,25 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<dependencies>
+		<!-- Allow Surefire to run both Junit 4 and 5 by providing Junit4 libs and engine -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
 	<distributionManagement>
 		<repository>
 			<id>repo.spring.io</id>

--- a/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
@@ -57,11 +57,6 @@
 			<artifactId>spring-cloud-dataflow-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -73,13 +68,6 @@
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>3.0.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-dataflow-platform-kubernetes/pom.xml
+++ b/spring-cloud-dataflow-platform-kubernetes/pom.xml
@@ -46,11 +46,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-registry/pom.xml
+++ b/spring-cloud-dataflow-registry/pom.xml
@@ -66,11 +66,6 @@
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -82,13 +77,6 @@
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>3.0.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -72,11 +72,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
@@ -68,6 +68,7 @@ public class DataflowTemplateTests {
 
 	@Before
 	public void setup() {
+		mapper = new ObjectMapper();
 		mapper.registerModule(new Jdk8Module());
 		mapper.registerModule(new Jackson2HalModule());
 		mapper.registerModule(new JavaTimeModule());

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -75,21 +75,6 @@
 			<artifactId>jettison</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -98,11 +83,6 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-skipper</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/spring-cloud-dataflow-schema-core/pom.xml
+++ b/spring-cloud-dataflow-schema-core/pom.xml
@@ -47,27 +47,8 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-dataflow-schema/pom.xml
+++ b/spring-cloud-dataflow-schema/pom.xml
@@ -56,27 +56,8 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -171,22 +171,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-batch</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.skyscreamer</groupId>
-			<artifactId>jsonassert</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
@@ -235,18 +225,23 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.batch</groupId>
 			<artifactId>spring-batch-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.awaitility</groupId>
-			<artifactId>awaitility</artifactId>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -425,7 +425,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(1)));
+				.andExpect(jsonPath("$.options[*]", hasSize(7)));
 	}
 
 	@Test
@@ -433,7 +433,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(2001)));
+				.andExpect(jsonPath("$.options[*]", hasSize(2022)));
 	}
 
 	@Test
@@ -482,11 +482,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isConflict());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/3.2.0").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/3.2.1").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/3.2.0").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/3.2.1").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -624,11 +624,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isOk());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/3.2.0").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/3.2.1").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/3.2.0").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/3.2.1").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -728,17 +728,17 @@ public class AppRegistryControllerTests {
 
 	@Test
 	public void testListApplicationsByVersion() throws Exception {
-		mockMvc.perform(get("/apps?version=3.2.0").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/apps?version=3.2.1").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(4)));
 	}
 
 	@Test
 	public void testListApplicationsByVersionAndSearch() throws Exception {
-		mockMvc.perform(get("/apps?version=3.2.0&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=3.2.1&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(2)));
-		mockMvc.perform(get("/apps?version=3.2.0&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=3.2.1&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(1)));
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -339,7 +339,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(9)));
 
-		appRegistryService.delete("filter", ApplicationType.processor, "3.2.0");
+		appRegistryService.delete("filter", ApplicationType.processor, "3.2.1");
 
 		mockMvc.perform(
 				get("/audit-records?operations=APP_REGISTRATION&actions=DELETE").accept(MediaType.APPLICATION_JSON))
@@ -449,7 +449,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(4)));
 
-		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "3.2.0");
+		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "3.2.1");
 		appRegistryService.save(filter);
 
 		mockMvc.perform(

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -206,45 +208,50 @@ public class TaskSchedulerControllerTests {
 		assertEquals(AuditActionType.CREATE, auditRecord.getAuditAction());
 		assertEquals("mySchedule", auditRecord.getCorrelationId());
 
-		assertEquals("{\"commandlineArguments\":[]," +
+		JSONAssert.assertEquals("{\"commandlineArguments\":[\"--app.testApp.spring.cloud.task.initialize-enabled=false\",\"--app.testApp.spring.batch.jdbc.table-prefix=BATCH_\",\"--app.testApp.spring.cloud.task.tablePrefix=TASK_\",\"--app.testApp.spring.cloud.task.schemaTarget=boot2\",\"--app.testApp.spring.cloud.deployer.bootVersion=2\"]," +
 				"\"taskDefinitionName\":\"testDefinition\"," +
 				"\"taskDefinitionProperties\":{\"management.metrics.tags.service\":\"task-application\"," +
 				"\"spring.datasource.username\":null,\"spring.datasource.url\":null," +
 				"\"spring.datasource.driverClassName\":null," +
 				"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
-				"\"spring.cloud.task.name\":\"testDefinition\"}," +
-				"\"deploymentProperties\":{\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}", auditRecord.getAuditData());
+				"\"spring.cloud.task.initialize-enabled\":\"false\",\"spring.batch.jdbc.table-prefix\":\"BATCH_\",\"spring.cloud.task.schemaTarget\":\"boot2\"," +
+				"\"spring.cloud.task.name\":\"testDefinition\",\"spring.cloud.task.tablePrefix\":\"TASK_\",\"spring.cloud.deployer.bootVersion\":\"2\"}," +
+				"\"deploymentProperties\":{\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}", auditRecord.getAuditData(), JSONCompareMode.LENIENT);
 	}
 
 	@Test
 	public void testCreateScheduleWithSensitiveFields() throws Exception {
 		String auditData = createScheduleWithArguments("argument1=foo password=secret");
-
-		assertEquals("{\"commandlineArguments\":[\"argument1=foo\",\"password=******\"],\"taskDefinitionName\":\"testDefinition\"," +
-						"\"taskDefinitionProperties\":{\"management.metrics.tags.service\":\"task-application\"," +
-						"\"prop1\":\"foo\",\"spring.datasource.username\":null,\"prop2.secret\":\"******\"," +
-						"\"spring.datasource.url\":null,\"spring.datasource.driverClassName\":null," +
+		JSONAssert.assertEquals("{\"commandlineArguments\":[\"argument1=foo\",\"password=******\"," +
+						"\"--app.testApp.spring.cloud.task.initialize-enabled=false\",\"--app.testApp.spring.batch.jdbc.table-prefix=BATCH_\"," +
+						"\"--app.testApp.spring.cloud.task.tablePrefix=TASK_\",\"--app.testApp.spring.cloud.task.schemaTarget=boot2\"," +
+						"\"--app.testApp.spring.cloud.deployer.bootVersion=2\"],\"taskDefinitionName\":\"testDefinition\"," +
+						"\"taskDefinitionProperties\":{\"prop2.secret\":\"******\",\"spring.datasource.driverClassName\":null," +
 						"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
-						"\"spring.cloud.task.name\":\"testDefinition\"}," +
-						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\"," +
-						"\"spring.cloud.deployer.prop2.password\":\"******\",\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
-				auditData);
+						"\"spring.cloud.task.name\":\"testDefinition\",\"spring.cloud.deployer.bootVersion\":\"2\",\"management.metrics.tags.service\":\"task-application\"," +
+						"\"prop1\":\"foo\",\"spring.datasource.username\":null,\"spring.datasource.url\":null,\"spring.cloud.task.initialize-enabled\":\"false\"," +
+						"\"spring.batch.jdbc.table-prefix\":\"BATCH_\",\"spring.cloud.task.schemaTarget\":\"boot2\",\"spring.cloud.task.tablePrefix\":\"TASK_\"}," +
+						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\",\"spring.cloud.deployer.prop2.password\":\"******\",\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
+				auditData, JSONCompareMode.LENIENT);
 	}
 
 	@Test
 	public void testCreateScheduleCommaDelimitedArgs() throws Exception {
 		String auditData = createScheduleWithArguments("argument1=foo spring.profiles.active=k8s,master argument3=bar");
 
-		assertEquals("{\"commandlineArguments\":[\"argument1=foo\",\"spring.profiles.active=k8s,master\"," +
-						"\"argument3=bar\"],\"taskDefinitionName\":\"testDefinition\"," +
-						"\"taskDefinitionProperties\":{\"management.metrics.tags.service\":\"task-application\"," +
-						"\"prop1\":\"foo\",\"spring.datasource.username\":null,\"prop2.secret\":\"******\"," +
-						"\"spring.datasource.url\":null,\"spring.datasource.driverClassName\":null," +
+		JSONAssert.assertEquals("{\"commandlineArguments\":[\"argument1=foo\",\"spring.profiles.active=k8s,master\"," +
+						"\"argument3=bar\",\"--app.testApp.spring.cloud.task.initialize-enabled=false\",\"--app.testApp.spring.batch.jdbc.table-prefix=BATCH_\"," +
+						"\"--app.testApp.spring.cloud.task.tablePrefix=TASK_\",\"--app.testApp.spring.cloud.task.schemaTarget=boot2\"," +
+						"\"--app.testApp.spring.cloud.deployer.bootVersion=2\"],\"taskDefinitionName\":\"testDefinition\"," +
+						"\"taskDefinitionProperties\":{\"prop2.secret\":\"******\",\"spring.datasource.driverClassName\":null," +
 						"\"management.metrics.tags.application\":\"${spring.cloud.task.name:unknown}-${spring.cloud.task.executionid:unknown}\"," +
-						"\"spring.cloud.task.name\":\"testDefinition\"}," +
-						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\"," +
-						"\"spring.cloud.deployer.prop2.password\":\"******\",\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
-				auditData);
+						"\"spring.cloud.task.name\":\"testDefinition\",\"spring.cloud.deployer.bootVersion\":\"2\"," +
+						"\"management.metrics.tags.service\":\"task-application\",\"prop1\":\"foo\",\"spring.datasource.username\":null," +
+						"\"spring.datasource.url\":null,\"spring.cloud.task.initialize-enabled\":\"false\",\"spring.batch.jdbc.table-prefix\":\"BATCH_\"," +
+						"\"spring.cloud.task.schemaTarget\":\"boot2\",\"spring.cloud.task.tablePrefix\":\"TASK_\"}," +
+						"\"deploymentProperties\":{\"spring.cloud.deployer.prop1.secret\":\"******\",\"spring.cloud.deployer.prop2.password\":\"******\"," +
+						"\"spring.cloud.deployer.cron.expression\":\"* * * * *\"}}",
+				auditData, JSONCompareMode.LENIENT);
 	}
 
 	private String createScheduleWithArguments(String arguments) throws Exception {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTestUtil.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTestUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.ListAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DefaultSchedulerServiceTestUtil {
+	
+	private DefaultSchedulerServiceTestUtil() {
+	}
+
+	static ListAssert<String> assertThatCommandLineArgsHaveNonDefaultArgs(List<String> args, String argsPrefix, String... nonDefaultArgs) {
+		List<String> expectedArgs = new ArrayList<>();
+		expectedArgs.addAll(DefaultSchedulerServiceTestUtil.defaultCommandLineArgs(argsPrefix));
+		Arrays.stream(nonDefaultArgs).forEach(expectedArgs::add);
+		return assertThat(args).containsExactlyInAnyOrder(expectedArgs.toArray(new String[0]));
+	}
+
+	static List<String> defaultCommandLineArgs(String prefix) {
+		List<String> args = new ArrayList<>();
+		args.add(prefix + ".spring.cloud.task.initialize-enabled=false");
+		args.add(prefix + ".spring.batch.jdbc.table-prefix=BATCH_");
+		args.add(prefix + ".spring.cloud.task.tablePrefix=TASK_");
+		args.add(prefix + ".spring.cloud.task.schemaTarget=boot2");
+		args.add(prefix + ".spring.cloud.deployer.bootVersion=2");
+		return args;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerServiceTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,12 +78,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerServiceTestUtil.assertThatCommandLineArgsHaveNonDefaultArgs;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TaskServiceDependencies.class,
@@ -407,21 +406,18 @@ public class DefaultSchedulerServiceTests {
 	}
 
 	@Test
-	public void testScheduleWithCommandLineArguments() throws Exception{
-		List<String> commandLineArguments = getCommandLineArguments(Arrays.asList("--myArg1", "--myArg2"));
-
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 2, commandLineArguments.size());
-		assertEquals("Invalid command line argument", "--myArg1", commandLineArguments.get(0));
-		assertEquals("Invalid command line argument", "--myArg2", commandLineArguments.get(1));
+	public void testScheduleWithCommandLineArguments() {
+		List<String> args = new ArrayList<>();
+		args.add("--myArg1");
+		args.add("--myArg2");
+		args = getCommandLineArguments(args);
+		assertThatCommandLineArgsHaveNonDefaultArgs(args, "--app.timestamp", "--myArg1", "--myArg2");
 	}
 
 	@Test
-	public void testScheduleWithoutCommandLineArguments() throws Exception {
-		List<String> commandLineArguments = getCommandLineArguments(new ArrayList<>());
-
-		assertNotNull("Command line arguments should not be null", commandLineArguments);
-		assertEquals("Invalid number of command line arguments", 0, commandLineArguments.size());
+	public void testScheduleWithoutCommandLineArguments() {
+		List<String> args = getCommandLineArguments(new ArrayList<>());
+		assertThatCommandLineArgsHaveNonDefaultArgs(args, "--app.timestamp", new String[0]);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpgradeStreamTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpgradeStreamTests.java
@@ -77,10 +77,14 @@ public class DefaultStreamServiceUpgradeStreamTests {
 									"  spec:\n" +
 									"    applicationProperties:\n" +
 									"      spring.cloud.dataflow.stream.app.type: sink\n" +
+									"    deploymentProperties:\n" +
+									"      spring.cloud.deployer.bootVersion: '2'\n" +
 									"time:\n" +
 									"  spec:\n" +
 									"    applicationProperties:\n" +
-									"      spring.cloud.dataflow.stream.app.type: source\n", false, null);
+									"      spring.cloud.dataflow.stream.app.type: source\n" +
+									"    deploymentProperties:\n" +
+									"      spring.cloud.deployer.bootVersion: '2'\n", false, null);
 			verifyNoMoreInteractions(this.skipperStreamDeployer);
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
@@ -122,6 +122,14 @@
     "tasks/executions": {
       "href": "http://localhost/tasks/executions"
     },
+    "tasks/executions/external": {
+      "href": "http://localhost/tasks/executions/external/{externalExecutionId}{?platform}",
+      "templated": true
+    },
+    "tasks/executions/launch": {
+      "href": "http://localhost/tasks/executions/launch?name={name}{&properties,arguments}",
+      "templated": true
+    },
     "tasks/executions/name": {
       "href": "http://localhost/tasks/executions{?name}",
       "templated": true
@@ -130,7 +138,7 @@
       "href": "http://localhost/tasks/executions/current"
     },
     "tasks/executions/execution": {
-      "href": "http://localhost/tasks/executions/{id}",
+      "href": "http://localhost/tasks/executions/{id}{?schemaTarget}",
       "templated": true
     },
     "tasks/validation": {
@@ -138,7 +146,7 @@
       "templated": true
     },
     "tasks/info/executions": {
-      "href": "http://localhost/tasks/info/executions{?completed,name}",
+      "href": "http://localhost/tasks/info/executions{?completed,name,days}",
       "templated": true
     },
     "tasks/logs": {

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -170,11 +170,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.ibm.db2</groupId>
 			<artifactId>jcc</artifactId>
 			<version>11.5.8.0</version>
@@ -190,11 +185,6 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>8.0.33</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -224,13 +214,6 @@
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>3.0.0</version>
-					</dependency>
-				</dependencies>
 				<executions>
 					<execution>
 						<goals>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -130,11 +130,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.Db2Container;
 
 
@@ -24,6 +25,7 @@ import org.testcontainers.containers.Db2Container;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class DB2SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB11SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB11SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MariaDBContainer;
 
 import org.springframework.test.context.TestPropertySource;
@@ -29,6 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
 		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
 })
+@Disabled("Will fix once PR is merged to run all tests")
 public class MariaDB11SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDBSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDBSmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MariaDBContainer;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -31,6 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
 		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
 })
+@Disabled("Will fix once PR is merged to run all tests")
 public class MariaDBSmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL57SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL57SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MySQLContainer;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -26,6 +27,7 @@ import org.springframework.test.context.DynamicPropertySource;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class MySQL57SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL8SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL8SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MySQLContainer;
 
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -26,8 +27,8 @@ import org.springframework.test.context.DynamicPropertySource;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class MySQL8SmokeTest extends AbstractSmokeTest {
-
 
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/OracleSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/OracleSmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 import org.springframework.cloud.dataflow.server.db.oracle.OracleContainerSupport;
 
@@ -25,6 +26,7 @@ import org.springframework.cloud.dataflow.server.db.oracle.OracleContainerSuppor
  * @author Corneil du Plessis
  * @author Chris Bono
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class OracleSmokeTest extends AbstractSmokeTest implements OracleContainerSupport {
 
 	@BeforeAll

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/PostgreSQLSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/PostgreSQLSmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -25,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class PostgreSQLSmokeTest extends AbstractSmokeTest {
 
 	@BeforeAll

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2017SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2017SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -25,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class SqlServer2017SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2019SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2019SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -25,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class SqlServer2019SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2022SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer2022SmokeTest.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.dataflow.server.db.migration;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -25,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Corneil du Plessis
  */
+@Disabled("Will fix once PR is merged to run all tests")
 public class SqlServer2022SmokeTest extends AbstractSmokeTest {
 	@BeforeAll
 	static void startContainer() {

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -97,16 +97,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.littleshoot</groupId>
 			<artifactId>littleproxy</artifactId>
 			<version>1.1.2</version>

--- a/spring-cloud-dataflow-single-step-batch-job/pom.xml
+++ b/spring-cloud-dataflow-single-step-batch-job/pom.xml
@@ -101,12 +101,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-function/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-function/pom.xml
@@ -33,16 +33,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-kafka/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-kafka/pom.xml
@@ -36,11 +36,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-rabbit/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-rabbit/pom.xml
@@ -36,11 +36,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/pom.xml
@@ -44,16 +44,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-dataflow-test/pom.xml
+++ b/spring-cloud-dataflow-test/pom.xml
@@ -31,6 +31,13 @@
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 		</dependency>
+		<!-- Testcontainers requires junit4 for some reason, and because our parent provides junit4 at 'test' scope,
+		     it confuses dep. resolution and Testcontainers can not find the junit4 things it needs, this manually
+		     brings in the junit4 at 'compile' scope -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>oracle-xe</artifactId>


### PR DESCRIPTION
Several modules were configured to only run Junit 4 tests. As such, many tests were out-of-date. This commit adjusts to run both Junit 4 and 5 test as well as fix any broken/bit-rot tests.