### PR TITLE
Update remaining occurrences of Boot 2.x metric prop names

### DIFF
--- a/src/carvel/test/servers.test.ts
+++ b/src/carvel/test/servers.test.ts
@@ -485,14 +485,14 @@ describe('servers', () => {
 
     const dataflowDoc = parseYamlDocument(dataflowApplicationYaml);
     const dataflowJson = dataflowDoc.toJSON();
-    const enabled1 = lodash.get(dataflowJson, 'management.metrics.export.prometheus.enabled') as boolean;
+    const enabled1 = lodash.get(dataflowJson, 'management.prometheus.metrics.export.enabled') as boolean;
     expect(enabled1).toBeTrue();
     const url = lodash.get(dataflowJson, 'spring.cloud.dataflow.metrics.dashboard.url') as string;
     expect(url).toBeFalsy();
 
     const skipperDoc = parseYamlDocument(skipperApplicationYaml);
     const skipperJson = skipperDoc.toJSON();
-    const enabled2 = lodash.get(skipperJson, 'management.metrics.export.prometheus.enabled') as boolean;
+    const enabled2 = lodash.get(skipperJson, 'management.prometheus.metrics.export.enabled') as boolean;
     expect(enabled2).toBeTrue();
   });
 

--- a/src/deploy/carvel/configure-prometheus-proxy.sh
+++ b/src/deploy/carvel/configure-prometheus-proxy.sh
@@ -2,10 +2,10 @@
 function set_properties() {
     PREFIX=$1
     yq "${PREFIX}.micrometer.prometheus.rsocket.host=\"$HOST\"" -i ./scdf-values.yml
-    yq "${PREFIX}.management.metrics.export.prometheus.pushgateway.base-url=\"http://$HOST:$PORT\"" -i ./scdf-values.yml
-    yq "${PREFIX}.management.metrics.export.prometheus.pushgateway.enabled=true" -i ./scdf-values.yml
-    yq "${PREFIX}.management.metrics.export.prometheus.pushgateway.shutdown-operation=\"PUSH\"" -i ./scdf-values.yml
-    yq "${PREFIX}.management.metrics.export.prometheus.step=\"$STEP\"" -i ./scdf-values.yml
+    yq "${PREFIX}.management.prometheus.metrics.export.pushgateway.base-url=\"http://$HOST:$PORT\"" -i ./scdf-values.yml
+    yq "${PREFIX}.management.prometheus.metrics.export.pushgateway.enabled=true" -i ./scdf-values.yml
+    yq "${PREFIX}.management.prometheus.metrics.export.pushgateway.shutdown-operation=\"PUSH\"" -i ./scdf-values.yml
+    yq "${PREFIX}.management.prometheus.metrics.export.step=\"$STEP\"" -i ./scdf-values.yml
 }
 if [ "$2" = "" ]; then
     echo "Usage is: <host> <port> [step]"

--- a/src/docker-compose/docker-compose-influxdb.yml
+++ b/src/docker-compose/docker-compose-influxdb.yml
@@ -8,7 +8,7 @@ services:
       - |
         SPRING_APPLICATION_JSON=
         {
-          "management.metrics.export.influx":{
+          "management.influx.metrics.export":{
               "enabled":true,
               "db":"myinfluxdb",
               "uri":"http://influxdb:8086"
@@ -29,4 +29,3 @@ services:
     container_name: grafana
     ports:
       - '3000:3000'
-

--- a/src/templates/docker-compose/docker-compose-influxdb.yml
+++ b/src/templates/docker-compose/docker-compose-influxdb.yml
@@ -8,7 +8,7 @@ services:
       - |
         SPRING_APPLICATION_JSON=
         {
-          "management.metrics.export.influx":{
+          "management.influx.metrics.export":{
               "enabled":true,
               "db":"myinfluxdb",
               "uri":"http://influxdb:8086"
@@ -29,4 +29,3 @@ services:
     container_name: grafana
     ports:
       - '3000:3000'
-


### PR DESCRIPTION
> [!NOTE]
> Ignore the 1st commit as this PR is based from https://github.com/spring-cloud/spring-cloud-dataflow/pull/5888

In Boot 3.x metrics names have switched from `management.metrics.export.<registry>` to `management.<registry>.metrics.export`. Most of these references have already been adjusted (e.g. https://github.com/spring-cloud/spring-cloud-dataflow/commit/21f59888bf8e13ae85a5c09be3586f70367e87cc) but there were a few stragglers that still needed this treatment. Enter stage left, commit 2 and 3.
