### PR TITLE
Add spring-cloud-dataflow-server to version-info.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -94,6 +94,9 @@ spring:
         dependency-fetch:
           enabled: false
         dependencies:
+          spring-cloud-dataflow-server:
+            name: Spring Cloud Dataflow
+            version: "@project.version@"
           spring-cloud-dataflow-dashboard:
             name: Spring Cloud Dataflow UI
             version: "@spring-cloud-dataflow-ui.version@"


### PR DESCRIPTION
This adds an entry to version-info that the UI can display to ensure OSS and PRO UI shows product name and version differently.

In Pro the entry has the following:

```yaml
    spring-cloud-dataflow-server:
        name: Spring Cloud Dataflow Pro Server

```            
in OSS:

```yaml
    spring-cloud-dataflow-server:
        name: Spring Cloud Dataflow Server

```            