### PR TITLE
fix jdbc driver failures smoketests

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -201,6 +201,7 @@
 					<artifactId>maven-failsafe-plugin</artifactId>
 					<version>${maven-failsafe-plugin.version}</version>
 					<configuration>
+						<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 						<groups>${groups}</groups>
 						<excludedGroups>${excludedGroups}</excludedGroups>
 					</configuration>
@@ -668,6 +669,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>${maven-surefire-plugin.version}</version>
 						<configuration>
+							<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 							<threadCount>1</threadCount>
 							<forkCount>1</forkCount>
 							<properties>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -426,6 +426,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0</version>
 				<configuration>
+					<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 					<excludes>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -205,6 +205,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 				</configuration>
@@ -305,6 +306,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.0.0</version>
 						<configuration>
+							<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 							<threadCount>1</threadCount>
 							<forkCount>1</forkCount>
 							<skipTests>true</skipTests>
@@ -316,6 +318,7 @@
 						<artifactId>maven-failsafe-plugin</artifactId>
 						<version>3.0.0</version>
 						<configuration>
+							<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 							<includes>
 								<include>**/*IT.java</include>
 							</includes>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -258,6 +258,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 					<failIfNoTests>true</failIfNoTests>
@@ -283,6 +284,7 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
+							<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 							<threadCount>1</threadCount>
 							<forkCount>1</forkCount>
 							<failIfNoTests>true</failIfNoTests>

--- a/spring-cloud-starter-dataflow-server/pom.xml
+++ b/spring-cloud-starter-dataflow-server/pom.xml
@@ -92,6 +92,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
 					<threadCount>1</threadCount>
 					<forkCount>1</forkCount>
 					<excludes>


### PR DESCRIPTION
added `<argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>` to surefire-plugin and failsafe-plugin configurations.