### PR TITLE
Use boot3 notation when restarting a batch job

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcAggregateJobQueryDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/JdbcAggregateJobQueryDao.java
@@ -567,6 +567,8 @@ public class JdbcAggregateJobQueryDao implements AggregateJobQueryDao {
 					value = new JobParameter((Date) typedValue, identifying);
 				} else if (typedValue instanceof Double) {
 					value = new JobParameter((Double) typedValue, identifying);
+				} else if (typedValue instanceof Long) {
+					value = new JobParameter((Long) typedValue, identifying);
 				} else if (typedValue instanceof Number) {
 					value = new JobParameter(((Number) typedValue).doubleValue(), identifying);
 				} else if (typedValue instanceof Instant) {


### PR DESCRIPTION
Following updates made:
1. Now supports Long type for boot3 app job parameters
2. Supports default format for boot 3 job parameters 
3. Added tests for both Boot2 and boot 3 job parameters.