### PR TITLE
Update scdf common deps (see below)

### DIFF
--- a/spring-cloud-dataflow-common/pom.xml
+++ b/spring-cloud-dataflow-common/pom.xml
@@ -18,8 +18,7 @@
 	</parent>
 
 	<properties>
-		<jayway-awaitility.version>1.7.0</jayway-awaitility.version>
-		<java-semver.version>0.9.0</java-semver.version>
+		<java-semver.version>0.10.2</java-semver.version>
 		<joda-time.version>2.12.7</joda-time.version>
 	</properties>
 
@@ -33,11 +32,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<groupId>com.jayway.awaitility</groupId>
-				<artifactId>awaitility</artifactId>
-				<version>${jayway-awaitility.version}</version>
-			</dependency>
 			<dependency>
 				<groupId>com.github.zafarkhaja</groupId>
 				<artifactId>java-semver</artifactId>

--- a/spring-cloud-dataflow-common/pom.xml
+++ b/spring-cloud-dataflow-common/pom.xml
@@ -50,19 +50,6 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
-				<configuration>
-					<source>17</source>
-					<target>17</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 	<profiles>
 		<profile>
 			<id>spring</id>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-flyway/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-flyway/pom.xml
@@ -62,16 +62,5 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
-				<configuration>
-					<source>17</source>
-					<target>17</target>
-				</configuration>
-			</plugin>
-		</plugins>
 	</build>
 </project>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/pom.xml
@@ -39,15 +39,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
-				<configuration>
-					<source>17</source>
-					<target>17</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin.version}</version>
 				<executions>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
@@ -35,7 +35,7 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.jayway.awaitility</groupId>
+			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 		</dependency>
 		<dependency>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/pom.xml
@@ -52,17 +52,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
-				<configuration>
-					<source>17</source>
-					<target>17</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/connection/waiting/ClusterWait.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/connection/waiting/ClusterWait.java
@@ -15,16 +15,17 @@
  */
 package org.springframework.cloud.dataflow.common.test.docker.compose.connection.waiting;
 
-import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.core.ConditionTimeoutException;
-
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.joda.time.ReadableDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.dataflow.common.test.docker.compose.connection.Cluster;
 
 public class ClusterWait {

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/execution/DefaultDockerCompose.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/execution/DefaultDockerCompose.java
@@ -15,13 +15,6 @@
  */
 package org.springframework.cloud.dataflow.common.test.docker.compose.execution;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.commons.lang3.Validate.validState;
-import static org.joda.time.Duration.standardMinutes;
-
-import com.github.zafarkhaja.semver.Version;
-import com.jayway.awaitility.Awaitility;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -29,10 +22,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
+import com.github.zafarkhaja.semver.Version;
 import org.apache.commons.io.IOUtils;
+import org.awaitility.Awaitility;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.dataflow.common.test.docker.compose.configuration.DockerComposeFiles;
 import org.springframework.cloud.dataflow.common.test.docker.compose.configuration.ProjectName;
 import org.springframework.cloud.dataflow.common.test.docker.compose.connection.Container;
@@ -41,6 +38,10 @@ import org.springframework.cloud.dataflow.common.test.docker.compose.connection.
 import org.springframework.cloud.dataflow.common.test.docker.compose.connection.DockerMachine;
 import org.springframework.cloud.dataflow.common.test.docker.compose.connection.Ports;
 import org.springframework.util.StringUtils;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.lang3.Validate.validState;
+import static org.joda.time.Duration.standardMinutes;
 
 public class DefaultDockerCompose implements DockerCompose {
 

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/test/java/org/springframework/cloud/dataflow/common/test/docker/compose/connection/ContainerIntegrationTests.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/test/java/org/springframework/cloud/dataflow/common/test/docker/compose/connection/ContainerIntegrationTests.java
@@ -15,29 +15,24 @@
  */
 package org.springframework.cloud.dataflow.common.test.docker.compose.connection;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeThat;
-import static org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerComposeExecArgument.arguments;
-import static org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerComposeExecOption.noOptions;
-
-import com.github.zafarkhaja.semver.Version;
-import com.jayway.awaitility.core.ConditionFactory;
-
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+
+import org.awaitility.core.ConditionFactory;
 import org.junit.Test;
-import org.mockito.internal.matchers.GreaterOrEqual;
+
 import org.springframework.cloud.dataflow.common.test.docker.compose.configuration.DockerComposeFiles;
 import org.springframework.cloud.dataflow.common.test.docker.compose.configuration.ProjectName;
-import org.springframework.cloud.dataflow.common.test.docker.compose.connection.Container;
-import org.springframework.cloud.dataflow.common.test.docker.compose.connection.DockerMachine;
-import org.springframework.cloud.dataflow.common.test.docker.compose.connection.State;
 import org.springframework.cloud.dataflow.common.test.docker.compose.execution.DefaultDockerCompose;
 import org.springframework.cloud.dataflow.common.test.docker.compose.execution.Docker;
 import org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerCompose;
 import org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerExecutable;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerComposeExecArgument.arguments;
+import static org.springframework.cloud.dataflow.common.test.docker.compose.execution.DockerComposeExecOption.noOptions;
 
 public class ContainerIntegrationTests {
 


### PR DESCRIPTION
* Remove duplicated maven-source-plugin from `spring-cloud-dataflow-common/**`

* Update Awaitility and Semver libs

This commit removes the dependency management for `com.jayway.awaitility` in
favor of the Spring Boot managed version at the new `org.awaitility`
coordinates.

* Also, the Semver lib is updated to 0.10.2

