### PR TITLE
Adjust order of DefaultEnvironmentPostProcessor

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,14 @@ public class DefaultEnvironmentPostProcessor implements EnvironmentPostProcessor
 	private static final Logger logger = LoggerFactory.getLogger(DefaultEnvironmentPostProcessor.class);
 
 	/**
-	 * The order for the processor - must run before the {@link ConfigDataEnvironmentPostProcessor}.
+	 * The order the processor is invoked.
+	 * <p>Must execute after the {@link ConfigDataEnvironmentPostProcessor} because they both use the {@code addLast}
+	 * API to add their property source and the default EPP should have lower precedence.
+	 * <p>Must execute before the {@code ConfigDataMissingEnvironmentPostProcessor} because the legacy config data
+	 * flag is set in the default dataflow properties and without this flag the server will not start. The config data
+	 * missing has an order of {@code ConfigDataEnvironmentPostProcessor.ORDER + 1000} so we simply anchor below that.
 	 */
-	public static final int ORDER = ConfigDataEnvironmentPostProcessor.ORDER - 5;
+	public static final int ORDER = ConfigDataEnvironmentPostProcessor.ORDER + 900;
 
 	private final Resource serverResource = new ClassPathResource("/dataflow-server.yml");
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/DefaultEnvironmentPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 
 package org.springframework.cloud.dataflow.server.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link DefaultEnvironmentPostProcessor}.
@@ -30,32 +29,41 @@ import static org.junit.Assert.assertNotNull;
  * @author Josh Long
  * @auhor Chris Bono
  */
-public class DefaultEnvironmentPostProcessorTests {
+class DefaultEnvironmentPostProcessorTests {
 
-	private static final String MANAGEMENT_CONTEXT_PATH = "management.contextPath";
-
-	private static final String CONTRIBUTED_PATH = "/bar";
+	private static final String MANAGEMENT_CONTEXT_PATH = "management.context-path";
 
 	@Test
-	public void testDefaultsBeingContributedByServerModule() throws Exception {
+	void defaultsAreContributedByServerModule() {
 		try (ConfigurableApplicationContext ctx = SpringApplication.run(EmptyDefaultTestApplication.class, "--server.port=0",
 				"--spring.main.allow-bean-definition-overriding=true",
 				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration,org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration")) {
-			String cp = ctx.getEnvironment().getProperty(MANAGEMENT_CONTEXT_PATH);
-			assertEquals(CONTRIBUTED_PATH, cp);
+
+			// this one comes from <test>/resources/dataflow-server.yml
+			assertThat(ctx.getEnvironment().getProperty(MANAGEMENT_CONTEXT_PATH)).isEqualTo("/foo");
+
+			// this one comes from dataflow-server-defaults.yml (we use 'spring.flyway.enabled' as the indicator)
+			assertThat(ctx.getEnvironment().getProperty("spring.flyway.enabled", Boolean.class)).isTrue();
 		}
 	}
 
 	@Test
-	public void testOverridingDefaultsWithAConfigFile() {
+	void defaultsCanBeOverridden() {
 		try (ConfigurableApplicationContext ctx = SpringApplication.run(EmptyDefaultTestApplication.class,
-				"--spring.config.name=test", "--server.port=0",
+				//"--spring.profiles.active=test",
+				"--server.port=0",
+				"--spring.config.name=test",
+				"--spring.flyway.enabled=false",
 				"--spring.main.allow-bean-definition-overriding=true",
 				"--spring.cloud.dataflow.server.profileapplicationlistener.ignore=true",
 				"--spring.autoconfigure.exclude=org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration,org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration")) {
-			String cp = ctx.getEnvironment().getProperty(MANAGEMENT_CONTEXT_PATH);
-			assertEquals(cp, "/foo");
-			assertNotNull(ctx.getEnvironment().getProperty("spring.flyway.locations[0]"));
+
+			// this one comes from <test>/resources/test.yml and overrides the entry from <test>/resources/dataflow-server.yml
+			assertThat(ctx.getEnvironment().getProperty(MANAGEMENT_CONTEXT_PATH)).isEqualTo("/bar");
+
+			// sys props overrides this one from dataflow-server-defaults.yml
+			assertThat(ctx.getEnvironment().getProperty("spring.flyway.enabled", Boolean.class)).isFalse();
+
 		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/resources/dataflow-server.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/dataflow-server.yml
@@ -1,2 +1,2 @@
 management:
-  contextPath: /bar
+  context-path: /foo

--- a/spring-cloud-dataflow-server-core/src/test/resources/test.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/test.yml
@@ -1,2 +1,2 @@
 management:
-  contextPath: /foo
+  contextPath: /bar


### PR DESCRIPTION
This commit adjusts the change of the order attribute made in commit de5824797fe7d765d4cdeb4f5a8b1aebed2ed9d4. The default EPP in fact needs to run after the ConfigDataEnvironmentPostProcessor and before the ConfigDataMissingEnvironmentPostProcessor.