### PR TITLE
Update json-path to 2.8.0

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -33,7 +33,7 @@
 		<revision>${project.version}</revision>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<jruby-complete.version>9.2.7.0</jruby-complete.version>
-
+		<json-path.version>2.8.0</json-path.version> <!-- CVE-2023-51074 -->
 		<!-- Sonar -->
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -99,6 +99,11 @@
 				<version>2.11.3-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-common/pom.xml
+++ b/spring-cloud-dataflow-common/pom.xml
@@ -21,6 +21,7 @@
 		<jayway-awaitility.version>1.7.0</jayway-awaitility.version>
 		<java-semver.version>0.9.0</java-semver.version>
 		<joda-time.version>2.10.6</joda-time.version>
+		<json-path.version>2.8.0</json-path.version>
 	</properties>
 
 	<modules>
@@ -47,6 +48,11 @@
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
 				<version>${joda-time.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -54,6 +54,7 @@
 		<jackson-bom.version>2.13.5</jackson-bom.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<logback.version>1.2.13</logback.version>
+		<json-path.version>2.8.0</json-path.version> <!-- CVE-2023-51074 -->
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -108,6 +109,11 @@
 				<groupId>org.codehaus.jettison</groupId>
 				<artifactId>jettison</artifactId>
 				<version>${jettison.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -227,6 +227,11 @@
 				<artifactId>commons-compress</artifactId>
 				<version>${commons-compress.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<build>


### PR DESCRIPTION
Had to add entries to dependencyManagement sections because adding the version property wasn't changing all the versions. Presuming that some external dependencies includes 2.7.0 directly and not via a property and is encountered before boot dependencies.

Fixes #5643