### PR TITLE
Serialize Job Parameters to the command Line Arguments on Job Restarts per Batch Standards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,10 @@
 		<module>spring-cloud-dataflow-shell</module>
 		<module>spring-cloud-dataflow-shell-core</module>
 		<module>spring-cloud-dataflow-completion</module>
-<!--		<module>spring-cloud-skipper</module>-->
+		<module>spring-cloud-skipper</module>
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
-<!--		<module>spring-cloud-dataflow-server</module>-->
+		<module>spring-cloud-dataflow-server</module>
 		<module>spring-cloud-dataflow-tasklauncher</module>
 		<module>spring-cloud-dataflow-single-step-batch-job</module>
 		<module>spring-cloud-dataflow-composed-task-runner</module>

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,10 @@
 		<module>spring-cloud-dataflow-shell</module>
 		<module>spring-cloud-dataflow-shell-core</module>
 		<module>spring-cloud-dataflow-completion</module>
-		<module>spring-cloud-skipper</module>
+<!--		<module>spring-cloud-skipper</module>-->
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
-		<module>spring-cloud-dataflow-server</module>
+<!--		<module>spring-cloud-dataflow-server</module>-->
 		<module>spring-cloud-dataflow-tasklauncher</module>
 		<module>spring-cloud-dataflow-single-step-batch-job</module>
 		<module>spring-cloud-dataflow-composed-task-runner</module>

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobExecutionsDocumentation.java
@@ -334,6 +334,7 @@ public class JobExecutionsDocumentation extends BaseDocumentation {
 	public void jobRestart() throws Exception {
 		this.mockMvc.perform(put("/jobs/executions/{id}", "2")
 						.queryParam("restart", "true")
+						.queryParam("useJsonJobParameters", "true")
 				)
 				.andDo(print())
 				.andExpect(status().isOk())
@@ -341,6 +342,9 @@ public class JobExecutionsDocumentation extends BaseDocumentation {
 								pathParameters(parameterWithName("id")
 										.description("The id of an existing job execution (required)"))
 								, queryParameters(
+										parameterWithName("useJsonJobParameters").description("If true dataflow will " +
+											"serialize job parameters as JSON.  Default is null, and the default " +
+											"configuration will be used to determine serialization method.").optional(),
 										parameterWithName("restart")
 												.description("Sends signal to restart the job if set to true")
 								)

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -2666,7 +2666,7 @@ include::{snippets}/job-executions-documentation/job-restart/path-parameters.ado
 [[api-guide-resources-job-executions-restart-request-parameters]]
 ===== Request Parameters
 
-include::{snippets}/job-executions-documentation/job-restart/request-parameters.adoc[]
+include::{snippets}/job-executions-documentation/job-restart/query-parameters.adoc[]
 
 
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobOperations.java
@@ -45,7 +45,7 @@ public interface JobOperations {
 	/**
 	 * Restarts a job by id
 	 *
-	 * @param id           job execution id
+	 * @param id job execution id
 	 * @param useJsonJobParameters if true {@link org.springframework.batch.core.JobParameters} will be serialized to JSON.
 	 *                             Default is {@code Null} which will serialize the {@link org.springframework.batch.core.JobParameters}
 	 *                             to the default specified in SCDF's configuration.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobOperations.java
@@ -43,6 +43,16 @@ public interface JobOperations {
 	void executionRestart(long id);
 
 	/**
+	 * Restarts a job by id
+	 *
+	 * @param id           job execution id
+	 * @param useJsonJobParameters if true {@link org.springframework.batch.core.JobParameters} will be serialized to JSON.
+	 *                             Default is {@code Null} which will serialize the {@link org.springframework.batch.core.JobParameters}
+	 *                             to the default specified in SCDF's configuration.
+	 */
+	void executionRestart(long id, Boolean useJsonJobParameters);
+
+	/**
 	 * @return the list job executions without step executions known to the system.
 	 */
 	PagedModel<JobExecutionThinResource> executionThinList();

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/JobTemplate.java
@@ -118,6 +118,14 @@ public class JobTemplate implements JobOperations {
 	}
 
 	@Override
+	public void executionRestart(long id, Boolean useJsonJobParameters) {
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(executionLink.expand(id).getHref()).queryParam("restart", "true")
+			.queryParam("useJsonJobParameters", useJsonJobParameters);
+
+		restTemplate.put(builder.toUriString(), null);
+	}
+
+	@Override
 	public PagedModel<JobExecutionThinResource> executionThinList() {
 		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(thinExecutionsLink.getHref()).queryParam("size", "2000");
 		return restTemplate.getForObject(builder.toUriString(), JobExecutionThinResource.Page.class);

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
@@ -24,8 +24,6 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,10 +39,8 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.cloud.dataflow.rest.Version;
 import org.springframework.cloud.dataflow.rest.job.StepExecutionHistory;
 import org.springframework.cloud.dataflow.rest.resource.RootResource;
-import org.springframework.cloud.dataflow.rest.support.jackson.Jackson2DataflowModule;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.LinkRelation;
-import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.ResourceAccessException;
@@ -71,10 +67,7 @@ public class DataflowTemplateTests {
 	@Before
 	public void setup() {
 		mapper = new ObjectMapper();
-		mapper.registerModule(new Jdk8Module());
-		mapper.registerModule(new Jackson2HalModule());
-		mapper.registerModule(new JavaTimeModule());
-		mapper.registerModule(new Jackson2DataflowModule());
+		DataFlowTemplate.prepareObjectMapper(mapper);
 		System.setProperty("sun.net.client.defaultConnectTimeout", String.valueOf(100));
 	}
 
@@ -104,9 +97,7 @@ public class DataflowTemplateTests {
 
 	@Test
 	public void testThatObjectMapperGetsPrepared() {
-		final ObjectMapper objectMapper = new ObjectMapper();
-		DataFlowTemplate.prepareObjectMapper(objectMapper);
-		assertCorrectMixins(objectMapper);
+		assertCorrectMixins(this.mapper);
 	}
 
 	@Test
@@ -116,7 +107,6 @@ public class DataflowTemplateTests {
 		jobParametersBuilder.addString("bar", "bar");
 
 		JobParameters jobParameters = jobParametersBuilder.toJobParameters();
-		DataFlowTemplate.prepareObjectMapper(this.mapper);
 		assertCorrectMixins(this.mapper);
 		String jobParametersSerialized = this.mapper.writeValueAsString(jobParameters);
 		jobParameters = this.mapper.readValue(jobParametersSerialized, JobParameters.class);

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -34,6 +35,7 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.cloud.dataflow.rest.Version;
@@ -105,6 +107,23 @@ public class DataflowTemplateTests {
 		final ObjectMapper objectMapper = new ObjectMapper();
 		DataFlowTemplate.prepareObjectMapper(objectMapper);
 		assertCorrectMixins(objectMapper);
+	}
+
+	@Test
+	public void testJobParameters() throws JsonProcessingException {
+		final ObjectMapper objectMapper = new ObjectMapper();
+		JobParametersBuilder jobParametersBuilder = new JobParametersBuilder();
+		jobParametersBuilder.addString("foo", "foo");
+		jobParametersBuilder.addString("bar", "bar");
+
+		JobParameters jobParameters = jobParametersBuilder.toJobParameters();
+		DataFlowTemplate.prepareObjectMapper(objectMapper);
+		assertCorrectMixins(objectMapper);
+		String jobParametersSerialized = objectMapper.writeValueAsString(jobParameters);
+		jobParameters = objectMapper.readValue(jobParametersSerialized, JobParameters.class);
+		assertEquals(jobParameters.getParameter("foo").getValue(), "foo");
+		assertEquals(jobParameters.getParameter("bar").getValue(), "bar");
+		assertEquals(jobParameters.getParameters().size(), 2);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/DataflowTemplateTests.java
@@ -111,16 +111,15 @@ public class DataflowTemplateTests {
 
 	@Test
 	public void testJobParameters() throws JsonProcessingException {
-		final ObjectMapper objectMapper = new ObjectMapper();
 		JobParametersBuilder jobParametersBuilder = new JobParametersBuilder();
 		jobParametersBuilder.addString("foo", "foo");
 		jobParametersBuilder.addString("bar", "bar");
 
 		JobParameters jobParameters = jobParametersBuilder.toJobParameters();
-		DataFlowTemplate.prepareObjectMapper(objectMapper);
-		assertCorrectMixins(objectMapper);
-		String jobParametersSerialized = objectMapper.writeValueAsString(jobParameters);
-		jobParameters = objectMapper.readValue(jobParametersSerialized, JobParameters.class);
+		DataFlowTemplate.prepareObjectMapper(this.mapper);
+		assertCorrectMixins(this.mapper);
+		String jobParametersSerialized = this.mapper.writeValueAsString(jobParameters);
+		jobParameters = this.mapper.readValue(jobParametersSerialized, JobParameters.class);
 		assertEquals(jobParameters.getParameter("foo").getValue(), "foo");
 		assertEquals(jobParameters.getParameter("bar").getValue(), "bar");
 		assertEquals(jobParameters.getParameters().size(), 2);

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
@@ -50,24 +50,16 @@ public class JobParameterJacksonDeserializer extends JsonDeserializer<JobParamet
 		String type = node.get("type").asText();
 
 		JobParameter jobParameter;
-		//TODO: Boot3x followup Verify that Job Parameters setup properly for Batch 5
-		if (!type.isEmpty() && !type.equalsIgnoreCase("java.lang.String")) {
-			if ("DATE".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(LocalDateTime.parse(value), LocalDateTime.class,  identifying);
-			}
-			else if ("DOUBLE".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(Double.valueOf(value), Double.class, identifying);
-			}
-			else if ("LONG".equalsIgnoreCase(type)) {
-				jobParameter = new JobParameter(Long.valueOf(value), Long.class, identifying);
-			}
-			else {
-				throw new IllegalStateException("Unsupported JobParameter type: " + type);
+		if (!type.isEmpty()) {
+			try {
+				jobParameter = new JobParameter(value, Class.forName(type), identifying);
+			} catch (ClassNotFoundException e) {
+				throw new IllegalArgumentException("JobParameter type %s is not supported by DataFlow".formatted(type), e);
 			}
 		}
 		else {
-			jobParameter = new JobParameter(value, String.class, identifying);
-		}
+            jobParameter = new JobParameter(value, String.class, identifying);
+        }
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("jobParameter - value: {} (type: {}, isIdentifying: {})",

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializer.java
@@ -51,7 +51,7 @@ public class JobParameterJacksonDeserializer extends JsonDeserializer<JobParamet
 
 		JobParameter jobParameter;
 		//TODO: Boot3x followup Verify that Job Parameters setup properly for Batch 5
-		if (!type.isEmpty() && !type.equalsIgnoreCase("STRING")) {
+		if (!type.isEmpty() && !type.equalsIgnoreCase("java.lang.String")) {
 			if ("DATE".equalsIgnoreCase(type)) {
 				jobParameter = new JobParameter(LocalDateTime.parse(value), LocalDateTime.class,  identifying);
 			}

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParametersJacksonMixIn.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParametersJacksonMixIn.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.dataflow.rest.support.jackson;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 
 /**
@@ -27,9 +30,12 @@ import org.springframework.batch.core.JobParameters;
  * @author Gunnar Hillert
  * @since 1.0
  */
-@JsonIgnoreProperties("empty")
+@JsonIgnoreProperties({"empty", "identifyingParameters"})
 public abstract class JobParametersJacksonMixIn {
 
 	@JsonProperty
 	abstract boolean isEmpty();
+
+	@JsonProperty
+	abstract Map<String, JobParameter<?>> getIdentifyingParameters();
 }

--- a/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializerTests.java
+++ b/spring-cloud-dataflow-rest-resource/src/test/java/org/springframework/cloud/dataflow/rest/support/jackson/JobParameterJacksonDeserializerTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.rest.support.jackson;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.UTF8StreamJsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobParameter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+public class JobParameterJacksonDeserializerTests {
+
+	@Test
+	public void validJobParameter() throws IOException {
+		JobParameterJacksonDeserializer jobParameterJacksonDeserializer = new JobParameterJacksonDeserializer();
+		String json = "{\"value\":\"BAR\",\"type\":\"java.lang.String\",\"identifying\":true}";
+		JobParameter jobParameter = jobParameterJacksonDeserializer.deserialize(getJsonParser(json), null);
+		assertThat(jobParameter.getType()).isEqualTo(String.class);
+		assertThat(jobParameter.getValue()).isEqualTo("BAR");
+		assertThat(jobParameter.isIdentifying()).isTrue();
+	}
+
+	@Test
+	public void inValidJobParameter() throws IOException {
+		JobParameterJacksonDeserializer jobParameterJacksonDeserializer = new JobParameterJacksonDeserializer();
+		String json = "{\"value\":\"BAR\",\"type\":\"java.lang.FOO\",\"identifying\":true}";
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> {
+				jobParameterJacksonDeserializer.deserialize(getJsonParser(json), null);
+			})
+			.withMessage("JobParameter type java.lang.FOO is not supported by DataFlow");
+	}
+
+	private JsonParser getJsonParser(String json) throws IOException {
+		JsonFactory factory = new JsonFactory();
+		byte[] jsonData = json.getBytes();
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonData);
+		UTF8StreamJsonParser jsonParser = (UTF8StreamJsonParser) factory.createParser(inputStream);
+		jsonParser.setCodec(new ObjectMapper());
+		return jsonParser;
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableStepExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableStepExecutionDao.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.dataflow.server.batch;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -201,8 +202,11 @@ public class JdbcSearchableStepExecutionDao extends JdbcStepExecutionDao impleme
 		public StepExecution mapRow(ResultSet rs, int rowNum) throws SQLException {
 			StepExecution stepExecution = new StepExecution(rs.getString(2), null);
 			stepExecution.setId(rs.getLong(1));
-			stepExecution.setStartTime(rs.getTimestamp(3).toLocalDateTime());
-			stepExecution.setEndTime(rs.getTimestamp(4).toLocalDateTime());
+			Timestamp startTimeStamp = rs.getTimestamp(3);
+			Timestamp endTimeStamp = rs.getTimestamp(4);
+
+			stepExecution.setStartTime((startTimeStamp == null) ? null : startTimeStamp.toLocalDateTime());
+			stepExecution.setEndTime((endTimeStamp == null) ? null : endTimeStamp.toLocalDateTime());
 			stepExecution.setStatus(BatchStatus.valueOf(rs.getString(5)));
 			stepExecution.setCommitCount(rs.getInt(6));
 			stepExecution.setReadCount(rs.getInt(7));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -272,13 +272,14 @@ public class TaskConfiguration {
 				DataflowTaskExplorer taskExplorer,
 				TaskDefinitionRepository taskDefinitionRepository,
 				TaskExecutionService taskExecutionService,
-				LauncherRepository launcherRepository) {
+				LauncherRepository launcherRepository, TaskConfigurationProperties taskConfigurationProperties) {
 			return new DefaultTaskJobService(
 					service,
 					taskExplorer,
 					taskDefinitionRepository,
 					taskExecutionService,
-					launcherRepository
+					launcherRepository,
+				taskConfigurationProperties
 			);
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -279,7 +279,7 @@ public class TaskConfiguration {
 					taskDefinitionRepository,
 					taskExecutionService,
 					launcherRepository,
-				taskConfigurationProperties
+					taskConfigurationProperties
 			);
 		}
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.dataflow.server.controller;
 
 import java.util.TimeZone;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
@@ -39,7 +41,6 @@ import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSuppor
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -62,6 +63,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RequestMapping("/jobs/executions")
 @ExposesResourceFor(JobExecutionResource.class)
 public class JobExecutionController {
+
+	private static final Logger logger = LoggerFactory.getLogger(JobExecutionController.class);
 
 	private final Assembler jobAssembler = new Assembler();
 
@@ -151,7 +154,12 @@ public class JobExecutionController {
 		@PathVariable("executionId") long jobExecutionId,
 		@RequestParam(value = "useJsonJobParameters", required = false) Boolean useJsonJobParameters)
 		throws NoSuchJobExecutionException {
+		try {
 			taskJobService.restartJobExecution(jobExecutionId, useJsonJobParameters);
+		} catch (NoSuchJobExecutionException e) {
+			logger.warn(e.getMessage(), e);
+			throw e;
+		}
 			return ResponseEntity.ok().build();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
@@ -148,8 +148,10 @@ public class JobExecutionController {
 	@RequestMapping(value = {"/{executionId}"}, method = RequestMethod.PUT, params = "restart=true")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<Void> restartJobExecution(
-			@PathVariable("executionId") long jobExecutionId) throws NoSuchJobExecutionException {
-		taskJobService.restartJobExecution(jobExecutionId);
+			@PathVariable("executionId") long jobExecutionId,
+			@RequestParam(value = "useJsonJobParameters", required = false) Boolean useJsonJobParameters
+	) throws NoSuchJobExecutionException {
+		taskJobService.restartJobExecution(jobExecutionId, useJsonJobParameters);
 		return ResponseEntity.ok().build();
 	}
 
@@ -188,7 +190,7 @@ public class JobExecutionController {
 					resource.add(linkTo(methodOn(JobExecutionController.class).stopJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("stop"));
 				}
 				if (!taskJobExecution.getJobExecution().getStatus().equals(BatchStatus.COMPLETED)) {
-					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("restart"));
+					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId(), false)).withRel("restart"));
 				}
 			} catch (NoSuchJobExecutionException | JobExecutionNotRunningException e) {
 				throw new RuntimeException(e);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
@@ -148,11 +148,11 @@ public class JobExecutionController {
 	@RequestMapping(value = {"/{executionId}"}, method = RequestMethod.PUT, params = "restart=true")
 	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<Void> restartJobExecution(
-			@PathVariable("executionId") long jobExecutionId,
-			@RequestParam(value = "useJsonJobParameters", required = false) Boolean useJsonJobParameters
-	) throws NoSuchJobExecutionException {
-		taskJobService.restartJobExecution(jobExecutionId, useJsonJobParameters);
-		return ResponseEntity.ok().build();
+		@PathVariable("executionId") long jobExecutionId,
+		@RequestParam(value = "useJsonJobParameters", required = false) Boolean useJsonJobParameters)
+		throws NoSuchJobExecutionException {
+			taskJobService.restartJobExecution(jobExecutionId, useJsonJobParameters);
+			return ResponseEntity.ok().build();
 	}
 
 	/**
@@ -190,7 +190,8 @@ public class JobExecutionController {
 					resource.add(linkTo(methodOn(JobExecutionController.class).stopJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("stop"));
 				}
 				if (!taskJobExecution.getJobExecution().getStatus().equals(BatchStatus.COMPLETED)) {
-					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId(), false)).withRel("restart"));
+					// In this case we use null for the useJsonJobParameters parameter, so we use the configured job parameter serialization method specified by dataflow.
+					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId(), null)).withRel("restart"));
 				}
 			} catch (NoSuchJobExecutionException | JobExecutionNotRunningException e) {
 				throw new RuntimeException(e);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -216,6 +216,7 @@ public class JobExecutionThinController {
 					resource.add(linkTo(methodOn(JobExecutionController.class).stopJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("stop"));
 				}
 				if (taskJobExecution.getJobExecution().getEndTime() != null && !taskJobExecution.getJobExecution().isRunning()) {
+					// In this case we use null for the useJsonJobParameters parameter so we use the configured job parameter serialization method specified by dataflow.
 					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId(), null)).withRel("restart"));
 				}
 			} catch (NoSuchJobExecutionException | JobExecutionNotRunningException e) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -216,7 +216,7 @@ public class JobExecutionThinController {
 					resource.add(linkTo(methodOn(JobExecutionController.class).stopJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("stop"));
 				}
 				if (taskJobExecution.getJobExecution().getEndTime() != null && !taskJobExecution.getJobExecution().isRunning()) {
-					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId())).withRel("restart"));
+					resource.add(linkTo(methodOn(JobExecutionController.class).restartJobExecution(taskJobExecution.getJobExecution().getJobId(), null)).withRel("restart"));
 				}
 			} catch (NoSuchJobExecutionException | JobExecutionNotRunningException e) {
 				throw new RuntimeException(e);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
@@ -111,7 +111,7 @@ public class StepExecutionProgressInfo {
 		double result = 0.0;
 		if (readHistory.getMean() == 0) {
 			percentCompleteBasis = PercentCompleteBasis.DURATION;
-			result = getDurationBasedEstimate(duration);
+			result = getDurationBasedEstimate();
 		}
 		else {
 			percentCompleteBasis = PercentCompleteBasis.READCOUNT;
@@ -120,7 +120,7 @@ public class StepExecutionProgressInfo {
 		return result;
 	}
 
-	private double getDurationBasedEstimate(double duration) {
+	private double getDurationBasedEstimate() {
 
 		CumulativeHistory durationHistory = stepExecutionHistory.getDuration();
 		if (durationHistory.getMean() == 0) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
@@ -64,7 +64,7 @@ public class StepExecutionProgressInfo {
 		if (startTime == null) {
 			startTime = LocalDateTime.now();
 		}
-		duration = Duration.between(startTime, endTime).get(ChronoUnit.NANOS);
+		duration = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
 		percentageComplete = calculatePercentageComplete();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
@@ -64,7 +64,7 @@ public class StepExecutionProgressInfo {
 		if (startTime == null) {
 			startTime = LocalDateTime.now();
 		}
-		duration = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
+		duration = Duration.between(startTime, endTime).get(ChronoUnit.NANOS);
 		percentageComplete = calculatePercentageComplete();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.dataflow.rest.job.JobInstanceExecutions;
 import org.springframework.cloud.dataflow.rest.job.TaskJobExecution;
 import org.springframework.cloud.dataflow.server.batch.JobExecutionWithStepCount;
 import org.springframework.cloud.dataflow.server.job.support.JobNotRestartableException;
+import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -99,14 +100,28 @@ public interface TaskJobService {
 	JobInstanceExecutions getJobInstance(long id) throws NoSuchJobInstanceException, NoSuchJobException;
 
 	/**
-	 * Restarts a {@link JobExecution} IF the respective {@link JobExecution} is actually
+	 * Restarts a {@link JobExecution} if the respective {@link JobExecution} is actually
 	 * deemed restartable. Otherwise a {@link JobNotRestartableException} is being thrown.
+	 * The system will use {@link TaskConfigurationProperties#isUseJsonJobParameters()} to
+	 * determine the {@link org.springframework.batch.core.JobParameter} serializer.
 	 *
 	 * @param jobExecutionId The id of the JobExecution to restart.
 	 * @throws NoSuchJobExecutionException if the JobExecution for the provided id does not
 	 *                                     exist.
 	 */
 	void restartJobExecution(long jobExecutionId) throws NoSuchJobExecutionException;
+
+	/**
+	 * Restarts a {@link JobExecution} if the respective {@link JobExecution} is actually
+	 * deemed restartable. Otherwise, a {@link JobNotRestartableException} is being thrown.
+	 *
+	 * @param jobExecutionId The id of the JobExecution to restart.
+	 * @param useJsonJobParameters serialize job parameters to the command line using the format provided by {@code JsonJobParametersConverter} if set to true.
+	 * else the system will use {@link TaskConfigurationProperties#isUseJsonJobParameters()} to determine the {@link org.springframework.batch.core.JobParameter} serializer.
+	 * @throws NoSuchJobExecutionException if the JobExecution for the provided id does not
+	 *                                     exist.
+	 */
+	void restartJobExecution(long jobExecutionId, Boolean useJsonJobParameters) throws NoSuchJobExecutionException;
 
 	/**
 	 * Requests a {@link JobExecution} to stop.

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -115,8 +115,11 @@ public interface TaskJobService {
 	 * deemed restartable. Otherwise, a {@link JobNotRestartableException} is being thrown.
 	 *
 	 * @param jobExecutionId The id of the JobExecution to restart.
-	 * @param useJsonJobParameters serialize job parameters to the command line using the format provided by {@code JsonJobParametersConverter} if set to true.
-	 * else the system will use {@link TaskConfigurationProperties#isUseJsonJobParameters()} to determine the {@link org.springframework.batch.core.JobParameter} serializer.
+	 * @param useJsonJobParameters if set to true, dataflow will serialize job parameters to the command line using the
+	 *                                format provided by {@code JsonJobParametersConverter}.
+	 *                                If set to false dataflow will use {@code DefaultParametersConverter}.
+	 *                                If null dataflow  will use {@link TaskConfigurationProperties#isUseJsonJobParameters()}
+	 *                                to determine the {@link org.springframework.batch.core.JobParameter} serializer.
 	 * @throws NoSuchJobExecutionException if the JobExecution for the provided id does not
 	 *                                     exist.
 	 */

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.dataflow.server.service;
 
 import java.util.Date;
-import java.util.List;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.h2.util.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,12 +32,10 @@ import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.converter.JsonJobParametersConverter;
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
 import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.springframework.batch.core.launch.NoSuchJobInstanceException;
-import org.springframework.cloud.dataflow.server.config.apps.CommonApplicationProperties;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorer;
 import org.springframework.cloud.dataflow.core.Launcher;
 import org.springframework.cloud.dataflow.core.TaskDefinition;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfDefaultJobParametersConverter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfDefaultJobParametersConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.converter.DefaultJobParametersConverter;
+
+public class ScdfDefaultJobParametersConverter extends DefaultJobParametersConverter implements ScdfJobParametersConverter {
+
+	public ScdfDefaultJobParametersConverter() {
+		super();
+	}
+
+	@Override
+	public String deserializeJobParameter(JobParameter jobParameter) {
+		return encode(jobParameter);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfDefaultJobParametersConverter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfDefaultJobParametersConverter.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.dataflow.server.service.impl;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.converter.DefaultJobParametersConverter;
 
+/**
+ * Provides methods to serialize a Spring Batch {@link JobParameter} to the Spring Batch's default format.
+ */
 public class ScdfDefaultJobParametersConverter extends DefaultJobParametersConverter implements ScdfJobParametersConverter {
 
 	public ScdfDefaultJobParametersConverter() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJobParametersConverter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJobParametersConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import org.springframework.batch.core.JobParameter;
+
+/**
+ * Provides methods to serialize a Spring Batch {@link JobParameter} to the proper format.
+ */
+public interface ScdfJobParametersConverter {
+
+	/**
+	 * Serializes a Spring Batch {@link JobParameter} to the proper format.
+	 * @param jobParameter to be serialized
+	 * @return Serialized job parameter
+	 */
+	String deserializeJobParameter(JobParameter jobParameter);
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJsonJobParametersConverter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJsonJobParametersConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.converter.JsonJobParametersConverter;
+
+public class ScdfJsonJobParametersConverter extends JsonJobParametersConverter implements ScdfJobParametersConverter {
+
+	public ScdfJsonJobParametersConverter() {
+		super();
+	}
+
+	@Override
+	public String deserializeJobParameter(JobParameter jobParameter) {
+		return encode(jobParameter);
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJsonJobParametersConverter.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ScdfJsonJobParametersConverter.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.dataflow.server.service.impl;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.converter.JsonJobParametersConverter;
 
+/**
+ * Provides methods to serialize a Spring Batch {@link JobParameter} to JSON.
+ */
 public class ScdfJsonJobParametersConverter extends JsonJobParametersConverter implements ScdfJobParametersConverter {
 
 	public ScdfJsonJobParametersConverter() {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,14 @@ public class TaskConfigurationProperties {
 	 * from secrets vs having dataflow pass them via properties.
 	 */
 	private boolean useKubernetesSecretsForDbCredentials;
+
+	/**
+	 * When SCDF reruns a failed batch jobs dataflow reconstitutes the job parameters.
+	 * By default, this will use the style specified by Spring Batch's DefaultJobParametersConverter.
+	 * but if this property is set to true the job parameters will reconstituted in the style specified by
+	 * Spring Batch's JsonJobParametersConverter.   Default is false.
+	 */
+	private boolean useJsonJobParameters = false;
 
 	@Deprecated
 	public String getComposedTaskRunnerUri() {
@@ -188,5 +196,13 @@ public class TaskConfigurationProperties {
 
 	public void setExecutionDeleteChunkSize(int executionDeleteChunkSize) {
 		this.executionDeleteChunkSize = executionDeleteChunkSize;
+	}
+
+	public boolean isUseJsonJobParameters() {
+		return useJsonJobParameters;
+	}
+
+	public void setUseJsonJobParameters(boolean useJsonJobParameters) {
+		this.useJsonJobParameters = useJsonJobParameters;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -69,11 +69,11 @@ public class TaskConfigurationProperties {
 	private boolean useKubernetesSecretsForDbCredentials;
 
 	/**
-	 * When SCDF reruns a failed batch jobs dataflow reconstitutes the job parameters.
-	 * By default, this will use the style specified by Spring Batch's DefaultJobParametersConverter.
-	 * but if this property is set to true the job parameters will reconstituted in the style specified by
-	 * Spring Batch's JsonJobParametersConverter.   Default is false.
+	 * Controls the style that Dataflow reconstitutes job parameters when re-running a
+	 * failed batch job. The style will be taken from Spring Batch's
+	 * DefaultJobParametersConverter when set to false or JsonJobParametersConverter when true.
 	 */
+
 	private boolean useJsonJobParameters = false;
 
 	@Deprecated

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -297,14 +297,16 @@ public class JobDependencies {
 			DataflowTaskExplorer taskExplorer,
 			TaskDefinitionRepository taskDefinitionRepository,
 			TaskExecutionService taskExecutionService,
-			LauncherRepository launcherRepository
+			LauncherRepository launcherRepository,
+			TaskConfigurationProperties taskConfigurationProperties
 	) {
 		return new DefaultTaskJobService(
 				jobService,
 				taskExplorer,
 				taskDefinitionRepository,
 				taskExecutionService,
-				launcherRepository);
+				launcherRepository,
+			taskConfigurationProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -306,7 +306,7 @@ public class JobDependencies {
 				taskDefinitionRepository,
 				taskExecutionService,
 				launcherRepository,
-			taskConfigurationProperties);
+				taskConfigurationProperties);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -203,8 +203,7 @@ public class JobExecutionControllerTests {
 			.andExpect(jsonPath("$.executionId", is(10)))
 			.andExpect(jsonPath("$.jobExecution.jobParameters.parameters", Matchers.hasKey(("javaUtilDate"))))
 			.andExpect(jsonPath("$.jobExecution.stepExecutions", hasSize(1))).andReturn();
-		assertThat(result.getResponse().getContentAsString()).contains("\"identifying\":true");
-		assertThat(result.getResponse().getContentAsString()).contains("\"type\":\"java.lang.String\"");
+		assertThat(result.getResponse().getContentAsString()).contains("\"identifying\":true", "\"type\":\"java.lang.String\"");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -224,8 +224,6 @@ public class JobExecutionControllerTests {
 				.andExpect(jsonPath("$._embedded.jobExecutionResourceList[*].executionId", containsInRelativeOrder(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)));
 	}
 
-	//TODO: Boot3x followup
-	@Disabled("TODO: Boot3x followup Until we implement the paging capabilities this tests is disabled.")
 	@Test
 	public void testGetAllExecutionsPageOffsetLargerThanIntMaxValue() throws Exception {
 		verify5XXErrorIsThrownForPageOffsetError(get("/jobs/executions"));
@@ -243,8 +241,6 @@ public class JobExecutionControllerTests {
 				.andExpect(jsonPath("$._embedded.jobExecutionResourceList", hasSize(1)));
 	}
 
-	//TODO: Boot3x followup
-	@Disabled("TODO: Boot3x followup Until we implement the paging capabilities this tests is disabled.")
 	@Test
 	public void testGetExecutionsByNamePageOffsetLargerThanIntMaxValue() throws Exception {
 		verify5XXErrorIsThrownForPageOffsetError(

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobExecutionControllerTests.java
@@ -188,7 +188,17 @@ public class JobExecutionControllerTests {
 	@Test
 	public void testGetExecutionWithJobProperties() throws Exception {
 		MvcResult result = mockMvc.perform(get("/jobs/executions/10").accept(MediaType.APPLICATION_JSON))
-			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.executionId", is(10)))
+			.andExpect(jsonPath("$.jobExecution.jobParameters.parameters", Matchers.hasKey(("javaUtilDate"))))
+			.andExpect(jsonPath("$.jobExecution.stepExecutions", hasSize(1))).andReturn();
+		assertThat(result.getResponse().getContentAsString()).contains("\"identifying\":true");
+		assertThat(result.getResponse().getContentAsString()).contains("\"type\":\"java.lang.String\"");
+	}
+
+	@Test
+	public void testGetExecutionWithJobPropertiesOverrideJobParam() throws Exception {
+		MvcResult result = mockMvc.perform(get("/jobs/executions/10?useJsonJobParameters=true").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.executionId", is(10)))
 			.andExpect(jsonPath("$.jobExecution.jobParameters.parameters", Matchers.hasKey(("javaUtilDate"))))

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -169,7 +169,7 @@ public class DefaultTaskJobServiceTests {
 		initializeJobs(true);
 
 		this.taskJobService.restartJobExecution(jobInstanceCount, true);
-		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
 		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param={\"value\":\"testparam\",\"type\":\"java.lang.String\",\"identifying\":\"true\"}");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobServiceTests.java
@@ -160,8 +160,19 @@ public class DefaultTaskJobServiceTests {
 		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
+		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param=testparam,java.lang.String,true");
+	}
 
-		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param=testparam,java.lang.String");
+	@Test
+	public void testRestartWithJsonParameters() throws Exception {
+		createBaseLaunchers();
+		initializeJobs(true);
+
+		this.taskJobService.restartJobExecution(jobInstanceCount, true);
+		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
+		verify(this.taskLauncher, times(1)).launch(argument.capture());
+		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
+		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param={\"value\":\"testparam\",\"type\":\"java.lang.String\",\"identifying\":\"true\"}");
 	}
 
 	@Test
@@ -184,7 +195,7 @@ public class DefaultTaskJobServiceTests {
 		final ArgumentCaptor<AppDeploymentRequest> argument = ArgumentCaptor.forClass(AppDeploymentRequest.class);
 		verify(this.taskLauncher, times(1)).launch(argument.capture());
 		AppDeploymentRequest appDeploymentRequest = argument.getAllValues().get(0);
-		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param=testparam,java.lang.String");
+		assertThat(appDeploymentRequest.getCommandlineArguments()).contains("identifying.param=testparam,java.lang.String,true");
 	}
 
 	private void initializeJobs(boolean insertTaskExecutionMetadata)

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/JobCommands.java
@@ -107,8 +107,17 @@ public class JobCommands {
 	@ShellMethod(key = EXECUTION_RESTART, value = "Restart a failed job by jobExecutionId")
 	@ShellMethodAvailability("availableWithViewRole")
 	public String executionRestart(
-			@ShellOption(help = "the job execution id") long id) {
-		jobOperations().executionRestart(id);
+			@ShellOption(help = "the job executiond id") long id,
+			@ShellOption(value = "--useJsonJobParameters",
+				help = "boolean value serialize job parameter as Json.  " +
+					"Default is null, meaning SCDF default will be used.",
+				defaultValue = ShellOption.NULL) String useJsonJobParameters) {
+		if(useJsonJobParameters == null) {
+			jobOperations().executionRestart(id);
+		}
+		else {
+			jobOperations().executionRestart(id, Boolean.valueOf(useJsonJobParameters));
+		}
 		return String.format("Restart request has been sent for job execution '%s'", id);
 	}
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -119,7 +119,15 @@ public abstract class AbstractShellIntegrationTest {
 					"--spring.jmx.default-domain=" + System.currentTimeMillis(), "--spring.jmx.enabled=false",
 					"--security.basic.enabled=false", "--spring.main.show_banner=false",
 					"--spring.cloud.config.enabled=false",
-					"--spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration,org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration,org.springframework.boot.autoconfigure.session.SessionAutoConfiguration,org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration,org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration",
+					"--spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration," +
+						"org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.session.SessionAutoConfiguration," +
+						"org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration," +
+						"org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration," +
+						"org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration," +
+						"org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration",
 					"--spring.datasource.url=" + dataSourceUrl,
 					"--spring.cloud.dataflow.features.schedules-enabled=true");
 			Shell shell = applicationContext.getBean(Shell.class);

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/AbstractShellIntegrationTest.java
@@ -124,10 +124,7 @@ public abstract class AbstractShellIntegrationTest {
 						"org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration," +
 						"org.springframework.boot.autoconfigure.session.SessionAutoConfiguration," +
 						"org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration," +
-						"org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration," +
-						"org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration," +
-						"org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration," +
-						"org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration",
+						"org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration",
 					"--spring.datasource.url=" + dataSourceUrl,
 					"--spring.cloud.dataflow.features.schedules-enabled=true");
 			Shell shell = applicationContext.getBean(Shell.class);

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,11 +30,14 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRepository;
@@ -80,6 +84,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		Thread.sleep(2000);
 		taskBatchDao = applicationContext.getBean(TaskBatchDao.class);
 		jobRepository = applicationContext.getBean(JobRepository.class);
+		taskExecutionDao = applicationContext.getBean(TaskExecutionDao.class);
 
 		taskExecutionIds.add(createSampleJob(JOB_NAME_ORIG, 1));
 		taskExecutionIds.add(createSampleJob(JOB_NAME_FOO, 1));
@@ -94,30 +99,27 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		}
 		JdbcTemplate template = new JdbcTemplate(applicationContext.getBean(DataSource.class));
 		template.afterPropertiesSet();
-		final String TASK_EXECUTION_FORMAT = "DELETE FROM task_execution WHERE task_execution_id = %d";
-		final String TASK_BATCH_FORMAT = "DELETE FROM task_task_batch WHERE task_execution_id = %d";
-
-		for (Long id : taskExecutionIds) {
-			template.execute(String.format(TASK_BATCH_FORMAT, id));
-			template.execute(String.format(TASK_EXECUTION_FORMAT, id));
-		}
 	}
 
 	private static long createSampleJob(String jobName, int jobExecutionCount)
 		throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobRestartException {
-		JobInstance instance = jobRepository.createJobInstance(jobName, new JobParameters());
-		jobInstances.add(instance);
 		TaskExecution taskExecution = taskExecutionDao.createTaskExecution(jobName, LocalDateTime.now(), new ArrayList<>(), null);
+
 		Map<String, JobParameter<?>> jobParameterMap = new HashMap<>();
-		jobParameterMap.put("foo", new JobParameter("FOO", String.class, true));
-		jobParameterMap.put("bar", new JobParameter("BAR", String.class, false));
+		jobParameterMap.put("foo", new JobParameter("FOO", String.class, false));
+		jobParameterMap.put("bar", new JobParameter("BAR", String.class, true));
 		JobParameters jobParameters = new JobParameters(jobParameterMap);
 		JobExecution jobExecution;
 		for (int i = 0; i < jobExecutionCount; i++) {
 			jobExecution = jobRepository.createJobExecution(jobName, jobParameters);
+			JobInstance instance = jobExecution.getJobInstance();
+			jobInstances.add(instance);
 			taskBatchDao.saveRelationship(taskExecution, jobExecution);
 			StepExecution stepExecution = new StepExecution("foobar", jobExecution);
 			jobRepository.add(stepExecution);
+			jobExecution.setStatus(BatchStatus.FAILED);
+			jobExecution.setExitStatus(ExitStatus.FAILED);
+			jobRepository.update(jobExecution);
 		}
 		return taskExecution.getExecutionId();
 	}
@@ -152,7 +154,6 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void testViewExecution() {
 		logger.info("Retrieve Job Execution Detail by Id");
-
 		Table table = getTable(job().executionDisplay(getFirstJobExecutionIdFromTable()));
 		verifyColumnNumber(table, 2);
 		assertEquals("Number of expected rows returned from the table is incorrect", 18,
@@ -177,10 +178,10 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		int paramRowOne = rowNumber++;
 		int paramRowTwo = rowNumber++;
 		boolean jobParamsPresent = false;
-		if ((table.getModel().getValue(paramRowOne, 0).equals("foo(STRING) ")
-				&& table.getModel().getValue(paramRowTwo, 0).equals("-bar(STRING) "))
-				|| (table.getModel().getValue(paramRowOne, 0).equals("-bar(STRING) ")
-						&& table.getModel().getValue(paramRowTwo, 0).equals("foo(STRING) "))) {
+		if ((table.getModel().getValue(paramRowOne, 0).equals("-foo(java.lang.String) ")
+				&& table.getModel().getValue(paramRowTwo, 0).equals("bar(java.lang.String) "))
+				|| (table.getModel().getValue(paramRowOne, 0).equals("bar(java.lang.String) ")
+						&& table.getModel().getValue(paramRowTwo, 0).equals("-foo(java.lang.String) "))) {
 			jobParamsPresent = true;
 		}
 		assertTrue("the table did not contain the correct job parameters ", jobParamsPresent);
@@ -189,7 +190,6 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 	@Test
 	public void testViewInstance() {
 		logger.info("Retrieve Job Instance Detail by Id");
-
 		Table table = getTable(job().instanceDisplay(jobInstances.get(0).getInstanceId()));
 		verifyColumnNumber(table, 5);
 		checkCell(table, 0, 0, "Name ");
@@ -198,8 +198,10 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, 0, 3, "Status ");
 		checkCell(table, 0, 4, "Job Parameters ");
 		boolean isValidCell = false;
-		if (table.getModel().getValue(1, 4).equals("foo=FOO,-bar=BAR")
-				|| table.getModel().getValue(1, 4).equals("-bar=BAR,foo=FOO")) {
+		if (table.getModel().getValue(1, 4).equals("-foo={value=FOO, type=class java.lang.String, identifying=false},java.lang.String,true\n" +
+			"bar={value=BAR, type=class java.lang.String, identifying=true},java.lang.String,true")
+				|| table.getModel().getValue(1, 4).equals("bar={value=BAR, type=class java.lang.String, identifying=true},java.lang.String,true\n" +
+			"-foo={value=FOO, type=class java.lang.String, identifying=false},java.lang.String,true")) {
 			isValidCell = true;
 		}
 		assertTrue("Job Parameters does match expected.", isValidCell);

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
@@ -108,6 +108,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		Map<String, JobParameter<?>> jobParameterMap = new HashMap<>();
 		jobParameterMap.put("foo", new JobParameter("FOO", String.class, false));
 		jobParameterMap.put("bar", new JobParameter("BAR", String.class, true));
+		jobParameterMap.put("baz", new JobParameter("55", Long.class, true));
 		JobParameters jobParameters = new JobParameters(jobParameterMap);
 		JobExecution jobExecution;
 		for (int i = 0; i < jobExecutionCount; i++) {
@@ -135,7 +136,6 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, 0, 3, "Start Time ");
 		checkCell(table, 0, 4, "Step Execution Count ");
 		checkCell(table, 0, 5, "Definition Status ");
-
  	 	}
 
 	@Test
@@ -156,7 +156,7 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		logger.info("Retrieve Job Execution Detail by Id");
 		Table table = getTable(job().executionDisplay(getFirstJobExecutionIdFromTable()));
 		verifyColumnNumber(table, 2);
-		assertEquals("Number of expected rows returned from the table is incorrect", 18,
+		assertEquals("Number of expected rows returned from the table is incorrect", 19,
 				table.getModel().getRowCount());
 		int rowNumber = 0;
 		checkCell(table, rowNumber++, 0, "Key ");
@@ -175,16 +175,28 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, rowNumber++, 0, "Exit Message ");
 		checkCell(table, rowNumber++, 0, "Definition Status ");
 		checkCell(table, rowNumber++, 0, "Job Parameters ");
-		int paramRowOne = rowNumber++;
-		int paramRowTwo = rowNumber++;
-		boolean jobParamsPresent = false;
-		if ((table.getModel().getValue(paramRowOne, 0).equals("-foo(java.lang.String) ")
-				&& table.getModel().getValue(paramRowTwo, 0).equals("bar(java.lang.String) "))
-				|| (table.getModel().getValue(paramRowOne, 0).equals("bar(java.lang.String) ")
-						&& table.getModel().getValue(paramRowTwo, 0).equals("-foo(java.lang.String) "))) {
-			jobParamsPresent = true;
+		int paramRowOne = rowNumber;
+
+		assertTrue("the table did not contain the correct job parameters for job parameter value foo",
+			checkModelColumn(paramRowOne, table, "-foo(java.lang.String) "));
+
+		assertTrue("the table did not contain the correct job parameters for job parameter value bar",
+			checkModelColumn(paramRowOne, table, "bar(java.lang.String) "));
+
+		assertTrue("the table did not contain the correct job parameters for job parameter value baz",
+			checkModelColumn(paramRowOne, table, "baz(java.lang.Long) "));
+
+	}
+
+	private boolean checkModelColumn(int rowNumber, Table table, String value) {
+		boolean result = false;
+		int paramRowNumber = rowNumber;
+		if (table.getModel().getValue(paramRowNumber++, 0).equals(value) ||
+			table.getModel().getValue(paramRowNumber++, 0).equals(value) ||
+			table.getModel().getValue(paramRowNumber, 0).equals(value)) {
+			result = true;
 		}
-		assertTrue("the table did not contain the correct job parameters ", jobParamsPresent);
+		return result;
 	}
 
 	@Test
@@ -198,10 +210,9 @@ public class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, 0, 3, "Status ");
 		checkCell(table, 0, 4, "Job Parameters ");
 		boolean isValidCell = false;
-		if (table.getModel().getValue(1, 4).equals("-foo={value=FOO, type=class java.lang.String, identifying=false},java.lang.String,true\n" +
-			"bar={value=BAR, type=class java.lang.String, identifying=true},java.lang.String,true")
-				|| table.getModel().getValue(1, 4).equals("bar={value=BAR, type=class java.lang.String, identifying=true},java.lang.String,true\n" +
-			"-foo={value=FOO, type=class java.lang.String, identifying=false},java.lang.String,true")) {
+		if (table.getModel().getValue(1, 4).toString().contains("-foo={value=FOO, type=class java.lang.String, identifying=false},java.lang.String,true") &&
+			table.getModel().getValue(1, 4).toString().contains("bar={value=BAR, type=class java.lang.String, identifying=true},java.lang.String,true") &&
+			table.getModel().getValue(1, 4).toString().contains("baz=55,java.lang.Long,true")) {
 			isValidCell = true;
 		}
 		assertTrue("Job Parameters does match expected.", isValidCell);


### PR DESCRIPTION
### What this PR is trying to do
Currently Spring Batch allows users to specify 2 formats for accepting Job parameters via the command line.  This PR allows SCDF to use both formats, where before it was only using the default.
* Default: `parameterValue,parameterType,identificationFlag`
* JSON

### This PR is initially broken up into 4 commits

1. Updates DefaultJobService to accept dataflow global configuration for which format should be use as its default.
     a. Update the controller so that user can specify a different format for a specific launch instead of using dataflow's configured default
     b. Update the model so if the user clicks the link for a restart it will use dataflow's configured default. 
     c. Notice some of the old tests had to be updated because the encoder provided by batch provides the isIdentifying field.  
2. Update the restful docs so can demonstrate the use  of `useJsonJobParameters`
3. Update shell and Data flow client API to allow users to specify a `useJsonJobParameters` if necessary.
    a. There are no tests for shell nor Data flow client yet.  This is because @EnableDataflowServer needs to be fixed first.
 4. Polish the PR to cleanup some things I missed or noticed during review.      
