### PR TITLE
Update Bouncycastle to 1.78.1 for CVE-2023-33201

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -30,6 +30,7 @@
 		<testcontainers.version>1.19.7</testcontainers.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
 		<tomcat.version>9.0.88</tomcat.version>
+		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
 		<netty.version>4.1.109.Final</netty.version>
 		<reactor-bom.version>2020.0.43</reactor-bom.version>
@@ -189,6 +190,22 @@
 				<groupId>io.pivotal.spring.cloud</groupId>
 				<artifactId>spring-cloud-services-starter-config-client</artifactId>
 				<version>${spring-cloud-services-starter-config-client.version}</version>
+			</dependency>
+			<!-- Provide Bouncycastle dep. mgmt. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -34,6 +34,7 @@
 		<jettison.version>1.5.4</jettison.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
 		<tomcat.version>9.0.88</tomcat.version>
+		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
 		<netty.version>4.1.109.Final</netty.version>
 		<reactor-bom.version>2020.0.43</reactor-bom.version>
@@ -142,7 +143,7 @@
 				<artifactId>logback-access</artifactId>
 				<version>${logback.version}</version>
 			</dependency>
-			<!-- There is no embedded tomcat BOM unfortunately -->
+			<!-- Override embedded Tomcat provided by Spring Boot (no BOM unfortunately) -->
 			<dependency>
 				<groupId>org.apache.tomcat.embed</groupId>
 				<artifactId>tomcat-embed-core</artifactId>
@@ -168,6 +169,7 @@
 				<artifactId>spring-kafka</artifactId>
 				<version>${spring-kafka.version}</version>
 			</dependency>
+			<!-- Override Netty provided by Spring Boot -->
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
@@ -175,6 +177,7 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Override Reactor provided by Spring Boot -->
 			<dependency>
 				<groupId>io.projectreactor</groupId>
 				<artifactId>reactor-bom</artifactId>
@@ -182,6 +185,7 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Override RSocket provided by Spring Boot -->
 			<dependency>
 				<groupId>io.rsocket</groupId>
 				<artifactId>rsocket-bom</artifactId>
@@ -189,6 +193,23 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Provide Bouncycastle dep. mgmt. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<!-- Override dependencies should go above this comment -->
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-framework-bom</artifactId>


### PR DESCRIPTION
Resolves #5780

## BEFORE
```
cbono@cbono-a01 spring-cloud-dataflow % ./mvnw dependency:tree -Dincludes='org.bouncycastle' | grep -E '1.73' | wc -l
      45
```

## AFTER
```
cbono@cbono-a01 spring-cloud-dataflow % ./mvnw dependency:tree -Dincludes='org.bouncycastle' | grep -E '1.73' | wc -l
      0

cbono@cbono-a01 spring-cloud-dataflow % ./mvnw dependency:tree -Dincludes='org.bouncycastle' | grep -E '1.78.1' | wc -l
      45
```