### PR TITLE
Add support for running MSSQL Testcontainers on Mac ARM64

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/AbstractSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/AbstractSmokeTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobParameters;
@@ -57,8 +56,6 @@ import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.LinkedMultiValueMap;
@@ -77,16 +74,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ExtendWith(OutputCaptureExtension.class)
 public abstract class AbstractSmokeTest {
-
-	protected static JdbcDatabaseContainer<?> container;
-
-	@DynamicPropertySource
-	static void databaseProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.datasource.url", container::getJdbcUrl);
-		registry.add("spring.datasource.username", container::getUsername);
-		registry.add("spring.datasource.password", container::getPassword);
-		registry.add("spring.datasource.driver-class-name", container::getDriverClassName);
-	}
 
 	@Autowired
 	private SchemaService schemaService;

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2_11_5_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2_11_5_SmokeTest.java
@@ -15,19 +15,14 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MySQLContainer;
+import org.springframework.cloud.dataflow.server.db.DB2_11_5_ContainerSupport;
+
 
 /**
- * Basic database schema and JPA tests for MySQL 8 or later.
+ * Basic database schema and JPA tests for DB2.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class MySQL8SmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		container = new MySQLContainer<>("mysql:8");
-		container.start();
-	}
+public class DB2_11_5_SmokeTest extends AbstractSmokeTest implements DB2_11_5_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB_10_6_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB_10_6_SmokeTest.java
@@ -13,22 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.db.migration;
+package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
-
+import org.springframework.cloud.dataflow.server.db.MariaDB_10_6_ContainerSupport;
+import org.springframework.test.context.TestPropertySource;
 
 /**
- * Basic database schema and JPA tests for PostgreSQL 11 or later.
+ * Basic database schema and JPA tests for MariaDB 10.4 or later.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class PostgreSQLSkipperSmokeTest extends AbstractSkipperSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"));
-		container.start();
-	}
+@TestPropertySource(properties = {
+		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
+})
+public class MariaDB_10_6_SmokeTest extends AbstractSmokeTest implements MariaDB_10_6_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB_11_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MariaDB_11_SmokeTest.java
@@ -15,28 +15,18 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import org.springframework.cloud.dataflow.server.db.ContainerSupport;
+import org.springframework.cloud.dataflow.server.db.MariaDB_11_ContainerSupport;
+import org.springframework.test.context.TestPropertySource;
 
 
 /**
- * Basic database schema and JPA tests for MS SQL Server.
+ * Basic database schema and JPA tests for MariaDB 10.4 or later.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class SqlServer2019SmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		if (ContainerSupport.runningOnMacArm64()) {
-			throw new RuntimeException("Unable to run SQLServer tests on Mac OS");
-		}
-		container = new MSSQLServerContainer<>(
-			DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2019-latest")
-		).acceptLicense();
-		container.start();
-	}
+@TestPropertySource(properties = {
+		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
+})
+public class MariaDB_11_SmokeTest extends AbstractSmokeTest implements MariaDB_11_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL_5_7_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL_5_7_SmokeTest.java
@@ -13,28 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.db.migration;
+package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MariaDBContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import org.springframework.test.context.TestPropertySource;
-
+import org.springframework.cloud.dataflow.server.db.MySQL_5_7_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for MariaDB 10.4 or later.
+ * Basic database schema and JPA tests for MySQL 5.7.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-@TestPropertySource(properties = {
-		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
-})
-public class MariaDBSkipperSmokeTest extends AbstractSkipperSmokeTest {
+public class MySQL_5_7_SmokeTest extends AbstractSmokeTest implements MySQL_5_7_ContainerSupport {
 
-	@BeforeAll
-	static void startContainer() {
-		container = new MariaDBContainer<>(DockerImageName.parse("mariadb:10.6"));
-		container.start();
+	@Override
+	protected boolean supportsRowNumberFunction() {
+		return false;
 	}
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL_8_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/MySQL_8_SmokeTest.java
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.db.migration;
+package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MySQLContainer;
+import org.springframework.cloud.dataflow.server.db.MySQL_8_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for MySQL 5.7.
+ * Basic database schema and JPA tests for MySQL 8 or later.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class MySQL57SkipperSmokeTest extends AbstractSkipperSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new MySQLContainer<>("mysql:5.7");
-		container.start();
-	}
+public class MySQL_8_SmokeTest extends AbstractSmokeTest implements MySQL_8_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/Oracle_XE_18_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/Oracle_XE_18_SmokeTest.java
@@ -15,24 +15,13 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MySQLContainer;
+import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for MySQL 5.7.
+ * Basic database schema and JPA tests for Oracle XE.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class MySQL57SmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		container = new MySQLContainer<>("mysql:5.7");
-		container.start();
-	}
-
-	@Override
-	protected boolean supportsRowNumberFunction() {
-		return false;
-	}
+public class Oracle_XE_18_SmokeTest extends AbstractSmokeTest implements Oracle_XE_18_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/PostgreSQL_14_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/PostgreSQL_14_SmokeTest.java
@@ -15,27 +15,14 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.cloud.dataflow.server.db.PostgreSQL_14_ContainerSupport;
 
-import org.springframework.cloud.dataflow.server.db.ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for MS SQL Server.
+ * Basic database schema and JPA tests for PostgreSQL 14 or later.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class SqlServer2017SmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		if (ContainerSupport.runningOnMacArm64()) {
-			throw new RuntimeException("Unable to run SQLServer tests on Mac OS");
-		}
-		container = new MSSQLServerContainer<>(DockerImageName.parse(
-			MSSQLServerContainer.IMAGE).withTag("2017-latest")
-		).acceptLicense();
-		container.start();
-	}
+public class PostgreSQL_14_SmokeTest extends AbstractSmokeTest implements PostgreSQL_14_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2017_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2017_SmokeTest.java
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.db.migration;
+package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.Db2Container;
-import org.testcontainers.utility.DockerImageName;
-
+import org.springframework.cloud.dataflow.server.db.SqlServer_2017_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for DB2.
+ * Basic database schema and JPA tests for MS SQL Server.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class DB2SkipperSmokeTest extends AbstractSkipperSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new Db2Container(
-			DockerImageName.parse("ibmcom/db2").withTag("11.5.8.0")
-		).acceptLicense();
-		container.start();
-	}
+public class SqlServer_2017_SmokeTest extends AbstractSmokeTest implements SqlServer_2017_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2019_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2019_SmokeTest.java
@@ -15,21 +15,14 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.cloud.dataflow.server.db.SqlServer_2019_ContainerSupport;
 
 
 /**
- * Basic database schema and JPA tests for PostgreSQL 14 or later.
+ * Basic database schema and JPA tests for MS SQL Server.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class PostgreSQLSmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		container = new PostgreSQLContainer<>(DockerImageName.parse("postgres:14"));
-		container.start();
-	}
+public class SqlServer_2019_SmokeTest extends AbstractSmokeTest implements SqlServer_2019_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2022_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/SqlServer_2022_SmokeTest.java
@@ -15,29 +15,14 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import org.springframework.cloud.dataflow.server.db.ContainerSupport;
+import org.springframework.cloud.dataflow.server.db.SqlServer_2022_ContainerSupport;
 
 
 /**
  * Basic database schema and JPA tests for MS SQL Server.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class SqlServer2022SmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		if (ContainerSupport.runningOnMacArm64()) {
-			throw new RuntimeException("Unable to run SQLServer tests on Mac OS");
-		}
-		container = new MSSQLServerContainer<>(
-			DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2022-latest")
-		).acceptLicense();
-		container.start();
-	}
-
+public class SqlServer_2022_SmokeTest extends AbstractSmokeTest implements SqlServer_2022_ContainerSupport {
 }

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/ContainerSupport.java
@@ -18,15 +18,21 @@ package org.springframework.cloud.dataflow.server.db;
 
 import java.util.Locale;
 
+/**
+ * Provides support for running on Mac ARM64.
+ *
+ * @author Chris Bono
+ */
 public final class ContainerSupport {
 
 	private ContainerSupport() {
-
 	}
 
 	public static boolean runningOnMacArm64() {
 		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 		String osArchitecture = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
-		return osName.contains("mac") && osArchitecture.equals("aarch64");
+		// When using Colima, the 'os.arch' property will report 'x86', therefore also look at the arch data model
+		String osArchDataModel = System.getProperty("sun.arch.data.model", "unknown").toLowerCase(Locale.ENGLISH);
+		return osName.contains("mac") && (osArchitecture.equals("aarch64") || osArchDataModel.equals("64"));
 	}
 }

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/DB2_11_5_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/DB2_11_5_ContainerSupport.java
@@ -23,6 +23,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Provides support for running a {@link Db2Container DB2 11.5 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
 public interface DB2_11_5_ContainerSupport {
 

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MariaDB_10_6_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MariaDB_10_6_ContainerSupport.java
@@ -24,6 +24,11 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
+/**
+ * Provides support for running a {@link MariaDBContainer MariaDB 10.6 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(properties = {
 		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MariaDB_11_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MariaDB_11_ContainerSupport.java
@@ -24,6 +24,11 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
+/**
+ * Provides support for running a {@link MariaDBContainer MariaDB 11 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(properties = {
 		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MySQL_5_7_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MySQL_5_7_ContainerSupport.java
@@ -23,6 +23,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Provides support for running a {@link MySQLContainer MySQL 5.7 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
 public interface MySQL_5_7_ContainerSupport {
 

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MySQL_8_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/MySQL_8_ContainerSupport.java
@@ -23,6 +23,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Provides support for running a {@link MySQLContainer MySQL 8 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
 public interface MySQL_8_ContainerSupport {
 

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/PostgreSQL_14_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/PostgreSQL_14_ContainerSupport.java
@@ -23,8 +23,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Provides support for running a {@link PostgreSQLContainer PostgreSQL 14 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
 @Testcontainers(disabledWithoutDocker = true)
-public interface Postgres_14_ContainerSupport {
+public interface PostgreSQL_14_ContainerSupport {
 
 	@Container
 	PostgreSQLContainer container = new PostgreSQLContainer<>("postgres:14");

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/SqlServer_2017_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/SqlServer_2017_ContainerSupport.java
@@ -16,27 +16,38 @@
 
 package org.springframework.cloud.dataflow.server.db;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import org.springframework.cloud.dataflow.server.db.arm64.SqlServerArm64ContainerSupport;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-@Testcontainers(disabledWithoutDocker = true)
-public interface SqlServer_2017_ContainerSupport {
+/**
+ * Provides support for running a {@link MSSQLServerContainer MSSQL 2017 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
+public interface SqlServer_2017_ContainerSupport extends SqlServerArm64ContainerSupport {
 
-	@Container
-	MSSQLServerContainer container = new MSSQLServerContainer(
-			DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2017-latest")).acceptLicense();
+	AtomicReference<MSSQLServerContainer> containerReference = new AtomicReference<>(null);
+
+	@BeforeAll
+	static void startContainer() {
+		MSSQLServerContainer container = SqlServerArm64ContainerSupport.startContainer(() ->
+				new MSSQLServerContainer(DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2017-latest")).acceptLicense());
+		containerReference.set(container);
+	}
 
 	@DynamicPropertySource
 	static void databaseProperties(DynamicPropertyRegistry registry) {
+		MSSQLServerContainer container = containerReference.get();
 		registry.add("spring.datasource.url", container::getJdbcUrl);
 		registry.add("spring.datasource.username", container::getUsername);
 		registry.add("spring.datasource.password", container::getPassword);
 		registry.add("spring.datasource.driver-class-name", container::getDriverClassName);
 	}
-
 }

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/SqlServer_2022_ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/SqlServer_2022_ContainerSupport.java
@@ -16,23 +16,35 @@
 
 package org.springframework.cloud.dataflow.server.db;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import org.springframework.cloud.dataflow.server.db.arm64.SqlServerArm64ContainerSupport;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-@Testcontainers(disabledWithoutDocker = true)
-public interface SqlServer_2022_ContainerSupport {
+/**
+ * Provides support for running a {@link MSSQLServerContainer MSSQL 2022 Testcontainer}.
+ *
+ * @author Chris Bono
+ */
+public interface SqlServer_2022_ContainerSupport extends SqlServerArm64ContainerSupport {
 
-	@Container
-	MSSQLServerContainer container = new MSSQLServerContainer(
-			DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2022-latest")).acceptLicense();
+	AtomicReference<MSSQLServerContainer> containerReference = new AtomicReference<>(null);
+
+	@BeforeAll
+	static void startContainer() {
+		MSSQLServerContainer container = SqlServerArm64ContainerSupport.startContainer(() ->
+				new MSSQLServerContainer(DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2022-latest")).acceptLicense());
+		containerReference.set(container);
+	}
 
 	@DynamicPropertySource
 	static void databaseProperties(DynamicPropertyRegistry registry) {
+		MSSQLServerContainer container = containerReference.get();
 		registry.add("spring.datasource.url", container::getJdbcUrl);
 		registry.add("spring.datasource.username", container::getUsername);
 		registry.add("spring.datasource.password", container::getPassword);

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/arm64/OracleArm64ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/arm64/OracleArm64ContainerSupport.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.db.arm64;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.OracleContainer;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import org.springframework.cloud.dataflow.server.db.ContainerSupport;
+import org.springframework.core.log.LogAccessor;
+
+/**
+ * Provides support for testing against an {@link OracleContainer Oracle testcontainer} on Mac ARM64.
+ *
+ * @author Corneil du Plessis
+ * @author Chris Bono
+ */
+@ExtendWith(SystemStubsExtension.class)
+public interface OracleArm64ContainerSupport {
+
+	LogAccessor LOG = new LogAccessor(OracleArm64ContainerSupport.class);
+
+	@SystemStub
+	EnvironmentVariables ENV_VARS = new EnvironmentVariables();
+
+	static OracleContainer startContainer(Supplier<OracleContainer> oracleContainerSupplier) {
+		if (ContainerSupport.runningOnMacArm64()) {
+			String wiki = "https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64";
+			LOG.warn(() -> "You are running on Mac ARM64. If this test fails, make sure Colima is running prior " +
+					"to test invocation. See " + wiki + " for details");
+			ENV_VARS.set("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock");
+			ENV_VARS.set("DOCKER_HOST", String.format("unix://%s/.colima/docker.sock", System.getProperty("user.home")));
+		}
+		OracleContainer oracleContainer = oracleContainerSupplier.get();
+		oracleContainer.start();
+		return oracleContainer;
+	}
+}

--- a/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/arm64/SqlServerArm64ContainerSupport.java
+++ b/spring-cloud-dataflow-test/src/main/java/org/springframework/cloud/dataflow/server/db/arm64/SqlServerArm64ContainerSupport.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.oracle;
+package org.springframework.cloud.dataflow.server.db.arm64;
+
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.containers.OracleContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.containers.MSSQLServerContainer;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -26,30 +27,28 @@ import org.springframework.cloud.dataflow.server.db.ContainerSupport;
 import org.springframework.core.log.LogAccessor;
 
 /**
- * Provides support for testing against an {@link OracleContainer Oracle testcontainer}.
+ * Provides support for testing against an {@link MSSQLServerContainer MSSQL testcontainer} on Mac ARM64.
  *
- * @author Corneil du Plessis
  * @author Chris Bono
  */
 @ExtendWith(SystemStubsExtension.class)
-public interface OracleContainerSupport {
+public interface SqlServerArm64ContainerSupport {
 
-	LogAccessor LOG = new LogAccessor(OracleContainerSupport.class);
+	LogAccessor LOG = new LogAccessor(SqlServerArm64ContainerSupport.class);
 
 	@SystemStub
 	EnvironmentVariables ENV_VARS = new EnvironmentVariables();
 
-	static OracleContainer startContainer() {
+	static MSSQLServerContainer startContainer(Supplier<MSSQLServerContainer> mssqlContainerSupplier) {
 		if (ContainerSupport.runningOnMacArm64()) {
-			String wiki = "https://github.com/spring-cloud/spring-cloud-dataflow/wiki/Oracle-on-Mac-ARM64";
+			String wiki = "https://github.com/spring-cloud/spring-cloud-dataflow/wiki/MSSQL-on-Mac-ARM64";
 			LOG.warn(() -> "You are running on Mac ARM64. If this test fails, make sure Colima is running prior " +
 					"to test invocation. See " + wiki + " for details");
 			ENV_VARS.set("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock");
 			ENV_VARS.set("DOCKER_HOST", String.format("unix://%s/.colima/docker.sock", System.getProperty("user.home")));
 		}
-		OracleContainer oracleContainer = new OracleContainer(DockerImageName.parse("gvenzl/oracle-xe")
-				.withTag("18-slim-faststart"));
-		oracleContainer.start();
-		return oracleContainer;
+		MSSQLServerContainer mssqlContainer = mssqlContainerSupplier.get();
+		mssqlContainer.start();
+		return mssqlContainer;
 	}
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/AbstractSkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/AbstractSkipperSmokeTest.java
@@ -22,7 +22,6 @@ import javax.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -38,8 +37,6 @@ import org.springframework.cloud.skipper.server.domain.AppDeployerData;
 import org.springframework.cloud.skipper.server.repository.jpa.AppDeployerDataRepository;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,8 +56,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class AbstractSkipperSmokeTest {
 	private static final Logger logger = LoggerFactory.getLogger(AbstractSkipperSmokeTest.class);
 
-	protected static JdbcDatabaseContainer<?> container;
-
 	@Autowired
 	AppDeployerDataRepository appDeployerDataRepository;
 
@@ -69,14 +64,6 @@ public abstract class AbstractSkipperSmokeTest {
 
 	@Autowired
 	EntityManagerFactory entityManagerFactory;
-
-	@DynamicPropertySource
-	static void databaseProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.datasource.url", container::getJdbcUrl);
-		registry.add("spring.datasource.username", container::getUsername);
-		registry.add("spring.datasource.password", container::getPassword);
-		registry.add("spring.datasource.driver-class-name", container::getDriverClassName);
-	}
 
 
 	@Test

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/DB2_11_5_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/DB2_11_5_SkipperSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,13 @@
  */
 package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.springframework.cloud.dataflow.server.db.DB2_11_5_ContainerSupport;
 
-import org.springframework.cloud.dataflow.server.db.oracle.OracleContainerSupport;
 
 /**
- * Basic database schema and JPA tests for Oracle XE.
+ * Basic database schema and JPA tests for DB2.
  *
  * @author Corneil du Plessis
- * @author Chris Bono
  */
-public class OracleSkipperSmokeTest extends AbstractSkipperSmokeTest implements OracleContainerSupport {
-
-	@BeforeAll
-	static void startContainer() {
-		container = OracleContainerSupport.startContainer();
-	}
+public class DB2_11_5_SkipperSmokeTest extends AbstractSkipperSmokeTest implements DB2_11_5_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MariaDB_10_6_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MariaDB_10_6_SkipperSmokeTest.java
@@ -15,19 +15,17 @@
  */
 package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.cloud.dataflow.server.db.MariaDB_10_6_ContainerSupport;
+import org.springframework.test.context.TestPropertySource;
+
 
 /**
- * Basic database schema and JPA tests for MySQL 8 or later.
+ * Basic database schema and JPA tests for MariaDB 10.4 or later.
  *
  * @author Corneil du Plessis
  */
-public class MySQL8SkipperSmokeTest extends AbstractSkipperSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new MySQLContainer<>(DockerImageName.parse("mysql:8"));
-		container.start();
-	}
+@TestPropertySource(properties = {
+		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
+})
+public class MariaDB_10_6_SkipperSmokeTest extends AbstractSkipperSmokeTest implements MariaDB_10_6_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MySQL_5_7_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MySQL_5_7_SkipperSmokeTest.java
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration;
+package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-
-import org.springframework.cloud.dataflow.server.db.oracle.OracleContainerSupport;
+import org.springframework.cloud.dataflow.server.db.MySQL_5_7_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for Oracle XE.
+ * Basic database schema and JPA tests for MySQL 5.7.
  *
  * @author Corneil du Plessis
- * @author Chris Bono
  */
-public class OracleSmokeTest extends AbstractSmokeTest implements OracleContainerSupport {
-
-	@BeforeAll
-	static void startContainer() {
-		container = OracleContainerSupport.startContainer();
-	}
+public class MySQL_5_7_SkipperSmokeTest extends AbstractSkipperSmokeTest implements MySQL_5_7_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MySQL_8_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/MySQL_8_SkipperSmokeTest.java
@@ -13,26 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration;
+package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MariaDBContainer;
-
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.cloud.dataflow.server.db.MySQL_8_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for MariaDB 10.4 or later.
+ * Basic database schema and JPA tests for MySQL 8 or later.
  *
  * @author Corneil du Plessis
  */
-@TestPropertySource(properties = {
-		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
-})
-public class MariaDBSmokeTest extends AbstractSmokeTest {
-
-	@BeforeAll
-	static void startContainer() {
-		container = new MariaDBContainer<>("mariadb:10.6");
-		container.start();
-	}
+public class MySQL_8_SkipperSmokeTest extends AbstractSkipperSmokeTest implements MySQL_8_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/Oracle_XE_18_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/Oracle_XE_18_SkipperSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration;
+package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.Db2Container;
-
+import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSupport;
 
 /**
- * Basic database schema and JPA tests for DB2.
+ * Basic database schema and JPA tests for Oracle XE.
  *
  * @author Corneil du Plessis
+ * @author Chris Bono
  */
-public class DB2SmokeTest extends AbstractSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new Db2Container("ibmcom/db2:11.5.0.0a").acceptLicense();
-		container.start();
-	}
+public class Oracle_XE_18_SkipperSmokeTest extends AbstractSkipperSmokeTest implements Oracle_XE_18_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/PostgreSQL_14_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/PostgreSQL_14_SkipperSmokeTest.java
@@ -13,26 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.dataflow.server.db.migration;
+package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MariaDBContainer;
-
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.cloud.dataflow.server.db.PostgreSQL_14_ContainerSupport;
 
 
 /**
- * Basic database schema and JPA tests for MariaDB 10.4 or later.
+ * Basic database schema and JPA tests for PostgreSQL 11 or later.
  *
  * @author Corneil du Plessis
  */
-@TestPropertySource(properties = {
-		"spring.jpa.database-platform=org.hibernate.dialect.MariaDB106Dialect"
-})
-public class MariaDB11SmokeTest extends AbstractSmokeTest {
-	@BeforeAll
-	static void startContainer() {
-		container = new MariaDBContainer<>("mariadb:11");
-		container.start();
-	}
+public class PostgreSQL_14_SkipperSmokeTest extends AbstractSkipperSmokeTest implements PostgreSQL_14_ContainerSupport {
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/SqlServer_2019_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/SqlServer_2019_SkipperSmokeTest.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.db.migration;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.containers.MSSQLServerContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.cloud.dataflow.server.db.SqlServer_2019_ContainerSupport;
 
 
 /**
@@ -25,13 +23,5 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Corneil du Plessis
  */
-public class SqlServerSkipperSmokeTest extends AbstractSkipperSmokeTest {
-	@SuppressWarnings("resource")
-	@BeforeAll
-	static void startContainer() {
-		container = new MSSQLServerContainer<>(
-			DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag("2019-latest")
-		).acceptLicense();
-		container.start();
-	}
+public class SqlServer_2019_SkipperSmokeTest extends AbstractSkipperSmokeTest implements SqlServer_2019_ContainerSupport {
 }


### PR DESCRIPTION
This commit adds the ability for Mac ARM64 machines to run MSSQL Testcontainers based tests. The same treatment was added for Oracle previously.

Also, the container support is the final arbiter of container creation and now all of the DB smoke tests are refactored to use the new support interfaces.