### PR TITLE
Update json-path to 2.9.0

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -40,6 +40,7 @@
 		<junit.version>4.13.1</junit.version>
 		<junit-jupiter.version>5.9.2</junit-jupiter.version>
 		<logback.version>1.2.13</logback.version>
+		<json-path.version>2.9.0</json-path.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -54,6 +54,7 @@
 		<jackson-bom.version>2.13.5</jackson-bom.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<logback.version>1.2.13</logback.version>
+		<json-path.version>2.9.0</json-path.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -93,6 +94,11 @@
 				<version>${jackson-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>${json-path.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
Had to add entries to dependencyManagement sections because adding the version property wasn't changing all the versions. Presuming that some external dependencies includes 2.7.0 directly and not via a property and is encountered before boot dependencies.

Fixes #5643