### PR TITLE
Remove the tailing / mark in the mockMVC urls

### DIFF
--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -238,7 +238,17 @@ import static org.mockito.Mockito.when;
 @EnableJpaAuditing
 @EnableMapRepositories("org.springframework.cloud.dataflow.server.job")
 @EnableTransactionManagement
-public class TestDependencies extends WebMvcConfigurationSupport {
+public class TestDependencies implements WebMvcConfigurer {
+
+	@Override
+	public void configurePathMatch(PathMatchConfigurer configurer) {
+		configurer.setUseSuffixPatternMatch(false);
+	}
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new AppBootVersionConverter());
+	}
 
 	@Bean
 	public RestControllerAdvice restControllerAdvice() {
@@ -853,22 +863,6 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		JpaTransactionManager transactionManager = new JpaTransactionManager();
 		transactionManagerCustomizers.ifAvailable((customizers) -> customizers.customize(transactionManager));
 		return transactionManager;
-	}
-
-	@Bean
-	public WebMvcConfigurer configurer() {
-		return new WebMvcConfigurer() {
-
-			@Override
-			public void configurePathMatch(PathMatchConfigurer configurer) {
-				configurer.setUseSuffixPatternMatch(false);
-			}
-
-			@Override
-			public void addFormatters(FormatterRegistry registry) {
-				registry.addConverter(new AppBootVersionConverter());
-			}
-		};
 	}
 
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -264,7 +264,7 @@ public class AppRegistryControllerTests {
 	public void testVersionOverrideNonExistentApp() throws Exception {
 		this.mockMvc.perform(post("/apps/sink/log1").param("uri", "maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE").accept(MediaType.APPLICATION_JSON))
 				.andDo(print()).andExpect(status().isCreated());
-		MvcResult mvcResult = this.mockMvc.perform(put("/apps/sink/log1/1.3.0.RELEASE/")).andDo(print()).andExpect(status().is4xxClientError()).andReturn();
+		MvcResult mvcResult = this.mockMvc.perform(put("/apps/sink/log1/1.3.0.RELEASE")).andDo(print()).andExpect(status().is4xxClientError()).andReturn();
 		Assert.isInstanceOf(NoSuchAppRegistrationException.class, mvcResult.getResolvedException());
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -124,9 +124,9 @@ public class AuditRecordControllerTests {
 
 		startDate = ZonedDateTime.now();
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream").param("definition", "time | log")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream").param("definition", "time | log")
 				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream1").param("definition", "time | log")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream1").param("definition", "time | log")
 				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
 
 		// Verify that the 4 app create and 2 stream create audit records have been recorded before setting the between date.
@@ -134,7 +134,7 @@ public class AuditRecordControllerTests {
 
 		betweenDate = ZonedDateTime.now();
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream2").param("definition", "time | log")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream2").param("definition", "time | log")
 				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
 
 		// Verify that the 4 app create and 3 stream create audit records have been recorded before setting the end date.

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -227,7 +227,7 @@ public class JobExecutionControllerTests {
 	public void testGetAllExecutionsFailed() throws Exception {
 		createDirtyJob();
 		// expecting to ignore dirty job
-		mockMvc.perform(get("/jobs/executions/").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/executions").accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.jobExecutionResourceList", hasSize(10)));
@@ -235,7 +235,7 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testGetAllExecutions() throws Exception {
-		mockMvc.perform(get("/jobs/executions/").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/executions").accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.jobExecutionResourceList", hasSize(10)))
@@ -244,13 +244,13 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testGetAllExecutionsPageOffsetLargerThanIntMaxValue() throws Exception {
-		verify5XXErrorIsThrownForPageOffsetError(get("/jobs/executions/"));
-		verifyBorderCaseForMaxInt(get("/jobs/executions/"));
+		verify5XXErrorIsThrownForPageOffsetError(get("/jobs/executions"));
+		verifyBorderCaseForMaxInt(get("/jobs/executions"));
 	}
 
 	@Test
 	public void testGetExecutionsByName() throws Exception {
-		mockMvc.perform(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG)
+		mockMvc.perform(get("/jobs/executions").param("name", JobExecutionUtils.JOB_NAME_ORIG)
 						.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -262,13 +262,13 @@ public class JobExecutionControllerTests {
 	@Test
 	public void testGetExecutionsByNamePageOffsetLargerThanIntMaxValue() throws Exception {
 		verify5XXErrorIsThrownForPageOffsetError(
-				get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG));
-		verifyBorderCaseForMaxInt(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_ORIG));
+				get("/jobs/executions").param("name", JobExecutionUtils.JOB_NAME_ORIG));
+		verifyBorderCaseForMaxInt(get("/jobs/executions").param("name", JobExecutionUtils.JOB_NAME_ORIG));
 	}
 
 	@Test
 	public void testGetExecutionsByNameMultipleResult() throws Exception {
-		mockMvc.perform(get("/jobs/executions/").param("name", JobExecutionUtils.JOB_NAME_FOOBAR)
+		mockMvc.perform(get("/jobs/executions").param("name", JobExecutionUtils.JOB_NAME_FOOBAR)
 						.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -281,7 +281,7 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testFilteringByStatusAndName_EmptyNameAndStatusGiven() throws Exception {
-		mockMvc.perform(get("/jobs/executions/")
+		mockMvc.perform(get("/jobs/executions")
 						.param("name", "")
 						.param("status", "FAILED")
 						.accept(MediaType.APPLICATION_JSON))
@@ -296,7 +296,7 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testFilteringByUnknownStatus() throws Exception {
-		mockMvc.perform(get("/jobs/executions/")
+		mockMvc.perform(get("/jobs/executions")
 						.param("status", "UNKNOWN")
 						.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
@@ -306,7 +306,7 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testFilteringByStatusAndName_NameAndStatusGiven() throws Exception {
-		mockMvc.perform(get("/jobs/executions/")
+		mockMvc.perform(get("/jobs/executions")
 						.param("name", JobExecutionUtils.BASE_JOB_NAME + "%")
 						.param("status", "COMPLETED")
 						.accept(MediaType.APPLICATION_JSON))
@@ -319,14 +319,14 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testGetExecutionsByNameNotFound() throws Exception {
-		mockMvc.perform(get("/jobs/executions/").param("name", "BAZ").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/executions").param("name", "BAZ").accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isNotFound());
 	}
 
 	@Test
 	public void testWildcardMatchMultipleResult() throws Exception {
-		mockMvc.perform(get("/jobs/executions/")
+		mockMvc.perform(get("/jobs/executions")
 						.param("name", JobExecutionUtils.BASE_JOB_NAME + "_FOO_ST%").accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -339,7 +339,7 @@ public class JobExecutionControllerTests {
 
 	@Test
 	public void testWildcardMatchSingleResult() throws Exception {
-		mockMvc.perform(get("/jobs/executions/")
+		mockMvc.perform(get("/jobs/executions")
 						.param("name", "m_Job_ORIG").accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinControllerTests.java
@@ -123,7 +123,7 @@ public class JobExecutionThinControllerTests {
 
 	@Test
 	public void testGetExecutionsByName() throws Exception {
-		mockMvc.perform(get("/jobs/thinexecutions/").param("name", JobExecutionUtils.JOB_NAME_ORIG)
+		mockMvc.perform(get("/jobs/thinexecutions").param("name", JobExecutionUtils.JOB_NAME_ORIG)
 				.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -135,7 +135,7 @@ public class JobExecutionThinControllerTests {
 	public void testGetExecutionsByDateRange() throws Exception {
 		final Date toDate = new Date();
 		final Date fromDate = DateUtils.addMinutes(toDate, -10);
-		mockMvc.perform(get("/jobs/thinexecutions/")
+		mockMvc.perform(get("/jobs/thinexecutions")
 				.param("fromDate",
 						new SimpleDateFormat(TimeUtils.DEFAULT_DATAFLOW_DATE_TIME_PARAMETER_FORMAT_PATTERN)
 								.format(fromDate))
@@ -150,7 +150,7 @@ public class JobExecutionThinControllerTests {
 
 	@Test
 	public void testGetExecutionsByJobInstanceId() throws Exception {
-		mockMvc.perform(get("/jobs/thinexecutions/").param("jobInstanceId", "1")
+		mockMvc.perform(get("/jobs/thinexecutions").param("jobInstanceId", "1")
 				.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -161,7 +161,7 @@ public class JobExecutionThinControllerTests {
 
 	@Test
 	public void testGetExecutionsByTaskExecutionId() throws Exception {
-		mockMvc.perform(get("/jobs/thinexecutions/").param("taskExecutionId", "4")
+		mockMvc.perform(get("/jobs/thinexecutions").param("taskExecutionId", "4")
 				.accept(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobInstanceControllerTests.java
@@ -144,7 +144,7 @@ public class JobInstanceControllerTests {
 
 	@Test
 	public void testGetInstancesByName() throws Exception {
-		mockMvc.perform(get("/jobs/instances/").param("name", JOB_NAME_ORIG).accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/instances").param("name", JOB_NAME_ORIG).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$._embedded.jobInstanceResourceList[0].jobName", is(JOB_NAME_ORIG)))
 			.andExpect(jsonPath("$._embedded.jobInstanceResourceList", hasSize(1)));
@@ -152,7 +152,7 @@ public class JobInstanceControllerTests {
 
 	@Test
 	public void testGetExecutionsByNameMultipleResult() throws Exception {
-		mockMvc.perform(get("/jobs/instances/").param("name", JOB_NAME_FOOBAR).accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/instances").param("name", JOB_NAME_FOOBAR).accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$._embedded.jobInstanceResourceList[0].jobName", is(JOB_NAME_FOOBAR)))
 			.andExpect(jsonPath("$._embedded.jobInstanceResourceList[0].jobExecutions[0].executionId", is(4)))
@@ -162,7 +162,7 @@ public class JobInstanceControllerTests {
 
 	@Test
 	public void testGetInstanceByNameNotFound() throws Exception {
-		mockMvc.perform(get("/jobs/instances/").param("name", "BAZ").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/jobs/instances").param("name", "BAZ").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().is4xxClientError())
 			.andExpect(content().string(containsString("NoSuchJobException")));
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -183,7 +183,7 @@ public class StreamControllerTests {
 	@Test
 	public void testSaveNoDeployJsonEncoded() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 				.param("name", "myStream")
 				.param("definition", "time | log")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -199,7 +199,7 @@ public class StreamControllerTests {
 		MultiValueMap<String, String> values = new LinkedMultiValueMap<>();
 		values.add("name", "myStream");
 		values.add("definition", "time | log");
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 				.params(values)
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.accept(MediaType.APPLICATION_JSON))
@@ -230,7 +230,7 @@ public class StreamControllerTests {
 		assertThat(repository.count()).isZero();
 		String definition = "time | log";
 		String streamName = "testSaveAndDeploy-stream";
-		MockHttpServletRequestBuilder requestBuilder = post("/streams/definitions/")
+		MockHttpServletRequestBuilder requestBuilder = post("/streams/definitions")
 			.param("name", streamName)
 			.param("definition", definition)
 			.param("deploy", "true")
@@ -281,7 +281,7 @@ public class StreamControllerTests {
 	@Test
 	public void testSaveWithSensitiveProperties() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream2")
 			.param("definition", "time --some.password=foobar --another-secret=kenny | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertThat(repository.count()).isEqualTo(1);
@@ -302,19 +302,19 @@ public class StreamControllerTests {
 	@Test
 	public void testFindRelatedStreams() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream1")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myAnotherStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myAnotherStream1")
 				.param("definition", "time | log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream2")
 			.param("definition", ":myStream1 > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream3")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream3")
 				.param("definition", ":myStream1.time > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream4")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream4")
 				.param("definition", ":myAnotherStream1 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
 		assertThat(repository.count()).isEqualTo(5);
@@ -336,15 +336,15 @@ public class StreamControllerTests {
 
 	@Test
 	public void testStreamSearchNameContainsSubstring() throws Exception {
-		mockMvc.perform(post("/streams/definitions/").param("name", "foo")
+		mockMvc.perform(post("/streams/definitions").param("name", "foo")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "foaz")
+		mockMvc.perform(post("/streams/definitions").param("name", "foaz")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "ooz")
+		mockMvc.perform(post("/streams/definitions").param("name", "ooz")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertThat(repository.count()).isEqualTo(3);
@@ -376,7 +376,7 @@ public class StreamControllerTests {
 	public void testFindRelatedStreams_gh2150() throws Exception {
 		assertThat(repository.count()).isZero();
 		// Bad definition, recursive reference
-		mockMvc.perform(post("/streams/definitions/").param("name", "mapper")
+		mockMvc.perform(post("/streams/definitions").param("name", "mapper")
 			.param("definition", ":mapper.time > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertThat(repository.count()).isEqualTo(1);
@@ -394,10 +394,10 @@ public class StreamControllerTests {
 	@Test
 	public void testFindRelatedStreams2_gh2150() throws Exception {
 		// bad streams, recursively referencing via each other
-		mockMvc.perform(post("/streams/definitions/").param("name", "foo")
+		mockMvc.perform(post("/streams/definitions").param("name", "foo")
 			.param("definition", ":bar.time > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "bar")
+		mockMvc.perform(post("/streams/definitions").param("name", "bar")
 			.param("definition", ":foo.time > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertThat(repository.count()).isEqualTo(2);
@@ -422,37 +422,37 @@ public class StreamControllerTests {
 	@Test
 	public void testFindRelatedAndNestedStreams() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream1")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "myAnotherStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myAnotherStream1")
 				.param("definition", "time | log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream2")
 			.param("definition", ":myStream1 > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "TapOnmyStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "TapOnmyStream2")
 				.param("definition", ":myStream2 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream3")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream3")
 				.param("definition", ":myStream1.time > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "TapOnMyStream3")
+		mockMvc.perform(post("/streams/definitions").param("name", "TapOnMyStream3")
 				.param("definition", ":myStream3 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "MultipleNestedTaps")
+		mockMvc.perform(post("/streams/definitions").param("name", "MultipleNestedTaps")
 				.param("definition", ":TapOnMyStream3 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream4")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream4")
 				.param("definition", ":myAnotherStream1 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream5")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream5")
 			.param("definition", "time | log --secret=foo")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream6")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream6")
 				.param("definition", ":myStream5.time > log --password=bar")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
@@ -499,31 +499,31 @@ public class StreamControllerTests {
 	@Test
 	public void testFindAll() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream1")
 			.param("definition", "time --password=foo| log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream1A")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream1A")
 			.param("definition", "time --foo=bar| log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myAnotherStream1")
+		mockMvc.perform(post("/streams/definitions").param("name", "myAnotherStream1")
 				.param("definition", "time | log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream2")
 			.param("definition", ":myStream1 > log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "TapOnmyStream2")
+		mockMvc.perform(post("/streams/definitions").param("name", "TapOnmyStream2")
 				.param("definition", ":myStream2 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream3")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream3")
 				.param("definition", ":myStream1.time > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "TapOnMyStream3")
+		mockMvc.perform(post("/streams/definitions").param("name", "TapOnMyStream3")
 				.param("definition", ":myStream3 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "MultipleNestedTaps")
+		mockMvc.perform(post("/streams/definitions").param("name", "MultipleNestedTaps")
 				.param("definition", ":TapOnMyStream3 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream4")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream4")
 				.param("definition", ":myAnotherStream1 > log").accept(MediaType.APPLICATION_JSON)).andDo(print())
 			.andExpect(status().isCreated());
 		mockMvc.perform(post("/streams/definitions")
@@ -534,21 +534,21 @@ public class StreamControllerTests {
 		mockMvc.perform(post("/streams/definitions").param("name", "timelogDoubleTick")
 			.param("definition", "a: time --format=\"YYYY MM DD\" | log")
 			.param("deploy", "false")).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "twoPassword")
+		mockMvc.perform(post("/streams/definitions").param("name", "twoPassword")
 			.param("definition", "time --password='foo'| log --password=bar")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "nameChannelPassword")
+		mockMvc.perform(post("/streams/definitions").param("name", "nameChannelPassword")
 			.param("definition", "time --password='foo'> :foobar")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "twoParam")
+		mockMvc.perform(post("/streams/definitions").param("name", "twoParam")
 			.param("definition", "time --password=foo --arg=foo | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
-		mockMvc.perform(post("/streams/definitions/").param("name", "twoPipeInQuotes")
+		mockMvc.perform(post("/streams/definitions").param("name", "twoPipeInQuotes")
 			.param("definition", "time --password='fo|o' --arg=bar | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 
 		assertThat(repository.count()).isEqualTo(15);
-		mockMvc.perform(get("/streams/definitions/").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/streams/definitions").accept(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -572,7 +572,7 @@ public class StreamControllerTests {
 
 	@Test
 	public void testSaveInvalidAppDefinitions() throws Exception {
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 				.param("name", "myStream")
 				.param("definition", "foo | bar")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isBadRequest())
@@ -585,7 +585,7 @@ public class StreamControllerTests {
 
 	@Test
 	public void testSaveInvalidAppDefinitionsDueToParseException() throws Exception {
-		mockMvc.perform(post("/streams/definitions/").param("name", "myStream")
+		mockMvc.perform(post("/streams/definitions").param("name", "myStream")
 				.param("definition", "foo --.spring.cloud.stream.metrics.properties=spring* | bar")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isBadRequest())
 			.andExpect(jsonPath("_embedded.errors[0].logref", is("InvalidStreamDefinitionException"))).andExpect(
@@ -596,7 +596,7 @@ public class StreamControllerTests {
 	public void testSaveDuplicate() throws Exception {
 		repository.save(new StreamDefinition("myStream", "time | log"));
 		assertThat(repository.count()).isEqualTo(1);
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isConflict());
@@ -607,7 +607,7 @@ public class StreamControllerTests {
 	public void testSaveWithParameters() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = "time --fixedDelay=500 --timeUnit=milliseconds | log";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -627,7 +627,7 @@ public class StreamControllerTests {
 	public void testStreamWithProcessor() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = "time | filter | log";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -656,7 +656,7 @@ public class StreamControllerTests {
 	public void testSourceDestinationWithSingleApp() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = ":foo > log";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -675,7 +675,7 @@ public class StreamControllerTests {
 	public void testSourceDestinationWithTwoApps() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = ":foo > filter | log";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -700,7 +700,7 @@ public class StreamControllerTests {
 	public void testSinkDestinationWithSingleApp() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = "time > :foo";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -718,7 +718,7 @@ public class StreamControllerTests {
 	public void testSinkDestinationWithTwoApps() throws Exception {
 		assertThat(repository.count()).isZero();
 		String definition = "time | filter > :foo";
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream")
 			.param("definition", definition)
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
@@ -743,7 +743,7 @@ public class StreamControllerTests {
 		assertThat(repository.count()).isZero();
 		String definition = ":bar > filter > :foo";
 
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 				.param("name", "myStream")
 				.param("definition", definition)
 				.param("deploy", "true").accept(MediaType.APPLICATION_JSON)).andDo(print())
@@ -1474,7 +1474,7 @@ public class StreamControllerTests {
 	@Test
 	public void testValidateStream() throws Exception {
 		assertThat(repository.count()).isZero();
-		mockMvc.perform(post("/streams/definitions/")
+		mockMvc.perform(post("/streams/definitions")
 			.param("name", "myStream1")
 			.param("definition", "time | log")
 			.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -252,7 +252,7 @@ public class TaskControllerTests {
 	public void testSaveErrorNotInRegistry() throws Exception {
 		assertThat(repository.count()).isZero();
 
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask").param("definition", "task")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isNotFound());
 
 		assertThat(repository.count()).isZero();
@@ -262,7 +262,7 @@ public class TaskControllerTests {
 	public void testSave() throws Exception {
 		assertThat(repository.count()).isZero();
 		this.registry.save("task", ApplicationType.task, "1.0.0", new URI("https://fake.example.com/"), null, null);
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask").param("definition", "task")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isOk());
 
 		assertThat(repository.count()).isEqualTo(1);
@@ -281,7 +281,7 @@ public class TaskControllerTests {
 	public void testSaveDuplicate() throws Exception {
 		this.registry.save("task", ApplicationType.task, "1.0.0", new URI("https://fake.example.com/"), null, null);
 		repository.save(new TaskDefinition("myTask", "task"));
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask").param("definition", "task")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask").param("definition", "task")
 				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isConflict());
 		assertThat(repository.count()).isEqualTo(1);
 	}
@@ -290,7 +290,7 @@ public class TaskControllerTests {
 	public void testSaveWithParameters() throws Exception {
 
 		this.registry.save("task", ApplicationType.task, "1.0.0", new URI("https://fake.example.com/"), null, null);
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask")
 						.param("definition", "task --foo=bar --bar=baz").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk());
 
@@ -309,7 +309,7 @@ public class TaskControllerTests {
 	@Test
 	public void testTaskDefinitionWithLastExecutionDetail() throws Exception {
 		this.registry.save("task", ApplicationType.task, "1.0.0", new URI("https://fake.example.com/"), null, null);
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask")
 						.param("definition", "task --foo=bar --bar=baz").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk());
 		mockMvc.perform(get("/tasks/definitions/myTask")
@@ -330,7 +330,7 @@ public class TaskControllerTests {
 	public void testSaveCompositeTaskWithParameters() throws Exception {
 
 		registry.save("task", ApplicationType.task, "1.0.0", new URI("https://fake.example.com/"), null, null);
-		mockMvc.perform(post("/tasks/definitions/").param("name", "myTask")
+		mockMvc.perform(post("/tasks/definitions").param("name", "myTask")
 						.param("definition", "t1: task --foo='bar rab' && t2: task --foo='one two'")
 						.accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk());
@@ -460,7 +460,7 @@ public class TaskControllerTests {
 
 		assertThat(repository.count()).isEqualTo(3);
 
-		mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+		mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(3)));
 
 		mockMvc.perform(delete("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andDo(print())
@@ -476,7 +476,7 @@ public class TaskControllerTests {
 		repository.save(new TaskDefinition("myTask-2", "task"));
 
 		assertThat(repository.count()).isEqualTo(3);
-		mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+		mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(3)));
 
 		mockMvc.perform(delete("/tasks/definitions/myTask-1").accept(MediaType.APPLICATION_JSON)).andDo(print())
@@ -494,7 +494,7 @@ public class TaskControllerTests {
 		repository.save(new TaskDefinition("a1-t1", "task"));
 		repository.save(new TaskDefinition("a1-t2", "task"));
 
-		mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+		mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(4)))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].name", is("a1")))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].composedTaskElement", is(false)))
@@ -517,7 +517,7 @@ public class TaskControllerTests {
 		repository.save(new TaskDefinition("a1-t1", "task"));
 		repository.save(new TaskDefinition("a1-t2", "task"));
 
-		mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+		mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(4)))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].name", is("a1")))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].composedTaskElement", is(false)))
@@ -725,7 +725,7 @@ public class TaskControllerTests {
 		assertThat(repository.count()).isEqualTo(3);
 
 		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$._embedded.taskDefinitionResourceList[0].lastTaskExecution.",
-				mockMvc.perform(get("/tasks/definitions/").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 						.andDo(print()))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(3)))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[*].name",

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -360,7 +360,7 @@ public class TaskExecutionControllerTests {
 	@Test
 	void getAllExecutions() throws Exception {
 		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$._embedded.taskExecutionResourceList[0].",
-				mockMvc.perform(get("/tasks/executions/").accept(MediaType.APPLICATION_JSON))
+				mockMvc.perform(get("/tasks/executions").accept(MediaType.APPLICATION_JSON))
 						.andDo(print())
 						.andExpect(status().isOk()))
 				.andExpect(jsonPath("$._embedded.taskExecutionResourceList[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
@@ -407,7 +407,7 @@ public class TaskExecutionControllerTests {
 		mapper.registerModule(new Jackson2DataflowModule());
 		LaunchResponseResource resource = mapper.readValue(response, LaunchResponseResource.class);
 		resultActions = mockMvc.perform(
-						get("/tasks/executions/" + resource.getExecutionId())
+						get("/tasks/executions" + resource.getExecutionId())
 								.accept(MediaType.APPLICATION_JSON)
 								.queryParam("schemaTarget", resource.getSchemaTarget())
 				)
@@ -481,7 +481,7 @@ public class TaskExecutionControllerTests {
 		mapper.registerModule(new Jackson2DataflowModule());
 		LaunchResponseResource resource = mapper.readValue(response, LaunchResponseResource.class);
 		resultActions = mockMvc.perform(
-						get("/tasks/executions/" + resource.getExecutionId())
+						get("/tasks/executions" + resource.getExecutionId())
 								.accept(MediaType.APPLICATION_JSON)
 								.queryParam("schemaTarget", resource.getSchemaTarget())
 				)

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskSchedulerControllerTests.java
@@ -190,7 +190,7 @@ public class TaskSchedulerControllerTests {
 				"1.0.0", new URI("file:src/test/resources/apps/foo-task"), null, null);
 
 		repository.save(new TaskDefinition("testDefinition", "testApp"));
-		mockMvc.perform(post("/tasks/schedules/").param("taskDefinitionName", "testDefinition")
+		mockMvc.perform(post("/tasks/schedules").param("taskDefinitionName", "testDefinition")
 				.param("scheduleName", scheduleName).param("properties", "scheduler.cron.expression=* * * * *")
 				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().isCreated());
 		assertEquals(1, simpleTestScheduler.list().size());
@@ -258,7 +258,7 @@ public class TaskSchedulerControllerTests {
 		this.registry.save("testApp", ApplicationType.task, "1.0.0", new URI("file:src/test/resources/apps/foo-task"), null, null);
 
 		repository.save(new TaskDefinition("testDefinition", "testApp"));
-		mockMvc.perform(post("/tasks/schedules/").param("taskDefinitionName", "testDefinition")
+		mockMvc.perform(post("/tasks/schedules").param("taskDefinitionName", "testDefinition")
 				.param("scheduleName", "mySchedule")
 				.param("properties",
 						"scheduler.cron.expression=* * * * *,app.testApp.prop1=foo,app.testApp.prop2.secret=kenny,deployer.*.prop1.secret=cartman,deployer.*.prop2.password=kyle")
@@ -288,7 +288,7 @@ public class TaskSchedulerControllerTests {
 				"1.0.0", new URI("file:src/test/resources/apps/foo-task"), null, null);
 
 		repository.save(new TaskDefinition("testDefinition", "testApp"));
-		mockMvc.perform(post("/tasks/schedules/").param("taskDefinitionName", "testDefinition")
+		mockMvc.perform(post("/tasks/schedules").param("taskDefinitionName", "testDefinition")
 				.param("scheduleName", "myScheduleBadCron")
 				.param("properties",
 						"scheduler.cron.expression=" + SimpleTestScheduler.INVALID_CRON_EXPRESSION)


### PR DESCRIPTION
These slash marks are not required by Boot3 and cause the tests to fail.

* Simplify TestDependencies class so that it implements WebMvcConfigurer 
instead of extending WebMvcConfigurationSupport while creating the WebMvcConfigurer bean.   
* This PR will reduce the number of test failures and expose other test failures.   

