### PR TITLE
Reduce Flyway logging to DEBUG during tests

### DIFF
--- a/spring-cloud-dataflow-aggregate-task/src/test/resources/logback-test.xml
+++ b/spring-cloud-dataflow-aggregate-task/src/test/resources/logback-test.xml
@@ -3,5 +3,4 @@
 	<include resource="org/springframework/boot/logging/logback/base.xml" />
 	<logger name="org.testcontainers" level="ERROR"/>
 	<logger name="com.github.dockerjava" level="ERROR"/>
-	<logger name="org.flywaydb" level="DEBUG"/>
 </configuration>

--- a/spring-cloud-dataflow-server-core/src/test/resources/logback-test.xml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/logback-test.xml
@@ -3,5 +3,4 @@
 	<include resource="org/springframework/boot/logging/logback/base.xml" />
 	<logger name="org.testcontainers" level="ERROR"/>
 	<logger name="com.github.dockerjava" level="ERROR"/>
-	<logger name="org.flywaydb" level="DEBUG"/>
 </configuration>

--- a/spring-cloud-dataflow-server/src/test/resources/logback-test.xml
+++ b/spring-cloud-dataflow-server/src/test/resources/logback-test.xml
@@ -3,8 +3,6 @@
     <include resource="org/springframework/boot/logging/logback/base.xml" />
     <!-- SmokeTests rely on output capture from this DAO - please leave as-is -->
     <logger name="org.springframework.cloud.dataflow.server.repository.JdbcAggregateJobQueryDao" level="DEBUG"/>
-	<logger name="org.flywaydb" level="DEBUG"/>
     <logger name="org.testcontainers" level="ERROR"/>
     <logger name="com.github.dockerjava" level="ERROR"/>
-    <logger name="org.flywaydb" level="DEBUG"/>
 </configuration>

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/resources/logback-test.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/resources/logback-test.xml
@@ -3,5 +3,4 @@
     <include resource="org/springframework/boot/logging/logback/base.xml" />
     <logger name="org.testcontainers" level="ERROR"/>
     <logger name="com.github.dockerjava" level="ERROR"/>
-    <logger name="org.flywaydb" level="DEBUG"/>
 </configuration>

--- a/spring-cloud-starter-dataflow-server/src/test/resources/logback-test.xml
+++ b/spring-cloud-starter-dataflow-server/src/test/resources/logback-test.xml
@@ -3,5 +3,4 @@
 	<include resource="org/springframework/boot/logging/logback/base.xml" />
 	<logger name="org.testcontainers" level="ERROR"/>
 	<logger name="com.github.dockerjava" level="ERROR"/>
-	<logger name="org.flywaydb" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
This commit adjusts the log level during tests for Flyway packages to INFO as the current setting of DEBUG is drowning all other log statements.