### PR TITLE
Overhaul metric deps and options

### DIFF
--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -40,7 +40,7 @@
 		<aws-java-sdk-ecr.version>1.12.513</aws-java-sdk-ecr.version>
 		<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
 		<stream-applications.version>3.2.1</stream-applications.version>
-		<wavefront-spring-boot-bom.version>2.3.4</wavefront-spring-boot-bom.version>
+		<wavefront-spring-boot-bom.version>3.2.0</wavefront-spring-boot-bom.version>
 		<spring-cloud-dataflow-apps-docs-plugin.version>1.0.7</spring-cloud-dataflow-apps-docs-plugin.version>
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.7</spring-cloud-dataflow-apps-metadata-plugin.version>
 		<springdoc-openapi.version>2.3.0</springdoc-openapi.version>

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -15,14 +15,22 @@ management:
             enabled: true # true is default to Boot 2.3.2 at least.
             percentiles-histogram: true
     export:
-      influx:
-        enabled: false
       prometheus:
-        enabled: false
         rsocket:
           enabled: false
-      wavefront:
+  influx:
+    metrics:
+      export:
         enabled: false
+  prometheus:
+    metrics:
+      export:
+        enabled: false
+  wavefront:
+    metrics:
+      export:
+        enabled: false
+
   endpoints:
     web:
       base-path: /management

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -26,13 +26,20 @@ management:
             enabled: true # true is default to Boot 2.3.2 at least.
             percentiles-histogram: true
     export:
-      influx:
-        enabled: false
       prometheus:
-        enabled: false
         rsocket:
           enabled: false
-      wavefront:
+  influx:
+    metrics:
+      export:
+        enabled: false
+  prometheus:
+    metrics:
+      export:
+        enabled: false
+  wavefront:
+    metrics:
+      export:
         enabled: false
 server:
   port: 7577


### PR DESCRIPTION
Align wavefront version so that we don't have misaligned versions coming out from other parts of a metric system. Short story is that boot doesn't manage wavefront but there is an explicit dependency to wavefront sdk libs in metric system.

Rename metric options within management for influx, prometheus and wavefront to align changes in boot itself.

For rsocket proxy keep old management.metrics.export.prometheus.rsocket.enabled as that is going to get moved under micrometer spesific namespace when they release boot3 support.

This commit was supposed to get skipper server to start but there is a new issue about missing bean
org.springframework.statemachine.data.jpa.JpaStateMachineRepository which will need to get fixed in a separate commit.

Fixes #5675