### PR TITLE
Fix problem with large Oracle container causing disk space issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,72 @@ jobs:
         find ~/.m2/repository -type d -name '*SNAPSHOT' | xargs rm -fr
     outputs:
       version: ${{ env.spring_cloud_dataflow_version }}
+  database-tests:
+    build:
+      if: github.repository_owner == 'spring-cloud'
+      runs-on: ubuntu-latest
+      matrix:
+        db: [ 'ORACLE', 'DB2' ]
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/cache@v3
+          with:
+            path: ~/.m2/repository
+            key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+            restore-keys: |
+              ${{ runner.os }}-m2-${{ matrix.db }}
+        - uses: actions/setup-java@v3
+          with:
+            java-version: '8'
+            distribution: 'liberica'
+        - uses: jvalkeal/setup-maven@v1
+          with:
+            maven-version: 3.8.8
+            maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
+        #     jfrog cli
+        - name: Login dockerhub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        - name: Configure JFrog Cli
+          run: |
+            jfrog rt mvnc \
+              --server-id-resolve=repo.spring.io \
+              --server-id-deploy=repo.spring.io \
+              --repo-resolve-releases=libs-milestone \
+              --repo-resolve-snapshots=libs-snapshot \
+              --repo-deploy-releases=libs-release-local \
+              --repo-deploy-snapshots=libs-snapshot-local
+        - uses: ./.github/actions/install-xmlutils
+        - name: Test
+          shell: bash
+          timeout-minutes: 75
+          run: |                        
+            jfrog rt mvn clean install -s .settings.xml -DskipTests -am -pl :spring-cloud-dataflow-server,:spring-cloud-skipper-server
+            export ENABLE_${{ matrix.db }}=true
+            jfrog rt mvn test -s .settings.xml -am -pl :spring-cloud-dataflow-server,:spring-cloud-skipper-server -Dgroups=${{ matrix.db }}
+        - name: Test Report
+          uses: dorny/test-reporter@v1
+          if: ${{ success() || failure() }}
+          with:
+            name: Unit Tests
+            path: '**/surefire-reports/*.xml'
+            reporter: java-junit
+            list-tests: failed
+        - name: Capture Test Results
+          if: ${{ always() }}
+          uses: actions/upload-artifact@v3
+          with:
+            name: test-results
+            path: '**/target/surefire-reports/**/*.*'
+            retention-days: 7
+            if-no-files-found: ignore
+        #     clean m2 cache
+        - name: Clean cache
+          run: |
+            find ~/.m2/repository -type d -name '*SNAPSHOT' | xargs rm -fr
+
   images:
     name: Build and Publish Images
     needs:
@@ -137,7 +203,7 @@ jobs:
         run: echo "::info ::Scanned"
   done:
     runs-on: ubuntu-latest
-    needs: [ scan, build, images ]
+    needs: [ scan, build, images, database-tests ]
     steps:
       - name: 'Done'
         shell: bash

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tasks/TaskExecutionQueryContainer.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/tasks/TaskExecutionQueryContainer.java
@@ -228,7 +228,8 @@ public class TaskExecutionQueryContainer {
 	static class PostgreSQL_TaskExecutionQueryIT extends AbstractLargeTaskExecutionDatabaseIT
 			implements PostgreSQL_14_ContainerSupport {
 	}
-
+	@EnabledIfEnvironmentVariable(named = "ENABLE_ORACLE", matches = "true", disabledReason = "Container is too big")
+	@Tag("ORACLE")
 	static class Oracle_TaskExecutionQueryIT extends AbstractLargeTaskExecutionDatabaseIT
 			implements Oracle_XE_18_ContainerSupport {
 	}

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/Oracle_XE_18_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/Oracle_XE_18_SmokeTest.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
 import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSupport;
 
 /**
@@ -23,5 +26,7 @@ import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSuppor
  * @author Corneil du Plessis
  * @author Chris Bono
  */
+@EnabledIfEnvironmentVariable(named = "ENABLE_ORACLE", matches = "true", disabledReason = "Container is too big")
+@Tag("ORACLE")
 public class Oracle_XE_18_SmokeTest extends AbstractSmokeTest implements Oracle_XE_18_ContainerSupport {
 }

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/support/DatabaseTypeTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/support/DatabaseTypeTests.java
@@ -92,6 +92,8 @@ class DatabaseTypeTests {
 	}
 
 	@Nested
+	@EnabledIfEnvironmentVariable(named = "ENABLE_ORACLE", matches = "true", disabledReason = "Container is too big")
+	@Tag("ORACLE")
 	class OracleDatabaseTypeSingleDbDatabaseTypeTests extends AbstractSingleDbDatabaseTypeTests implements Oracle_XE_18_ContainerSupport {
 	}
 

--- a/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/Oracle_XE_18_SkipperSmokeTest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/db/migration/Oracle_XE_18_SkipperSmokeTest.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.skipper.server.db.migration;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
 import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSupport;
 
 /**
@@ -23,5 +26,7 @@ import org.springframework.cloud.dataflow.server.db.Oracle_XE_18_ContainerSuppor
  * @author Corneil du Plessis
  * @author Chris Bono
  */
+@EnabledIfEnvironmentVariable(named = "ENABLE_ORACLE", matches = "true", disabledReason = "Container is too big")
+@Tag("ORACLE")
 public class Oracle_XE_18_SkipperSmokeTest extends AbstractSkipperSmokeTest implements Oracle_XE_18_ContainerSupport {
 }


### PR DESCRIPTION
Fix issue with large Oracle container causing disk space issue by running DB2 and Oracle specific tests in separate parallel jobs.

Found the following in ci and build-snapshot-worker logs.

```
##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 20 MB
```
