### PR TITLE
Reuse CriteriaQuery when retrieving result count.

### DIFF
--- a/spring-cloud-dataflow-audit/src/main/java/org/springframework/cloud/dataflow/audit/repository/jpa/AuditRecordRepositoryImpl.java
+++ b/spring-cloud-dataflow-audit/src/main/java/org/springframework/cloud/dataflow/audit/repository/jpa/AuditRecordRepositoryImpl.java
@@ -28,6 +28,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.springframework.cloud.dataflow.audit.repository.AuditRecordRepositoryCustom;
 import org.springframework.cloud.dataflow.core.AuditActionType;
 import org.springframework.cloud.dataflow.core.AuditOperationType;
@@ -121,14 +122,7 @@ public class AuditRecordRepositoryImpl implements AuditRecordRepositoryCustom {
 
 		final List<AuditRecord> resultList = typedQuery.getResultList();
 
-		final CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
-		countQuery.select(cb.count(countQuery.from(AuditRecord.class)));
-
-		if (!finalQueryPredicates.isEmpty()) {
-			countQuery.where(finalQueryPredicates.toArray(new Predicate[0]));
-		}
-
-		final Long totalCount = entityManager.createQuery(countQuery)
+		final Long totalCount = (Long)entityManager.createQuery(((SqmSelectStatement)select).createCountQuery())
 				  .getSingleResult();
 
 		return new PageImpl<>(resultList, pageable, totalCount);

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepositoryImpl.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/repository/AppRegistrationRepositoryImpl.java
@@ -28,6 +28,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.dataflow.core.AppRegistration;
@@ -91,17 +92,11 @@ public class AppRegistrationRepositoryImpl implements AppRegistrationRepositoryC
 				appRegistration.setVersions(versions);
 			});
 		}
-		return new PageImpl<>(resultList, pageable, getTotalCount(cb, predicates.toArray(new Predicate[0])));
+		return new PageImpl<>(resultList, pageable, getTotalCount(cq));
 	}
 
-	private Long getTotalCount(CriteriaBuilder criteriaBuilder, Predicate[] predicateArray) {
-		CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
-		Root<AppRegistration> root = criteriaQuery.from(AppRegistration.class);
-
-		criteriaQuery.select(criteriaBuilder.count(root));
-		criteriaQuery.where(predicateArray);
-
-		return entityManager.createQuery(criteriaQuery).getSingleResult();
+	private Long getTotalCount(CriteriaQuery<AppRegistration> criteriaQuery) {
+		return (Long) entityManager.createQuery(((SqmSelectStatement)criteriaQuery).createCountQuery()).getSingleResult();
 	}
 
 }

--- a/spring-cloud-skipper/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper/pom.xml
@@ -59,7 +59,6 @@
 			<groupId>org.hibernate.orm</groupId>
 			<artifactId>hibernate-core</artifactId>
 			<scope>provided</scope>
-			<version>6.1.7.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.zeroturnaround</groupId>


### PR DESCRIPTION
When migrating to the latest Hibernate we saw the following exception:
```
Caused by: java.lang.IllegalArgumentException: Already registered a copy: SqmBasicValuedSimplePath
```
This is because we were recreating a CriteriaQuery for our count Queries. Hibernate no longer allows us to do that,
but rather allows us to use the existing CriteriaQuery,
but use the convenience method createCountQuery to provide the criteria query for our createQuery.

Also removed 6.1.7 version for hibernate core  that allows us to use the Boot bom. 
This also caused some downstream issues where dataflow was using the old version brought in from skipper