### PR TITLE
Add column missed from conversion from OID to Text

### DIFF
--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/postgresql/V4__ChangeTextTypes.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/postgresql/V4__ChangeTextTypes.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.db.migration.postgresql;
+
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.cloud.dataflow.common.flyway.AbstractMigration;
+import org.springframework.cloud.skipper.server.db.migration.PostgreSQLTextToOID;
+
+public class V4__ChangeTextTypes extends AbstractMigration {
+
+	public V4__ChangeTextTypes() {
+		super(null);
+	}
+
+	@Override
+	public void migrate(final Context context) {
+		PostgreSQLTextToOID.convertColumnFromOID("skipper_manifest", "id", "data", context.getConfiguration()
+																						  .getDataSource());
+	}
+}


### PR DESCRIPTION
It seems there is a bug in the latest SCDF version where the `data` column in the `skipper_manifest` was **not** converted from OID into text like most of the other columns. This addition fixes the this