### PR TITLE
Remove Dependency Mgmt for H2 and rely on Boot Bom

### DIFF
--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -53,7 +53,6 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>[2.2.222,)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>

--- a/spring-cloud-dataflow-single-step-batch-job/pom.xml
+++ b/spring-cloud-dataflow-single-step-batch-job/pom.xml
@@ -23,11 +23,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.h2database</groupId>
-				<artifactId>h2</artifactId>
-				<version>[2.2.222,3.0)</version>
-			</dependency>
-			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
 				<artifactId>mariadb-java-client</artifactId>
 				<version>[3.1.2,)</version>


### PR DESCRIPTION
This change is only for the Single Step Batch Job and Composed Task Runner.