### PR TITLE
Dataflow needs to be compilable using boot 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
 		<module>spring-cloud-dataflow-server</module>
-		<module>spring-cloud-dataflow-tasklauncher</module>
-		<module>spring-cloud-dataflow-single-step-batch-job</module>
-		<module>spring-cloud-dataflow-composed-task-runner</module>
+<!--		<module>spring-cloud-dataflow-tasklauncher</module>-->
+<!--		<module>spring-cloud-dataflow-single-step-batch-job</module>-->
+<!--		<module>spring-cloud-dataflow-composed-task-runner</module>-->
 		<module>spring-cloud-dataflow-test</module>
 		<module>spring-cloud-dataflow-dependencies</module>
 		<module>spring-cloud-dataflow-classic-docs</module>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
 		<module>spring-cloud-dataflow-server</module>
+<!--		TODO: Boot3x followup -->
 <!--		<module>spring-cloud-dataflow-tasklauncher</module>-->
 <!--		<module>spring-cloud-dataflow-single-step-batch-job</module>-->
 <!--		<module>spring-cloud-dataflow-composed-task-runner</module>-->

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AppRegistryDocumentation.java
@@ -32,7 +32,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -83,7 +83,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 										parameterWithName("name").description("The name of the application to register"),
 										parameterWithName("version").description("The version of the application to register")
 								),
-								requestParameters(
+								queryParameters(
 										parameterWithName("uri").description("URI where the application bits reside"),
 										parameterWithName("metadata-uri").optional()
 												.description("URI where the application metadata jar can be found"),
@@ -108,7 +108,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 				.andExpect(status().isCreated())
 				.andDo(
 						this.documentationHandler.document(
-								requestParameters(
+								queryParameters(
 										parameterWithName("uri").optional().description("URI where a properties file containing registrations can be fetched. Exclusive with `apps`."),
 										parameterWithName("apps").optional().description("Inline set of registrations. Exclusive with `uri`."),
 										parameterWithName("force").optional().description("Must be true if a registration with the same name and type already exists, otherwise an error will occur")
@@ -133,7 +133,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 				)
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("search").description("The search string performed on the name (optional)"),
 								parameterWithName("type")
 										.description("Restrict the returned apps to the type of the app. One of " + Arrays.asList(ApplicationType.values())),
@@ -167,7 +167,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 										parameterWithName("type").description("The type of application to query. One of " + Arrays.asList(ApplicationType.values())),
 										parameterWithName("name").description("The name of the application to query")
 								),
-								requestParameters(
+								queryParameters(
 										parameterWithName("exhaustive").optional()
 												.description("Return all application properties, including common Spring Boot properties")
 								),
@@ -205,7 +205,7 @@ public class AppRegistryDocumentation extends BaseDocumentation {
 										parameterWithName("type").description("The type of application to register. One of " + Arrays.asList(ApplicationType.values())),
 										parameterWithName("name").description("The name of the application to register")
 								),
-								requestParameters(
+								queryParameters(
 										parameterWithName("uri").description("URI where the application bits reside"),
 										parameterWithName("metadata-uri").optional().description("URI where the application metadata jar can be found"),
 										parameterWithName("bootVersion").optional().description("The Spring Boot version of the application.Default is 2"),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AuditRecordsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/AuditRecordsDocumentation.java
@@ -28,7 +28,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -80,7 +80,7 @@ public class AuditRecordsDocumentation extends BaseDocumentation {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 					parameterWithName("page").description("The zero-based page number (optional)"),
 					parameterWithName("size").description("The requested page size (optional)"),
 					parameterWithName("operations").description("Comma-separated list of Audit Operations (optional)"),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/BaseDocumentation.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,14 +33,7 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.cloud.dataflow.core.ApplicationType;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskPlatform;
-import org.springframework.cloud.dataflow.core.database.support.MultiSchemaIncrementerFactory;
-import org.springframework.cloud.dataflow.schema.SchemaVersionTarget;
-import org.springframework.cloud.dataflow.schema.service.SchemaService;
 import org.springframework.cloud.dataflow.server.controller.TaskSchedulerController;
-import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionMetadataDao;
-import org.springframework.cloud.dataflow.server.repository.DataflowTaskExecutionMetadataDaoContainer;
-import org.springframework.cloud.dataflow.server.repository.JdbcDataflowTaskExecutionMetadataDao;
-import org.springframework.cloud.dataflow.server.repository.support.SchemaUtilities;
 import org.springframework.cloud.dataflow.server.service.SchedulerService;
 import org.springframework.cloud.dataflow.server.single.LocalDataflowResource;
 import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
@@ -203,28 +197,6 @@ public abstract class BaseDocumentation {
 								delete("/streams/definitions/{name}", name))
 						.andExpect(status().isOk())
 		);
-	}
-
-	protected DataflowTaskExecutionMetadataDaoContainer createDataFlowTaskExecutionMetadataDaoContainer(SchemaService schemaService) {
-		DataflowTaskExecutionMetadataDaoContainer result = new DataflowTaskExecutionMetadataDaoContainer();
-		MultiSchemaIncrementerFactory incrementerFactory = new MultiSchemaIncrementerFactory(dataSource);
-		String databaseType;
-		try {
-			databaseType = DatabaseType.fromMetaData(dataSource).name();
-		} catch (MetaDataAccessException e) {
-			throw new IllegalStateException(e);
-		}
-		for (SchemaVersionTarget target : schemaService.getTargets().getSchemas()) {
-			DataflowTaskExecutionMetadataDao dao = new JdbcDataflowTaskExecutionMetadataDao(
-					dataSource,
-					incrementerFactory.getIncrementer(databaseType,
-							SchemaUtilities.getQuery("%PREFIX%EXECUTION_METADATA_SEQ", target.getTaskPrefix())
-					),
-					target.getTaskPrefix()
-			);
-			result.add(target.getName(), dao);
-		}
-		return result;
 	}
 
 	/**

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobInstancesDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobInstancesDocumentation.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +26,10 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.dataflow.aggregate.task.AggregateExecutionSupport;
@@ -49,7 +52,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -93,7 +96,7 @@ public class JobInstancesDocumentation extends BaseDocumentation {
 						.param("size", "10"))
 				.andDo(print())
 				.andExpect(status().isOk()).andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 						parameterWithName("page")
 								.description("The zero-based page number (optional)"),
 						parameterWithName("size")
@@ -117,7 +120,7 @@ public class JobInstancesDocumentation extends BaseDocumentation {
 					pathParameters(
 						parameterWithName("id").description("The id of an existing job instance (required)")
 					),
-					requestParameters(
+					queryParameters(
 							parameterWithName("schemaTarget").description("Schema target").optional()
 					),
 					responseFields(
@@ -138,16 +141,16 @@ public class JobInstancesDocumentation extends BaseDocumentation {
 		this.taskBatchDaoContainer = context.getBean(TaskBatchDaoContainer.class);
 	}
 
-	private void createJobExecution(String name, BatchStatus status) {
+	private void createJobExecution(String name, BatchStatus status) throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobRestartException {
 		SchemaVersionTarget schemaVersionTarget = this.aggregateExecutionSupport.findSchemaVersionTarget(name, taskDefinitionReader);
 		TaskExecutionDao dao = this.daoContainer.get(schemaVersionTarget.getName());
-		TaskExecution taskExecution = dao.createTaskExecution(name, new Date(), new ArrayList<>(), null);
+		TaskExecution taskExecution = dao.createTaskExecution(name, LocalDateTime.now(), new ArrayList<>(), null);
 		JobRepository jobRepository = this.jobRepositoryContainer.get(schemaVersionTarget.getName());
-		JobExecution jobExecution = jobRepository.createJobExecution(jobRepository.createJobInstance(name, new JobParameters()), new JobParameters(), null);
+		JobExecution jobExecution = jobRepository.createJobExecution(name, new JobParameters());
 		TaskBatchDao taskBatchDao = this.taskBatchDaoContainer.get(schemaVersionTarget.getName());
 		taskBatchDao.saveRelationship(taskExecution, jobExecution);
 		jobExecution.setStatus(status);
-		jobExecution.setStartTime(new Date());
+		jobExecution.setStartTime(LocalDateTime.now());
 		jobRepository.update(jobExecution);
 	}
 }

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDefinitionsDocumentation.java
@@ -33,7 +33,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -77,7 +77,7 @@ public class StreamDefinitionsDocumentation extends BaseDocumentation {
 					.param("deploy", "false"))
 			.andExpect(status().isCreated())
 			.andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 					parameterWithName("name").description("The name for the created task definitions"),
 					parameterWithName("definition").description("The definition for the stream, using Data Flow DSL"),
 					parameterWithName("description").description("The description of the stream definition"),
@@ -107,7 +107,7 @@ public class StreamDefinitionsDocumentation extends BaseDocumentation {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 					parameterWithName("page").description("The zero-based page number (optional)"),
 					parameterWithName("search").description("The search string performed on the name (optional)"),
 					parameterWithName("sort").description("The sort on the list (optional)"),
@@ -179,7 +179,7 @@ public class StreamDefinitionsDocumentation extends BaseDocumentation {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
-                requestParameters(
+                queryParameters(
                     parameterWithName("nested")
                         .description("Should we recursively findByTaskNameContains for related stream definitions (optional)"),
                     parameterWithName("page").description("The zero-based page number (optional)"),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/StreamDeploymentsDocumentation.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.dataflow.server.rest.documentation;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +41,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -136,7 +135,7 @@ public class StreamDeploymentsDocumentation extends BaseDocumentation {
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("timelog")
 								.description("The name of an existing stream definition (required)")),
-						requestParameters(parameterWithName("reuse-deployment-properties")
+						queryParameters(parameterWithName("reuse-deployment-properties")
 								.description(parameterWithName("The name of the flag to reuse the deployment properties")))
 				));
 	}

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
@@ -32,7 +32,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -65,7 +65,7 @@ public class TaskDefinitionsDocumentation extends BaseDocumentation {
 				.param("description", "Demo task definition for testing"))
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 					parameterWithName("name").description("The name for the created task definition"),
 					parameterWithName("definition").description("The definition for the task, using Data Flow DSL"),
 					parameterWithName("description").description("The description of the task definition")
@@ -97,7 +97,7 @@ public class TaskDefinitionsDocumentation extends BaseDocumentation {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(
-				requestParameters(
+				queryParameters(
 					parameterWithName("page").description("The zero-based page number (optional)"),
 					parameterWithName("size").description("The requested page size (optional)"),
 					parameterWithName("search").description("The search string performed on the name (optional)"),
@@ -122,7 +122,7 @@ public class TaskDefinitionsDocumentation extends BaseDocumentation {
 				pathParameters(
 					parameterWithName("my-task").description("The name of an existing task definition (required)")
 				),
-				requestParameters(
+				queryParameters(
 					parameterWithName("manifest").description("The flag to include the task manifest into the latest task execution (optional)")
 				),
 				responseFields(
@@ -149,7 +149,7 @@ public class TaskDefinitionsDocumentation extends BaseDocumentation {
 			.andDo(this.documentationHandler.document(
 				pathParameters(
 					parameterWithName("my-task").description("The name of an existing task definition (required)")),
-				requestParameters(
+				queryParameters(
 						parameterWithName("cleanup").description("The flag to indicate if the associated task executions needed to be cleaned up")
 				)
 			));

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -37,7 +37,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -83,7 +83,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 				)
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
-								requestParameters(
+								queryParameters(
 										parameterWithName("name").description("The name of the task definition to launch"),
 										parameterWithName("properties")
 												.description("Application and Deployer properties to use while launching. (optional)"),
@@ -109,7 +109,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 				)
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
-								requestParameters(
+								queryParameters(
 										parameterWithName("name").description("The name of the task definition to launch"),
 										parameterWithName("properties")
 												.description("Application and Deployer properties to use while launching. (optional)"),
@@ -148,7 +148,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 						pathParameters(
 								parameterWithName("id").description("The id of an existing task execution (required)")
 						),
-						requestParameters(
+						queryParameters(
 								parameterWithName("schemaTarget").description("The schemaTarget provided in Task execution detail")
 						),
 						responseFields(
@@ -203,7 +203,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 						pathParameters(
 								parameterWithName("externalExecutionId").description("The external ExecutionId of an existing task execution (required)")
 						),
-						requestParameters(
+						queryParameters(
 								parameterWithName("platform").description("The name of the platform.")
 						),
 						responseFields(
@@ -246,7 +246,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 								.param("size", "2"))
 				.andDo(print())
 				.andExpect(status().isOk()).andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("page")
 										.description("The zero-based page number (optional)"),
 								parameterWithName("size")
@@ -273,7 +273,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 				)
 				.andDo(print())
 				.andExpect(status().isOk()).andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("page")
 										.description("The zero-based page number (optional)"),
 								parameterWithName("size")
@@ -306,7 +306,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 								pathParameters(
 										parameterWithName("id").description("The ids of an existing task execution (required)")
 								),
-								requestParameters(
+								queryParameters(
 										parameterWithName("schemaTarget").description("The schemaTarget provided in Task execution detail. (optional)"))
 						)
 				);
@@ -327,7 +327,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(parameterWithName("action").description("Optional. Defaults to: CLEANUP.")),
+						queryParameters(parameterWithName("action").description("Optional. Defaults to: CLEANUP.")),
 						pathParameters(parameterWithName("ids")
 								.description("The id of an existing task execution (required). Multiple comma separated values are accepted."))
 				));
@@ -340,7 +340,7 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("action").description("Using both actions CLEANUP and REMOVE_DATA simultaneously."),
 								parameterWithName("schemaTarget").description("Schema target for task. (optional)")
 						),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskLogsDocumentation.java
@@ -33,7 +33,7 @@ import java.time.Duration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -76,7 +76,7 @@ public class TaskLogsDocumentation extends BaseDocumentation {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("platformName").description("The name of the platform the task is launched."))
 				));
 	}

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskPlatformDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskPlatformDocumentation.java
@@ -24,7 +24,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -46,7 +46,7 @@ public class TaskPlatformDocumentation extends BaseDocumentation {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("page")
 										.description("The zero-based page number (optional)"),
 								parameterWithName("size")

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskSchedulerDocumentation.java
@@ -31,7 +31,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,7 +67,7 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 						.param("arguments", "--foo=bar"))
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("scheduleName").description("The name for the created schedule"),
 								parameterWithName("platform").description("The name of the platform the task is launched"),
 								parameterWithName("taskDefinitionName")
@@ -99,7 +99,7 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 				.andDo(this.documentationHandler.document(
 						pathParameters(parameterWithName("task-definition-name")
 								.description("Filter schedules based on the specified task definition (required)")),
-						requestParameters(
+						queryParameters(
 								parameterWithName("page")
 										.description("The zero-based page number (optional)"),
 								parameterWithName("size")
@@ -120,7 +120,7 @@ public class TaskSchedulerDocumentation extends BaseDocumentation {
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						requestParameters(
+						queryParameters(
 								parameterWithName("page")
 										.description("The zero-based page number (optional)"),
 								parameterWithName("size")

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.dataflow.rest.job;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import org.springframework.batch.core.StepExecution;
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
@@ -20,7 +20,6 @@ import java.text.DateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
@@ -20,11 +20,8 @@ import java.text.DateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -51,6 +51,10 @@
 			<artifactId>hibernate-micrometer</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-ant</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-schema</artifactId>
 			<version>${dataflow.version}</version>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -51,10 +51,6 @@
 			<artifactId>hibernate-micrometer</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate.orm</groupId>
-			<artifactId>hibernate-ant</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-schema</artifactId>
 			<version>${dataflow.version}</version>
@@ -255,6 +251,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-ant</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/DataflowPagingQueryProvider.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/DataflowPagingQueryProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.batch;
+
+//TODO: Boot3x followup
+public interface DataflowPagingQueryProvider {
+
+	/**
+	 *
+	 * Generate the query that will provide the jump to item query.  The itemIndex provided could be in the middle of
+	 * the page and together with the page size it will be used to calculate the last index of the preceding page
+	 * to be able to retrieve the sort key for this row.
+	 *
+	 * @param itemIndex the index for the next item to be read
+	 * @param pageSize number of rows to read for each page
+	 * @return the generated query
+	 */
+	String generateJumpToItemQuery(int itemIndex, int pageSize);
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/DataflowSqlPagingQueryProvider.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/DataflowSqlPagingQueryProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.batch;
+
+
+//TODO: Boot3x followup
+
+import org.springframework.batch.item.database.support.AbstractSqlPagingQueryProvider;
+import org.springframework.cloud.dataflow.server.repository.support.PagingQueryProvider;
+
+/**
+ * This class provides the implementation for methods removed by Spring Batch but are still
+ * needed by SCDF.  This comment will be need to be updated prior to release to
+ * discuss that it implements extra features needed beyond the {@code SqlPagingQueryProviderFactoryBean}.
+ */
+public abstract class DataflowSqlPagingQueryProvider implements DataflowPagingQueryProvider {
+	public String generateJumpToItemQuery(int start, int count) {
+		throw new UnsupportedOperationException("This method is not yet supported by SCDF.");
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
@@ -121,21 +121,39 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 
 	private PagingQueryProvider allExecutionsPagingQueryProvider;
 
+	private DataflowPagingQueryProvider dataflowAllExecutionsPagingQueryProvider;
+
 	private PagingQueryProvider byJobNamePagingQueryProvider;
+
+	private DataflowPagingQueryProvider dataflowByJobNamePagingQueryProvider;
 
 	private PagingQueryProvider byStatusPagingQueryProvider;
 
+	private DataflowPagingQueryProvider dataflowByStatusPagingQueryProvider;
+
 	private PagingQueryProvider byJobNameAndStatusPagingQueryProvider;
+
+	private DataflowPagingQueryProvider dataflowByJobNameAndStatusPagingQueryProvider;
 
 	private PagingQueryProvider byJobNameWithStepCountPagingQueryProvider;
 
+	private DataflowPagingQueryProvider dataflowByJobNameWithStepCountPagingQueryProvider;
+
 	private PagingQueryProvider executionsWithStepCountPagingQueryProvider;
+
+	private DataflowPagingQueryProvider dataflowExecutionsWithStepCountPagingQueryProvider;
 
 	private PagingQueryProvider byDateRangeWithStepCountPagingQueryProvider;
 
+	private DataflowPagingQueryProvider dataflowByDateRangeWithStepCountPagingQueryProvider;
+
 	private PagingQueryProvider byJobInstanceIdWithStepCountPagingQueryProvider;
 
+	private DataflowPagingQueryProvider dataflowByJobInstanceIdWithStepCountPagingQueryProvider;
+
 	private PagingQueryProvider byTaskExecutionIdWithStepCountPagingQueryProvider;
+
+	private DataflowPagingQueryProvider dataFlowByTaskExecutionIdWithStepCountPagingQueryProvider;
 
 	private final ConfigurableConversionService conversionService;
 
@@ -180,17 +198,42 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		});
 
 		allExecutionsPagingQueryProvider = getPagingQueryProvider();
+		dataflowAllExecutionsPagingQueryProvider = getDataflowPagingQueryProvider();
+
+
 		executionsWithStepCountPagingQueryProvider = getPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null, null);
+
+		dataflowExecutionsWithStepCountPagingQueryProvider = getDataflowPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null, null);
+
+
 		byJobNamePagingQueryProvider = getPagingQueryProvider(NAME_FILTER);
+		dataflowByJobNamePagingQueryProvider =getDataflowPagingQueryProvider(NAME_FILTER);
+
 		byStatusPagingQueryProvider = getPagingQueryProvider(STATUS_FILTER);
+		dataflowByStatusPagingQueryProvider = getDataflowPagingQueryProvider(STATUS_FILTER);
+
 		byJobNameAndStatusPagingQueryProvider = getPagingQueryProvider(NAME_AND_STATUS_FILTER);
+		dataflowByJobNameAndStatusPagingQueryProvider = getDataflowPagingQueryProvider(NAME_AND_STATUS_FILTER);
+
 		byJobNameWithStepCountPagingQueryProvider = getPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null, NAME_FILTER);
+
+		dataflowByJobNameWithStepCountPagingQueryProvider = getDataflowPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null, NAME_FILTER);
+
+
 		byDateRangeWithStepCountPagingQueryProvider = getPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null,
 				DATE_RANGE_FILTER);
+		dataflowByDateRangeWithStepCountPagingQueryProvider = getDataflowPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null,
+			DATE_RANGE_FILTER);
+
 		byJobInstanceIdWithStepCountPagingQueryProvider = getPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null,
 				JOB_INSTANCE_ID_FILTER);
+		dataflowByJobInstanceIdWithStepCountPagingQueryProvider = getDataflowPagingQueryProvider(FIELDS_WITH_STEP_COUNT, null,
+			JOB_INSTANCE_ID_FILTER);
+
 		byTaskExecutionIdWithStepCountPagingQueryProvider = getPagingQueryProvider(FIELDS_WITH_STEP_COUNT,
 				FROM_CLAUSE_TASK_TASK_BATCH, TASK_EXECUTION_ID_FILTER);
+		dataFlowByTaskExecutionIdWithStepCountPagingQueryProvider = getDataflowPagingQueryProvider(FIELDS_WITH_STEP_COUNT,
+			FROM_CLAUSE_TASK_TASK_BATCH, TASK_EXECUTION_ID_FILTER);
 
 		super.afterPropertiesSet();
 
@@ -254,12 +297,31 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 	}
 
 	/**
-	 * @return a {@link PagingQueryProvider} for all job executions with the provided
+	 * @return a {@link PagingQueryProvider} for all job executions
+	 * @throws Exception if page provider is not created.
+	 */
+	private DataflowPagingQueryProvider getDataflowPagingQueryProvider() throws Exception {
+		return getDataflowPagingQueryProvider(null);
+	}
+
+	/**
+	 * @return a {@link DataflowPagingQueryProvider} for all job executions with the provided
 	 * where clause
 	 * @throws Exception if page provider is not created.
 	 */
 	private PagingQueryProvider getPagingQueryProvider(String whereClause) throws Exception {
 		return getPagingQueryProvider(null, whereClause);
+	}
+
+	//TODO: Boot3x followup Need to create the {@link DataflowPagingQueryProvider} to call method generateJumpToItemQuery.
+	/**
+	 * @return a {@link DataflowPagingQueryProvider} for all job executions with the provided
+	 * where clause
+	 * @throws Exception if page provider is not created.
+	 */
+	private DataflowPagingQueryProvider getDataflowPagingQueryProvider(String whereClause) {
+		throw new UnsupportedOperationException("Need to create DataflowSqlPagingQueryProvider so that dataflow can call " +
+			"generateJumpToItemQuery");
 	}
 
 	/**
@@ -291,6 +353,16 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		factory.setWhereClause(whereClause);
 
 		return factory.getObject();
+	}
+
+	//TODO: Boot3x followup Need to create the {@link DataflowPagingQueryProvider} to call method generateJumpToItemQuery.
+	/**
+	 * @return a {@link PagingQueryProvider} with a where clause to narrow the query
+	 * @throws Exception if page provider is not created.
+	 */
+	private DataflowPagingQueryProvider getDataflowPagingQueryProvider(String fields, String fromClause, String whereClause) {
+		throw new UnsupportedOperationException("Need to create DataflowSqlPagingQueryProvider so that dataflow can call " +
+			"generateJumpToItemQuery");
 	}
 
 	/**
@@ -339,7 +411,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byDateRangeWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
+					dataflowByDateRangeWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
 					fromDate, toDate);
 			return getJdbcTemplate().query(
 					byDateRangeWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
@@ -360,7 +432,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byJobInstanceIdWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
+					dataflowByJobInstanceIdWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
 					jobInstanceId);
 			return getJdbcTemplate().query(
 					byJobInstanceIdWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
@@ -381,7 +453,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byTaskExecutionIdWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
+					dataFlowByTaskExecutionIdWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
 					taskExecutionId);
 			return getJdbcTemplate().query(
 					byTaskExecutionIdWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
@@ -411,7 +483,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byJobNameAndStatusPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, jobName,
+					dataflowByJobNameAndStatusPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, jobName,
 					status.name());
 			return getJdbcTemplate().query(byJobNameAndStatusPagingQueryProvider.generateRemainingPagesQuery(count),
 					new SearchableJobExecutionRowMapper(), jobName, status.name(), startAfterValue);
@@ -432,7 +504,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byJobNamePagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, jobName);
+					dataflowByJobNamePagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, jobName);
 			return getJdbcTemplate().query(byJobNamePagingQueryProvider.generateRemainingPagesQuery(count),
 					new SearchableJobExecutionRowMapper(), jobName, startAfterValue);
 		}
@@ -449,7 +521,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byStatusPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, status.name());
+					dataflowByStatusPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class, status.name());
 			return getJdbcTemplate().query(byStatusPagingQueryProvider.generateRemainingPagesQuery(count),
 					new SearchableJobExecutionRowMapper(), status.name(), startAfterValue);
 		}
@@ -469,7 +541,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					byJobNameWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
+					dataflowByJobNameWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class,
 					jobName);
 			return getJdbcTemplate().query(byJobNameWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
 					new JobExecutionStepCountRowMapper(), jobName, startAfterValue);
@@ -490,7 +562,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate()
-				.queryForObject(allExecutionsPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
+				.queryForObject(dataflowAllExecutionsPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
 			return getJdbcTemplate().query(allExecutionsPagingQueryProvider.generateRemainingPagesQuery(count),
 					new SearchableJobExecutionRowMapper(), startAfterValue);
 		}
@@ -507,7 +579,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
-					executionsWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
+					dataflowExecutionsWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
 			return getJdbcTemplate().query(
 					executionsWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
 					new JobExecutionStepCountRowMapper(), startAfterValue);
@@ -570,8 +642,9 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 
 	}
 
+	//TODO: Boot3x followup - need to handle LocalDateTime and possibly Integer
 	protected JobParameters getJobParametersBatch5(Long executionId) {
-		Map<String, JobParameter> map = new HashMap<>();
+		Map<String, JobParameter<?>> map = new HashMap<>();
 		RowCallbackHandler handler = rs -> {
 			String parameterName = rs.getString("PARAMETER_NAME");
 
@@ -588,29 +661,29 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 			boolean identifying = rs.getString("IDENTIFYING").equalsIgnoreCase("Y");
 
 			if (typedValue instanceof String) {
-				map.put(parameterName, new JobParameter((String) typedValue, identifying));
+				map.put(parameterName, new JobParameter(typedValue, String.class, identifying));
 			}
 			else if (typedValue instanceof Integer) {
-				map.put(parameterName, new JobParameter(((Integer) typedValue).longValue(), identifying));
+				map.put(parameterName, new JobParameter(((Integer) typedValue).longValue(), Integer.class, identifying));
 			}
 			else if (typedValue instanceof Long) {
-				map.put(parameterName, new JobParameter((Long) typedValue, identifying));
+				map.put(parameterName, new JobParameter(typedValue, Long.class, identifying));
 			}
 			else if (typedValue instanceof Float) {
-				map.put(parameterName, new JobParameter(((Float) typedValue).doubleValue(), identifying));
+				map.put(parameterName, new JobParameter(((Float) typedValue).doubleValue(), Float.class, identifying));
 			}
 			else if (typedValue instanceof Double) {
-				map.put(parameterName, new JobParameter((Double) typedValue, identifying));
+				map.put(parameterName, new JobParameter(typedValue, Double.class, identifying));
 			}
 			else if (typedValue instanceof Timestamp) {
-				map.put(parameterName, new JobParameter(new Date(((Timestamp) typedValue).getTime()), identifying));
+				map.put(parameterName, new JobParameter(new Date(((Timestamp) typedValue).getTime()), Timestamp.class, identifying));
 			}
 			else if (typedValue instanceof Date) {
-				map.put(parameterName, new JobParameter((Date) typedValue, identifying));
+				map.put(parameterName, new JobParameter(typedValue, Date.class, identifying));
 			}
 			else {
 				map.put(parameterName,
-						new JobParameter(typedValue != null ? typedValue.toString() : "null", identifying));
+						new JobParameter(typedValue != null ? typedValue.toString() : "null", String.class, identifying));
 			}
 		};
 
@@ -639,12 +712,12 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		jobExecution = new JobExecution(jobInstance, jobParameters);
 		jobExecution.setId(id);
 
-		jobExecution.setStartTime(rs.getTimestamp(2));
-		jobExecution.setEndTime(rs.getTimestamp(3));
+		jobExecution.setStartTime(rs.getTimestamp(2).toLocalDateTime());
+		jobExecution.setEndTime(rs.getTimestamp(3).toLocalDateTime());
 		jobExecution.setStatus(BatchStatus.valueOf(rs.getString(4)));
 		jobExecution.setExitStatus(new ExitStatus(rs.getString(5), rs.getString(6)));
-		jobExecution.setCreateTime(rs.getTimestamp(7));
-		jobExecution.setLastUpdated(rs.getTimestamp(8));
+		jobExecution.setCreateTime(rs.getTimestamp(7).toLocalDateTime());
+		jobExecution.setLastUpdated(rs.getTimestamp(8).toLocalDateTime());
 		jobExecution.setVersion(rs.getInt(9));
 		return jobExecution;
 	}
@@ -669,20 +742,19 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 			Long id = rs.getLong(1);
 			JobParameters jobParameters = getJobParameters(id);
 			JobExecution jobExecution;
-			String jobConfigurationLocation = batchVersion.equals(BatchVersion.BATCH_4) ? rs.getString(10) : null;
 			if (jobInstance == null) {
-				jobExecution = new JobExecution(id, jobParameters, jobConfigurationLocation);
+				jobExecution = new JobExecution(id, jobParameters);
 			}
 			else {
-				jobExecution = new JobExecution(jobInstance, id, jobParameters, jobConfigurationLocation);
+				jobExecution = new JobExecution(jobInstance, id, jobParameters);
 			}
 
-			jobExecution.setStartTime(rs.getTimestamp(2));
-			jobExecution.setEndTime(rs.getTimestamp(3));
+			jobExecution.setStartTime(rs.getTimestamp(2).toLocalDateTime());
+			jobExecution.setEndTime(rs.getTimestamp(3).toLocalDateTime());
 			jobExecution.setStatus(BatchStatus.valueOf(rs.getString(4)));
 			jobExecution.setExitStatus(new ExitStatus(rs.getString(5), rs.getString(6)));
-			jobExecution.setCreateTime(rs.getTimestamp(7));
-			jobExecution.setLastUpdated(rs.getTimestamp(8));
+			jobExecution.setCreateTime(rs.getTimestamp(7).toLocalDateTime());
+			jobExecution.setLastUpdated(rs.getTimestamp(8).toLocalDateTime());
 			jobExecution.setVersion(rs.getInt(9));
 			return jobExecution;
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobRestartRuntimeException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobRestartRuntimeException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.batch;
+
+public class JobRestartRuntimeException extends RuntimeException {
+
+	public JobRestartRuntimeException(Long jobExecutionId, Exception cause) {
+		super(String.format("JobExecutionId '%d' was not restarted.", jobExecutionId), cause);
+	}
+
+	public JobRestartRuntimeException(Long jobExecutionId) {
+		super(String.format("JobExecutionId '%d' was not restarted.", jobExecutionId));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobRestartRuntimeException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobRestartRuntimeException.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.batch;
 
+//TODO: Boot3x followup
 public class JobRestartRuntimeException extends RuntimeException {
 
 	public JobRestartRuntimeException(Long jobExecutionId, Exception cause) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStartRuntimeException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStartRuntimeException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.batch;
+
+public class JobStartRuntimeException extends RuntimeException {
+
+	public JobStartRuntimeException(String jobName, Exception cause) {
+		super(String.format("JobExecutionId '%s' was not started.", jobName), cause);
+	}
+
+	public JobStartRuntimeException(Long jobExecutionId) {
+		super(String.format("JobExecutionId '%s' was not started.", jobExecutionId));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStartRuntimeException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStartRuntimeException.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.batch;
 
+//TODO: Boot3x followup
 public class JobStartRuntimeException extends RuntimeException {
 
 	public JobStartRuntimeException(String jobName, Exception cause) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStopException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStopException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.batch;
+
+public class JobStopException extends RuntimeException {
+
+	public JobStopException(Long jobExecutionId, Exception cause) {
+		super(String.format("JobExecutionId '%d' was not stopped.", jobExecutionId), cause);
+	}
+
+	public JobStopException(Long jobExecutionId) {
+		super(String.format("JobExecutionId '%d' was not stopped.", jobExecutionId));
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStopException.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobStopException.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.server.batch;
 
+//TODO: Boot3x followup
 public class JobStopException extends RuntimeException {
 
 	public JobStopException(Long jobExecutionId, Exception cause) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobServiceFactoryBean.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobServiceFactoryBean.java
@@ -21,10 +21,10 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.batch.core.configuration.support.MapJobRegistry;
 import org.springframework.batch.core.explore.JobExplorer;
-import org.springframework.batch.core.jsr.JsrJobParametersConverter;
-import org.springframework.batch.core.jsr.launch.JsrJobOperator;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.SimpleJobOperator;
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
@@ -323,13 +323,14 @@ public class SimpleJobServiceFactoryBean implements FactoryBean<JobService>, Ini
 	 */
 	@Override
 	public JobService getObject() throws Exception {
-		JsrJobParametersConverter jobParametersConverter = new JsrJobParametersConverter(dataSource);
-		jobParametersConverter.afterPropertiesSet();
-		JsrJobOperator jsrJobOperator = new JsrJobOperator(jobExplorer, jobRepository, jobParametersConverter,
-				transactionManager);
-		jsrJobOperator.afterPropertiesSet();
+
+		SimpleJobOperator jobOperator = new SimpleJobOperator();
+		jobOperator.setJobExplorer(this.jobExplorer);
+		jobOperator.setJobLauncher(this.jobLauncher);
+		jobOperator.setJobRepository(this.jobRepository);
+		jobOperator.setJobRegistry(new MapJobRegistry());
 		return new SimpleJobService(createJobInstanceDao(), createJobExecutionDao(), createStepExecutionDao(),
-			jobRepository, createExecutionContextDao(), jsrJobOperator, createAggregateJobQueryDao(), schemaVersionTarget);
+			jobRepository, createExecutionContextDao(), jobOperator, createAggregateJobQueryDao(), schemaVersionTarget);
 	}
 
 	/**

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/AggregateDataFlowTaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/AggregateDataFlowTaskConfiguration.java
@@ -58,6 +58,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.jdbc.support.MetaDataAccessException;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.sql.SQLException;
+
 /**
  * Configuration for DAO Containers use for multiple schema targets.
  *
@@ -78,7 +80,8 @@ public class AggregateDataFlowTaskConfiguration {
 	}
 
 	@Bean
-	public DataflowTaskExecutionDaoContainer dataflowTaskExecutionDao(DataSource dataSource, SchemaService schemaService, TaskProperties taskProperties) {
+	public DataflowTaskExecutionDaoContainer dataflowTaskExecutionDao(DataSource dataSource, SchemaService schemaService,
+																	  TaskProperties taskProperties) {
 		DataflowTaskExecutionDaoContainer result = new DataflowTaskExecutionDaoContainer();
 		for (SchemaVersionTarget target : schemaService.getTargets().getSchemas()) {
 			TaskProperties properties = new TaskProperties();
@@ -91,7 +94,9 @@ public class AggregateDataFlowTaskConfiguration {
 	}
 
 	@Bean
-	public DataflowTaskExecutionMetadataDaoContainer dataflowTaskExecutionMetadataDao(DataSource dataSource, SchemaService schemaService) {
+	public DataflowTaskExecutionMetadataDaoContainer dataflowTaskExecutionMetadataDao(DataSource dataSource,
+																					  SchemaService schemaService)
+		throws SQLException {
 		DataFieldMaxValueIncrementerFactory incrementerFactory = new MultiSchemaIncrementerFactory(dataSource);
 		String databaseType;
 		try {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataflowOAuthSecurityConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataflowOAuthSecurityConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.cloud.common.security.support.OnOAuth2SecurityEnabled
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 
 /**
  * Setup Spring Security OAuth for the Rest Endpoints of Spring Cloud Data Flow.
@@ -34,8 +35,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 public class DataflowOAuthSecurityConfiguration extends OAuthSecurityConfiguration {
 
 	@Override
-	protected void configure(HttpSecurity http) throws Exception {
-		super.configure(http);
+	protected HttpBasicConfigurer configure(HttpSecurity http) throws Exception {
+		return super.configure(http);
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
@@ -79,7 +79,7 @@ public class SpringDocAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebSecurityCustomizer springDocWebSecurityCustomizer() {
-		return (webSecurity -> webSecurity.ignoring().antMatchers(
+		return (webSecurity -> webSecurity.ignoring().requestMatchers(
 				"/swagger-ui/**",
 				getApiDocsPathContext() + "/**",
 				swaggerUiConfigProperties.getPath(),

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AboutController.java
@@ -18,9 +18,16 @@ package org.springframework.cloud.dataflow.server.controller;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -281,8 +288,11 @@ public class AboutController {
 			String version) {
 		String result = defaultValue;
 		if (result == null && StringUtils.hasText(url)) {
+			Lookup<ConnectionSocketFactory> connSocketFactoryLookup = RegistryBuilder.<ConnectionSocketFactory> create()
+				.register("http", new PlainConnectionSocketFactory())
+				.build();
 			CloseableHttpClient httpClient = HttpClients.custom()
-					.setSSLHostnameVerifier(new NoopHostnameVerifier())
+					.setConnectionManager(new BasicHttpClientConnectionManager(connSocketFactoryLookup))
 					.build();
 			HttpComponentsClientHttpRequestFactory requestFactory
 					= new HttpComponentsClientHttpRequestFactory();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
@@ -16,8 +16,10 @@
 
 package org.springframework.cloud.dataflow.server.job.support;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Date;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.cloud.dataflow.rest.job.CumulativeHistory;
@@ -51,18 +53,18 @@ public class StepExecutionProgressInfo {
 	public StepExecutionProgressInfo(StepExecution stepExecution, StepExecutionHistory stepExecutionHistory) {
 		this.stepExecution = stepExecution;
 		this.stepExecutionHistory = stepExecutionHistory;
-		Date startTime = stepExecution.getStartTime();
-		Date endTime = stepExecution.getEndTime();
+		LocalDateTime startTime = stepExecution.getStartTime();
+		LocalDateTime endTime = stepExecution.getEndTime();
 		if (endTime == null) {
-			endTime = new Date();
+			endTime = LocalDateTime.now();
 		}
 		else {
 			isFinished = true;
 		}
 		if (startTime == null) {
-			startTime = new Date();
+			startTime = LocalDateTime.now();
 		}
-		duration = endTime.getTime() - startTime.getTime();
+		duration = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
 		percentageComplete = calculatePercentageComplete();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/AggregateJobQueryDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/AggregateJobQueryDao.java
@@ -17,7 +17,6 @@ package org.springframework.cloud.dataflow.server.repository;
 
 
 import java.util.Date;
-import java.util.List;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobInstance;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowSqlPagingQueryUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/DataflowSqlPagingQueryUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.repository;
+
+import org.springframework.batch.item.database.support.AbstractSqlPagingQueryProvider;
+
+
+//TODO: Boot3x followup
+public class DataflowSqlPagingQueryUtils {
+
+	public static String generateRowNumSqlQueryWithNesting(AbstractSqlPagingQueryProvider provider,
+														   String innerSelectClause, String outerSelectClause,
+														   boolean remainingPageQuery, String rowNumClause) {
+		throw new UnsupportedOperationException("Need to create DataflowSqlPagingQueryUtils so that dataflow can call " +
+			"generateRowNumSqlQueryWithNesting");
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -254,10 +254,12 @@ public class DefaultTaskJobService implements TaskJobService {
 	 * identifying job parameters not in the original task execution arguments.
 	 */
 	private List<String> restartExecutionArgs(List<String> taskExecutionArgs, JobParameters jobParameters, String schemaTarget) {
+		if(schemaTarget.equals(SchemaVersionTarget.createDefault(AppBootSchemaVersion.BOOT2).getName())) {
+			throw new UnsupportedOperationException("Boot 2 operations are not supported");
+		}
 		List<String> result = new ArrayList<>(taskExecutionArgs);
-		String boot3Version = SchemaVersionTarget.createDefault(AppBootSchemaVersion.BOOT3).getName();
 		String type;
-		Map<String, JobParameter> jobParametersMap = jobParameters.getParameters();
+		Map<String, JobParameter<?>> jobParametersMap = jobParameters.getParameters();
 		for (String key : jobParametersMap.keySet()) {
 			if (!key.startsWith("-")) {
 				boolean existsFlag = false;
@@ -268,27 +270,8 @@ public class DefaultTaskJobService implements TaskJobService {
 					}
 				}
 				if (!existsFlag) {
-					String param;
-					if (boot3Version.equals(schemaTarget)) {
-						if (JobParameter.ParameterType.LONG.equals(jobParametersMap.get(key).getType())) {
-							type = Long.class.getCanonicalName();
-						} else if (JobParameter.ParameterType.DATE.equals(jobParametersMap.get(key).getType())) {
-							type = Date.class.getCanonicalName();
-						} else if (JobParameter.ParameterType.DOUBLE.equals(jobParametersMap.get(key).getType())) {
-							type = Double.class.getCanonicalName();
-						} else if (JobParameter.ParameterType.STRING.equals(jobParametersMap.get(key).getType())) {
-							type = String.class.getCanonicalName();
-						} else  {
-							throw new IllegalArgumentException("Unable to convert " +
-								jobParametersMap.get(key).getType() + " to known type of JobParameters");
-						}
-						param = String.format("%s=%s,%s", key, jobParametersMap.get(key).getValue(), type);
-					} else {
-						param = String.format("%s(%s)=%s", key,
-							jobParametersMap.get(key).getType().toString().toLowerCase(),
-							jobParameters.getString(key));
-					}
-					result.add(param);
+					type = jobParametersMap.get(key).getType().getCanonicalName();
+					result.add(String.format("%s=%s,%s", key, jobParametersMap.get(key).getValue(), type));
 				}
 			}
 		}
@@ -325,14 +308,14 @@ public class DefaultTaskJobService implements TaskJobService {
 		return taskJobExecutions;
 	}
 
+	//TODO: Boot3x followup Brute force replacement when checking for schema target.   Need to have executions only look for boot3
 	private TaskJobExecution getTaskJobExecutionWithStepCount(JobExecutionWithStepCount jobExecutionWithStepCount) {
-		SchemaVersionTarget schemaVersionTarget = aggregateExecutionSupport.findSchemaVersionTarget(jobExecutionWithStepCount.getJobConfigurationName(), taskDefinitionReader);
 		return new TaskJobExecution(
-				getTaskExecutionId(jobExecutionWithStepCount, schemaVersionTarget.getName()),
+				getTaskExecutionId(jobExecutionWithStepCount, "boot3"),
 				jobExecutionWithStepCount,
 				isTaskDefined(jobExecutionWithStepCount),
 				jobExecutionWithStepCount.getStepCount(),
-				schemaVersionTarget.getName()
+				"boot3"
 		);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -243,6 +243,7 @@ public class DefaultTaskJobService implements TaskJobService {
 
 	}
 
+	//TODO: Boot3x followup Remove boot2 check in this method once boot2 suuport code has been removed.
 	/**
 	 * Apply identifying job parameters to arguments.  There are cases (incrementers)
 	 * that add parameters to a job and thus must be added for each restart so that the

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DockerRegistryValidator.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/validation/DockerRegistryValidator.java
@@ -21,9 +21,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,19 +119,25 @@ public class DockerRegistryValidator {
 
 	private RestTemplate configureRestTemplate() {
 		CloseableHttpClient httpClient
-				= HttpClients.custom()
-				.setSSLHostnameVerifier(new NoopHostnameVerifier())
+				= httpClientBuilder()
 				.build();
 		HttpComponentsClientHttpRequestFactory requestFactory
 				= new HttpComponentsClientHttpRequestFactory();
 		requestFactory.setHttpClient(httpClient);
 		requestFactory.setConnectTimeout(dockerValidatiorProperties.getConnectTimeoutInMillis());
-		requestFactory.setReadTimeout(dockerValidatiorProperties.getReadTimeoutInMillis());
-
 		RestTemplate restTemplate = new RestTemplate(requestFactory);
 		return restTemplate;
 	}
 
+
+	private HttpClientBuilder httpClientBuilder() {
+		// Register http/s connection factories
+		Lookup<ConnectionSocketFactory> connSocketFactoryLookup = RegistryBuilder.<ConnectionSocketFactory> create()
+			.register("http", new PlainConnectionSocketFactory())
+			.build();
+		return HttpClients.custom()
+			.setConnectionManager(new BasicHttpClientConnectionManager(connSocketFactoryLookup));
+	}
 	private DockerAuth getDockerAuth() {
 		DockerAuth result = null;
 		String userName = dockerValidatiorProperties.getUserName();

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.server.batch;
 
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -388,22 +390,22 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 		DataFieldMaxValueIncrementer jobExecutionIncrementer = incrementerFactory.getIncrementer(databaseType.name(),
 				prefix + "JOB_EXECUTION_SEQ");
 		for (int i = 0; i < numberOfJobs; i++) {
-			JobExecution jobExecution = new JobExecution(jobInstance, null, name);
+			JobExecution jobExecution = new JobExecution(jobInstance, new JobParameters());
 			result.add(jobExecution);
 			jobExecution.setId(jobExecutionIncrementer.nextLongValue());
-			jobExecution.setStartTime(new Date());
+			jobExecution.setStartTime(LocalDateTime.now());
 			if (!isRunning) {
-				jobExecution.setEndTime(new Date());
+				jobExecution.setEndTime(LocalDateTime.now());
 			}
 			jobExecution.setVersion(3);
 			Timestamp startTime = jobExecution.getStartTime() == null ? null : Timestamp
-				.valueOf(jobExecution.getStartTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+				.valueOf(jobExecution.getStartTime().toInstant(OffsetDateTime.now().getOffset()).atZone(ZoneId.systemDefault()).toLocalDateTime());
 			Timestamp endTime = jobExecution.getEndTime() == null ? null : Timestamp
-				.valueOf(jobExecution.getEndTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+				.valueOf(jobExecution.getEndTime().toInstant(OffsetDateTime.now().getOffset()).atZone(ZoneId.systemDefault()).toLocalDateTime());
 			Timestamp createTime = jobExecution.getCreateTime() == null ? null : Timestamp
-				.valueOf(jobExecution.getCreateTime().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+				.valueOf(jobExecution.getCreateTime().toInstant(OffsetDateTime.now().getOffset()).atZone(ZoneId.systemDefault()).toLocalDateTime());
 			Timestamp lastUpdated = jobExecution.getLastUpdated() == null ? null : Timestamp
-				.valueOf(jobExecution.getLastUpdated().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+				.valueOf(jobExecution.getLastUpdated().toInstant(OffsetDateTime.now().getOffset()).atZone(ZoneId.systemDefault()).toLocalDateTime());
 			Object[] parameters = new Object[] { jobExecution.getId(), jobExecution.getJobId(), startTime, endTime,
 					batchStatus, jobExecution.getExitStatus().getExitCode(),
 					jobExecution.getExitStatus().getExitDescription(), jobExecution.getVersion(), createTime,
@@ -432,7 +434,7 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 			stepExecution.setId(stepExecutionIncrementer.nextLongValue());
 		}
 		if (stepExecution.getStartTime() == null) {
-			stepExecution.setStartTime(new Date());
+			stepExecution.setStartTime(LocalDateTime.now());
 		}
 		boolean isBatch4 = schemaVersionTarget.getSchemaVersion().equals(AppBootSchemaVersion.BOOT2);
 		Object[] parameters = isBatch4
@@ -441,7 +443,7 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 						stepExecution.getStatus().toString(), stepExecution.getLastUpdated() }
 				: new Object[] { stepExecution.getId(), stepExecution.getStepName(), stepExecution.getJobExecutionId(),
 						stepExecution.getStartTime(), stepExecution.getEndTime(), stepExecution.getVersion(),
-						stepExecution.getStatus().toString(), stepExecution.getLastUpdated(), new Date() };
+						stepExecution.getStatus().toString(), stepExecution.getLastUpdated(), LocalDateTime.now() };
 		String sql = getQuery(isBatch4 ? SAVE_STEP_EXECUTION_4 : SAVE_STEP_EXECUTION_5, schemaVersionTarget);
 		int[] argTypes4 = { Types.BIGINT, Types.VARCHAR, Types.BIGINT, Types.TIMESTAMP, Types.TIMESTAMP, Types.INTEGER,
 				Types.VARCHAR, Types.TIMESTAMP };
@@ -462,7 +464,7 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 		TaskRepository taskRepository = taskRepositoryContainer.get(appBootSchemaVersion);
 
 		TaskExecution taskExecution = new TaskExecution();
-		taskExecution.setStartTime(new Date());
+		taskExecution.setStartTime(LocalDateTime.now());
 		taskExecution = taskRepository.createTaskExecution(taskExecution);
 		getJdbcTemplate().execute(
 				String.format(INSERT_TASK_BATCH, taskPrefix, taskExecution.getExecutionId(), jobExecution.getJobId()));

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
@@ -126,7 +126,7 @@ public class SpringDocAutoConfigurationTests {
 		WebSecurity webSecurity = mock(WebSecurity.class, Answers.RETURNS_DEEP_STUBS);
 		customizer.customize(webSecurity);
 		ArgumentCaptor<String> antMatchersCaptor = ArgumentCaptor.forClass(String.class);
-		verify(webSecurity.ignoring()).antMatchers(antMatchersCaptor.capture());
+		verify(webSecurity.ignoring()).requestMatchers(antMatchersCaptor.capture());
 		assertThat(antMatchersCaptor.getAllValues()).containsExactly(expected);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.batch.BatchDataSourceInitializer;
+import org.springframework.boot.autoconfigure.batch.BatchDataSourceScriptDatabaseInitializer;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -111,7 +111,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.DefaultResourceLoader;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -412,9 +411,9 @@ public class JobDependencies {
 
 
 	@Bean
-	public BatchDataSourceInitializer batchRepositoryInitializerForDefaultDBForServer(DataSource dataSource,
-																					  ResourceLoader resourceLoader, BatchProperties properties) {
-		return new BatchDataSourceInitializer(dataSource, resourceLoader, properties);
+	public BatchDataSourceScriptDatabaseInitializer batchRepositoryInitializerForDefaultDBForServer(DataSource dataSource,
+																									BatchProperties properties) {
+		return new BatchDataSourceScriptDatabaseInitializer(dataSource, properties.getJdbc());
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
@@ -24,6 +24,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
@@ -89,7 +92,7 @@ public class JobExecutionThinControllerTests {
 	TaskDefinitionReader taskDefinitionReader;
 
 	@Before
-	public void setupMockMVC() {
+	public void setupMockMVC() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobRestartException {
 		this.mockMvc = JobExecutionUtils.createBaseJobExecutionMockMvc(
 				jobRepositoryContainer,
 				taskBatchDaoContainer,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -17,9 +17,9 @@
 package org.springframework.cloud.dataflow.server.controller;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -196,14 +196,14 @@ public class TaskControllerTests {
 
 		TaskExecution taskExecutionRunning = this.taskExecutionCreationService.createTaskExecution("myTask", null);
 		assertThat(taskExecutionRunning.getExecutionId()).isGreaterThan(0L);
-		taskExecutionRunning.setStartTime(new Date());
+		taskExecutionRunning.setStartTime(LocalDateTime.now());
 		taskExecutionRunning.setArguments(SAMPLE_ARGUMENT_LIST);
 		SchemaVersionTarget schemaVersionTarget = this.aggregateExecutionSupport.findSchemaVersionTarget("myTask", taskDefinitionReader);
 
 		TaskExecutionDao taskExecutionDao = this.taskExecutionDaoContainer.get(schemaVersionTarget.getName());
 		taskExecutionDao.startTaskExecution(taskExecutionRunning.getExecutionId(),
 				taskExecutionRunning.getTaskName(),
-				new Date(),
+				LocalDateTime.now(),
 				SAMPLE_ARGUMENT_LIST,
 				Long.toString(taskExecutionRunning.getExecutionId()));
 		taskExecutionRunning = taskExecutionDao.getTaskExecution(taskExecutionRunning.getExecutionId());
@@ -216,10 +216,10 @@ public class TaskControllerTests {
 		taskExecutionDao = this.taskExecutionDaoContainer.get(schemaVersionTarget2.getName());
 		taskExecutionDao.startTaskExecution(taskExecutionComplete.getExecutionId(),
 				taskExecutionComplete.getTaskName(),
-				new Date(),
+				LocalDateTime.now(),
 				SAMPLE_ARGUMENT_LIST,
 				Long.toString(taskExecutionComplete.getExecutionId()));
-		taskExecutionDao.completeTaskExecution(taskExecutionComplete.getExecutionId(), 0, new Date(), null);
+		taskExecutionDao.completeTaskExecution(taskExecutionComplete.getExecutionId(), 0, LocalDateTime.now(), null);
 		taskExecutionComplete = taskExecutionDao.getTaskExecution(taskExecutionComplete.getExecutionId());
 		dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget2.getName());
 		dataflowTaskExecutionMetadataDao.save(taskExecutionComplete, taskManifest);
@@ -754,8 +754,8 @@ public class TaskControllerTests {
 		final TaskExecution taskExecutionComplete = this.taskExecutionCreationService.createTaskExecution("myTask3", null);
 		assertThat(taskExecutionComplete.getExecutionId()).isGreaterThan(0L);
 		taskExecutionComplete.setTaskName("myTask3");
-		taskExecutionComplete.setStartTime(new Date());
-		taskExecutionComplete.setEndTime(new Date());
+		taskExecutionComplete.setStartTime(LocalDateTime.now());
+		taskExecutionComplete.setEndTime(LocalDateTime.now());
 		taskExecutionComplete.setExitCode(0);
 		repository.save(new TaskDefinition("myTask3", "foo"));
 		this.registry.save("foo", ApplicationType.task,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerCleanupAsyncTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerCleanupAsyncTests.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import org.awaitility.Awaitility;
@@ -141,8 +141,8 @@ public class TaskExecutionControllerCleanupAsyncTests {
 
 		List<String> taskArgs = new ArrayList<>();
 		taskArgs.add("foo=bar");
-		TaskExecution taskExecution1 = taskExecutionDao.createTaskExecution(taskName, new Date(), taskArgs, taskExecutionId);
-		taskExecutionDao.createTaskExecution(taskName, new Date(), taskArgs, taskExecutionId, taskExecution1.getExecutionId());
+		TaskExecution taskExecution1 = taskExecutionDao.createTaskExecution(taskName, LocalDateTime.now(), taskArgs, taskExecutionId);
+		taskExecutionDao.createTaskExecution(taskName, LocalDateTime.now(), taskArgs, taskExecutionId, taskExecution1.getExecutionId());
 
 		TaskDeployment taskDeployment = new TaskDeployment();
 		taskDeployment.setTaskDefinitionName(taskName);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/SchemaGenerationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/repository/SchemaGenerationTests.java
@@ -25,7 +25,9 @@ import java.util.stream.Collectors;
 import jakarta.persistence.spi.PersistenceUnitInfo;
 
 import org.hibernate.HibernateException;
+
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
@@ -39,7 +41,6 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
-import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -102,7 +103,7 @@ public class SchemaGenerationTests {
 		final MetadataSources metadata = new MetadataSources(
 				new StandardServiceRegistryBuilder()
 					.applySetting("hibernate.dialect", "org.hibernate.dialect." + dialect + "Dialect")
-					.applySetting("hibernate.physical_naming_strategy", SpringPhysicalNamingStrategy.class.getName())
+					.applySetting("hibernate.physical_naming_strategy", CamelCaseToUnderscoresNamingStrategy.class.getName())
 					.applySetting("hibernate.implicit_naming_strategy", SpringImplicitNamingStrategy.class.getName())
 					.build());
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskDeleteServiceTests.java
@@ -17,10 +17,10 @@
 package org.springframework.cloud.dataflow.server.service.impl;
 
 import javax.sql.DataSource;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -176,9 +176,9 @@ public abstract class DefaultTaskDeleteServiceTests {
 		TaskRepository taskRepository = this.taskRepositoryContainer.get(schemaVersionTarget.getName());
 		for (int i = 1; i <= numberOfExecutions; i++) {
 			TaskExecution taskExecution = taskRepository.createTaskExecution(new TaskExecution(i, 0, TASK_NAME_ORIG,
-					new Date(), new Date(), "", args, "", null,
+					LocalDateTime.now(), LocalDateTime.now(), "", args, "", null,
 					null));
-			taskRepository.completeTaskExecution(taskExecution.getExecutionId(), 0, new Date(), "complete");
+			taskRepository.completeTaskExecution(taskExecution.getExecutionId(), 0, LocalDateTime.now(), "complete");
 			JobExecution jobExecution = this.jobLauncherTestUtils.launchJob();
 			TaskBatchDao taskBatchDao = taskBatchDaoContainer.get(SchemaVersionTarget.defaultTarget().getName());
 			taskBatchDao.saveRelationship(taskExecution, jobExecution);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionServiceTests.java
@@ -19,9 +19,9 @@ package org.springframework.cloud.dataflow.server.service.impl;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -250,7 +250,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			this.launcherRepository.save(new Launcher(TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, TaskPlatformFactory.CLOUDFOUNDRY_PLATFORM_TYPE, taskLauncher));
 			initializeSuccessfulRegistry(appRegistry);
 			SchemaVersionTarget schemaVersionTarget = aggregateExecutionSupport.findSchemaVersionTarget(TASK_NAME_ORIG, taskDefinitionReader);
-			TaskExecution taskExecution = new TaskExecution(1, 0, TASK_NAME_ORIG, new Date(), new Date(), "", Collections.emptyList(), "", null, null);
+			TaskExecution taskExecution = new TaskExecution(1, 0, TASK_NAME_ORIG, LocalDateTime.now(), LocalDateTime.now(), "", Collections.emptyList(), "", null, null);
 			TaskRepository taskRepository = taskRepositoryContainer.get(schemaVersionTarget.getName());
 			taskRepository.createTaskExecution(taskExecution);
 			TaskManifest taskManifest = new TaskManifest();
@@ -395,8 +395,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
+			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, LocalDateTime.now(), null);
 
 
 			when(taskLauncher.launch(any())).thenReturn("0");
@@ -420,7 +420,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask(TASK_NAME_ORIG, properties, new LinkedList<>());
 			long firstTaskExecutionId = launchResponse.getExecutionId();
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(launchResponse.getSchemaTarget());
-			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			this.taskExecutionService.executeTask(TASK_NAME_ORIG, Collections.emptyMap(), new LinkedList<>());
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(launchResponse.getSchemaTarget());
 			TaskManifest lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
@@ -446,7 +446,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask("t1", properties, new LinkedList<>());
 			long firstTaskExecutionId = launchResponse.getExecutionId();
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(launchResponse.getSchemaTarget());
-			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(launchResponse.getSchemaTarget());
 			TaskManifest lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest("t1");
 
@@ -471,7 +471,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask("t1", properties, new LinkedList<>());
 			long firstTaskExecutionId = launchResponse.getExecutionId();
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(launchResponse.getSchemaTarget());
-			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(launchResponse.getSchemaTarget());
 			TaskManifest lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest("t1");
 
@@ -485,7 +485,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			long secondTaskExecutionId = launchResponse2.getExecutionId();
 
 			taskRepository = taskRepositoryContainer.get(launchResponse2.getSchemaTarget());
-			taskRepository.completeTaskExecution(secondTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(secondTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(launchResponse2.getSchemaTarget());
 			lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest("t1");
 			// without passing version, we should not get back to default app, in this case foo-task100
@@ -511,7 +511,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			long firstTaskExecutionId = launchResponse.getExecutionId();
 			SchemaVersionTarget schemaVersionTarget = aggregateExecutionSupport.findSchemaVersionTarget("t2", taskDefinitionReader);
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(schemaVersionTarget.getName());
-			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			TaskManifest lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest("t2");
 
@@ -536,7 +536,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask(TASK_NAME_ORIG, properties, new LinkedList<>());
 			long firstTaskExecutionId = launchResponse.getExecutionId();
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(launchResponse.getSchemaTarget());
-			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, new Date(), "all done");
+			taskRepository.completeTaskExecution(firstTaskExecutionId, 0, LocalDateTime.now(), "all done");
 			this.taskExecutionService.executeTask(TASK_NAME_ORIG, Collections.emptyMap(), new LinkedList<>());
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(launchResponse.getSchemaTarget());
 			TaskManifest lastManifest = dataflowTaskExecutionMetadataDao.getLatestManifest(TASK_NAME_ORIG);
@@ -575,7 +575,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
 			taskRepository.updateExternalExecutionId(myTask.getExecutionId(), "abc");
 			when(this.taskLauncher.launch(any())).thenReturn("abc");
 			when(this.taskLauncher.status("abc")).thenReturn(new TaskStatus("abc", LaunchState.running, new HashMap<>()));
@@ -602,7 +602,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
 			taskRepository.updateExternalExecutionId(myTask.getExecutionId(), "abc");
 			when(this.taskLauncher.launch(any())).thenReturn("abc");
 			when(this.taskLauncher.status("abc")).thenReturn(new TaskStatus("abc", LaunchState.failed, new HashMap<>()));
@@ -627,8 +627,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
+			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, LocalDateTime.now(), null);
 			taskRepository.updateExternalExecutionId(myTask.getExecutionId(), "0");
 
 			initializeSuccessfulRegistry(appRegistry);
@@ -688,8 +688,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
+			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, LocalDateTime.now(), null);
 
 			initializeSuccessfulRegistry(appRegistry);
 
@@ -725,8 +725,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
+			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, LocalDateTime.now(), null);
 
 			initializeSuccessfulRegistry(appRegistry);
 
@@ -757,8 +757,8 @@ public abstract class DefaultTaskExecutionServiceTests {
 			manifest.setTaskDeploymentRequest(request);
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
-			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, new Date(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
+			taskRepository.completeTaskExecution(myTask.getExecutionId(), 0, LocalDateTime.now(), null);
 
 			initializeSuccessfulRegistry(appRegistry);
 
@@ -796,7 +796,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 			DataflowTaskExecutionMetadataDao dataflowTaskExecutionMetadataDao = this.dataflowTaskExecutionMetadataDaoContainer.get(schemaVersionTarget.getName());
 			dataflowTaskExecutionMetadataDao.save(myTask, manifest);
-			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, new Date(), new ArrayList<>(), null);
+			taskRepository.startTaskExecution(myTask.getExecutionId(), TASK_NAME_ORIG, LocalDateTime.now(), new ArrayList<>(), null);
 			taskRepository.updateExternalExecutionId(myTask.getExecutionId(), "abc");
 			when(this.taskLauncher.launch(any())).thenReturn("abc");
 			when(this.taskLauncher.status("abc")).thenReturn(new TaskStatus("abc", LaunchState.running, new HashMap<>()));
@@ -928,7 +928,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(schemaVersionTarget.getName());
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 			assertThat(launchResponse.getExecutionId()).isEqualTo(1L);
-			TaskExecution taskExecution = new TaskExecution(2L, 0, "childTask", new Date(), new Date(), "", Collections.emptyList(), "", "1234A", 1L);
+			TaskExecution taskExecution = new TaskExecution(2L, 0, "childTask", LocalDateTime.now(), LocalDateTime.now(), "", Collections.emptyList(), "", "1234A", 1L);
 			taskRepository.createTaskExecution(taskExecution);
 			Set<Long> executionIds = new HashSet<>(1);
 			executionIds.add(2L);
@@ -945,7 +945,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 			LaunchResponse launchResponse = this.taskExecutionService.executeTask(TASK_NAME_ORIG, new HashMap<>(), new LinkedList<>());
 			assertThat(launchResponse.getExecutionId()).isEqualTo(1L);
-			TaskExecution taskExecution = new TaskExecution(2L, 0, "childTask", new Date(), new Date(), "", Collections.emptyList(), "", "1234A", null);
+			TaskExecution taskExecution = new TaskExecution(2L, 0, "childTask", LocalDateTime.now(), LocalDateTime.now(), "", Collections.emptyList(), "", "1234A", null);
 			TaskRepository taskRepository = taskRepositoryContainer.get(launchResponse.getSchemaTarget());
 			taskRepository.createTaskExecution(taskExecution);
 			Set<Long> executionIds = new HashSet<>(1);
@@ -981,7 +981,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 
 			TaskRepository taskRepository = this.taskRepositoryContainer.get(launchResponse.getSchemaTarget());
 			TaskExecution taskExecution = taskRepository.createTaskExecution();
-			taskRepository.startTaskExecution(taskExecution.getExecutionId(), "invalidChildTaskExecution", new Date(), Collections.emptyList(), null, 1L);
+			taskRepository.startTaskExecution(taskExecution.getExecutionId(), "invalidChildTaskExecution", LocalDateTime.now(), Collections.emptyList(), null, 1L);
 			validateFailedTaskStop(2, launchResponse.getSchemaTarget());
 		}
 
@@ -1086,7 +1086,7 @@ public abstract class DefaultTaskExecutionServiceTests {
 			taskDeployment.setTaskDefinitionName(taskName);
 			this.taskDeploymentRepository.save(taskDeployment);
 			TaskExecution taskExecution = new TaskExecution();
-			taskExecution.setStartTime(new Date());
+			taskExecution.setStartTime(LocalDateTime.now());
 			taskExecution.setTaskName(taskName);
 			taskExecution.setExternalExecutionId("12346");
 			SchemaVersionTarget schemaVersionTarget = aggregateExecutionSupport.findSchemaVersionTarget(taskName, taskDefinitionReader);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/support/ArgumentSanitizerTest.java
@@ -66,20 +66,20 @@ public class ArgumentSanitizerTest {
 	public void testSanitizeJobParameters() {
 		String[] JOB_PARAM_KEYS = {"username", "password", "name", "C", "D", "E"};
 		Date testDate = new Date();
-		JobParameter[] PARAMETERS = {new JobParameter("foo", true),
-				new JobParameter("bar", true),
-				new JobParameter("baz", true),
-				new JobParameter(1L, true),
-				new JobParameter(1D, true),
-				new JobParameter(testDate, false)};
+		JobParameter[] PARAMETERS = {new JobParameter("foo", String.class, true),
+				new JobParameter("bar", String.class, true),
+				new JobParameter("baz", String.class, true),
+				new JobParameter(1L, Long.class, true),
+				new JobParameter(1D, Double.class, true),
+				new JobParameter(testDate, Date.class, false)};
 
-		Map<String, JobParameter> jobParamMap = new LinkedHashMap<>();
+		Map<String, JobParameter<?>> jobParamMap = new LinkedHashMap<>();
 		for (int paramCount = 0; paramCount < JOB_PARAM_KEYS.length; paramCount++) {
 			jobParamMap.put(JOB_PARAM_KEYS[paramCount], PARAMETERS[paramCount]);
 		}
 		JobParameters jobParameters = new JobParameters(jobParamMap);
 		JobParameters sanitizedJobParameters = this.sanitizer.sanitizeJobParameters(jobParameters);
-		for(Map.Entry<String, JobParameter> entry : sanitizedJobParameters.getParameters().entrySet()) {
+		for(Map.Entry<String, JobParameter<?>> entry : sanitizedJobParameters.getParameters().entrySet()) {
 			if (entry.getKey().equals("username") || entry.getKey().equals("password")) {
 				Assert.assertEquals("******", entry.getValue().getValue());
 			}

--- a/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
+++ b/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
@@ -26,7 +26,7 @@ import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
-import org.springframework.cloud.task.configuration.MetricsAutoConfiguration;
+import org.springframework.cloud.task.configuration.observation.ObservationTaskAutoConfiguration;
 import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
 
 /**
@@ -37,7 +37,7 @@ import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
  * @author Janne Valkealahti
  */
 @SpringBootApplication(exclude = {
-		MetricsAutoConfiguration.class,
+		ObservationTaskAutoConfiguration.class,
 		SessionAutoConfiguration.class,
 		SimpleTaskAutoConfiguration.class,
 		ManagementWebSecurityAutoConfiguration.class,

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/JobExecutionTestUtils.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/JobExecutionTestUtils.java
@@ -18,9 +18,8 @@ package org.springframework.cloud.dataflow.server.db.migration;
 
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.ZoneId;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 
 import javax.sql.DataSource;
 
@@ -88,13 +87,13 @@ class JobExecutionTestUtils
 		// BATCH_JOB_EXECUTION differs and the DAO can not be used for BATCH4/5 inserting
 		DataFieldMaxValueIncrementer jobExecutionIncrementer = incrementerFactory.getIncrementer(incrementerFallbackType.name(), schemaVersionTarget.getBatchPrefix() + "JOB_EXECUTION_SEQ");
 		TaskBatchDao taskBatchDao = this.taskBatchDaoContainer.get(schemaVersion);
-		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, new Date(), new ArrayList<>(), null);
+		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, LocalDateTime.now(), new ArrayList<>(), null);
 		JobInstance jobInstance = jobInstanceDao.createJobInstance(jobName, jobParameters);
 		for (int i = 0; i < jobExecutionCount; i++) {
 			JobExecution jobExecution = new JobExecution(jobInstance, new JobParameters());
 			jobExecution.setStatus(batchStatus);
 			jobExecution.setId(jobExecutionIncrementer.nextLongValue());
-			jobExecution.setStartTime(new Date());
+			jobExecution.setStartTime(LocalDateTime.now());
 			saveJobExecution(jobExecution, jdbcTemplate, schemaVersionTarget);
 			taskBatchDao.saveRelationship(taskExecution, jobExecution);
 		}
@@ -115,7 +114,7 @@ class JobExecutionTestUtils
 	}
 
 	private JobExecution saveJobExecution(JobExecution jobExecution, JdbcTemplate jdbcTemplate, SchemaVersionTarget schemaVersionTarget) {
-		jobExecution.setStartTime(new Date());
+		jobExecution.setStartTime(LocalDateTime.now());
 		jobExecution.setVersion(1);
 		Timestamp startTime = timestampFromDate(jobExecution.getStartTime());
 		Timestamp endTime = timestampFromDate(jobExecution.getEndTime());
@@ -134,8 +133,8 @@ class JobExecutionTestUtils
 		return jobExecution;
 	}
 
-	private Timestamp timestampFromDate(Date date) {
-		return (date != null) ? Timestamp.valueOf(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()) : null;
+	private Timestamp timestampFromDate(LocalDateTime date) {
+		return (date != null) ? Timestamp.valueOf(date) : null;
 	}
 
 

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/HttpCommands.java
@@ -157,14 +157,14 @@ public class HttpCommands {
 		restTemplate.setErrorHandler(new ResponseErrorHandler() {
 			@Override
 			public boolean hasError(ClientHttpResponse response) throws IOException {
-				HttpStatus status = response.getStatusCode();
+				HttpStatus status = (HttpStatus) response.getStatusCode();
 				return (status == HttpStatus.BAD_GATEWAY || status == HttpStatus.GATEWAY_TIMEOUT
 						|| status == HttpStatus.INTERNAL_SERVER_ERROR);
 			}
 
 			@Override
 			public void handleError(ClientHttpResponse response) throws IOException {
-				outputError(response.getStatusCode(), buffer);
+				outputError((HttpStatus)response.getStatusCode(), buffer);
 			}
 		});
 
@@ -181,7 +181,7 @@ public class HttpCommands {
 	}
 
 	private void outputResponse(ResponseEntity<String> response, StringBuilder buffer) {
-		buffer.append("> ").append(response.getStatusCode().value()).append(" ").append(response.getStatusCode().name())
+		buffer.append("> ").append(response.getStatusCode().value()).append(" ").append(((HttpStatus)response.getStatusCode()).name())
 				.append(System.lineSeparator());
 		String maybeJson = response.getBody();
 		if (maybeJson != null) {

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
@@ -150,13 +150,13 @@ public class JobCommands {
 				.addValue(jobExecutionResource.isDefined() ? "Created" : "Destroyed");
 		modelBuilder.addRow().addValue("Schema Target").addValue(jobExecutionResource.getSchemaTarget());
 		modelBuilder.addRow().addValue("Job Parameters ").addValue("");
-		for (Map.Entry<String, JobParameter> jobParameterEntry : jobExecutionResource.getJobExecution()
+		for (Map.Entry<String, JobParameter<?>> jobParameterEntry : jobExecutionResource.getJobExecution()
 				.getJobParameters().getParameters().entrySet()) {
 			String key = org.springframework.util.StringUtils.trimLeadingCharacter(jobParameterEntry.getKey(), '-');
 			if (!jobParameterEntry.getValue().isIdentifying()) {
 				key = "-" + key;
 			}
-			String updatedKey = String.format("%s(%s) ", key, jobParameterEntry.getValue().getType().name());
+			String updatedKey = String.format("%s(%s) ", key, jobParameterEntry.getValue().getType().getName());
 			modelBuilder.addRow().addValue(updatedKey).addValue(new ArgumentSanitizer().sanitize(key, String.valueOf(jobParameterEntry.getValue())));
 		}
 

--- a/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpClientConfigurer.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/util/HttpClientConfigurer.java
@@ -17,14 +17,11 @@ package org.springframework.cloud.skipper.client.util;
 
 import java.net.URI;
 
-import javax.net.ssl.SSLContext;
-
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
@@ -102,7 +99,6 @@ public class HttpClientConfigurer {
 
 	public HttpClientConfigurer targetHost(URI targetHost) {
 		this.targetHost = new HttpHost(targetHost.getScheme(), targetHost.getHost(), targetHost.getPort());
-
 		return this;
 	}
 

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -49,7 +49,10 @@
 		<dependency>
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-micrometer</artifactId>
-			<version>6.1.7.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.orm</groupId>
+			<artifactId>hibernate-ant</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -143,6 +146,10 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
 		</dependency>
 		<!-- commons lang needed for date-format-yaml? -->
 		<dependency>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/security/SkipperOAuthSecurityConfiguration.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/security/SkipperOAuthSecurityConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -48,7 +49,7 @@ public class SkipperOAuthSecurityConfiguration extends OAuthSecurityConfiguratio
 	private AuthorizationProperties authorizationProperties;
 
 	@Override
-	protected void configure(HttpSecurity http) throws Exception {
+	protected HttpBasicConfigurer configure(HttpSecurity http) throws Exception {
 
 		final BasicAuthenticationEntryPoint basicAuthenticationEntryPoint = new BasicAuthenticationEntryPoint();
 		basicAuthenticationEntryPoint.setRealmName(SecurityConfigUtils.BASIC_AUTH_REALM_NAME);
@@ -69,10 +70,10 @@ public class SkipperOAuthSecurityConfiguration extends OAuthSecurityConfiguratio
 
 		ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry security =
 				http.authorizeRequests()
-						.antMatchers(getAuthorizationProperties().getPermitAllPaths()
+						.requestMatchers(getAuthorizationProperties().getPermitAllPaths()
 								.toArray(new String[0]))
 						.permitAll()
-						.antMatchers(getAuthorizationProperties().getAuthenticatedPaths()
+						.requestMatchers(getAuthorizationProperties().getAuthenticatedPaths()
 								.toArray(new String[0]))
 						.authenticated();
 
@@ -99,5 +100,6 @@ public class SkipperOAuthSecurityConfiguration extends OAuthSecurityConfiguratio
 		}
 
 		getSecurityStateBean().setAuthenticationEnabled(true);
+		return http.getConfigurer(HttpBasicConfigurer.class);
 	}
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/SkipperFlywayMigrationStrategy.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/SkipperFlywayMigrationStrategy.java
@@ -16,8 +16,8 @@
 package org.springframework.cloud.skipper.server.db.migration;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.CoreMigrationType;
 import org.flywaydb.core.api.MigrationInfo;
-import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,7 @@ public class SkipperFlywayMigrationStrategy implements FlywayMigrationStrategy {
 	@Override
 	public void migrate(Flyway flyway) {
 		MigrationInfo current = flyway.info().current();
-		if (current != null && current.getVersion().equals(INITIAL) && current.getType() == MigrationType.SQL) {
+		if (current != null && current.getVersion().equals(INITIAL) && current.getType() == CoreMigrationType.SQL) {
 			logger.info("Detected initial version based on SQL scripts, doing repair to switch to Java based migrations.");
 			flyway.repair();
 		}

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
@@ -15,21 +15,21 @@
  */
 package org.springframework.cloud.skipper.server.domain;
 
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hibernate.annotations.Type;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
 
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AbstractEntity;
@@ -53,7 +53,7 @@ public class AppDeployerData extends AbstractEntity {
 
 	// Store deployment Ids associated with the given release.
 	@Lob
-	@Type(type = "org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobType")
+	@JdbcTypeCode(Types.LONGVARCHAR)
 	private String deploymentData;
 
 	public AppDeployerData() {

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletContext;
-
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.skipper.server.controller.docs;
 
 import jakarta.servlet.RequestDispatcher;
-
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/SchemaGenerationTests.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/SchemaGenerationTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import jakarta.persistence.spi.PersistenceUnitInfo;
-
 import org.hibernate.HibernateException;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -35,9 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
-import org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
 import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.data.mapping.model.CamelCaseAbbreviatingFieldNamingStrategy;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,7 +85,7 @@ public class SchemaGenerationTests extends AbstractIntegrationTest {
 		final MetadataSources metadata = new MetadataSources(
 				new StandardServiceRegistryBuilder()
 						.applySetting("hibernate.dialect", "org.hibernate.dialect." + dialect + "Dialect")
-						.applySetting("hibernate.physical_naming_strategy", SpringPhysicalNamingStrategy.class.getName())
+						.applySetting("hibernate.physical_naming_strategy", CamelCaseAbbreviatingFieldNamingStrategy.class.getName())
 						.applySetting("hibernate.implicit_naming_strategy", SpringImplicitNamingStrategy.class.getName())
 						.build());
 

--- a/spring-cloud-skipper/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ManifestCommands.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ManifestCommands.java
@@ -16,7 +16,6 @@
 package org.springframework.cloud.skipper.shell.command;
 
 import jakarta.validation.constraints.NotNull;
-
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 

--- a/spring-cloud-skipper/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import jakarta.validation.constraints.NotNull;
-
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/local/security/LdapServerResource.java
@@ -27,7 +27,6 @@ import org.springframework.security.ldap.server.ApacheDSContainer;
 import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
-import org.springframework.util.SocketUtils;
 
 /**
  * @author Marius Bogoevici

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
@@ -38,7 +38,6 @@ import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoa
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.util.TestSocketUtils;
-import org.springframework.util.SocketUtils;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalDataflowResource.java
@@ -57,11 +57,9 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.test.util.TestSocketUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.util.SocketUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
* Batch removed some methods that are still required by dataflow. 
  * Created dataflow version of those classes so that we can implement those methods
* Removed hibernate version from skipper (use boot's bom)
* Updated Skipper so that it is 3.0 compliant. 
* Update classic docs to be restful doc 3.0 compliant
* Disabled CTR, TaskLauncher, SingleStepBatch jobs for this effort.  Will need be addressed when worked on.

* Work to be done once merged:
  * Check to see if versions are up to date in modules
  * Remove versions when possible ( use boot's bom)
  * Deprecations were not updated in this process.  This still needs to be done.