### PR TITLE
the document plugin needs to use the current spring javadoc location

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -90,6 +90,8 @@
 		<maven-dependency-plugin-for-guides.phase>generate-resources</maven-dependency-plugin-for-guides.phase>
 		<groups />
 		<excludedGroups>slow,docker</excludedGroups>
+		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
+		<spring-javadoc.version>6.1.3</spring-javadoc.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -91,7 +91,7 @@
 		<groups />
 		<excludedGroups>slow,docker</excludedGroups>
 		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<spring-javadoc.version>6.1.3</spring-javadoc.version>
+		<javadoc-spring.version>6.1.3</javadoc-spring.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -36,7 +36,7 @@
 		<junit.version>4.13.1</junit.version>
 		<json-path.version>2.9.0</json-path.version>
 		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<spring-javadoc.version>6.1.3</spring-javadoc.version>
+		<javadoc-spring.version>6.1.3</javadoc-spring.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -35,6 +35,8 @@
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>
 		<junit.version>4.13.1</junit.version>
 		<json-path.version>2.9.0</json-path.version>
+		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
+		<spring-javadoc.version>6.1.3</spring-javadoc.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-docs/pom.xml
+++ b/spring-cloud-dataflow-docs/pom.xml
@@ -95,7 +95,7 @@
 									<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 									<links>
 										<link>
-											https://docs.spring.io/spring-framework/docs/${spring-javadoc.version}/javadoc-api/
+											https://docs.spring.io/spring-framework/docs/${javadoc-spring.version}/javadoc-api/
 										</link>
 										<link>https://docs.spring.io/spring-shell/docs/current/api/</link>
 									</links>

--- a/spring-cloud-dataflow-docs/pom.xml
+++ b/spring-cloud-dataflow-docs/pom.xml
@@ -95,7 +95,7 @@
 									<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 									<links>
 										<link>
-											https://docs.spring.io/spring-framework/docs/${spring.version}/javadoc-api/
+											https://docs.spring.io/spring-framework/docs/current/javadoc-api/
 										</link>
 										<link>https://docs.spring.io/spring-shell/docs/current/api/</link>
 									</links>

--- a/spring-cloud-dataflow-docs/pom.xml
+++ b/spring-cloud-dataflow-docs/pom.xml
@@ -95,7 +95,7 @@
 									<stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
 									<links>
 										<link>
-											https://docs.spring.io/spring-framework/docs/current/javadoc-api/
+											https://docs.spring.io/spring-framework/docs/${spring-javadoc.version}/javadoc-api/
 										</link>
 										<link>https://docs.spring.io/spring-shell/docs/current/api/</link>
 									</links>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -48,6 +48,8 @@
 		<spring-security.version>5.7.11</spring-security.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<json-path.version>2.9.0</json-path.version>
+		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
+		<spring-javadoc.version>6.1.3</spring-javadoc.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -49,7 +49,7 @@
 		<guava.version>32.1.3-jre</guava.version>
 		<json-path.version>2.9.0</json-path.version>
 		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<spring-javadoc.version>6.1.3</spring-javadoc.version>
+		<javadoc-spring.version>6.1.3</javadoc-spring.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
It was set to use a configurable spring version that was not set in the main-3.   When ever possible we want to use the BOM or current when determining versions.