### PR TITLE
Update prometheus-rsocket-proxy to 1.6.0-SNAPSHOT

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -29,7 +29,7 @@
 		<nimbus-jose-jwt.version>9.37</nimbus-jose-jwt.version>
 		<snappy-java.version>1.1.10.5</snappy-java.version>
 		<commons-compress.version>1.24.0</commons-compress.version>
-		<prometheus-rsocket.version>1.5.2</prometheus-rsocket.version>
+		<prometheus-rsocket.version>1.6.0-SNAPSHOT</prometheus-rsocket.version>
 		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<spring-cloud-services-starter-config-client.version>3.5.4</spring-cloud-services-starter-config-client.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>

--- a/src/carvel/config/values/values.yml
+++ b/src/carvel/config/values/values.yml
@@ -108,5 +108,5 @@ scdf:
         enabled: false
         image:
           repository: micrometermetrics/prometheus-rsocket-proxy
-          tag: 1.5.2
+          tag: 1.6.0-SNAPSHOT
           digest: ""

--- a/src/deploy/carvel/load-images.sh
+++ b/src/deploy/carvel/load-images.sh
@@ -67,7 +67,7 @@ else
     sh "$K8S/load-image.sh" "springcloud/spring-cloud-dataflow-server" "$DATAFLOW_VERSION" true
 fi
 if [ "$PROMETHEUS" = "true" ]; then
-    sh "$K8S/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy" "1.5.2" false
+    sh "$K8S/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy" "1.6.0-SNAPSHOT" false
 fi
 if [ "$REGISTRY" = "" ]; then
     REGISTRY=springcloud

--- a/src/deploy/images/pull-prometheus-rsocket-proxy.sh
+++ b/src/deploy/images/pull-prometheus-rsocket-proxy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker pull "micrometermetrics/prometheus-rsocket-proxy:1.5.2"
+docker pull "micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT"

--- a/src/deploy/k8s/deploy-scdf.sh
+++ b/src/deploy/k8s/deploy-scdf.sh
@@ -171,7 +171,7 @@ if [ "$PROMETHEUS" = "true" ] || [ "$METRICS" = "prometheus" ]; then
     if [ "$K8S_DRIVER" != "tmc" ] && [ "$K8S_DRIVER" != "gke" ]; then
         sh "$SCDIR/load-image.sh" "springcloud/spring-cloud-dataflow-grafana-prometheus:$DATAFLOW_VERSION" false
         sh "$SCDIR/load-image.sh" "prom/prometheus:v2.37.8"
-        sh "$SCDIR/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy:1.5.2"
+        sh "$SCDIR/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT"
     fi
     set +e
     kubectl create --namespace "$NS" serviceaccount prometheus-rsocket-proxy

--- a/src/docker-compose/docker-compose-prometheus.yml
+++ b/src/docker-compose/docker-compose-prometheus.yml
@@ -22,7 +22,7 @@ services:
       #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:1.5.2
+    image: micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-rsocket-proxy
       containers:
         - name: prometheus-rsocket-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:1.5.2
+          image: micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           ports:
             - name: scrape

--- a/src/templates/docker-compose/docker-compose-prometheus.yml
+++ b/src/templates/docker-compose/docker-compose-prometheus.yml
@@ -22,7 +22,7 @@ services:
       #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:1.5.2
+    image: micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-rsocket-proxy
       containers:
         - name: prometheus-rsocket-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:1.5.2
+          image: micrometermetrics/prometheus-rsocket-proxy:1.6.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           ports:
             - name: scrape


### PR DESCRIPTION
This commit updates the Prometheus RSocket proxy to 1.6.x which in turn is updated to Spring Boot 3.2.x.

> [!NOTE]
> The container versions are kept in-sync as there is a [SNAPSHOT container](https://hub.docker.com/layers/micrometermetrics/prometheus-rsocket-proxy/1.6.0-SNAPSHOT/images/sha256-fc385586652eb5fbc2364676828bdc06e794134d13ddb411294d86d1217904e8?context=explore) published