### PR TITLE
Update build-images and integration tests

### DIFF
--- a/.github/actions/build-images/build-images.sh
+++ b/.github/actions/build-images/build-images.sh
@@ -4,8 +4,8 @@ if [ "$TAG" == "" ]; then
     exit 1
 fi
 if [ "$DEFAULT_JDK" = "" ]; then
-    echo "DEFAULT_JDK not found using 11"
-    DEFAULT_JDK=11
+    echo "DEFAULT_JDK not found using 17"
+    DEFAULT_JDK=17
 else
     echo "DEFAULT_JDK=$DEFAULT_JDK"
 fi
@@ -20,7 +20,7 @@ function pack_image {
     fi
     echo "Creating: $REPO:$TAG-jdk$v"
     # --buildpack "paketo-buildpacks/java@10.0.0" --buildpack "paketo-buildpacks/bellsoft-liberica@10.3.2"
-    pack build --builder gcr.io/paketo-buildpacks/builder:base \
+    pack build --builder paketobuildpacks/builder-jammy-base:latest \
             --path "$JAR" \
             --trust-builder --verbose \
             --env BP_JVM_VERSION=$v "$REPO:$TAG-jdk$v"
@@ -37,7 +37,7 @@ for ((i = 0; i < LEN; i++)); do
     IMAGE="$(jq -r --argjson index $i '.include[$index] | .image' .github/workflows/images.json)"
     ARTIFACT_ID="$(jq -r --argjson index $i '.include[$index] | .name' .github/workflows/images.json)"
     # 8 11 17 21
-    for v in 8 11 17; do
+    for v in 17 21; do
         pack_image "$TARGET/$ARTIFACT_ID"  $IMAGE $v $ARTIFACT_ID
         RC=$?
         if [ $RC -ne 0 ]; then

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
@@ -62,35 +62,18 @@ public abstract class AbstractDatabaseTests extends AbstractDataflowTests {
 
 	@Test
 	@DataflowMain
-	public void testLatestSharedDbJdk8() {
+	public void testLatestSharedDbJdk21() {
 		log.info("Running testLatestSharedDb()");
 		// start defined database
 		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
 		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
 
 		// start defined skipper server and check it started
-		this.dataflowCluster.startSkipper(TagNames.SKIPPER_main + "-jdk8");
+		this.dataflowCluster.startSkipper(TagNames.SKIPPER_main + "-jdk21");
 		assertSkipperServerRunning(this.dataflowCluster);
 
 		// start defined dataflow server and check it started
-		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main + "-jdk8");
-		assertDataflowServerRunning(this.dataflowCluster);
-	}
-
-	@Test
-	@DataflowMain
-	public void testLatestSharedDbJdk11() {
-		log.info("Running testLatestSharedDb()");
-		// start defined database
-		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
-		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
-
-		// start defined skipper server and check it started
-		this.dataflowCluster.startSkipper(TagNames.SKIPPER_main + "-jdk11");
-		assertSkipperServerRunning(this.dataflowCluster);
-
-		// start defined dataflow server and check it started
-		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main + "-jdk11");
+		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_main + "-jdk21");
 		assertDataflowServerRunning(this.dataflowCluster);
 	}
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
@@ -169,7 +169,7 @@ public abstract class AbstractDataflowTests {
 	protected List<ClusterContainer> getDataflowContainers() {
 		ArrayList<ClusterContainer> containers = new ArrayList<>(DATAFLOW_CONTAINERS);
 		containers.add(ClusterContainer.from(TagNames.DATAFLOW_main, DATAFLOW_IMAGE_PREFIX + getDataflowLatestVersion()));
-		List<Integer> jdkTags = Arrays.asList(8, 11, 17);
+		List<Integer> jdkTags = Arrays.asList(17, 21);
 		for(Integer jdk : jdkTags) {
 			containers.add(ClusterContainer.from(TagNames.DATAFLOW_main + "-jdk" + jdk, DATAFLOW_IMAGE_PREFIX + getDataflowLatestVersion() + "-jdk" + jdk));
 		}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDataflowTests.java
@@ -64,7 +64,7 @@ public abstract class AbstractDataflowTests {
 		ClusterContainer.from(TagNames.DATAFLOW_2_8, DATAFLOW_IMAGE_PREFIX + "2.8.4"),
 		ClusterContainer.from(TagNames.DATAFLOW_2_9, DATAFLOW_IMAGE_PREFIX + "2.9.6"),
 		ClusterContainer.from(TagNames.DATAFLOW_2_10, DATAFLOW_IMAGE_PREFIX + "2.10.3"),
-		ClusterContainer.from(TagNames.DATAFLOW_2_11, DATAFLOW_IMAGE_PREFIX + "2.11.0")
+		ClusterContainer.from(TagNames.DATAFLOW_2_11, DATAFLOW_IMAGE_PREFIX + "2.11.3")
 	);
 
 	public final static List<ClusterContainer> SKIPPER_CONTAINERS = Arrays.asList(
@@ -72,7 +72,7 @@ public abstract class AbstractDataflowTests {
 		ClusterContainer.from(TagNames.SKIPPER_2_7, SKIPPER_IMAGE_PREFIX + "2.7.4"),
 		ClusterContainer.from(TagNames.SKIPPER_2_8, SKIPPER_IMAGE_PREFIX + "2.8.6"),
 		ClusterContainer.from(TagNames.SKIPPER_2_9, SKIPPER_IMAGE_PREFIX + "2.9.3"),
-		ClusterContainer.from(TagNames.SKIPPER_2_11, SKIPPER_IMAGE_PREFIX + "2.11.0")
+		ClusterContainer.from(TagNames.SKIPPER_2_11, SKIPPER_IMAGE_PREFIX + "2.11.3")
 	);
 
 	public final static List<ClusterContainer> DATABASE_CONTAINERS = Arrays.asList(
@@ -159,7 +159,7 @@ public abstract class AbstractDataflowTests {
 	protected List<ClusterContainer> getSkipperContainers() {
 		ArrayList<ClusterContainer> containers = new ArrayList<>(SKIPPER_CONTAINERS);
 		containers.add(ClusterContainer.from(TagNames.SKIPPER_main, SKIPPER_IMAGE_PREFIX + getSkipperLatestVersion()));
-		List<Integer> jdkTags = Arrays.asList(8, 11, 17);
+		List<Integer> jdkTags = Arrays.asList(17, 21);
 		for(Integer jdk : jdkTags) {
 			containers.add(ClusterContainer.from(TagNames.SKIPPER_main + "-jdk" + jdk, SKIPPER_IMAGE_PREFIX + getSkipperLatestVersion() + "-jdk" + jdk));
 		}


### PR DESCRIPTION
Add JDK 21 and remove 8, 11 from build-images.
Remove JDK pre 17 from container tests.
Add JDK 21 to container tests.
Update DataflowOAuthIT to dump last error output from curl.