### PR TITLE
Fix Tomcat embedded dep. mgmt.

### DIFF
--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -144,22 +144,22 @@
 			</dependency>
 			<!-- There is no embedded tomcat BOM unfortunately -->
 			<dependency>
-				<groupId>org.apache.tomcat</groupId>
+				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-core</artifactId>
 				<version>${tomcat.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.tomcat</groupId>
+				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-el</artifactId>
 				<version>${tomcat.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.tomcat</groupId>
+				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-jasper</artifactId>
 				<version>${tomcat.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.tomcat</groupId>
+				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-websocket</artifactId>
 				<version>${tomcat.version}</version>
 			</dependency>
@@ -167,8 +167,8 @@
 				<groupId>org.springframework.kafka</groupId>
 				<artifactId>spring-kafka</artifactId>
 				<version>${spring-kafka.version}</version>
-    </dependency>
-    <dependency>
+		    </dependency>
+		    <dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
 				<version>${netty.version}</version>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -167,8 +167,8 @@
 				<groupId>org.springframework.kafka</groupId>
 				<artifactId>spring-kafka</artifactId>
 				<version>${spring-kafka.version}</version>
-		    </dependency>
-		    <dependency>
+			</dependency>
+			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
 				<version>${netty.version}</version>


### PR DESCRIPTION
Update the dep. mgmt. entries for Tomcat embedded as the previous commit used the wrong groupId (missing `.embed` suffix).

See #5780