### PR TITLE
Upgrade spring-shell 3.2.2

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -22,7 +22,7 @@
 		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
 		<spring-boot.version>3.2.2</spring-boot.version>
 		<spring-cloud.version>2023.0.0</spring-cloud.version>
-		<spring-shell.version>2.1.13</spring-shell.version>
+		<spring-shell.version>3.2.2</spring-shell.version>
 		<commons-io.version>2.15.1</commons-io.version>
 		<commons-text.version>1.11.0</commons-text.version>
 		<!-- Specific version overrides to deal w/ CVEs -->

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -26,6 +26,16 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-rest-client</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-data-jpa</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.cloud</groupId>
+					<artifactId>spring-cloud-dataflow-common-persistence</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.shell</groupId>

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandRunner.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandRunner.java
@@ -24,6 +24,7 @@ import org.jline.reader.impl.DefaultParser;
 import org.springframework.shell.Input;
 import org.springframework.shell.Shell;
 import org.springframework.shell.Utils;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,7 +63,9 @@ public class ShellCommandRunner {
 	public Object executeCommand(String command) {
 		Parser parser = new DefaultParser();
 		ParsedLine parsedLine = parser.parse(command, command.length() + 1);
-		Object rawResult = this.shell.evaluate(new ParsedLineInput(parsedLine));
+		// TODO: evaluate is not private method in spring-shell so calling it via
+		//       reflection until we refactor to use new shell testing system
+		Object rawResult = ReflectionTestUtils.invokeMethod(this.shell, "evaluate", new ParsedLineInput(parsedLine));
 		if (!this.validateCommandSuccess) {
 			assertThat(rawResult).isNotNull();
 			assertThat(rawResult).isNotInstanceOf(Exception.class);

--- a/spring-cloud-dataflow-shell/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-shell/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
 logging:
   pattern:
     console:
-  file:
-    name: dataflow-shell.log
-  level:
-    org:
-      springframework:
-        shell: debug
+  # file:
+  #   name: dataflow-shell.log
+  # level:
+  #   org:
+  #     springframework:
+  #       shell: debug

--- a/spring-cloud-dataflow-shell/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-shell/src/main/resources/application.yml
@@ -6,3 +6,9 @@ spring:
 logging:
   pattern:
     console:
+  file:
+    name: dataflow-shell.log
+  level:
+    org:
+      springframework:
+        shell: debug

--- a/spring-cloud-skipper/spring-cloud-skipper-shell-commands/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-shell-commands/pom.xml
@@ -40,6 +40,10 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-data-jpa</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.cloud</groupId>
+					<artifactId>spring-cloud-dataflow-common-persistence</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/spring-cloud-skipper/spring-cloud-skipper-shell/src/main/resources/application.yml
+++ b/spring-cloud-skipper/spring-cloud-skipper-shell/src/main/resources/application.yml
@@ -6,3 +6,9 @@ spring:
 logging:
   pattern:
     console:
+  # file:
+  #   name: skipper-shell.log
+  # level:
+  #   org:
+  #     springframework:
+  #       shell: debug


### PR DESCRIPTION
- Exclude spring-cloud-dataflow-common-persistence as it caused jdbc stuff in shell and then failures with datasource autoconfig
- Temporarily in tests use reflection as some methods in spring-shell are not public anymore. Long term todo is to migrate to new spring-shell testing utils
- Add commented shell log file settings which is a way to log hard shell startup errors