### PR TITLE
Update Spring Kafka to 2.9.13 for CVE-2023-34040

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -29,6 +29,7 @@
 		<commons-text.version>1.10.0</commons-text.version>
 		<testcontainers.version>1.19.7</testcontainers.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
+		<spring-kafka.version>2.9.13</spring-kafka.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<json-smart.version>2.4.11</json-smart.version>
 		<nimbus-jose-jwt.version>9.37</nimbus-jose-jwt.version>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -33,6 +33,7 @@
 		<codearte-props2yml.version>0.5</codearte-props2yml.version>
 		<jettison.version>1.5.4</jettison.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
+		<spring-kafka.version>2.9.13</spring-kafka.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<json-smart.version>2.4.11</json-smart.version>
 		<nimbus-jose-jwt.version>9.37</nimbus-jose-jwt.version>
@@ -137,6 +138,11 @@
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-access</artifactId>
 				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.kafka</groupId>
+				<artifactId>spring-kafka</artifactId>
+				<version>${spring-kafka.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/spring-cloud-dataflow-single-step-batch-job/pom.xml
+++ b/spring-cloud-dataflow-single-step-batch-job/pom.xml
@@ -23,11 +23,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.springframework.kafka</groupId>
-				<artifactId>spring-kafka</artifactId>
-				<version>2.9.12</version>
-			</dependency>
-			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
 				<version>[2.2.222,3.0)</version>


### PR DESCRIPTION
The updated version (2.9.13) has 1 CVE for its use of json-path 2.6.0. 
This is mitigated by the pre-existing override to json-path 2.9.0.

Resolves #5794