### PR TITLE
Add Autoconfiguration.imports to resource includes in pom.xmls

### DIFF
--- a/spring-cloud-dataflow-autoconfigure/pom.xml
+++ b/spring-cloud-dataflow-autoconfigure/pom.xml
@@ -74,6 +74,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>META-INF/spring.factories</include>
+					<include>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</include>
 				</includes>
 			</resource>
 		</resources>

--- a/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/main/java/org/springframework/cloud/dataflow/configuration/metadata/ApplicationConfigurationMetadataResolverAutoConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.context.annotation.Configuration;
  * @author Christian Tzolov
  */
 @AutoConfiguration
-@Configuration
 public class ApplicationConfigurationMetadataResolverAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryAutoConfiguration.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryAutoConfiguration.java
@@ -46,7 +46,6 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  */
 @AutoConfiguration
-@Configuration
 @EnableConfigurationProperties({ContainerRegistryProperties.class})
 public class ContainerRegistryAutoConfiguration {
 

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -266,6 +266,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>META-INF/spring.factories</include>
+					<include>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</include>
 					<include>banner.txt</include>
 					<include>META-INF/dataflow-server-defaults.yml</include>
 					<include>META-INF/application-stream-common-properties-defaults.yml</include>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -88,7 +88,6 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.2.222</version>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
+++ b/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
@@ -17,7 +17,11 @@
 package org.springframework.cloud.dataflow.server.single;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.influx.InfluxMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront.WavefrontMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
@@ -36,7 +40,16 @@ import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
  */
+//TODO: Boot3x followup - remove the following exclusions once we have identified the proper way to handle metrics:
+// 		WavefrontMetricsExportAutoConfiguration.class,
+//		WavefrontAutoConfiguration.class,
+//		ObservationAutoConfiguration.class,
+//		InfluxMetricsExportAutoConfiguration.class,
 @SpringBootApplication(exclude = {
+		WavefrontMetricsExportAutoConfiguration.class,
+		WavefrontAutoConfiguration.class,
+		ObservationAutoConfiguration.class,
+		InfluxMetricsExportAutoConfiguration.class,
 		ObservationTaskAutoConfiguration.class,
 		SessionAutoConfiguration.class,
 		SimpleTaskAutoConfiguration.class,

--- a/spring-cloud-dataflow-server/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server/src/main/resources/application.yml
@@ -7,10 +7,3 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-debug: true
-logging:
-  level:
-    org:
-      springframework:
-        cloud:
-          dataflow: debug

--- a/spring-cloud-dataflow-server/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server/src/main/resources/application.yml
@@ -7,3 +7,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+debug: true
+logging:
+  level:
+    org:
+      springframework:
+        cloud:
+          dataflow: debug

--- a/spring-cloud-skipper/spring-cloud-skipper-autoconfigure/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-autoconfigure/pom.xml
@@ -46,6 +46,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>META-INF/spring.factories</include>
+					<include>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</include>
 				</includes>
 			</resource>
 		</resources>


### PR DESCRIPTION
### 1st Commit
* We had an issue where some of the auto configurations were not firing.
This is because when a user specifies the resource tag in maven,
the boot plugin expects the user to fill the resources manually vs. Its default behavior
* Also removed the version from the H2 dependency so that it can be managed by the bom
* Removed unnecessary `@Configuration` annotations where a `@Autoconfiguration` annotation is present
### 2nd Commit
- Currently SCDF fails to start with errors around metrics.
- These will need to be re-added when metric migration begins
- Remove debug settings from previous commit