### PR TITLE
Add DatabaseAwareLobUserType for @Lob columns

### DIFF
--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/src/main/java/org/springframework/cloud/dataflow/common/persistence/type/DatabaseAwareLobUserType.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/src/main/java/org/springframework/cloud/dataflow/common/persistence/type/DatabaseAwareLobUserType.java
@@ -1,0 +1,45 @@
+package org.springframework.cloud.dataflow.common.persistence.type;
+
+import java.util.function.BiConsumer;
+
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.StringJavaType;
+import org.hibernate.type.descriptor.jdbc.AdjustableJdbcType;
+import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+import org.hibernate.usertype.BaseUserTypeSupport;
+import org.hibernate.usertype.UserType;
+
+import org.springframework.util.Assert;
+
+/**
+ * A {@link UserType} that provides for Hibernate and Postgres incompatibility for columns of
+ * type text.
+ *
+ * @author Corneil du Plessis
+ * @author Chris Bono
+ * @since 3.0.0
+ */
+public class DatabaseAwareLobUserType extends BaseUserTypeSupport<String> {
+
+	@Override
+	protected void resolve(BiConsumer<BasicJavaType<String>, JdbcType> resolutionConsumer) {
+		resolutionConsumer.accept(StringJavaType.INSTANCE, getDbDescriptor());
+	}
+
+	public static AdjustableJdbcType getDbDescriptor() {
+		if( isPostgres() ) {
+			return VarcharJdbcType.INSTANCE;
+		}
+		else {
+			return ClobJdbcType.DEFAULT;
+		}
+	}
+
+	private static boolean isPostgres() {
+		Boolean postgresDatabase = DatabaseTypeAwareInitializer.getPostgresDatabase();
+		Assert.notNull(postgresDatabase, "Expected postgresDatabase to be set");
+		return postgresDatabase;
+	}
+}

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/src/main/java/org/springframework/cloud/dataflow/common/persistence/type/DatabaseAwareLobUserType.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-persistence/src/main/java/org/springframework/cloud/dataflow/common/persistence/type/DatabaseAwareLobUserType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.dataflow.common.persistence.type;
 
 import java.util.function.BiConsumer;

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.skipper.server.domain;
 
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,8 +28,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
 
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AbstractEntity;
 
@@ -53,7 +53,7 @@ public class AppDeployerData extends AbstractEntity {
 
 	// Store deployment Ids associated with the given release.
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String deploymentData;
 
 	public AppDeployerData() {

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Manifest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Manifest.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import java.sql.Types;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 
 
 /**
@@ -31,10 +31,9 @@ import org.hibernate.annotations.JdbcTypeCode;
 @Table(name = "SkipperManifest")
 public class Manifest extends AbstractEntity {
 
-	//TODO: Boot3x followup
 	@NotNull
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String data;
 
 	public Manifest() {

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import java.sql.Types;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -28,7 +26,9 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 
 
 /**
@@ -92,14 +92,14 @@ public class PackageMetadata extends AbstractEntity {
 	 * Location to source code for this package.
 	 */
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String packageSourceUrl;
 
 	/**
 	 * The home page of the package
 	 */
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String packageHomeUrl;
 
 	/**
@@ -115,7 +115,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * A comma separated list of tags to use for searching
 	 */
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String tags;
 
 	/**
@@ -127,7 +127,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * Brief description of the package. The packages README.md will contain more information.
 	 */
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String description;
 
 	/**
@@ -139,7 +139,7 @@ public class PackageMetadata extends AbstractEntity {
 	 * Url location of a icon.
 	 */
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String iconUrl;
 
 	public PackageMetadata() {

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -16,7 +16,6 @@
 package org.springframework.cloud.skipper.domain;
 
 import java.io.IOException;
-import java.sql.Types;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,8 +32,9 @@ import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
 
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.util.StringUtils;
 
@@ -70,17 +70,15 @@ public class Release extends AbstractEntity {
 	@JsonIgnore
 	private Long repositoryId;
 
-	//TODO: Boot3x followup
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String pkgJsonString;
 
 	@Transient
 	private ConfigValues configValues = new ConfigValues();
 
-	//TODO: Boot3x followup
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String configValuesString;
 
 	@OneToOne(cascade = { CascadeType.ALL })

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import java.sql.Types;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
+
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 
 
 /**
@@ -48,19 +48,17 @@ public class Repository extends AbstractEntity {
 	 * The root url that points to the location of an index.yaml file and other files
 	 * supporting the index e.g. myapp-1.0.0.zip, icons-64x64.zip
 	 */
-	//TODO: Boot3x followup
 	@NotNull
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String url;
 
 	/**
 	 * The url that points to the source package files that was used to create the index and
 	 * packages.
 	 */
-	//TODO: Boot3x followup
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String sourceUrl;
 
 	/**

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,8 +33,9 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
 
+import org.springframework.cloud.dataflow.common.persistence.type.DatabaseAwareLobUserType;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
@@ -55,9 +55,8 @@ public class Status extends NonVersionedAbstractEntity {
 	private StatusCode statusCode;
 
 	// Status from the underlying platform
-	//TODO: Boot3x followup
 	@Lob
-	@JdbcTypeCode(Types.LONGVARCHAR)
+	@Type(DatabaseAwareLobUserType.class)
 	private String platformStatus;
 
 	public Status() {


### PR DESCRIPTION
Hibernate 6.0 removed support for string values in `@Type` mappings in favor of specifying UserTypes. 
This commit creates a `DatabaseAwareLobUserType` that provides the same functionality as the previous `DatabaseAwareLobType`.