### PR TITLE
Use the single hibernate_sequence strategy

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -60,9 +60,10 @@ spring:
   jpa:
     properties:
       hibernate:
+        # continue using a single hibernate_sequence table
+        id.db_structure_naming_strategy: single
+        # use the sequence style identifier generator
         id.new_generator_mappings: true
-        # Statistics generation is required for publishing JPA micrometer metrics.
-        # generate_statistics: true
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -50,9 +50,10 @@ spring:
     generate-ddl: false
     properties:
       hibernate:
+        # continue using a single hibernate_sequence table
+        id.db_structure_naming_strategy: single
+        # use the sequence style identifier generator
         id.new_generator_mappings: true
-        # Statistics generation is required for publishing JPA micrometer metrics.
-        # generate_statistics: true
   cloud:
     skipper:
       server:


### PR DESCRIPTION
Hibernate 6.0 now creates a sequence per entity hierarchy instead of a single hibernate_sequence. 
This commit sets the `hibernate.id.db_structure_naming_strategy` property to `single` to preserve the previous behavior of using a single hibernate_sequence.

The setting is in both Dataflow and Skipper default properties so that it is in effect system-wide.