### PR TITLE
Set context max size to flush db connections

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/SimpleJobServicePostgresTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/SimpleJobServicePostgresTests.java
@@ -31,7 +31,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@JdbcTest(properties = "spring.jpa.hibernate.ddl-auto=none")
+@JdbcTest(properties = {"spring.jpa.hibernate.ddl-auto=none", "spring.test.context.cache.maxSize=4"})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(classes = SimpleJobServicePostgresTests.SimpleJobTestPostgresConfiguration.class)
 @Testcontainers


### PR DESCRIPTION
We maybe caching too many contexts and thus we run out of db connections. 
This PR sets the max context cache size to 4.  The default is 32.

Thoughts?