### PR TITLE
Add support for binary/octet-stream.

### DIFF
--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -210,6 +210,7 @@ public class ContainerImageRestTemplateFactory {
 		ArrayList<MediaType> mediaTypeList = new ArrayList(octetSupportJsonConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
 		mediaTypeList.add(MediaType.TEXT_PLAIN);
+		mediaTypeList.add(MediaType.parseMediaType("binary/octet-stream")); // quay.io responds with binary/octet-stream instead of application/octet-stream
 		octetSupportJsonConverter.setSupportedMediaTypes(mediaTypeList);
 
 		return restTemplateBuilder

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -202,10 +202,10 @@ public class ContainerImageRestTemplateFactory {
 								.setDefaultRequestConfig(RequestConfig.custom().setNormalizeUri(false).build())
 								.build());
 
-		// DockerHub response's media-type is application/octet-stream although the content is in JSON.
-		// Similarly the Github CR response's media-type is always text/plain although the content is in JSON.
-		// Therefore we extend the MappingJackson2HttpMessageConverter media-types to
-		// include application/octet-stream and text/plain.
+		// Extend the MappingJackson2HttpMessageConverter to support the following:
+		// - DockerHub response media-type is application/octet-stream although the content is in JSON
+		// - Github CR response media-type is text/plain although the content is in JSON
+		// - quay.io response media-type is binary/octet-stream although the content is in JSON
 		MappingJackson2HttpMessageConverter octetSupportJsonConverter = new MappingJackson2HttpMessageConverter();
 		ArrayList<MediaType> mediaTypeList = new ArrayList(octetSupportJsonConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);


### PR DESCRIPTION
Quay.io responds with binary/octet-stream when reading imageBlob.

application/octet-stream is identical to binary/octet-stream.

Fixes #5885