### PR TITLE
Make SCDF and Skipper compilable for boot 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/IgnoreAllSecurityConfiguration.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/IgnoreAllSecurityConfiguration.java
@@ -42,7 +42,7 @@ public class IgnoreAllSecurityConfiguration implements WebSecurityConfigurer<Web
 
 	@Override
 	public void configure(WebSecurity builder) {
-		builder.ignoring().antMatchers("/**");
+		builder.ignoring().requestMatchers("/**");
 	}
 
 }

--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -60,8 +60,9 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
@@ -104,8 +105,9 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Corneil du Plessis
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(WebSecurityConfigurerAdapter.class)
-@ConditionalOnMissingBean(WebSecurityConfigurerAdapter.class)
+// SCDF 3.0 Migration - Need to re add this later with a different class or bean.
+// @ConditionalOnClass(WebSecurityConfigurerAdapter.class)
+// @ConditionalOnMissingBean(WebSecurityConfigurerAdapter.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.ANY)
 @EnableWebSecurity
 @Conditional(OnOAuth2SecurityEnabled.class)
@@ -122,7 +124,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 		OAuthSecurityConfiguration.ProviderManagerConfig.class,
 		OAuthSecurityConfiguration.AuthenticationProviderConfig.class
 })
-public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class OAuthSecurityConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(OAuthSecurityConfiguration.class);
 
@@ -199,8 +201,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		this.securityStateBean = securityStateBean;
 	}
 
-	@Override
-	protected void configure(HttpSecurity http) throws Exception {
+	protected HttpBasicConfigurer configure(HttpSecurity http) throws Exception {
 
 		final RequestMatcher textHtmlMatcher = new MediaTypeRequestMatcher(
 				new BrowserDetectingContentNegotiationStrategy(),
@@ -238,7 +239,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		security.anyRequest().denyAll();
 
 
-		http.httpBasic().and()
+		ExceptionHandlingConfigurer configurer = http.httpBasic().and()
 				.logout()
 				.logoutSuccessHandler(logoutSuccessHandler)
 				.and().csrf().disable()
@@ -268,6 +269,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		}
 
 		this.securityStateBean.setAuthenticationEnabled(true);
+		return http.getConfigurer(HttpBasicConfigurer.class);
 	}
 
 	protected static String dashboard(AuthorizationProperties authorizationProperties, String path) {

--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/SecurityConfigUtils.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/support/SecurityConfigUtils.java
@@ -69,7 +69,7 @@ public class SecurityConfigUtils {
 			String attribute = matcher.group(3).trim();
 
 			logger.info("Authorization '{}' | '{}' | '{}'", method, attribute, urlPattern);
-			security = security.antMatchers(method, urlPattern).access(attribute);
+			security = security.requestMatchers(method, urlPattern).access(attribute);
 		}
 		return security;
 	}

--- a/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/AggregateTaskConfiguration.java
+++ b/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/AggregateTaskConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.dataflow.aggregate.task;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.slf4j.Logger;
@@ -91,8 +90,4 @@ public class AggregateTaskConfiguration {
 				taskDeploymentReader);
 	}
 
-	@PostConstruct
-	public void setup() {
-		logger.info("created: org.springframework.cloud.dataflow.aggregate.task.AggregateTaskConfiguration");
-	}
 }

--- a/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultAggregateExecutionSupport.java
+++ b/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultAggregateExecutionSupport.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.dataflow.aggregate.task.impl;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -148,8 +149,8 @@ public class DefaultAggregateExecutionSupport implements AggregateExecutionSuppo
 					execution.getExecutionId(),
 					execution.getExitCode(),
 					execution.getTaskName(),
-					execution.getStartTime(),
-					execution.getEndTime(),
+					java.util.Date.from(execution.getStartTime().toInstant(ZoneId.systemDefault().getRules().getOffset(execution.getStartTime()))),
+					java.util.Date.from(execution.getEndTime().toInstant(ZoneId.systemDefault().getRules().getOffset(execution.getEndTime()))),
 					execution.getExitMessage(),
 					execution.getArguments(),
 					execution.getErrorMessage(),

--- a/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultAggregateTaskExplorer.java
+++ b/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultAggregateTaskExplorer.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.dataflow.aggregate.task.impl;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -278,8 +277,4 @@ public class DefaultAggregateTaskExplorer implements AggregateTaskExplorer {
 		return aggregateExecutionSupport.from(taskExplorer.getLatestTaskExecutionForTaskName(taskName), target.getName(), getPlatformName(taskName));
 	}
 
-	@PostConstruct
-	public void setup() {
-		logger.info("created: org.springframework.cloud.dataflow.aggregate.task.impl.DefaultAggregateTaskExplorer");
-	}
 }

--- a/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultTaskRepositoryContainer.java
+++ b/spring-cloud-dataflow-aggregate-task/src/main/java/org/springframework/cloud/dataflow/aggregate/task/impl/DefaultTaskRepositoryContainer.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.aggregate.task.impl;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,8 +64,4 @@ public class DefaultTaskRepositoryContainer implements TaskRepositoryContainer {
 		return repository;
 	}
 
-	@PostConstruct
-	public void setup() {
-		logger.info("created: org.springframework.cloud.dataflow.aggregate.task.impl.DefaultTaskRepositoryContainer");
-	}
 }

--- a/spring-cloud-dataflow-audit/pom.xml
+++ b/spring-cloud-dataflow-audit/pom.xml
@@ -45,8 +45,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -14,7 +14,7 @@
 	</modules>
 	<url>https://spring.io/projects/spring-cloud-dataflow</url>
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<resource.delimiter>@</resource.delimiter>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
 		<spring-boot.version>3.2.2</spring-boot.version>
-		<spring-cloud.version>2021.0.9</spring-cloud.version>
+		<spring-cloud.version>2023.0.0</spring-cloud.version>
 		<spring-shell.version>2.1.13</spring-shell.version>
 		<commons-io.version>2.15.1</commons-io.version>
 		<commons-text.version>1.11.0</commons-text.version>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-tools/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-tools/pom.xml
@@ -24,8 +24,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-dataflow-common/pom.xml
+++ b/spring-cloud-dataflow-common/pom.xml
@@ -57,8 +57,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-flyway/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-flyway/pom.xml
@@ -68,8 +68,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
@@ -42,8 +42,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
@@ -59,8 +59,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -17,7 +17,7 @@
 
 	<packaging>jar</packaging>
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<plexus.utils.version>3.3.0</plexus.utils.version>
 		<failIfNoTests>true</failIfNoTests>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -73,8 +73,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-configuration-metadata/pom.xml
+++ b/spring-cloud-dataflow-configuration-metadata/pom.xml
@@ -49,7 +49,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-loader</artifactId>
+			<artifactId>spring-boot-loader-classic</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/S3SignedRedirectRequestServerResource.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/S3SignedRedirectRequestServerResource.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.dataflow.container.registry.authorization.support.S3SignedRedirectRequestServerApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 /**
  * @author Adam J. Weigold
@@ -43,7 +43,7 @@ public class S3SignedRedirectRequestServerResource extends ExternalResource {
     @Override
     protected void before() throws Throwable {
 
-        this.s3SignedRedirectServerPort = SocketUtils.findAvailableTcpPort();
+        this.s3SignedRedirectServerPort = TestSocketUtils.findAvailableTcpPort();
 
         logger.info("Setting S3 Signed Redirect Server port to " + this.s3SignedRedirectServerPort);
 

--- a/spring-cloud-dataflow-container-registry/pom.xml
+++ b/spring-cloud-dataflow-container-registry/pom.xml
@@ -80,8 +80,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-container-registry/pom.xml
+++ b/spring-cloud-dataflow-container-registry/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>aws-java-sdk-ecr</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5-fluent</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-docker</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.container.registry;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
@@ -25,16 +28,18 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
-import org.apache.http.HttpHost;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.dataflow.container.registry.authorization.DropAuthorizationHeaderRequestRedirectStrategy;
@@ -42,6 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
 
 /**
  * On demand creates a cacheable {@link RestTemplate} instances for the purpose of the Container Registry access.
@@ -171,19 +177,25 @@ public class ContainerImageRestTemplateFactory {
 		SSLContext sslContext = SSLContext.getInstance("SSL");
 		// Install trust manager to SSL Context.
 		sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+		ConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+
+		Registry<ConnectionSocketFactory> socketFactoryRegistry =
+			RegistryBuilder.<ConnectionSocketFactory> create()
+				.register("https", sslsf)
+				.register("http", new PlainConnectionSocketFactory())
+				.build();
+		final BasicHttpClientConnectionManager connectionManager = new BasicHttpClientConnectionManager(socketFactoryRegistry);
 
 		// Create a RestTemplate that uses custom request factory
 		return initRestTemplate(
-				HttpClients.custom()
-						.setSSLContext(sslContext)
-						.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE),
+				HttpClients.custom().setConnectionManager(connectionManager),
 				withHttpProxy,
 				extra);
 	}
 
 	private RestTemplate initRestTemplate(HttpClientBuilder clientBuilder, boolean withHttpProxy, Map<String, String> extra) {
 
-		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());
+		clientBuilder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(StandardCookieSpec.RELAXED).build());
 
 		// Set the HTTP proxy if configured.
 		if (withHttpProxy) {
@@ -199,7 +211,7 @@ public class ContainerImageRestTemplateFactory {
 						clientBuilder
 								.setRedirectStrategy(new DropAuthorizationHeaderRequestRedirectStrategy(extra))
 								// Azure redirects may contain double slashes and on default those are normilised
-								.setDefaultRequestConfig(RequestConfig.custom().setNormalizeUri(false).build())
+								.setDefaultRequestConfig(RequestConfig.custom().build())
 								.build());
 
 		// DockerHub response's media-type is application/octet-stream although the content is in JSON.

--- a/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/AuditRecord.java
+++ b/spring-cloud-dataflow-core/src/main/java/org/springframework/cloud/dataflow/core/AuditRecord.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.core;
 
+import java.sql.Types;
 import java.time.Instant;
 
 import jakarta.persistence.Column;
@@ -29,7 +30,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
-import org.hibernate.annotations.Type;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -58,7 +59,7 @@ public class AuditRecord {
 	private String correlationId;
 
 	@Lob
-	@Type(type = "org.hibernate.type.TextType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	@Column(name = "audit_data")
 	private String auditData;
 

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -23,7 +23,7 @@
 		<spring-cloud-dataflow-common.version>${dataflow.version}</spring-cloud-dataflow-common.version>
 		<spring-cloud-skipper.version>${dataflow.version}</spring-cloud-skipper.version>
 		<spring-cloud-deployer.version>3.0.0-SNAPSHOT</spring-cloud-deployer.version>
-		<spring-cloud-task.version>2.4.6</spring-cloud-task.version>
+		<spring-cloud-task.version>3.1.0</spring-cloud-task.version>
 		<spring-cloud-common-security-config.version>${dataflow.version}</spring-cloud-common-security-config.version>
 		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 		<sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
@@ -310,6 +310,10 @@
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
+		<dependency>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+		</dependency>
 		<!-- Allow Surefire to run both Junit 4 and 5 by providing Junit4 libs and engine -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -55,7 +55,6 @@
 		<guava.version>32.1.3-jre</guava.version>
 		<logback.version>1.2.13</logback.version>
 		<json-path.version>2.9.0</json-path.version>
-		<http-client>5.2.4</http-client>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -307,11 +306,6 @@
 				<version>${spring-cloud-deployer.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>${http-client}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -14,7 +14,7 @@
 		<!-- NOTE: this needs to be updated and kept in sync w/ the project.version -->
 		<git-commit-id-plugin.version>4.9.9</git-commit-id-plugin.version>
 		<dataflow.version>3.0.0-SNAPSHOT</dataflow.version>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<spring-boot.version>3.2.2</spring-boot.version>
@@ -22,7 +22,7 @@
 		<spring-cloud-dataflow-ui.version>3.4.3-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<spring-cloud-dataflow-common.version>${dataflow.version}</spring-cloud-dataflow-common.version>
 		<spring-cloud-skipper.version>${dataflow.version}</spring-cloud-skipper.version>
-		<spring-cloud-deployer.version>2.9.3-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>3.0.0-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-task.version>2.4.6</spring-cloud-task.version>
 		<spring-cloud-common-security-config.version>${dataflow.version}</spring-cloud-common-security-config.version>
 		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>

--- a/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-platform-cloudfoundry/pom.xml
@@ -28,6 +28,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-cloudfoundry</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/security/CloudFoundryOAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-platform-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/config/cloudfoundry/security/CloudFoundryOAuthSecurityConfiguration.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.dataflow.server.config.cloudfoundry.security;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring-cloud-dataflow-platform-kubernetes/pom.xml
+++ b/spring-cloud-dataflow-platform-kubernetes/pom.xml
@@ -58,8 +58,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-platform-kubernetes/pom.xml
+++ b/spring-cloud-dataflow-platform-kubernetes/pom.xml
@@ -34,6 +34,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-kubernetes-fabric8-config</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.fabric8</groupId>

--- a/spring-cloud-dataflow-rest-client/pom.xml
+++ b/spring-cloud-dataflow-rest-client/pom.xml
@@ -80,8 +80,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -92,8 +92,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -46,8 +46,8 @@
 			<artifactId>spring-cloud-task-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.dataflow.rest.job;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import org.springframework.batch.core.StepExecution;
@@ -59,9 +62,9 @@ public class StepExecutionHistory {
 			// ignore unfinished executions
 			return;
 		}
-		Date startTime = stepExecution.getStartTime();
-		Date endTime = stepExecution.getEndTime();
-		long time = endTime.getTime() - startTime.getTime();
+		LocalDateTime startTime = stepExecution.getStartTime();
+		LocalDateTime endTime = stepExecution.getEndTime();
+		long time = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
 		duration.append(time);
 		if (stepExecution.getReadCount() > 0) {
 			durationPerRead.append(time / stepExecution.getReadCount());

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
@@ -17,6 +17,9 @@
 package org.springframework.cloud.dataflow.rest.resource;
 
 import java.text.DateFormat;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -131,8 +134,9 @@ public class JobExecutionResource extends RepresentationModel<JobExecutionResour
 		if (jobExecution.getStartTime() != null) {
 			this.startDate = dateFormat.format(jobExecution.getStartTime());
 			this.startTime = timeFormat.format(jobExecution.getStartTime());
-			Date endTime = jobExecution.getEndTime() != null ? jobExecution.getEndTime() : new Date();
-			this.duration = durationFormat.format(new Date(endTime.getTime() - jobExecution.getStartTime().getTime()));
+			//TODO: Boot3x followup
+			LocalDateTime endTime = jobExecution.getEndTime() != null ? jobExecution.getEndTime() : LocalDateTime.now();
+			this.duration = durationFormat.format(Duration.between(jobExecution.getStartTime(), endTime).get(ChronoUnit.MILLIS));
 		}
 	}
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
@@ -17,6 +17,9 @@
 package org.springframework.cloud.dataflow.rest.resource;
 
 import java.text.DateFormat;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -72,7 +75,7 @@ public class JobExecutionThinResource extends RepresentationModel<JobExecutionTh
 
 	private String startTime = "";
 
-	private Date startDateTime = null;
+	private LocalDateTime startDateTime = null;
 
 	private String duration = "";
 
@@ -140,8 +143,8 @@ public class JobExecutionThinResource extends RepresentationModel<JobExecutionTh
 		if (jobExecution.getStartTime() != null) {
 			this.startDate = dateFormat.format(jobExecution.getStartTime());
 			this.startTime = timeFormat.format(jobExecution.getStartTime());
-			Date endTime = jobExecution.getEndTime() != null ? jobExecution.getEndTime() : new Date();
-			this.duration = durationFormat.format(new Date(endTime.getTime() - jobExecution.getStartTime().getTime()));
+			LocalDateTime endTime = jobExecution.getEndTime() != null ? jobExecution.getEndTime() : LocalDateTime.now();
+			this.duration = durationFormat.format(Duration.between(jobExecution.getStartTime(), endTime).get(ChronoUnit.MILLIS));
 			this.startDateTime = jobExecution.getStartTime();
 		}
 
@@ -207,7 +210,7 @@ public class JobExecutionThinResource extends RepresentationModel<JobExecutionTh
 		return status;
 	}
 
-	public Date getStartDateTime() {
+	public LocalDateTime getStartDateTime() {
 		return startDateTime;
 	}
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.rest.support.jackson;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,7 +25,6 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,37 +42,37 @@ public class JobParameterJacksonDeserializer extends JsonDeserializer<JobParamet
 
 	@Override
 	public JobParameter deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-			throws IOException, JsonProcessingException {
+			throws IOException {
 		ObjectCodec oc = jsonParser.getCodec();
 		JsonNode node = oc.readTree(jsonParser);
 
-		final String value = node.get("value").asText();
-		final boolean identifying = node.get("identifying").asBoolean();
-		final String type = node.get("type").asText();
+		String value = node.get("value").asText();
+		boolean identifying = node.get("identifying").asBoolean();
+		String type = node.get("type").asText();
 
-		final JobParameter jobParameter;
-
+		JobParameter jobParameter;
+		//TODO: Boot3x followup
 		if (!type.isEmpty() && !type.equalsIgnoreCase("STRING")) {
 			if ("DATE".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(DateTime.parse(value).toDate(), identifying);
+				jobParameter = new JobParameter(LocalDateTime.parse(value), LocalDateTime.class,  identifying);
 			}
 			else if ("DOUBLE".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(Double.valueOf(value), identifying);
+				jobParameter = new JobParameter(Double.valueOf(value), Double.class, identifying);
 			}
 			else if ("LONG".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(Long.valueOf(value), identifying);
+				jobParameter = new JobParameter(Long.valueOf(value), Long.class, identifying);
 			}
 			else {
 				throw new IllegalStateException("Unsupported JobParameter type: " + type);
 			}
 		}
 		else {
-			jobParameter = new JobParameter(value, identifying);
+			jobParameter = new JobParameter(value, String.class, identifying);
 		}
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("jobParameter - value: {} (type: {}, isIdentifying: {})",
-					jobParameter.getValue(), jobParameter.getType().name(), jobParameter.isIdentifying());
+					jobParameter.getValue(), jobParameter.getType(), jobParameter.isIdentifying());
 		}
 
 		return jobParameter;

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ArgumentSanitizer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ArgumentSanitizer.java
@@ -140,11 +140,11 @@ public class ArgumentSanitizer {
 	 * @return the sanitized job parameters
 	 */
 	public JobParameters sanitizeJobParameters(JobParameters jobParameters) {
-		Map<String, JobParameter> newJobParameters = new HashMap<>();
+		Map<String, JobParameter<?>> newJobParameters = new HashMap<>();
 		jobParameters.getParameters().forEach((key, jobParameter) -> {
 			String updatedKey = !jobParameter.isIdentifying() ? "-" + key : key;
-			if (jobParameter.getType().equals(JobParameter.ParameterType.STRING)) {
-				newJobParameters.put(updatedKey, new JobParameter(this.sanitize(key, jobParameter.toString())));
+			if (jobParameter.getType().isInstance(String.class)) {
+				newJobParameters.put(updatedKey, new JobParameter(this.sanitize(key, jobParameter.toString()), String.class));
 			} else {
 				newJobParameters.put(updatedKey, jobParameter);
 			}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
@@ -17,20 +17,31 @@ package org.springframework.cloud.dataflow.rest.util;
 
 import java.net.URI;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+import org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy;
+import org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+;
 
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.Assert;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Utility for configuring a {@link CloseableHttpClient}. This class allows for
@@ -60,12 +71,18 @@ public class HttpClientConfigurer {
 
 	protected HttpClientConfigurer(URI targetHost) {
 		httpClientBuilder = HttpClientBuilder.create();
-		this.targetHost = new HttpHost(targetHost.getHost(), targetHost.getPort(), targetHost.getScheme());
+		this.targetHost = new HttpHost(targetHost.getScheme(), targetHost.getHost(), targetHost.getPort());
 	}
 
 	public HttpClientConfigurer basicAuthCredentials(String username, String password) {
 		final CredentialsProvider credentialsProvider = this.getOrInitializeCredentialsProvider();
-		credentialsProvider.setCredentials(new AuthScope(this.targetHost), new UsernamePasswordCredentials(username, password));
+		if(credentialsProvider instanceof BasicCredentialsProvider basicCredentialsProvider) {
+			basicCredentialsProvider.setCredentials(new AuthScope(this.targetHost),
+				new UsernamePasswordCredentials(username, password.toCharArray()));
+		} else if (credentialsProvider instanceof SystemDefaultCredentialsProvider systemDefaultCredProvider) {
+			systemDefaultCredProvider.setCredentials(new AuthScope(this.targetHost),
+				new UsernamePasswordCredentials(username, password.toCharArray()));
+		}
 		httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 		useBasicAuth = true;
 		return this;
@@ -94,14 +111,18 @@ public class HttpClientConfigurer {
 		Assert.hasText(proxyUri.getScheme(), "The scheme component of the proxyUri must not be empty.");
 
 		httpClientBuilder
-			.setProxy(new HttpHost(proxyUri.getHost(), proxyUri.getPort(), proxyUri.getScheme()));
+			.setProxy(new HttpHost(proxyUri.getScheme(), proxyUri.getHost(), proxyUri.getPort()));
 		if (proxyUsername !=null && proxyPassword != null) {
 			final CredentialsProvider credentialsProvider = this.getOrInitializeCredentialsProvider();
-			credentialsProvider.setCredentials(
-				new AuthScope(proxyUri.getHost(), proxyUri.getPort()),
-				new UsernamePasswordCredentials(proxyUsername, proxyPassword));
+			if(credentialsProvider instanceof BasicCredentialsProvider basicCredentialsProvider) {
+				basicCredentialsProvider.setCredentials(new AuthScope(proxyUri.getHost(), proxyUri.getPort()),
+					new UsernamePasswordCredentials(proxyUsername, proxyPassword.toCharArray()));
+			} else if (credentialsProvider instanceof SystemDefaultCredentialsProvider systemDefaultCredProvider) {
+				systemDefaultCredProvider.setCredentials(new AuthScope(proxyUri.getHost(), proxyUri.getPort()),
+					new UsernamePasswordCredentials(proxyUsername, proxyPassword.toCharArray()));
+			}
 			httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
-				.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+				.setProxyAuthenticationStrategy(new DefaultAuthenticationStrategy());
 		}
 		return this;
 	}
@@ -113,8 +134,14 @@ public class HttpClientConfigurer {
 	 * @return a reference to {@code this} to enable chained method invocation
 	 */
 	public HttpClientConfigurer skipTlsCertificateVerification() {
-		httpClientBuilder.setSSLContext(HttpUtils.buildCertificateIgnoringSslContext());
-		httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+		ConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(HttpUtils.buildCertificateIgnoringSslContext(), NoopHostnameVerifier.INSTANCE);
+			Registry<ConnectionSocketFactory> socketFactoryRegistry =
+				RegistryBuilder.<ConnectionSocketFactory> create()
+					.register("https", sslsf)
+					.register("http", new PlainConnectionSocketFactory())
+					.build();
+			final BasicHttpClientConnectionManager connectionManager = new BasicHttpClientConnectionManager(socketFactoryRegistry);
+			httpClientBuilder.setConnectionManager(connectionManager);
 
 		return this;
 	}
@@ -128,7 +155,7 @@ public class HttpClientConfigurer {
 	}
 
 	public HttpClientConfigurer addInterceptor(HttpRequestInterceptor interceptor) {
-		httpClientBuilder.addInterceptorLast(interceptor);
+		httpClientBuilder.addRequestInterceptorLast(interceptor);
 
 		return this;
 	}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurer.java
@@ -32,16 +32,13 @@ import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-;
 
-import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.Registry;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.Assert;
 
-import javax.net.ssl.SSLContext;
 
 /**
  * Utility for configuring a {@link CloseableHttpClient}. This class allows for

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpUtils.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/HttpUtils.java
@@ -15,17 +15,18 @@
  */
 package org.springframework.cloud.dataflow.rest.util;
 
+import org.apache.hc.core5.ssl.SSLContexts;
+
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.ssl.SSLContexts;
+
 
 /**
- * Provides utilities for the Apache {@link HttpClient}, used to make REST calls
+ * Provides utilities for the Apache {@code HttpClient}, used to make REST calls
  *
  * @author Gunnar Hillert
  */

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
@@ -17,14 +17,15 @@ package org.springframework.cloud.dataflow.rest.util;
 
 import java.net.URI;
 
-import org.apache.http.HttpHost;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.HttpContext;
+
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+import org.apache.hc.client5.http.impl.auth.BasicScheme;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/util/ResourceBasedAuthorizationInterceptor.java
@@ -18,11 +18,12 @@ package org.springframework.cloud.dataflow.rest.util;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.http.HttpException;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
@@ -42,7 +43,7 @@ public class ResourceBasedAuthorizationInterceptor implements HttpRequestInterce
 	}
 
 	@Override
-	public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
+	public void process(HttpRequest httpRequest, EntityDetails entityDetails, HttpContext httpContext) throws HttpException, IOException {
 		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8).trim();
 		resource.check();
 		httpRequest.addHeader(HttpHeaders.AUTHORIZATION, credentials);

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.rest.resource;
 import java.io.IOException;
 import java.net.URI;
 
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/HttpClientTest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.dataflow.rest.resource;
 import java.io.IOException;
 import java.net.URI;
 
+import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -66,7 +67,7 @@ public class HttpClientTest {
 		final URI targetHost = new URI("http://test.com");
 		try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
 				.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
-				.addInterceptor((request, context) -> {
+				.addInterceptor((request, entityDetails, context) -> {
 					final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
 					Assertions.assertThat(authorization).isEqualTo(credentials);
 
@@ -90,7 +91,7 @@ public class HttpClientTest {
 		final URI targetHost = new URI("http://test.com");
 		try (final CloseableHttpClient client = HttpClientConfigurer.create(targetHost)
 				.addInterceptor(new ResourceBasedAuthorizationInterceptor(resource))
-				.addInterceptor((request, context) -> {
+				.addInterceptor((request, entityDetails, context) -> {
 					final String authorization = request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue();
 					Assertions.assertThat(authorization).isEqualTo(credentials);
 

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/resource/TaskExecutionResourceTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.cloud.dataflow.core.TaskManifest;
 import org.springframework.cloud.dataflow.rest.job.TaskJobExecution;
 import org.springframework.cloud.dataflow.rest.job.TaskJobExecutionRel;
@@ -143,7 +144,7 @@ public class TaskExecutionResourceTests {
 			taskExecutionResource = new TaskExecutionResource(taskJobExecutionRel);
 			assertThat(taskExecutionResource.getPlatformName()).isNull();
 			assertThat(taskExecutionResource.getTaskExecutionStatus()).isEqualTo(TaskExecutionStatus.COMPLETE);
-			JobExecution jobExecution = new JobExecution(1L, null, "foo");
+			JobExecution jobExecution = new JobExecution(1L, new JobParameters());
 			jobExecution.setExitStatus(ExitStatus.FAILED);
 
 			TaskJobExecution ctrTaskJobExecution = new TaskJobExecution(1, jobExecution, true, target.getName());

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/StepExecutionJacksonMixInTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/StepExecutionJacksonMixInTests.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 
@@ -82,7 +83,7 @@ public class StepExecutionJacksonMixInTests {
 	}
 
 	private StepExecution getStepExecution() {
-		JobExecution jobExecution = new JobExecution(1L, null, "hi");
+		JobExecution jobExecution = new JobExecution(1L, new JobParameters());
 		final StepExecution stepExecution = new StepExecution("step1", jobExecution);
 		jobExecution.createStepExecution("step1");
 		final ExecutionContext executionContext = stepExecution.getExecutionContext();

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/util/HttpClientConfigurerTests.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.rest.util;
 import java.lang.reflect.Field;
 import java.net.URI;
 
-import org.apache.http.auth.AuthScope;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ import static org.junit.Assert.fail;
 public class HttpClientConfigurerTests {
 
 	/**
-	 * Basic test ensuring that the {@link HttpClient} is built successfully.
+	 * Basic test ensuring that the {@code HttpClient} is built successfully.
 	 */
 	@Test
 	public void testThatHttpClientWithProxyIsCreated() throws Exception {
@@ -47,7 +46,7 @@ public class HttpClientConfigurerTests {
 	}
 
 	/**
-	 * Basic test ensuring that the {@link HttpClient} is built successfully with
+	 * Basic test ensuring that the {@code HttpClient} is built successfully with
 	 * null username and password.
 	 */
 	@Test
@@ -107,8 +106,8 @@ public class HttpClientConfigurerTests {
 		final Field credentialsProviderField = ReflectionUtils.findField(HttpClientConfigurer.class, "credentialsProvider");
 		ReflectionUtils.makeAccessible(credentialsProviderField);
 		CredentialsProvider credentialsProvider = (CredentialsProvider) credentialsProviderField.get(builder);
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
-		Assert.assertNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
+		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80), null));
+		Assert.assertNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80), null));
 	}
 
 	/**
@@ -124,7 +123,7 @@ public class HttpClientConfigurerTests {
 		final Field credentialsProviderField = ReflectionUtils.findField(HttpClientConfigurer.class, "credentialsProvider");
 		ReflectionUtils.makeAccessible(credentialsProviderField);
 		CredentialsProvider credentialsProvider = (CredentialsProvider) credentialsProviderField.get(builder);
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80)));
-		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80)));
+		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("test.com", 80), null));
+		Assert.assertNotNull(credentialsProvider.getCredentials(new AuthScope("spring.io", 80), null));
 	}
 }

--- a/spring-cloud-dataflow-schema-core/src/main/java/org/springframework/cloud/dataflow/schema/AggregateTaskExecution.java
+++ b/spring-cloud-dataflow-schema-core/src/main/java/org/springframework/cloud/dataflow/schema/AggregateTaskExecution.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.dataflow.schema;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -227,12 +229,13 @@ public class AggregateTaskExecution {
 				'}';
 	}
 
+	//TODO: Boot3x followup
 	public TaskExecution toTaskExecution() {
 		return new TaskExecution(executionId,
 				exitCode,
 				taskName,
-				startTime,
-				endTime,
+				LocalDateTime.ofInstant(startTime.toInstant(), ZoneId.systemDefault()),
+				LocalDateTime.ofInstant(endTime.toInstant(), ZoneId.systemDefault()),
 				exitMessage,
 				arguments,
 				errorMessage,

--- a/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/SchemaServiceConfiguration.java
+++ b/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/SchemaServiceConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.dataflow.schema.service;
 
-import javax.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +40,4 @@ public class SchemaServiceConfiguration {
 		}
 	}
 
-	@PostConstruct
-	public void setup() {
-		logger.info("created: org.springframework.cloud.dataflow.schema.service.SchemaServiceConfiguration");
-	}
 }

--- a/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
+++ b/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.schema.service.impl;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;

--- a/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
+++ b/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
@@ -31,7 +31,6 @@ import org.springframework.cloud.dataflow.schema.AppBootSchemaVersions;
 import org.springframework.cloud.dataflow.schema.SchemaVersionTarget;
 import org.springframework.cloud.dataflow.schema.SchemaVersionTargets;
 import org.springframework.cloud.dataflow.schema.service.SchemaService;
-import org.springframework.stereotype.Service;
 
 /**
  * Implements a simple service to provide Schema versions and targets.

--- a/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
+++ b/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.schema.service.impl;
 
-import jakarta.annotation.PostConstruct;
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;

--- a/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
+++ b/spring-cloud-dataflow-schema/src/main/java/org/springframework/cloud/dataflow/schema/service/impl/DefaultSchemaService.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.schema.service.impl;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -67,9 +66,5 @@ public class DefaultSchemaService implements SchemaService {
 			name = getDefaultSchemaTarget();
 		}
 		return targets.get(name);
-	}
-	@PostConstruct
-	public void setup() {
-		logger.info("created: org.springframework.cloud.dataflow.schema.service.impl.DefaultSchemaService");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/AggregateDataFlowTaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/AggregateDataFlowTaskConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.dataflow.server.config;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.slf4j.Logger;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsReplicationEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/MetricsReplicationEnvironmentPostProcessor.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.influx.InfluxProperties;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusProperties;
-import org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront.WavefrontProperties;
+import org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.cloud.dataflow.core.RelaxedNames;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/UpperCaseSpringPhysicalNamingStrategy.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/support/UpperCaseSpringPhysicalNamingStrategy.java
@@ -15,16 +15,15 @@
  */
 package org.springframework.cloud.dataflow.server.repository.support;
 
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
-
-import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 
 /**
  * Override {@code isCaseInsensitive} to always return false
  *
  * @author Mark Pollack
  */
-public class UpperCaseSpringPhysicalNamingStrategy extends SpringPhysicalNamingStrategy {
+public class UpperCaseSpringPhysicalNamingStrategy extends CamelCaseToUnderscoresNamingStrategy {
 
 	@Override
 	protected boolean isCaseInsensitive(JdbcEnvironment jdbcEnvironment) {

--- a/spring-cloud-dataflow-shell/pom.xml
+++ b/spring-cloud-dataflow-shell/pom.xml
@@ -29,8 +29,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-single-step-batch-job/pom.xml
+++ b/spring-cloud-dataflow-single-step-batch-job/pom.xml
@@ -14,7 +14,7 @@
 
 	<packaging>jar</packaging>
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<plexus.utils.version>3.3.0</plexus.utils.version>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.7</spring-cloud-dataflow-apps-metadata-plugin.version>
@@ -115,8 +115,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-dependencies/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-dependencies/pom.xml
@@ -25,10 +25,6 @@
 			<artifactId>micrometer-registry-wavefront</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>
 			<artifactId>stream-applications-micrometer-common</artifactId>
 		</dependency>
@@ -49,6 +45,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-binder</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
@@ -63,10 +64,6 @@
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-spring</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-sleuth</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud.stream.app</groupId>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/pom.xml
@@ -38,9 +38,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream</artifactId>
-			<type>test-jar</type>
-			<classifier>test-binder</classifier>
+			<artifactId>spring-cloud-stream-test-binder</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/src/main/java/org/springframework/cloud/dataflow/tasklauncher/sink/TriggerProperties.java
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink/src/main/java/org/springframework/cloud/dataflow/tasklauncher/sink/TriggerProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.tasklauncher.sink;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -22,7 +22,7 @@
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 
 		<spring-statemachine.version>2.5.1</spring-statemachine.version>
 		<spring-cloud-deployer.version>2.9.3-SNAPSHOT</spring-cloud-deployer.version>
@@ -46,7 +46,7 @@
 		<asciidoctorj.pdf.version>2.3.7</asciidoctorj.pdf.version>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<jruby.version>9.2.11.1</jruby.version>
-		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+		<maven-antrun-plugin.version>17</maven-antrun-plugin.version>
 		<ant-contrib.version>1.0b3</ant-contrib.version>
 		<ant-nodeps.version>1.8.1</ant-nodeps.version>
 		<antelopetasks.version>3.2.10</antelopetasks.version>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -51,7 +51,6 @@
 		<ant-nodeps.version>1.8.1</ant-nodeps.version>
 		<antelopetasks.version>3.2.10</antelopetasks.version>
 		<build-helper-maven-plugin>3.0.0</build-helper-maven-plugin>
-		<http-client>5.2.4</http-client>
 	</properties>
 
 	<modules>
@@ -84,11 +83,6 @@
 				<version>${spring-cloud-deployer.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>${http-client}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-client/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/pom.xml
@@ -16,8 +16,8 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpClientConfigurer.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpClientConfigurer.java
@@ -17,14 +17,23 @@ package org.springframework.cloud.skipper.client.util;
 
 import java.net.URI;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import javax.net.ssl.SSLContext;
+
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -60,7 +69,7 @@ public class HttpClientConfigurer {
 
 	public HttpClientConfigurer basicAuthCredentials(String username, String password) {
 		final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-		credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+		credentialsProvider.setCredentials(new AuthScope(null, null, -1, null, null), new UsernamePasswordCredentials(username, password.toCharArray()));
 		httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
 		useBasicAuth = true;
@@ -75,12 +84,22 @@ public class HttpClientConfigurer {
 	 * @return a reference to {@code this} to enable chained method invocation
 	 */
 	public HttpClientConfigurer skipTlsCertificateVerification() {
-		httpClientBuilder.setSSLContext(HttpUtils.buildCertificateIgnoringSslContext());
-		httpClientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
-
+		Lookup<ConnectionSocketFactory> connSocketFactoryLookup = RegistryBuilder.<ConnectionSocketFactory> create()
+			.register("https", new SSLConnectionSocketFactory(HttpUtils.buildCertificateIgnoringSslContext(), NoopHostnameVerifier.INSTANCE))
+			.register("http", new PlainConnectionSocketFactory())
+			.build();
+		httpClientBuilder.setConnectionManager(new BasicHttpClientConnectionManager(connSocketFactoryLookup));
 		return this;
 	}
-
+	private HttpClientBuilder httpClientBuilder(SSLContext sslContext) {
+		// Register http/s connection factories
+		Lookup<ConnectionSocketFactory> connSocketFactoryLookup = RegistryBuilder.<ConnectionSocketFactory> create()
+			.register("https", new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE))
+			.register("http", new PlainConnectionSocketFactory())
+			.build();
+		return HttpClients.custom()
+			.setConnectionManager(new BasicHttpClientConnectionManager(connSocketFactoryLookup));
+	}
 	public HttpClientConfigurer skipTlsCertificateVerification(boolean skipTlsCertificateVerification) {
 		if (skipTlsCertificateVerification) {
 			skipTlsCertificateVerification();
@@ -90,13 +109,13 @@ public class HttpClientConfigurer {
 	}
 
 	public HttpClientConfigurer targetHost(URI targetHost) {
-		this.targetHost = new HttpHost(targetHost.getHost(), targetHost.getPort(), targetHost.getScheme());
+		this.targetHost = new HttpHost(targetHost.getScheme(), targetHost.getHost(), targetHost.getPort());
 
 		return this;
 	}
 
 	public HttpClientConfigurer addInterceptor(HttpRequestInterceptor interceptor) {
-		httpClientBuilder.addInterceptorLast(interceptor);
+		httpClientBuilder.addRequestInterceptorLast(interceptor);
 
 		return this;
 	}

--- a/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpUtils.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpUtils.java
@@ -21,11 +21,10 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.client.HttpClient;
-import org.apache.http.ssl.SSLContexts;
+import org.apache.hc.core5.ssl.SSLContexts;
 
 /**
- * Provides utilities for the Apache {@link HttpClient}, used to make REST calls
+ * Provides utilities for the Apache {@code HttpClient}, used to make REST calls
  *
  * @author Gunnar Hillert
  */

--- a/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/PreemptiveBasicAuthHttpComponentsClientHttpRequestFactory.java
@@ -17,14 +17,15 @@ package org.springframework.cloud.skipper.client.util;
 
 import java.net.URI;
 
-import org.apache.http.HttpHost;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.HttpContext;
+
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+import org.apache.hc.client5.http.impl.auth.BasicScheme;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;

--- a/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/ResourceBasedAuthorizationInterceptor.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/ResourceBasedAuthorizationInterceptor.java
@@ -18,11 +18,12 @@ package org.springframework.cloud.skipper.client.util;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.http.HttpException;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
 
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
@@ -42,7 +43,7 @@ public class ResourceBasedAuthorizationInterceptor implements HttpRequestInterce
 	}
 
 	@Override
-	public void process(HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
+	public void process(HttpRequest httpRequest, EntityDetails entityDetails, HttpContext httpContext) throws HttpException, IOException {
 		final String credentials = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8).trim();
 		httpRequest.addHeader(HttpHeaders.AUTHORIZATION, credentials);
 	}

--- a/spring-cloud-skipper/spring-cloud-skipper-docs/src/main/asciidoc/appendix-building.adoc
+++ b/spring-cloud-skipper/spring-cloud-skipper-docs/src/main/asciidoc/appendix-building.adoc
@@ -103,7 +103,7 @@ Working build file for _Maven_ would look like something shown below:
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<spring-cloud.version>2021.0.9</spring-cloud.version>
 		<spring-cloud-skipper.version>{project-version}</spring-cloud-skipper.version>
 		<!--
@@ -179,7 +179,7 @@ apply plugin: 'org.springframework.boot'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = 1.8
+sourceCompatibility = 17
 
 repositories {
 	mavenLocal()

--- a/spring-cloud-skipper/spring-cloud-skipper-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-platform-cloudfoundry/pom.xml
@@ -24,6 +24,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-cloudfoundry</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-platform-cloudfoundry/pom.xml
@@ -48,8 +48,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-skipper/spring-cloud-skipper-platform-kubernetes/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-platform-kubernetes/pom.xml
@@ -37,6 +37,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-kubernetes-fabric8-config</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -261,8 +261,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-skipper/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper/pom.xml
@@ -84,6 +84,11 @@
 			<artifactId>equalsverifier</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-common-persistence</artifactId>
+			<version>3.0.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-skipper/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper/pom.xml
@@ -92,8 +92,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AbstractEntity.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AbstractEntity.java
@@ -15,13 +15,12 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Version;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * Base class for entity implementations. Uses a {@link Long} id.

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Manifest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Manifest.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.sql.Types;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.JdbcTypeCode;
 
-import org.hibernate.annotations.Type;
 
 /**
  * @author Mark Pollack
@@ -29,9 +31,10 @@ import org.hibernate.annotations.Type;
 @Table(name = "SkipperManifest")
 public class Manifest extends AbstractEntity {
 
+	//TODO: Boot3x followup
 	@NotNull
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String data;
 
 	public Manifest() {

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/NonVersionedAbstractEntity.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/NonVersionedAbstractEntity.java
@@ -15,12 +15,11 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * Base class for entity implementations that don't need optimistic locking.

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.sql.Types;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,9 +28,8 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.JdbcTypeCode;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.hibernate.annotations.Type;
 
 /**
  * Metadata for the Package.
@@ -90,14 +92,14 @@ public class PackageMetadata extends AbstractEntity {
 	 * Location to source code for this package.
 	 */
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String packageSourceUrl;
 
 	/**
 	 * The home page of the package
 	 */
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String packageHomeUrl;
 
 	/**
@@ -113,7 +115,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * A comma separated list of tags to use for searching
 	 */
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String tags;
 
 	/**
@@ -125,7 +127,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * Brief description of the package. The packages README.md will contain more information.
 	 */
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String description;
 
 	/**
@@ -137,7 +139,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * Url location of a icon.
 	 */
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String iconUrl;
 
 	public PackageMetadata() {

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -16,7 +16,12 @@
 package org.springframework.cloud.skipper.domain;
 
 import java.io.IOException;
+import java.sql.Types;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ForeignKey;
@@ -28,13 +33,7 @@ import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
-
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hibernate.annotations.Type;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.util.StringUtils;
@@ -71,15 +70,17 @@ public class Release extends AbstractEntity {
 	@JsonIgnore
 	private Long repositoryId;
 
+	//TODO: Boot3x followup
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String pkgJsonString;
 
 	@Transient
 	private ConfigValues configValues = new ConfigValues();
 
+	//TODO: Boot3x followup
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String configValuesString;
 
 	@OneToOne(cascade = { CascadeType.ALL })

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
@@ -15,14 +15,16 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.sql.Types;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.JdbcTypeCode;
 
-import org.hibernate.annotations.Type;
 
 /**
  * Repository for the packages.
@@ -46,17 +48,19 @@ public class Repository extends AbstractEntity {
 	 * The root url that points to the location of an index.yaml file and other files
 	 * supporting the index e.g. myapp-1.0.0.zip, icons-64x64.zip
 	 */
+	//TODO: Boot3x followup
 	@NotNull
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String url;
 
 	/**
 	 * The url that points to the source package files that was used to create the index and
 	 * packages.
 	 */
+	//TODO: Boot3x followup
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String sourceUrl;
 
 	/**

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
@@ -15,16 +15,10 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,7 +29,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.hibernate.annotations.Type;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
@@ -56,8 +55,9 @@ public class Status extends NonVersionedAbstractEntity {
 	private StatusCode statusCode;
 
 	// Status from the underlying platform
+	//TODO: Boot3x followup
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String platformStatus;
 
 	public Status() {

--- a/spring-cloud-starter-dataflow-server/pom.xml
+++ b/spring-cloud-starter-dataflow-server/pom.xml
@@ -115,8 +115,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
@@ -24,6 +24,7 @@ import org.junit.rules.TemporaryFolder;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.ldap.server.ApacheDSContainer;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.SocketUtils;
@@ -81,7 +82,7 @@ public class LdapServerResource extends ExternalResource {
 		temporaryFolder.create();
 		apacheDSContainer = new ApacheDSContainer("dc=springframework,dc=org",
 				"classpath:org/springframework/cloud/dataflow/server/local/security/" + this.ldapFileName);
-		int ldapPort = SocketUtils.findAvailableTcpPort();
+		int ldapPort = TestSocketUtils.findAvailableTcpPort();
 		if (enabledSsl) {
 
 			apacheDSContainer.setLdapOverSslEnabled(true);

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.dataflow.server.single.nodataflowapp.LocalTestN
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.SocketUtils;
 
 import static org.hamcrest.Matchers.is;
@@ -68,7 +69,7 @@ public class LocalConfigurationTests {
 	@Test
 	public void testConfig() {
 		SpringApplication app = new SpringApplication(LocalTestDataFlowServer.class);
-		int randomPort = SocketUtils.findAvailableTcpPort();
+		int randomPort = TestSocketUtils.findAvailableTcpPort();
 		String dataSourceUrl = String.format("jdbc:h2:tcp://localhost:%s/mem:dataflow;DATABASE_TO_UPPER=FALSE", randomPort);
 		context = app.run(new String[] { "--debug","--spring.cloud.kubernetes.enabled=false", "--server.port=0", "--spring.datasource.url=" + dataSourceUrl });
 		assertNotNull(context.getBean(AppRegistryService.class));

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
@@ -54,6 +54,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.SocketUtils;
@@ -145,7 +146,7 @@ public class LocalDataflowResource extends ExternalResource {
 	protected void before() {
 		originalDataflowServerPort = System.getProperty(DATAFLOW_PORT_PROPERTY);
 
-		this.dataflowServerPort = SocketUtils.findAvailableTcpPort();
+		this.dataflowServerPort = TestSocketUtils.findAvailableTcpPort();
 
 		logger.info("Setting Dataflow Server port to " + this.dataflowServerPort);
 


### PR DESCRIPTION
* Replaced SocketUtils with TestSocketUtils 
  * It was moved to the test package.
* Migrated httpclient to httpclient5 ** Removed use of httpclient 4.x dependencies added yesterday
* Updated Types in AuditRecord Entity to use JdbcTypeCode
* `DropAuthorizationHeaderRequestRedirectStrategy` requires a bit more scrutiny.  
    Some of the changes required were not exact matches, so had to research.   But there maybe better ways.   

I disabled spring-cloud-common-security-config to push forward .  It was re-added before PR was submitted.