### PR TITLE
stream update should not require --properties

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/StreamCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,7 +203,7 @@ public class StreamCommands {
 	@ShellMethodAvailability("availableWithModifyRole")
 	public String updateStream(
 			@ShellOption(value = { "", "--name" }, help = "the name of the stream", valueProvider = StreamNameValueProvider.class) String name,
-			@ShellOption(help = "Flattened YAML style properties to update the stream") String properties,
+			@ShellOption(value = "--properties", help = "Flattened YAML style properties to update the stream", defaultValue = ShellOption.NULL) String properties,
 			@ShellOption(value = "--propertiesFile", help = "the properties for the stream update (as a File)", defaultValue = ShellOption.NULL) File propertiesFile,
 			@ShellOption(value = "--packageVersion", help = "the package version of the package to update when using Skipper", defaultValue = ShellOption.NULL) String packageVersion,
 			@ShellOption(value = "--repoName", help = "the name of the local repository to upload the package when using Skipper", defaultValue = ShellOption.NULL) String repoName,

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTemplate.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,30 @@ public class StreamCommandTemplate {
 		assertThat(result).isEqualTo(deployMsg);
 
 		verifyExists(streamname, actualDefinition, deploy);
+	}
+
+	/**
+	 * Update the given stream
+	 *
+	 * @param streamname name of the stream
+	 * @param propertyValue the value to update stream
+	 *
+	 */
+	public void update(String streamname, String propertyValue, String expectedResult) {
+		Object result = commandRunner.executeCommand("stream update --name " + streamname + " --properties " + propertyValue);
+		assertThat((String)result).contains(expectedResult);
+	}
+
+	/**
+	 * Update the given stream
+	 *
+	 * @param streamname name of the stream
+	 * @param propertyFile the file that contains the properties
+	 *
+	 */
+	public void updateFile(String streamname, String propertyFile, String expectedResult) {
+		Object result = commandRunner.executeCommand("stream update --name " + streamname + " --propertiesFile " + propertyFile);
+		assertThat((String)result).contains(expectedResult);
 	}
 
 	/**

--- a/spring-cloud-dataflow-shell-core/src/test/resources/myproperties.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/myproperties.properties
@@ -1,0 +1,1 @@
+version.log=3.2.1


### PR DESCRIPTION
Currently a user can not set --propertiesFile option on a stream update command This fix allows users to use --properties or --properties file with a stream update command.
Added tests to verify

resolves #5783