### PR TITLE
Fix startup and EPP ordering

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -48,6 +49,11 @@ import org.springframework.core.io.Resource;
 public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
 	private static final Logger logger = LoggerFactory.getLogger(DefaultEnvironmentPostProcessor.class);
+
+	/**
+	 * The order for the processor - must run before the {@link ConfigDataEnvironmentPostProcessor}.
+	 */
+	public static final int ORDER = ConfigDataEnvironmentPostProcessor.ORDER - 5;
 
 	private final Resource serverResource = new ClassPathResource("/dataflow-server.yml");
 
@@ -106,6 +112,6 @@ public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor
 
 	@Override
 	public int getOrder() {
-		return 0;
+		return ORDER;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -52,6 +52,8 @@ server:
   error:
     include-message: always
 spring:
+  config:
+    use-legacy-processing: true
   mvc.async.request-timeout: 120000
   batch:
     initialize-schema: never


### PR DESCRIPTION
This gets past the server startup error @jvalkeal .

2 things...

**ONE** as you mentioned, we have to adjust ordering - but the important piece is that we run before the ConfigDataEPP (otherwise it will never see our dataflow-server-defaults).

**TWO** we opt-out of the new config server model via `spring.config.use-legacy-processing` for now. 

Now when you `java -jar target/spring-cloud-dataflow-server-3.0.0-SNAPSHOT.jar` it starts up. Onto the next failure - complaining about Flyway - BUT I did not have DB running so....