### PR TITLE
Update SpringDoc OpenAPI to latest 2.x

### DIFF
--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -43,7 +43,7 @@
 		<wavefront-spring-boot-bom.version>2.3.4</wavefront-spring-boot-bom.version>
 		<spring-cloud-dataflow-apps-docs-plugin.version>1.0.7</spring-cloud-dataflow-apps-docs-plugin.version>
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.7</spring-cloud-dataflow-apps-metadata-plugin.version>
-		<springdoc-openapi-ui.version>1.6.6</springdoc-openapi-ui.version>
+		<springdoc-openapi.version>2.3.0</springdoc-openapi.version>
 		<!-- update to ensure it is same as spring-boot-dependencies property, which doesn't seem to be imported -->
 		<spring-security.version>5.7.11</spring-security.version>
 		<guava.version>32.1.3-jre</guava.version>
@@ -221,8 +221,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springdoc</groupId>
-				<artifactId>springdoc-openapi-ui</artifactId>
-				<version>${springdoc-openapi-ui.version}</version>
+				<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+				<version>${springdoc-openapi.version}</version>
 			</dependency>
 			<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
 			<dependency>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -81,7 +81,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-ui</artifactId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfiguration.java
@@ -20,9 +20,9 @@ import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springdoc.core.SpringDocConfigProperties;
-import org.springdoc.core.SpringDocConfiguration;
-import org.springdoc.core.SwaggerUiConfigProperties;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.webmvc.ui.SwaggerConfig;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/SpringDocAutoConfigurationTests.java
@@ -19,11 +19,11 @@ package org.springframework.cloud.dataflow.server.config;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.springdoc.core.Constants;
-import org.springdoc.core.SpringDocConfigProperties;
-import org.springdoc.core.SpringDocConfiguration;
-import org.springdoc.core.SwaggerUiConfigProperties;
-import org.springdoc.core.SwaggerUiOAuthProperties;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springdoc.core.utils.Constants;
 import org.springdoc.webmvc.ui.SwaggerConfig;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;


### PR DESCRIPTION
This commit updates to Open API 2.x which is the version that supports Boot 3.

The SpringDocs migration guide was followed:
https://springdoc.org/#migrating-from-springdoc-v1