### PR TITLE
Update various lib deps patch versions 

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -26,18 +26,18 @@
 		<spring-security.version>5.7.12</spring-security.version>
 		<spring-shell.version>2.1.13</spring-shell.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<testcontainers.version>1.19.7</testcontainers.version>
+		<testcontainers.version>1.19.8</testcontainers.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
 		<tomcat.version>9.0.90</tomcat.version>
 		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
-		<netty.version>4.1.109.Final</netty.version>
-		<reactor-bom.version>2020.0.43</reactor-bom.version>
+		<netty.version>4.1.111.Final</netty.version>
+		<reactor-bom.version>2020.0.45</reactor-bom.version>
 		<rsocket.version>1.1.4</rsocket.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
-		<jackson-bom.version>2.17.1</jackson-bom.version>
+		<jackson-bom.version>2.17.2</jackson-bom.version>
 		<json-smart.version>2.4.11</json-smart.version>
-		<nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
 		<snappy-java.version>1.1.10.5</snappy-java.version>
 		<commons-compress.version>1.26.1</commons-compress.version>
 		<commons-io.version>2.15.1</commons-io.version>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -36,21 +36,21 @@
 		<tomcat.version>9.0.90</tomcat.version>
 		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
-		<netty.version>4.1.109.Final</netty.version>
-		<reactor-bom.version>2020.0.43</reactor-bom.version>
+		<netty.version>4.1.111.Final</netty.version>
+		<reactor-bom.version>2020.0.45</reactor-bom.version>
 		<rsocket.version>1.1.4</rsocket.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<json-smart.version>2.4.11</json-smart.version>
-		<nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
 		<snappy-java.version>1.1.10.5</snappy-java.version>
 		<commons-compress.version>1.26.1</commons-compress.version>
 		<commons-io.version>2.15.1</commons-io.version>
-		<jackson-bom.version>2.17.1</jackson-bom.version>
+		<jackson-bom.version>2.17.2</jackson-bom.version>
 		<json-unit.version>2.11.1</json-unit.version>
 		<findbugs.version>3.0.2</findbugs.version>
 		<joda-time.version>2.10.6</joda-time.version>
 		<aws-java-sdk-ecr.version>1.12.676</aws-java-sdk-ecr.version>
-		<testcontainers.version>1.19.7</testcontainers.version>
+		<testcontainers.version>1.19.8</testcontainers.version>
 		<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
 		<stream-applications.version>3.2.1</stream-applications.version>
 		<wavefront-spring-boot-bom.version>2.3.4</wavefront-spring-boot-bom.version>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -39,9 +39,6 @@
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 
 		<jmockit.version>1.24</jmockit.version>
-
-		<testcontainers.version>1.19.7</testcontainers.version>
-		<commons-compress.version>1.26.0</commons-compress.version>
 		<asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
 		<asciidoctorj.pdf.version>2.3.7</asciidoctorj.pdf.version>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
@@ -208,24 +205,6 @@
 				<groupId>org.jmockit</groupId>
 				<artifactId>jmockit</artifactId>
 				<version>${jmockit.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.testcontainers</groupId>
-				<artifactId>testcontainers-bom</artifactId>
-				<version>${testcontainers.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.apache.commons</groupId>
-						<artifactId>commons-compress</artifactId>
-					</exclusion>
-				</exclusions>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>${commons-compress.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Update various lib deps patch versions
- netty to 4.1.111.Final
- reactor-bom to 2020.0.45
- jackson-bom to 2.17.2
- nimbus-jose-jwt to 9.37.3
- testcontainers to 1.19.8

Also removes unnecessary dependency management.
