### PR TITLE
Updated CI workflows to publish skipper docs

### DIFF
--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -77,7 +77,16 @@ jobs:
         jfrog rt mvn install -Pfull -B
         jfrog rt mvn install -pl spring-cloud-dataflow-package -B
         jfrog rt build-publish
-        echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
+        PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        SKIPPER_DOCS_PATTERN=$(.github/workflows/skipper-docs-name.sh $PROJECT_VERSION libs-snapshot-local)
+        if [[ "$SKIPPER_DOCS_PATTERN" == *"does not exist"* ]]; then
+          echo "::error ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+        else
+          echo "::info ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+          jfrog rt sp --build "$SKIPPER_DOCS_PATTERN" "buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+          echo "::info ::Skipper Docs Set Properties buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+        fi
+        echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_version=$PROJECT_VERSION >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildname=spring-cloud-dataflow-main >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildnumber=$GITHUB_RUN_NUMBER >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_skipper_version=$(mvn help:evaluate -Dexpression=spring-cloud-skipper.version -pl spring-cloud-dataflow-parent -q -DforceStdout) >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,16 @@ jobs:
         jfrog rt mvn install -Pfull,asciidoctordocs,restdocs -B
         jfrog rt mvn install -pl spring-cloud-dataflow-package -B
         jfrog rt build-publish
+        export JFROG_CLI_BUILD_NAME="${JFROG_CLI_BUILD_NAME/spring-cloud-dataflow/spring-cloud-skipper}"
+        PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        SKIPPER_DOCS_PATTERN=$(.github/workflows/skipper-docs-name.sh $PROJECT_VERSION libs-snapshot-local)
+        if [[ "$SKIPPER_DOCS_PATTERN" == *"does not exist"* ]]; then
+          echo "::error ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+        else
+          echo "::info ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+          jfrog rt sp --build "$SKIPPER_DOCS_PATTERN" "buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+          echo "::info ::Skipper Docs Set Properties buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+        fi
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: ${{ success() || failure() }}

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -98,7 +98,16 @@ jobs:
         ./spring-cloud-dataflow-package/set-package-version.sh
         jfrog rt mvn -gs .github/settings.xml -Pstagingmilestone,full,deploymentfiles -B install -DskipTests 
         jfrog rt build-publish
-        echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_version=$(mvn -gs .github/settings.xml -Pstagingmilestone help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_ENV
+        PROJECT_VERSION=$(mvn -gs .github/settings.xml -Pstagingmilestone help:evaluate -Dexpression=project.version -q -DforceStdout)
+        SKIPPER_DOCS_PATTERN=$(.github/workflows/skipper-docs-name.sh $PROJECT_VERSION libs-milestone-local)
+        if [[ "$SKIPPER_DOCS_PATTERN" == *"does not exist"* ]]; then
+          echo "::error ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+        else
+          echo "::info ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+          jfrog rt sp --build "$SKIPPER_DOCS_PATTERN" "buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+          echo "::info ::Skipper Docs Set Properties buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+        fi
+        echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_version=$PROJECT_VERSION >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildname=spring-cloud-dataflow-main-milestone >> $GITHUB_ENV
         echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildnumber=$GITHUB_RUN_NUMBER >> $GITHUB_ENV
     # zoo tag

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -107,7 +107,16 @@ jobs:
           jfrog rt mvn -gs .github/settings.xml -Pstagingrelease,full,deploymentfiles -B install -DskipTests
           echo "::notice ::build-publish"
           jfrog rt build-publish
-          spring_cloud_dataflow_version=$(mvn -gs .github/settings.xml -Pstagingrelease help:evaluate -Dexpression=project.version -q -DforceStdout)
+          PROJECT_VERSION=$(mvn -gs .github/settings.xml -Pstagingrelease help:evaluate -Dexpression=project.version -q -DforceStdout)
+          SKIPPER_DOCS_PATTERN=$(.github/workflows/skipper-docs-name.sh $PROJECT_VERSION libs-staging-local)
+          if [[ "$SKIPPER_DOCS_PATTERN" == *"does not exist"* ]]; then
+            echo "::error ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+          else
+            echo "::info ::Skipper Docs URL=$SKIPPER_DOCS_PATTERN"
+            jfrog rt sp --build "$SKIPPER_DOCS_PATTERN" "buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+            echo "::info ::Skipper Docs Set Properties buildName=$JFROG_CLI_BUILD_NAME;buildNumber=$JFROG_CLI_BUILD_NUMBER"
+          fi
+          spring_cloud_dataflow_version=$PROJECT_VERSION
           echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_version=$spring_cloud_dataflow_version >> $GITHUB_ENV
           echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildname=spring-cloud-dataflow-main-release >> $GITHUB_ENV
           echo BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildnumber=$GITHUB_RUN_NUMBER >> $GITHUB_ENV

--- a/.github/workflows/skipper-docs-name.sh
+++ b/.github/workflows/skipper-docs-name.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+VERSION=$1
+if [ "$1" == "" ]; then
+    echo "Version is required"
+    exit 1
+fi
+if [ "$2" != "" ]; then
+    REPO="$2"
+fi
+
+if [ -z "$REPO" ]; then
+    if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
+        REPO="libs-snapshot-local"
+    elif [[ "$VERSION" == *"-M"* ]] || [[ "${VERSION}" == *"-RC"* ]]; then
+        REPO="libs-milestone-local"
+    else
+        REPO="libs-release-local"
+    fi
+fi
+CURL_TOKEN="$ARTIFACTORY_USERNAME:$ARTIFACTORY_PASSWORD"
+if [[ "$REPO" == *"snapshot"* ]]; then
+    META_DATA_URL="https://repo.spring.io/artifactory/$REPO/org/springframework/cloud/spring-cloud-skipper-docs/${VERSION}/maven-metadata.xml"
+    curl -u "$CURL_TOKEN" --basic -o maven-metadata.xml -s -XGET -L "$META_DATA_URL" # > /dev/null
+    DL_TS=$(xmllint --xpath "/metadata/versioning/snapshot/timestamp/text()" maven-metadata.xml | sed 's/\.//')
+    DL_VERSION=$(xmllint --xpath "/metadata/versioning/snapshotVersions/snapshotVersion[extension/text() = 'pom' and updated/text() = '$DL_TS']/value/text()" maven-metadata.xml)
+    REMOTE_PATH="org/springframework/cloud/spring-cloud-skipper-docs/${VERSION}/spring-cloud-skipper-docs-${DL_VERSION}.zip"
+else
+    REMOTE_PATH="org/springframework/cloud/spring-cloud-skipper-docs/${VERSION}/spring-cloud-skipper-docs-${VERSION}.zip"
+fi
+REMOTE_FILE="https://repo.spring.io/artifactory/${REPO}/$REMOTE_PATH"
+RC=$(curl -u "$CURL_TOKEN" --basic -o /dev/null -L -s -Iw '%{http_code}' "$REMOTE_FILE")
+if ((RC<300)); then
+  echo "$REMOTE_PATH"
+else
+  echo "$REMOTE_FILE does not exist. Error code $RC"
+  exit 2
+fi


### PR DESCRIPTION
Updated CI workflows to set property with spring-cloud-skipper-* on skipper docs to ensure it is published to docs.spring.io

Fixes #5778