### PR TITLE
Add trailing slash to dashboard

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/UiController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/UiController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @author Gunnar Hillert
  */
 @Controller
-@RequestMapping(UiController.WEB_UI_INDEX_PAGE_ROUTE)
+@RequestMapping({ UiController.WEB_UI_INDEX_PAGE_ROUTE, UiController.WEB_UI_INDEX_PAGE_ROUTE + "/" })
 public class UiController {
 
 	public static final String WEB_UI_INDEX_PAGE_ROUTE = "/dashboard";


### PR DESCRIPTION
- Boot 3.x changed handling of trailing slash meaning it's now adviced to define both /dashboard and /dashboard/ in UiController

Essentially to fix latter:
```
jvalkealahti@cypher:/tmp/xxx$ http --headers http://localhost:9393/dashboard
HTTP/1.1 302 
Connection: keep-alive
Content-Language: en-GB
Content-Length: 0
Date: Mon, 13 May 2024 12:36:17 GMT
Keep-Alive: timeout=60
Location: http://localhost:9393/dashboard/index.html

jvalkealahti@cypher:/tmp/xxx$ http --headers http://localhost:9393/dashboard/
HTTP/1.1 500 
Connection: close
Content-Type: application/hal+json
Date: Mon, 13 May 2024 12:36:21 GMT
Transfer-Encoding: chunked
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
```