### PR TITLE
Script should not end terminal if not using bash

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-local-k8s-development.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-local-k8s-development.adoc
@@ -78,7 +78,7 @@ Since these scripts export environmental variable they need to be executes as in
 
 [source,shell]
 ....
-source ./k8s/use-mk-docker.sh test-ns postgresql rabbitmq
+source ./k8s/use-mk-docker.sh postgresql rabbitmq --namespace test-ns
 ....
 
 ===== TMC or GKE Cluster in Cloud

--- a/src/deploy/k8s/set-ver.sh
+++ b/src/deploy/k8s/set-ver.sh
@@ -64,6 +64,9 @@ while [ "$1" != "" ]; do
     shift
 done
 echo "Namespace: $NS"
+if [ "$NS" = "" ]; then
+    NS=default
+fi
 export NS
 if [ "$BROKER" != "" ]; then
     echo "BROKER: $BROKER"

--- a/src/deploy/k8s/set-ver.sh
+++ b/src/deploy/k8s/set-ver.sh
@@ -65,7 +65,7 @@ while [ "$1" != "" ]; do
 done
 echo "Namespace: $NS"
 if [ "$NS" = "" ]; then
-    NS=default
+    NS=scdf
 fi
 export NS
 if [ "$BROKER" != "" ]; then

--- a/src/deploy/k8s/use-mk-docker.sh
+++ b/src/deploy/k8s/use-mk-docker.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
-(return 0 2>/dev/null) && sourced=1 || sourced=0
-if [ "$sourced" = "0" ]; then
-  echo "This script must be invoked using: source $0 $*"
-  exit 1
-fi
 if [ -z "$BASH_VERSION" ]; then
-    echo "This script requires Bash. Use: bash $0 $*"
-    exit 0
+    echo "This script requires Bash. For example:\n bash \n $0 $*"
+else
+    echo "Setting variables"
+    SCDIR=$(readlink -f "${BASH_SOURCE[0]}")
+    SCDIR=$(dirname "$SCDIR")
+    SCDIR=$(realpath $SCDIR)
+    source $SCDIR/use-mk.sh docker $*
 fi
-SCDIR=$(readlink -f "${BASH_SOURCE[0]}")
-SCDIR=$(dirname "$SCDIR")
-SCDIR=$(realpath $SCDIR)
-source $SCDIR/use-mk.sh docker $*


### PR DESCRIPTION
If the user hit the exit 0 (when using source) and they did not use bash  terminal would exit.
The user would not know why the terminal exited.

Updated script to just check to see if there is bash available.