### PR TITLE
Remove use of security starter

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -104,9 +104,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
+			<artifactId>spring-cloud-common-security-config-web</artifactId>
 			<scope>test</scope>
-			<type>test-jar</type>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -126,19 +126,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-mapper-asl</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -186,19 +186,6 @@
 			<version>${dataflow.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-common-security-config-web</artifactId>
-			<version>${dataflow.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-mapper-asl</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>


### PR DESCRIPTION
- Remove spring-cloud-starter-common-security-config-web as a test-jar dependency as its know to cause issues with jdt based ide's.
- skipper/dataflow servers don't even need it and composed task runner can use spring-cloud-common-security-config-web as plain test scope.
- This should make project structure import into vscode work again.