### PR TITLE
Retrieve logs using externalExecutionId for tasks

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -853,26 +853,6 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 	 */
 	@Override
 	public String getLog(String platformName, String taskId, String schemaTarget) {
-		Launcher launcher = this.launcherRepository.findByName(platformName);
-		// In case of Cloud Foundry, fetching logs by external execution Id isn't valid as the execution instance is destroyed.
-		// We need to use the task name instead.
-		if (launcher != null && launcher.getType().equals(TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE)) {
-			try {
-				TaskDeployment taskDeployment = this.taskDeploymentRepository.findByTaskDeploymentId(taskId);
-				if (taskDeployment == null) {
-					throw new IllegalArgumentException();
-				}
-				String taskName = taskDeployment.getTaskDefinitionName();
-				AggregateTaskExecution taskExecution = this.taskExplorer.getLatestTaskExecutionForTaskName(taskName);
-				if (taskExecution != null && !taskExecution.getExternalExecutionId().equals(taskId)) {
-					return "";
-				}
-				// Override the task ID to be task name as task execution log is identified by the task name on CF.
-				taskId = taskName;
-			} catch (Exception e) {
-				return "Log could not be retrieved as the task instance is not running by the ID: " + taskId;
-			}
-		}
 		String result;
 		try {
 			result = findTaskLauncher(platformName).getLog(taskId);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -108,6 +108,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -217,7 +218,9 @@ public class TaskServiceDependencies extends WebMvcConfigurationSupport {
 
 	@Bean
 	TaskLauncher taskLauncher() {
-		return mock(TaskLauncher.class);
+		TaskLauncher taskLauncher = mock(TaskLauncher.class);
+		when(taskLauncher.getLog(any())).thenReturn("");
+		return taskLauncher;
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -1057,7 +1057,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			taskDeployment.setTaskDeploymentId(taskDeploymentId);
 			this.taskDeploymentRepository.save(taskDeployment);
 			this.launcherRepository.save(new Launcher(platformName, TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
-			when(taskLauncher.getLog(taskDefinitionName)).thenReturn("Logs");
+			when(taskLauncher.getLog("12345")).thenReturn("Logs");
 			SchemaVersionTarget schemaVersionTarget = aggregateExecutionSupport.findSchemaVersionTarget(taskDefinitionName, taskDefinitionReader);
 			assertEquals("Logs", this.taskExecutionService.getLog(taskDeployment.getPlatformName(), taskDeploymentId, schemaVersionTarget.getName()));
 		}
@@ -1067,9 +1067,11 @@ public abstract class DefaultTaskExecutionServiceTests {
 		public void getCFTaskLogByInvalidTaskId() {
 			String platformName = "cf-test-platform";
 			String taskDeploymentId = "12345";
-			this.launcherRepository.save(new Launcher(platformName, TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
+			TaskLauncher taskLauncherCF = mock(TaskLauncher.class);
+			when(taskLauncherCF.getLog(any())).thenThrow(new IllegalArgumentException("could not find a GUID app id for the task guid id"));
+			this.launcherRepository.save(new Launcher(platformName, TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncherCF));
 			SchemaVersionTarget schemaVersionTarget = SchemaVersionTarget.defaultTarget();
-			assertEquals("Log could not be retrieved as the task instance is not running by the ID: 12345", this.taskExecutionService.getLog(platformName, taskDeploymentId, schemaVersionTarget.getName()));
+			assertEquals("Log could not be retrieved.  Verify that deployments are still available.", this.taskExecutionService.getLog(platformName, taskDeploymentId, schemaVersionTarget.getName()));
 		}
 
 		@Test


### PR DESCRIPTION
In the past we had to use the task-app-name when retrieving logs.   
This process is no longer necessary as we can use external execution id.
Do not merge this change until https://github.com/spring-cloud/spring-cloud-deployer/pull/413 
has been merged