### PR TITLE
Update apps version refs to 5.0.0 / 3.0.0

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-create-containers.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/appendix-create-containers.adoc
@@ -85,7 +85,7 @@ Downloads all applications needed by `create-containers.sh` from Maven repositor
 
 Usage: `download-apps.sh [version] [broker] [filter]`
 
-* `version` is the stream applications version like `3.2.1` or default is `3.2.2-SNAPSHOT`
+* `version` is the stream applications version like `5.0.0` or default is `5.0.1-SNAPSHOT`
 * `broker` is one of rabbitmq, rabbit or kafka
 * `filter` is a name of an application or a partial name that will be matched.
 
@@ -96,9 +96,9 @@ This script requires link:https://github.com/GoogleContainerTools/jib/tree/maste
 
 Usage: `create-containers.sh [version] [broker] [jre-version] [filter]`
 
-* `version` is the stream-applications version like `3.2.1` or default is `3.2.2-SNAPSHOT`
+* `version` is the stream-applications version like `5.0.0` or default is `5.0.1-SNAPSHOT`
 * `broker` is one of rabbitmq, rabbit or kafka
-* `jre-version` should be one of 11, 17
+* `jre-version` must be 17
 * `filter` is a name of an application or a partial name that will be matched.
 
 If the file is not present required to create the container the script will skip the one.
@@ -110,9 +110,9 @@ This script requires link:https://buildpacks.io/docs/tools/pack[packeto pack]
 
 Usage: `pack-containers.sh [version] [broker] [jre-version] [filter]`
 
-* `version` is the stream-applications version like `3.2.1` or default is `3.2.2-SNAPSHOT`
+* `version` is the stream-applications version like `5.0.0` or default is `5.0.1-SNAPSHOT`
 * `broker` is one of rabbitmq, rabbit or kafka
-* `jre-version` should be one of 11, 17
+* `jre-version` must be 17
 * `filter` is a name of an application or a partial name that will be matched.
 
 If the required file is not present to create the container the script will skip that one.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-carvel.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration-carvel.adoc
@@ -87,7 +87,7 @@ The default _app-name_ is `scdf-${SCDF_TYPE}`.
 | register-apps.sh
 | <broker> [stream-application-version]
 | _broker_ must be one of rabbit or kafka.
-_stream-application-version_ is optional and will install the latest version. The latest version is 2021.1.2
+_stream-application-version_ is optional and will install the latest version. The latest version is 2024.0.0
 |===
 
 NOTE: Take note that the registration of application in the _pro_ version can take a few minutes since it retrieves all version information and metadata upfront.

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/dashboard.adoc
@@ -67,8 +67,8 @@ The following examples show typical application definitions:
 ====
 [source,subs=properties]
 ----
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:1.2.0.RELEASE
-processor.transform=maven://org.springframework.cloud.stream.app:transform-processor-rabbit:1.2.0.RELEASE
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:3.0.0
+processor.transform=maven://org.springframework.cloud.stream.app:transform-processor-rabbit:5.0.0
 ----
 ====
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -24,7 +24,7 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :docker-log-sink-kafka-version: 5.0.0
 :docker-http-source-kafka-version: 5.0.0
 :docker-time-source-kafka-version: 5.0.0
-:docker-timestamp-task-version: 2.0.2
+:docker-timestamp-task-version: 3.0.0
 
 ifdef::backend-html5[]
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/index.adoc
@@ -18,12 +18,12 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :scs-stream-apps-docs: https://docs.spring.io/stream-applications/docs/current/reference/html
 :dataflow-asciidoc-images: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/main/spring-cloud-dataflow-docs/src/main/asciidoc/images
 
-:docker-http-source-rabbit-version: 3.2.1
-:docker-time-source-rabbit-version: 3.2.1
-:docker-log-sink-rabbit-version: 3.2.1
-:docker-log-sink-kafka-version: 3.2.1
-:docker-http-source-kafka-version: 3.2.1
-:docker-time-source-kafka-version: 3.2.1
+:docker-http-source-rabbit-version: 5.0.0
+:docker-time-source-rabbit-version: 5.0.0
+:docker-log-sink-rabbit-version: 5.0.0
+:docker-log-sink-kafka-version: 5.0.0
+:docker-http-source-kafka-version: 5.0.0
+:docker-time-source-kafka-version: 5.0.0
 :docker-timestamp-task-version: 2.0.2
 
 ifdef::backend-html5[]

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -340,20 +340,20 @@ The following table includes the `dataflow.spring.io` links to the stream applic
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |RabbitMQ + Maven
-|https://dataflow.spring.io/rabbitmq-maven-latest
-|https://dataflow.spring.io/rabbitmq-maven-latest-snapshot
+|https://dataflow.spring.io/rabbitmq-maven-5-0-x
+|https://dataflow.spring.io/rabbitmq-maven-5-0-x-snapshot
 
 |RabbitMQ + Docker
-|https://dataflow.spring.io/rabbitmq-docker-latest
-|https://dataflow.spring.io/rabbitmq-docker-latest-snapshot
+|https://dataflow.spring.io/rabbitmq-docker-5-0-x
+|https://dataflow.spring.io/rabbitmq-docker-5-0-x-snapshot
 
 |Apache Kafka + Maven
-|https://dataflow.spring.io/kafka-maven-latest
-|https://dataflow.spring.io/kafka-maven-latest-snapshot
+|https://dataflow.spring.io/kafka-maven-5-0-x
+|https://dataflow.spring.io/kafka-maven-5-0-x-snapshot
 
 |Apache Kafka + Docker
-|https://dataflow.spring.io/kafka-docker-latest
-|https://dataflow.spring.io/kafka-docker-latest-snapshot
+|https://dataflow.spring.io/kafka-docker-5-0-x
+|https://dataflow.spring.io/kafka-docker-5-0-x-snapshot
 |======================
 
 NOTE: By default, the out-of-the-box app's actuator endpoints are secured. You can disable security by deploying streams by setting the following property: `[small]#app.*.spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration#`
@@ -370,12 +370,12 @@ The following table includes the `dataflow.spring.io` links to the task applicat
 |Artifact Type |Stable Release |SNAPSHOT Release
 
 |Maven
-|https://dataflow.spring.io/task-maven-latest
-|https://dataflow.spring.io/task-maven-latest-snapshot
+|https://dataflow.spring.io/task-maven-3-0-x
+|https://dataflow.spring.io/task-maven-3-0-x-snapshot
 
 |Docker
-|https://dataflow.spring.io/task-docker-latest
-|https://dataflow.spring.io/task-docker-latest-snapshot
+|https://dataflow.spring.io/task-docker-3-0-x
+|https://dataflow.spring.io/task-docker-3-0-x-snapshot
 |======================
 
 For more information about the available out-of-the-box stream applications see the https://cloud.spring.io/spring-cloud-task-app-starters/[Spring Cloud Stream Applications] project page.
@@ -387,7 +387,7 @@ As an example, if you would like to register all out-of-the-box stream applicati
 ====
 [source,bash,subs=attributes]
 ----
-$ dataflow:>app import --uri https://dataflow.spring.io/kafka-maven-latest
+$ dataflow:>app import --uri https://dataflow.spring.io/kafka-maven-5-0-x
 ----
 ====
 
@@ -396,7 +396,7 @@ Alternatively, you can register all the stream applications with the Rabbit bind
 ====
 [source,bash,subs=attributes]
 ----
-$ dataflow:>app import --uri https://dataflow.spring.io/rabbitmq-maven-latest
+$ dataflow:>app import --uri https://dataflow.spring.io/rabbitmq-maven-5-0-x
 ----
 ====
 

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/streams.adoc
@@ -206,8 +206,8 @@ applications built with the RabbitMQ binder, you could do the following:
 ====
 [source,bash]
 ----
-dataflow:>app register --name http --type source --uri maven://org.springframework.cloud.stream.app:http-source-rabbit:3.2.1
-dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+dataflow:>app register --name http --type source --uri maven://org.springframework.cloud.stream.app:http-source-rabbit:5.0.0
+dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
 ----
 ====
 
@@ -218,8 +218,8 @@ For example, to register the snapshot versions of the `http` and `log` applicati
 ====
 [source,bash]
 ----
-source.http=maven://org.springframework.cloud.stream.app:http-source-rabbit:3.2.1
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+source.http=maven://org.springframework.cloud.stream.app:http-source-rabbit:5.0.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
 ----
 ====
 
@@ -486,9 +486,9 @@ The following listing shows the exposed properties for the `time` application:
 ----
 dataflow:> app info --name time --type source
 Information about source application 'time':
-Version: '3.2.1':
+Version: '5.0.0':
 Default application version: 'true':
-Resource URI: maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.1
+Resource URI: maven://org.springframework.cloud.stream.app:time-source-rabbit:5.0.0
 ╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
 ║         Option Name          │         Description          │           Default            │             Type             ║
 ╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣
@@ -521,9 +521,9 @@ The following listing shows the exposed properties for the `log` application:
 ----
 dataflow:> app info --name log --type sink
 Information about sink application 'log':
-Version: '3.2.1':
+Version: '5.0.0':
 Default application version: 'true':
-Resource URI: maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+Resource URI: maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
 ╔══════════════════════════════╤══════════════════════════════╤══════════════════════════════╤══════════════════════════════╗
 ║         Option Name          │         Description          │           Default            │             Type             ║
 ╠══════════════════════════════╪══════════════════════════════╪══════════════════════════════╪══════════════════════════════╣
@@ -790,13 +790,13 @@ Stream Deployment properties: {
 ----
 ====
 
-Then the following command updates the stream to use the `3.2.1` version of the log application.
+Then the following command updates the stream to use the `5.0.0` version of the log application.
 Before updating the stream with the specific version of the application, we need to make sure that the application is registered with that version:
 
 ====
 [source,bash]
 ----
-dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
 Successfully registered application 'sink:log'
 ----
 ====
@@ -806,7 +806,7 @@ Then we can update the application:
 ====
 [source,bash]
 ----
-dataflow:>stream update --name httptest --properties version.log=3.2.1
+dataflow:>stream update --name httptest --properties version.log=5.0.0
 ----
 ====
 
@@ -829,11 +829,11 @@ Stream Deployment properties: {
     "spring.cloud.deployer.indexed" : "true",
     "spring.cloud.deployer.count" : "1",
     "spring.cloud.deployer.group" : "httptest",
-    "maven://org.springframework.cloud.stream.app:log-sink-rabbit" : "3.2.1"
+    "maven://org.springframework.cloud.stream.app:log-sink-rabbit" : "5.0.0"
   },
   "http" : {
     "spring.cloud.deployer.group" : "httptest",
-    "maven://org.springframework.cloud.stream.app:http-source-rabbit" : "3.2.1"
+    "maven://org.springframework.cloud.stream.app:http-source-rabbit" : "5.0.0"
   }
 }
 ----

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -128,7 +128,7 @@ For example, if you would like to register all the task applications that ship w
 ====
 [source,bash]
 ----
-dataflow:>app import --uri https://dataflow.spring.io/task-maven-latest
+dataflow:>app import --uri https://dataflow.spring.io/task-maven-3-0-x
 ----
 ====
 

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -39,7 +39,7 @@
 		<joda-time.version>2.12.7</joda-time.version>
 		<aws-java-sdk-ecr.version>1.12.513</aws-java-sdk-ecr.version>
 		<!-- only used for dataflow managed stream applications, e.g., tasklauncher -->
-		<stream-applications.version>3.2.1</stream-applications.version>
+		<stream-applications.version>5.0.0</stream-applications.version>
 		<wavefront-spring-boot-bom.version>3.2.0</wavefront-spring-boot-bom.version>
 		<spring-cloud-dataflow-apps-docs-plugin.version>1.0.14</spring-cloud-dataflow-apps-docs-plugin.version>
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/service/DefaultAppRegistryService.java
@@ -432,8 +432,6 @@ public class DefaultAppRegistryService implements AppRegistryService {
 				} catch (Exception e) {
 					throw new IllegalArgumentException(e);
 				}
-			} else if (!"bootVersion".equals(extra)) {
-				throw new IllegalArgumentException("Invalid property: " + lineSplit[0]);
 			}
 		}
 		registrations.put(key, ar);

--- a/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
+++ b/spring-cloud-dataflow-registry/src/main/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommon.java
@@ -101,9 +101,9 @@ public class AppResourceCommon {
 	/**
 	 * Parse the version number from a {@link UrlResource}. It can match a simple
 	 * {@code <artifactId>-<version>.jar} formatted name. For example, a resource ending in
-	 * {@code file-sink-rabbit-1.2.0.RELEASE.jar} will return {@code 1.2.0.RELEASE}. Snapshot
-	 * builds of the form {@code file-sink-rabbit-1.2.0.BUILD-SNAPSHOT.jar} and
-	 * {@code file-sink-rabbit-1.2.0-SNAPSHOT.jar} and {@code file-sink-rabbit-1.2.0-SNAPSHOT-metadata.jar} are also supported
+	 * {@code file-sink-rabbit-5.0.0.jar} will return {@code 5.0.0}. Snapshot
+	 * builds of the form {@code file-sink-rabbit-5.0.1-SNAPSHOT.jar} and
+	 * {@code file-sink-rabbit-5.0.1-SNAPSHOT-metadata.jar} are also supported
 	 * @param urlResource
 	 * @return
 	 */

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -138,9 +138,9 @@ public class AppResourceCommonTests {
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//No dashes in artfiact name - BUILD-SNAPSHOT
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-4.0.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-5.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
+		assertThat(version).isEqualTo("5.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
@@ -152,16 +152,16 @@ public class AppResourceCommonTests {
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
 		//Spring style snapshots naming scheme
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-4.0.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-5.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
+		assertThat(version).isEqualTo("5.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//Standard maven style naming scheme
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-4.0.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-5.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
+		assertThat(version).isEqualTo("5.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 	}
@@ -195,8 +195,8 @@ public class AppResourceCommonTests {
 
 	@Test
 	public void testGetMetadataResourceVersion() {
-		String httpUri = "http://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/cassandra-sink-rabbit/4.0.1-SNAPSHOT/cassandra-sink-rabbit-4.0.1-SNAPSHOT-metadata.jar";
+		String httpUri = "http://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/cassandra-sink-rabbit/5.0.1-SNAPSHOT/cassandra-sink-rabbit-5.0.1-SNAPSHOT-metadata.jar";
 		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(httpUri));
-		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
+		assertThat(version).isEqualTo("5.0.1-SNAPSHOT");
 	}
 }

--- a/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
+++ b/spring-cloud-dataflow-registry/src/test/java/org/springframework/cloud/dataflow/registry/support/AppResourceCommonTests.java
@@ -47,15 +47,15 @@ public class AppResourceCommonTests {
 
 	@Test
 	public void testBadNamedJars() throws Exception {
-		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit.jar");
+		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/5.0.0/file-sink-rabbit.jar");
 		assertThatIllegalArgumentException().isThrownBy( () -> appResourceCommon.getUrlResourceVersion(urlResource));
 	}
 
 	@Test
 	public void testInvalidUrlResourceWithoutVersion() throws Exception {
 		assertThat(appResourceCommon.getUrlResourceWithoutVersion(
-				new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar")))
-				.isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit");
+				new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/5.0.0/file-sink-rabbit-5.0.0.jar")))
+				.isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/5.0.0/file-sink-rabbit");
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class AppResourceCommonTests {
 
 	@Test
 	public void testDockerUriString() throws Exception {
-		String dockerUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
+		String dockerUri = "docker:springcloudstream/log-sink-rabbit:5.0.0";
 		Resource resource = appResourceCommon.getResource(dockerUri);
 		assertThat(resource instanceof DockerResource).isTrue();
 		assertThat(resource.getURI().toString().equals(dockerUri));
@@ -91,15 +91,15 @@ public class AppResourceCommonTests {
 
 	@Test
 	public void testJarMetadataUriDockerApp() throws Exception {
-		String appUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
-		String metadataUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar";
+		String appUri = "docker:springcloudstream/log-sink-rabbit:5.0.0";
+		String metadataUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/5.0.0/file-sink-rabbit-5.0.0.jar";
 		appResourceCommon.getMetadataResource(new URI(appUri), new URI(metadataUri));
 		verify(resourceLoader).getResource(eq(metadataUri));
 	}
 
 	@Test
 	public void testMetadataUriHttpApp() throws Exception {
-		String appUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/3.2.1/file-sink-rabbit-3.2.1.jar";
+		String appUri = "https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/5.0.0/file-sink-rabbit-5.0.0.jar";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), null);
 		assertThat(metadataResource instanceof UrlResource).isTrue();
 		assertThat(metadataResource.getURI().toString().equals(appUri));
@@ -107,7 +107,7 @@ public class AppResourceCommonTests {
 
 	@Test
 	public void testMetadataUriDockerApp() throws Exception {
-		String appUri = "docker:springcloudstream/log-sink-rabbit:3.2.1";
+		String appUri = "docker:springcloudstream/log-sink-rabbit:5.0.0";
 		Resource metadataResource = appResourceCommon.getMetadataResource(new URI(appUri), null);
 		assertThat(metadataResource).isNotNull();
 		assertThat(metadataResource instanceof DockerResource).isTrue();
@@ -130,38 +130,38 @@ public class AppResourceCommonTests {
 	@Test
 	public void testJars() throws MalformedURLException {
 		//Dashes in artifact name
-		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1.jar");
+		UrlResource urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-5.0.0.jar");
 		String version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("3.2.1");
+		assertThat(version).isEqualTo("5.0.0");
 
 		String theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//No dashes in artfiact name - BUILD-SNAPSHOT
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-3.2.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-4.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
+		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
 		//No dashes in artfiact name - RELEASE
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-3.2.1.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file-5.0.0.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("3.2.1");
+		assertThat(version).isEqualTo("5.0.0");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file/file");
 
 		//Spring style snapshots naming scheme
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-4.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
+		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 
 		//Standard maven style naming scheme
-		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-3.2.1-SNAPSHOT.jar");
+		urlResource = new UrlResource("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit-4.0.1-SNAPSHOT.jar");
 		version = appResourceCommon.getUrlResourceVersion(urlResource);
-		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
+		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
 		theRest = appResourceCommon.getResourceWithoutVersion(urlResource);
 		assertThat(theRest).isEqualTo("https://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/file-sink-rabbit/file-sink-rabbit");
 	}
@@ -169,34 +169,34 @@ public class AppResourceCommonTests {
 	@Test
 	public void testGetResourceWithoutVersion() {
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec:3.2.1")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec:5.0.0")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:war:exec");
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit::exec:3.2.1")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit::exec:5.0.0")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar:exec");
 		assertThat(appResourceCommon.getResourceWithoutVersion(
-				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1")))
+				MavenResource.parse("org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:5.0.0")))
 				.isEqualTo("maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:jar");
 	}
 
 	@Test
 	public void testGetResource() {
-		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1";
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:5.0.0";
 		Resource resource = appResourceCommon.getResource(mavenUri);
 		assertThat(resource).isInstanceOf(MavenResource.class);
 	}
 
 	@Test
 	public void testGetResourceVersion() {
-		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:3.2.1";
+		String mavenUri = "maven://org.springframework.cloud.stream.app:aggregate-counter-sink-rabbit:5.0.0";
 		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(mavenUri));
-		assertThat(version).isEqualTo("3.2.1");
+		assertThat(version).isEqualTo("5.0.0");
 	}
 
 	@Test
 	public void testGetMetadataResourceVersion() {
-		String httpUri = "http://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/cassandra-sink-rabbit/3.2.1-SNAPSHOT/cassandra-sink-rabbit-3.2.1-SNAPSHOT-metadata.jar";
+		String httpUri = "http://repo.maven.apache.org/maven2/org/springframework/cloud/stream/app/cassandra-sink-rabbit/4.0.1-SNAPSHOT/cassandra-sink-rabbit-4.0.1-SNAPSHOT-metadata.jar";
 		String version = appResourceCommon.getResourceVersion(appResourceCommon.getResource(httpUri));
-		assertThat(version).isEqualTo("3.2.1-SNAPSHOT");
+		assertThat(version).isEqualTo("4.0.1-SNAPSHOT");
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -320,26 +320,26 @@ public class AppRegistryControllerTests {
 	public void testRegisterAllWithoutForce() throws Exception {
 		this.appRegistryService.importAll(false, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
 		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:time-source-rabbit:5.0.0");
 		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:filter-processor-rabbit:5.0.0");
 		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString())
-				.isEqualTo("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:3.2.1");
+				.isEqualTo("maven://org.springframework" + ".cloud.stream.app:log-sink-rabbit:5.0.0");
 		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.task.app:timestamp-task:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.task.app:timestamp-task:5.0.0");
 	}
 
 	@Test
 	public void testRegisterAllWithForce() throws Exception {
 		this.appRegistryService.importAll(true, new ClassPathResource("META-INF/test-apps-overwrite.properties"));
 		assertThat(this.appRegistryService.find("time", ApplicationType.source).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:time-source-kafka:5.0.0");
 		assertThat(this.appRegistryService.find("filter", ApplicationType.processor).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.stream.app:filter-processor-kafka:5.0.0");
 		assertThat(this.appRegistryService.find("log", ApplicationType.sink).getUri().toString())
-				.isEqualTo("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:3.2.1");
+				.isEqualTo("maven://org.springframework" + ".cloud.stream.app:log-sink-kafka:5.0.0");
 		assertThat(this.appRegistryService.find("timestamp", ApplicationType.task).getUri().toString())
-				.isEqualTo("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:3.2.1");
+				.isEqualTo("maven://org" + ".springframework.cloud.task.app:timestamp-overwrite-task:5.0.0");
 	}
 
 	@Test
@@ -429,7 +429,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(2022)));
+				.andExpect(jsonPath("$.options[*]", hasSize(1946)));
 	}
 
 	@Test
@@ -478,11 +478,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isConflict());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/3.2.1").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/5.0.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/3.2.1").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/5.0.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -620,11 +620,11 @@ public class AppRegistryControllerTests {
 				.andExpect(status().isOk());
 
 		// This log sink v1.0.BS is part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/sink/log/3.2.1").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/sink/log/5.0.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source v1.0 BS is not part of a deployed stream, so it can be unregistered
-		mockMvc.perform(delete("/apps/source/time/3.2.1").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(delete("/apps/source/time/5.0.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 
 		// This time source is part of a deployed stream, so it can not be unregistered.
@@ -724,17 +724,17 @@ public class AppRegistryControllerTests {
 
 	@Test
 	public void testListApplicationsByVersion() throws Exception {
-		mockMvc.perform(get("/apps?version=3.2.1").accept(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/apps?version=5.0.0").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(4)));
 	}
 
 	@Test
 	public void testListApplicationsByVersionAndSearch() throws Exception {
-		mockMvc.perform(get("/apps?version=3.2.1&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=5.0.0&search=time").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(2)));
-		mockMvc.perform(get("/apps?version=3.2.1&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
+		mockMvc.perform(get("/apps?version=5.0.0&search=timestamp").accept(MediaType.APPLICATION_JSON)).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("_embedded.appRegistrationResourceList", hasSize(1)));
 	}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AppRegistryControllerTests.java
@@ -429,7 +429,7 @@ public class AppRegistryControllerTests {
 		mockMvc.perform(get("/apps/source/time?exhaustive=true").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk()).andExpect(jsonPath("name", is("time")))
 				.andExpect(jsonPath("type", is("source")))
-				.andExpect(jsonPath("$.options[*]", hasSize(1946)));
+				.andExpect(jsonPath("$.options[*]", hasSize(2059)));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/AuditRecordControllerTests.java
@@ -352,7 +352,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(9)));
 
-		appRegistryService.delete("filter", ApplicationType.processor, "3.2.1");
+		appRegistryService.delete("filter", ApplicationType.processor, "5.0.0");
 
 		mockMvc.perform(
 				get("/audit-records?operations=APP_REGISTRATION&actions=DELETE").accept(MediaType.APPLICATION_JSON))
@@ -462,7 +462,7 @@ public class AuditRecordControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.auditRecordResourceList.*", hasSize(4)));
 
-		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "3.2.1");
+		AppRegistration filter = appRegistryService.find("filter", ApplicationType.processor, "5.0.0");
 		appRegistryService.save(filter);
 
 		mockMvc.perform(

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/StreamControllerTests.java
@@ -943,7 +943,7 @@ public class StreamControllerTests {
 		assertThat(timePackage).isNotNull();
 
 		SpringCloudDeployerApplicationSpec logSpec = parseSpec(logPackage.getConfigValues().getRaw());
-		assertThat(logSpec.getApplicationProperties().get("log.level")).isEqualTo("WARN");
+		assertThat(logSpec.getApplicationProperties().get("log.consumer.level")).isEqualTo("WARN");
 		assertThat(logSpec.getApplicationProperties().get("level")).isNull();
 
 		SpringCloudDeployerApplicationSpec timeSpec = parseSpec(timePackage.getConfigValues().getRaw());
@@ -986,9 +986,9 @@ public class StreamControllerTests {
 		assertThat(timePackage).isNotNull();
 
 		SpringCloudDeployerApplicationSpec logSpec = parseSpec(logPackage.getConfigValues().getRaw());
-		assertThat(logSpec.getApplicationProperties()).containsKey("log.level");
+		assertThat(logSpec.getApplicationProperties()).containsKey("log.consumer.level");
 		assertThat(logSpec.getApplicationProperties()).containsKey("extra");
-		assertThat(logSpec.getApplicationProperties().get("log.level")).isEqualTo("ERROR");
+		assertThat(logSpec.getApplicationProperties().get("log.consumer.level")).isEqualTo("ERROR");
 		assertThat(logSpec.getApplicationProperties().get("extra")).isEqualTo("foo-bar");
 
 
@@ -1026,7 +1026,7 @@ public class StreamControllerTests {
 		SpringCloudDeployerApplicationSpec logSpec = parseSpec(logPackage.getConfigValues().getRaw());
 		logger.info("log:applicationProperties={}", logSpec.getApplicationProperties());
 		logger.info("log:deploymentProperties={}", logSpec.getDeploymentProperties());
-		assertThat(logSpec.getApplicationProperties().get("log.level")).isEqualTo("ERROR");
+		assertThat(logSpec.getApplicationProperties().get("log.consumer.level")).isEqualTo("ERROR");
 
 		SpringCloudDeployerApplicationSpec timeSpec = parseSpec(timePackage.getConfigValues().getRaw());
 		logger.info("time:applicationProperties={}", timeSpec.getApplicationProperties());

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests.java
@@ -86,7 +86,7 @@ public class DefaultStreamServiceUpdateTests {
 	@Test
 	public void testCreateUpdateRequestsWithRegisteredApp() throws IOException {
 		this.appRegistryService.save("log", ApplicationType.sink, "1.1.1.RELEASE",
-				URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:3.2.1"),
+				URI.create("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:5.0.0"),
 				null);
 		testCreateUpdateRequests();
 	}

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps-overwrite.properties
@@ -1,8 +1,8 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:3.2.1
-source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-kafka:3.2.1
-processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:3.2.1
-processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-kafka:3.2.1
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:3.2.1
-sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-kafka:3.2.1
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:3.2.1
-task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:3.2.1
+source.time=maven://org.springframework.cloud.stream.app:time-source-kafka:5.0.0
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-kafka:5.0.0
+processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-kafka:5.0.0
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-kafka:5.0.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-kafka:5.0.0
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-kafka:5.0.0
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:5.0.0
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-overwrite-task:5.0.0

--- a/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
+++ b/spring-cloud-dataflow-server-core/src/test/resources/META-INF/test-apps.properties
@@ -1,8 +1,8 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.1
-source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.1
-processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:3.2.1
-processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:3.2.1
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
-sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
-task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:3.2.1
-task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-task:3.2.1
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:5.0.0
+source.time.metadata=maven://org.springframework.cloud.stream.app:time-source-rabbit:5.0.0
+processor.filter=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:5.0.0
+processor.filter.metadata=maven://org.springframework.cloud.stream.app:filter-processor-rabbit:5.0.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
+sink.log.metadata=maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
+task.timestamp=maven://org.springframework.cloud.task.app:timestamp-task:5.0.0
+task.timestamp.metadata=maven://org.springframework.cloud.task.app:timestamp-task:5.0.0

--- a/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests-update.yml
+++ b/spring-cloud-dataflow-server-core/src/test/resources/org/springframework/cloud/dataflow/server/service/impl/DefaultStreamServiceUpdateTests-update.yml
@@ -2,7 +2,7 @@ log:
   spec:
     applicationProperties:
       server.port: '9999'
-      log.level: 'ERROR'
+      log.consumer.level: 'ERROR'
       endpoints.sensitive: 'false'
       spring.cloud.dataflow.stream.app.type: 'sink'
     version: '1.1.1.RELEASE'

--- a/spring-cloud-dataflow-server/README.adoc
+++ b/spring-cloud-dataflow-server/README.adoc
@@ -157,7 +157,7 @@ SCDF, Skipper servers installed, or the versions Stream and Task apps:
 ----
 ./mvnw clean test-compile failsafe:integration-test -pl spring-cloud-dataflow-server -Pfailsafe -Dgroups="docker-compose" \
    -Dtest.docker.compose.paths="../src/docker-compose/docker-compose.yml,../src/docker-compose/docker-compose-influxdb.yml,../src/docker-compose/docker-compose-postgres.yml,../src/docker-compose/docker-compose-rabbitmq.yml" \
-   -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/rabbitmq-maven-latest \
+   -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/rabbitmq-maven-5-0-x \
    -Dtest.docker.compose.dataflow.version=2.8.0-SNAPSHOT \
    -Dtest.docker.compose.skipper.version=2.7.0-SNAPSHOT \
 ----
@@ -171,8 +171,8 @@ The `test.docker.compose.paths` property accepts comma separated list of docker 
     ../src/docker-compose/docker-compose-kafka.yml, \
     ../src/docker-compose/docker-compose-dood.yml, \
     ../src/docker-compose/docker-compose-prometheus.yml" \
-   -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/kafka-docker-latest \
-   -Dtest.docker.compose.task.apps.uri=https://dataflow.spring.io/task-docker-latest \
+   -Dtest.docker.compose.stream.apps.uri=https://dataflow.spring.io/kafka-docker-5-0-x \
+   -Dtest.docker.compose.task.apps.uri=https://dataflow.spring.io/task-docker-3-0-x \
    -Dtest.docker.compose.dataflow.version=2.8.0-SNAPSHOT \
    -Dtest.docker.compose.skipper.version=2.7.0-SNAPSHOT \
    -Dtest.docker.compose.apps.port.range=80 \

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/DataFlowIT.java
@@ -180,13 +180,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
  * https://dataflow.spring.io/docs/installation/kubernetes/kubectl/#choose-a-message-broker
  * - Set the TEST_PLATFORM_NAME to 'k8s'. - In the DockerMachine configuration set the
  * STREAM_APPS_URI variable to link loading Kafka/Docker apps (e.g
- * https://dataflow.spring.io/rabbitmq-maven-latest).
+ * https://dataflow.spring.io/rabbitmq-maven-5-0-x).
  * <p>
  * Stream tests on CloudFoundry (CF) platform: - Add the docker-compose-cf.yml to the
  * DOCKER_COMPOSE_PATHS list. - On the CF platform start a RabbitMQ service called
  * 'rabbit'. - Set the TEST_PLATFORM_NAME to 'cf'. - In the DockerMachine configuration
  * set the STREAM_APPS_URI variable to link loading Rabbit/Maven apps. (e.g.
- * https://dataflow.spring.io/rabbitmq-maven-latest)
+ * https://dataflow.spring.io/rabbitmq-maven-5-0-x)
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
@@ -94,7 +94,7 @@ public abstract class AbstractPostgresDatabaseTests extends AbstractDatabaseTest
 		objectMapper.registerModule(new Jackson2DataflowModule());
 		final DataFlowTemplate dataFlowTemplate = new DataFlowTemplate(new URI(dataflowCluster.getDataflowUrl()), objectMapper);
 		dataFlowTemplate.appRegistryOperations().register("time", ApplicationType.source, "docker:springcloudstream/time-source-rabbit:5.0.0", null, false);
-		dataFlowTemplate.appRegistryOperations().register("log", ApplicationType.sink, "docker:springcloudstream/log-sink-rabbit:3.2.1", null, false);
+		dataFlowTemplate.appRegistryOperations().register("log", ApplicationType.sink, "docker:springcloudstream/log-sink-rabbit:5.0.0", null, false);
 		dataFlowTemplate.streamOperations().createStream("timelogger", "time | log", "timelogger", false);
 
 		StreamDefinitionResource timelogger = dataFlowTemplate.streamOperations().getStreamDefinition("timelogger");

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
@@ -93,7 +93,7 @@ public abstract class AbstractPostgresDatabaseTests extends AbstractDatabaseTest
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new Jackson2DataflowModule());
 		final DataFlowTemplate dataFlowTemplate = new DataFlowTemplate(new URI(dataflowCluster.getDataflowUrl()), objectMapper);
-		dataFlowTemplate.appRegistryOperations().register("time", ApplicationType.source, "docker:springcloudstream/time-source-rabbit:3.2.1", null, false);
+		dataFlowTemplate.appRegistryOperations().register("time", ApplicationType.source, "docker:springcloudstream/time-source-rabbit:5.0.0", null, false);
 		dataFlowTemplate.appRegistryOperations().register("log", ApplicationType.sink, "docker:springcloudstream/log-sink-rabbit:3.2.1", null, false);
 		dataFlowTemplate.streamOperations().createStream("timelogger", "time | log", "timelogger", false);
 

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/util/DockerComposeFactory.java
@@ -56,14 +56,14 @@ public class DockerComposeFactory {
 	/**
 	 * Pre-registered Task apps used for testing.
 	 */
-	public static final String DEFAULT_TASK_APPS_URI = "https://dataflow.spring.io/task-maven-latest&force=true";
+	public static final String DEFAULT_TASK_APPS_URI = "https://dataflow.spring.io/task-maven-3-0-x&force=true";
 
 	/**
 	 * Common Apps URIs
 	 */
-	public static final String KAFKA_MAVEN_STREAM_APPS_URI = "https://dataflow.spring.io/kafka-maven-latest&force=true"; // local/kafka
-	public static final String RABBITMQ_MAVEN_STREAM_APPS_URI = "https://dataflow.spring.io/rabbitmq-maven-latest&force=true"; // cf or local/rabbit
-	public static final String KAFKA_DOCKER_STREAM_APPS_URI = "https://dataflow.spring.io/kafka-docker-latest&force=true"; // k8s
+	public static final String KAFKA_MAVEN_STREAM_APPS_URI = "https://dataflow.spring.io/kafka-maven-5-0-x&force=true"; // local/kafka
+	public static final String RABBITMQ_MAVEN_STREAM_APPS_URI = "https://dataflow.spring.io/rabbitmq-maven-5-0-x&force=true"; // cf or local/rabbit
+	public static final String KAFKA_DOCKER_STREAM_APPS_URI = "https://dataflow.spring.io/kafka-docker-5-0-x&force=true"; // k8s
 
 	/**
 	 * Pre-registered Stream apps used in the tests
@@ -106,7 +106,7 @@ public class DockerComposeFactory {
 			.withAdditionalEnvironmentVariable("STREAM_APPS_URI",
 					DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_STREAM_APPS_URI, (isDood ? KAFKA_DOCKER_STREAM_APPS_URI : DEFAULT_STREAM_APPS_URI)))
 			.withAdditionalEnvironmentVariable("TASK_APPS_URI",
-					DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI, (isDood ? "https://dataflow.spring.io/task-docker-latest" : DEFAULT_TASK_APPS_URI)))
+					DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI, (isDood ? "https://dataflow.spring.io/task-docker-3-0-x" : DEFAULT_TASK_APPS_URI)))
 			.withAdditionalEnvironmentVariable("APPS_PORT_RANGE",
 					DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_APPS_PORT_RANGE, "20000-20195:20000-20195"))
 			.withAdditionalEnvironmentVariable("DOCKER_DELETE_CONTAINER_ON_EXIT",
@@ -156,7 +156,7 @@ public class DockerComposeFactory {
 		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_STREAM_APPS_URI,
 				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_STREAM_APPS_URI, (isDood ? KAFKA_DOCKER_STREAM_APPS_URI : DEFAULT_STREAM_APPS_URI)));
 		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI,
-				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI, (isDood ? "https://dataflow.spring.io/task-docker-latest" : DEFAULT_TASK_APPS_URI)));
+				DockerComposeFactoryProperties.get(DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_TASK_APPS_URI, (isDood ? "https://dataflow.spring.io/task-docker-3-0-x" : DEFAULT_TASK_APPS_URI)));
 		logger.info("{} = {}", DockerComposeFactoryProperties.TEST_DOCKER_COMPOSE_PATHS,
 				DockerComposeFactoryProperties.getDockerComposePaths(DEFAULT_DOCKER_COMPOSE_PATHS));
 

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommandsTests.java
@@ -102,8 +102,8 @@ public class AppRegistryCommandsTests extends AbstractShellIntegrationTest {
 
 		@Test
 		void taskAppBootVersion() {
-			AppRegistration registration = registerTimestampTask("timestamp3", "3.2.1", "--bootVersion 3", false);
-			assertThat(registration.getVersion()).isEqualTo("3.2.1");
+			AppRegistration registration = registerTimestampTask("timestamp3", "5.0.0", "--bootVersion 3", false);
+			assertThat(registration.getVersion()).isEqualTo("5.0.0");
 		}
 
 		@Test
@@ -111,8 +111,8 @@ public class AppRegistryCommandsTests extends AbstractShellIntegrationTest {
 			AppRegistration registration = registerTimestampTask("timestamp2to3", "3.2.0", "-b 2", false);
 			assertThat(registration.getVersion()).isEqualTo("3.2.0");
 			// The 'force=true' signals to udpate the existing 'timestamp2to3' app
-			registration = registerTimestampTask("timestamp2to3", "3.2.1", "-b 3", true);
-			assertThat(registration.getVersion()).isEqualTo("3.2.1");
+			registration = registerTimestampTask("timestamp2to3", "5.0.0", "-b 3", true);
+			assertThat(registration.getVersion()).isEqualTo("5.0.0");
 		}
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
@@ -86,7 +86,7 @@ public class StreamCommandTests extends AbstractShellIntegrationTest {
 		Deployer deployer = new Deployer("testDeployer", "testType", appDeployer, mock(ActuatorOperations.class));
 		when(skipperClient.listDeployers()).thenReturn(Arrays.asList(deployer));
 		stream().create(streamName, "time | log");
-		stream().update(streamName, "version.log=3.2.1","Update request has been sent for the stream");
+		stream().update(streamName, "version.log=5.0.0","Update request has been sent for the stream");
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-stream-apps.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/META-INF/test-stream-apps.properties
@@ -1,2 +1,2 @@
-source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:3.2.1
-sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+source.time=maven://org.springframework.cloud.stream.app:time-source-rabbit:5.0.0
+sink.log=maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerSink_log.txt
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/commands/registerSink_log.txt
@@ -1,1 +1,1 @@
-app register --type sink --force --name log --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.2.1
+app register --type sink --force --name log --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0

--- a/spring-cloud-dataflow-shell-core/src/test/resources/myproperties.properties
+++ b/spring-cloud-dataflow-shell-core/src/test/resources/myproperties.properties
@@ -1,1 +1,1 @@
-version.log=3.2.1
+version.log=5.0.0

--- a/spring-cloud-skipper/README.adoc
+++ b/spring-cloud-skipper/README.adoc
@@ -151,7 +151,7 @@ skipper:>release upgrade --release-name mylog --package-name log --package-versi
 mylog has been upgraded.  Now at version v2.
 ----
 
-You should see the java app named `log-sink-rabbit-1.2.0.RELEASE.jar` running in the output of the `jps` command.
+You should see the java app named `log-sink-rabbit-5.0.0.jar` running in the output of the `jps` command.
 
 The status command should shortly show it has been deployed successfully.  Note you can type `!status` to execute the last command that started with the word `status`
 
@@ -225,4 +225,3 @@ You should not see any `log-sink-rabbit` apps in the `jps` command.
 Then navigate to `Intellij IDEA > Preferences` and select the Eclipse Code Formatter.  Select the `eclipse-code-formatter.xml` file for the field `Eclipse Java Formatter config file` and the file `eclipse.importorder` for the field `Import order`.
 Enable the `Eclipse code formatter` by clicking `Use the Eclipse code formatter` then click the *OK* button.
 ** NOTE: If you configure the `Eclipse Code Formatter` from `File > Other Settings > Default Settings` it will set this policy across all of your Intellij projects.
-

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -168,7 +168,7 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 
 		// Deploy
 		String releaseName = "test2";
-		Release release = install("log", "3.2.1", releaseName);
+		Release release = install("log", "5.0.0", releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 
 		// Check manifest
@@ -210,7 +210,7 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 	@Test
 	public void packageDeployAndUpgrade() throws Exception {
 		String releaseName = "myLog";
-		Release release = install("log", "3.2.1", releaseName);
+		Release release = install("log", "5.0.0", releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 
 		// Upgrade
@@ -254,7 +254,7 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 	public void packageUpgradeWithNoDifference() throws Exception {
 		String releaseName = "myPackage";
 		String packageName = "log";
-		String packageVersion = "3.2.1";
+		String packageVersion = "5.0.0";
 		Release release = install(packageName, packageVersion, releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 

--- a/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifest.java
+++ b/spring-cloud-skipper/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifest.java
@@ -32,8 +32,8 @@ import org.springframework.cloud.skipper.SkipperException;
  *   name: log-sink
  *   type: sink
  * spec:
- * resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.2.0.RELEASE
- * resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.2.0.RELEASE
+ * resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit:5.0.0
+ * resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:5.0.0
  * applicationProperties:
  *  log.level: INFO
  *  log.expression: hellobaby

--- a/src/deploy/README.html
+++ b/src/deploy/README.html
@@ -732,7 +732,7 @@ The default <em>app-name</em> is <code>scdf-${SCDF_TYPE}</code>.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;broker&gt; [stream-application-version]</p></td>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
 <p><em>broker</em> must be one of rabbit or kafka.
-<em>stream-application-version</em> is optional and will install the latest version. The latest version is 2021.1.2</p>
+<em>stream-application-version</em> is optional and will install the latest version. The latest version is 2024.0.0</p>
 </div></div></td>
 </tr>
 </tbody>

--- a/src/deploy/carvel/register-apps.sh
+++ b/src/deploy/carvel/register-apps.sh
@@ -69,14 +69,14 @@ echo "Registering Stream applications at $DATAFLOW_URL using $STREAM_URI"
 wget -qO- $DATAFLOW_URL/apps --post-data="uri=$STREAM_URI"
 
 # replace with individual invocations of register_app for only those applications used.
-#register_app "source/file" "docker:springcloudstream/file-source-$BROKER_NAME:3.2.1"
-#register_app "source/ftp" "docker:springcloudstream/ftp-source-$BROKER_NAME:3.2.1"
-#register_app "processor/aggregator" "docker:springcloudstream/aggregator-processor-$BROKER_NAME:3.2.1"
-#register_app "processor/filter" "docker:springcloudstream/filter-processor-$BROKER_NAME:3.2.1"
-#register_app "processor/groovy" "docker:springcloudstream/groovy-processor-$BROKER_NAME:3.2.1"
-#register_app "processor/script" "docker:springcloudstream/script-processor-$BROKER_NAME:3.2.1"
-#register_app "processor/splitter" "docker:springcloudstream/splitter-processor-$BROKER_NAME:3.2.1"
-#register_app "processor/transform" "docker:springcloudstream/transform-processor-$BROKER_NAME:3.2.1"
+#register_app "source/file" "docker:springcloudstream/file-source-$BROKER_NAME:5.0.0"
+#register_app "source/ftp" "docker:springcloudstream/ftp-source-$BROKER_NAME:5.0.0"
+#register_app "processor/aggregator" "docker:springcloudstream/aggregator-processor-$BROKER_NAME:5.0.0"
+#register_app "processor/filter" "docker:springcloudstream/filter-processor-$BROKER_NAME:5.0.0"
+#register_app "processor/groovy" "docker:springcloudstream/groovy-processor-$BROKER_NAME:5.0.0"
+#register_app "processor/script" "docker:springcloudstream/script-processor-$BROKER_NAME:5.0.0"
+#register_app "processor/splitter" "docker:springcloudstream/splitter-processor-$BROKER_NAME:5.0.0"
+#register_app "processor/transform" "docker:springcloudstream/transform-processor-$BROKER_NAME:5.0.0"
 
 TASK_URI=https://dataflow.spring.io/task-${TYPE}-latest
 echo "Registering Task applications at $DATAFLOW_URL using $TASK_URI"

--- a/src/deploy/carvel/register-apps.sh
+++ b/src/deploy/carvel/register-apps.sh
@@ -23,7 +23,7 @@ if [ "$BROKER" = "" ]; then
 fi
 if [ "$1" = "" ]; then
     echo "Arguments: [stream-applications-version] [type]"
-    echo "  stream-applications-version: Optional. Use 2021.1.2 for latest release."
+    echo "  stream-applications-version: Optional. Use 2024.0.0 for latest release."
     echo "  type: docker or maven"
 fi
 if [ "$TYPE" = "" ]; then

--- a/src/deploy/k8s/register-apps.sh
+++ b/src/deploy/k8s/register-apps.sh
@@ -44,10 +44,7 @@ else
     BROKER_NAME=$BROKER
 fi
 if [ "$STREAM_APPS_VERSION" = "" ]; then
-    # export STREAM_APPS_VERSION=2022.0.0-SNAPSHOT
-    # export STREAM_APPS_VERSION=2021.1.2 # release for Boot 2.x
-    # export STREAM_APPS_VERSION=2022.0.0 # release for Boot 3.x
-    export STREAM_APPS_VERSION=2022.0.0
+    export STREAM_APPS_VERSION=2024.0.0
 fi
 echo "STREAM_APPS_VERSION=$STREAM_APPS_VERSION"
 if [ "$PLATFORM_TYPE" != "kubernetes" ]; then

--- a/src/docker-compose/docker-compose-dood.yml
+++ b/src/docker-compose/docker-compose-dood.yml
@@ -5,8 +5,8 @@ version: '3'
 #
 # How to use:
 #   COMPOSE_PROJECT_NAME=scdf \
-#   STREAM_APPS_URI=https://dataflow.spring.io/kafka-docker-latest \
-#   TASK_APPS_URI=https://dataflow.spring.io/task-docker-latest \
+#   STREAM_APPS_URI=https://dataflow.spring.io/kafka-docker-5-0-x \
+#   TASK_APPS_URI=https://dataflow.spring.io/task-docker-3-0-x \
 #   docker-compose -f ./docker-compose.yml -f ./docker-compose-dood.yml up
 #
 # - The docker-compose-dood.yml extends docker-compose.yml by installing the Docker CLI to the DataFlow and Skipper
@@ -76,7 +76,7 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-latest&force=true}';               
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-5-0-x&force=true}';               
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}' --no-check-certificate --post-data='uri=docker:springcloud/spring-cloud-dataflow-tasklauncher-sink-kafka:${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}${BP_JVM_VERSION:-}';
         echo 'Docker Stream apps imported'"
 
@@ -84,7 +84,5 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate  --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-latest&force=true}';
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/timestamp3' --no-check-certificate --post-data='bootVersion=3&uri=docker:springcloudtask/timestamp-task:3.0.0';
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/timestamp-batch3' --no-check-certificate --post-data='bootVersion=3&uri=docker:springcloudtask/timestamp-batch-task:3.0.0';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate  --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-3-0-x&force=true}';
         echo 'Docker Task apps imported'"

--- a/src/docker-compose/docker-compose-kafka.yml
+++ b/src/docker-compose/docker-compose-kafka.yml
@@ -71,6 +71,6 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-5-0-x&force=true}';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}' --no-check-certificate --post-data='uri=maven://org.springframework.cloud:spring-cloud-dataflow-tasklauncher-sink-kafka:${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}';
         echo 'Maven Stream apps imported'"

--- a/src/docker-compose/docker-compose-rabbitmq.yml
+++ b/src/docker-compose/docker-compose-rabbitmq.yml
@@ -31,7 +31,6 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/rabbitmq-maven-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/rabbitmq-maven-5-0-x&force=true}';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}' --no-check-certificate --post-data='uri=maven://org.springframework.cloud:spring-cloud-dataflow-tasklauncher-sink-rabbit:${DATAFLOW_VERSION:-2.11.2-SNAPSHOT}';
         echo 'Stream apps imported'"
-

--- a/src/docker-compose/docker-compose.yml
+++ b/src/docker-compose/docker-compose.yml
@@ -57,9 +57,7 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-latest&force=true}';
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/timestamp3' --no-check-certificate --post-data='bootVersion=3&uri=maven://uri=maven:io.spring:timestamp-task:3.0.0';
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/timestamp-batch3' --no-check-certificate --post-data='bootVersion=3&uri=maven://uri=maven:io.spring:timestamp-batch:3.0.0';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-3-0-x&force=true}';
         echo 'Maven Task apps imported'"
 
   skipper-server:

--- a/src/local/README.md
+++ b/src/local/README.md
@@ -10,7 +10,7 @@ Downloads all applications needed by `create-containers.sh` from Maven repositor
 *If the timestamp of snapshots matches the download will be skipped.*
 
 Usage: `download-apps.sh [version]`
-* `version` is the dataflow-server version like `2.10.3`. Default is `2.11.2-SNAPSHOT`
+* `version` is the dataflow-server version like `3.0.0`. Default is `3.0.1-SNAPSHOT`
 
 ## `create-containers.sh`
 Creates all containers and pushes to local docker registry.
@@ -18,5 +18,5 @@ Creates all containers and pushes to local docker registry.
 This script requires [jib-cli](https://github.com/GoogleContainerTools/jib/tree/master/jib-cli)
 
 Usage: `create-containers.sh [version] [jre-version]`
-* `version` is the dataflow-server version like `2.9.6`. Default is `2.11.2-SNAPSHOT`
-* `jre-version` should be one of 11, 17. Default is 11
+* `version` is the dataflow-server version like `3.0.0`. Default is `3.0.1-SNAPSHOT`
+* `jre-version` must be 17

--- a/src/local/create-containers.sh
+++ b/src/local/create-containers.sh
@@ -11,12 +11,12 @@ ROOT_DIR=$(realpath $SCDIR/../..)
 if [ "$1" != "" ]; then
     TAG=$1
 else
-    TAG=2.11.2-SNAPSHOT
+    TAG=3.0.1-SNAPSHOT
 fi
 if [ "$2" != "" ]; then
     v=$2
 else
-    v=11
+    v=17
 fi
 PROCESSOR=$(uname -p)
 # export ARCH=arm64v8 for ARM64 image

--- a/src/local/register-apps.sh
+++ b/src/local/register-apps.sh
@@ -39,9 +39,7 @@ else
     BROKER_NAME=$BROKER
 fi
 if [ "$STREAM_APPS_VERSION" = "" ]; then
-    export STREAM_APPS_VERSION=2022.0.0
-    # export STREAM_APPS_VERSION=2021.1.2 # release for Boot 2.x
-    # export STREAM_APPS_VERSION=2022.0.0 # release for Boot 3.x
+    export STREAM_APPS_VERSION=2024.0.0
 fi
 echo "STREAM_APPS_VERSION=$STREAM_APPS_VERSION"
 TYPE=maven

--- a/src/templates/docker-compose/docker-compose-dood.yml
+++ b/src/templates/docker-compose/docker-compose-dood.yml
@@ -5,8 +5,8 @@ version: '3'
 #
 # How to use:
 #   COMPOSE_PROJECT_NAME=scdf \
-#   STREAM_APPS_URI=https://dataflow.spring.io/kafka-docker-latest \
-#   TASK_APPS_URI=https://dataflow.spring.io/task-docker-latest \
+#   STREAM_APPS_URI=https://dataflow.spring.io/kafka-docker-5-0-x \
+#   TASK_APPS_URI=https://dataflow.spring.io/task-docker-3-0-x \
 #   docker-compose -f ./docker-compose.yml -f ./docker-compose-dood.yml up
 #
 # - The docker-compose-dood.yml extends docker-compose.yml by installing the Docker CLI to the DataFlow and Skipper
@@ -64,7 +64,7 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-docker-5-0-x&force=true}';
                 wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-@project.version@}' --no-check-certificate --post-data='uri=docker:springcloud/spring-cloud-dataflow-tasklauncher-sink-kafka:${DATAFLOW_VERSION:-@project.version@}${BP_JVM_VERSION:-}';
         echo 'Docker Stream apps imported'"
 
@@ -72,5 +72,5 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate  --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate  --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-docker-3-0-x&force=true}';
         echo 'Docker Task apps imported'"

--- a/src/templates/docker-compose/docker-compose-rabbitmq.yml
+++ b/src/templates/docker-compose/docker-compose-rabbitmq.yml
@@ -24,9 +24,8 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/rabbitmq-maven-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/rabbitmq-maven-5-0-x&force=true}';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/ver-log/3.0.1' --no-check-certificate --post-data='uri=maven://org.springframework.cloud.stream.app:log-sink-rabbit:3.0.1';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/ver-log/2.1.5.RELEASE' --no-check-certificate --post-data='uri=maven://org.springframework.cloud.stream.app:log-sink-rabbit:2.1.5.RELEASE';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-@project.version@}' --no-check-certificate --post-data='uri=maven://org.springframework.cloud:spring-cloud-dataflow-tasklauncher-sink-rabbit:${DATAFLOW_VERSION:-@project.version@}';
         echo 'Stream apps imported'"
-

--- a/src/templates/docker-compose/docker-compose.yml
+++ b/src/templates/docker-compose/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${STREAM_APPS_URI:-https://dataflow.spring.io/kafka-maven-5-0-x&force=true}';
         wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps/sink/dataflow-tasklauncher/${DATAFLOW_VERSION:-@project.version@}' --no-check-certificate --post-data='uri=maven://org.springframework.cloud:spring-cloud-dataflow-tasklauncher-sink-kafka:${DATAFLOW_VERSION:-@project.version@}';
         echo 'Maven Stream apps imported'"
 
@@ -105,7 +105,7 @@ services:
     command: >
       /bin/sh -c "
         ./wait-for-it.sh -t 360 dataflow-server:9393;
-        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-latest&force=true}';
+        wget -qO- '${DATAFLOW_URI:-http://dataflow-server:9393}/apps' --no-check-certificate --post-data='uri=${TASK_APPS_URI:-https://dataflow.spring.io/task-maven-3-0-x&force=true}';
         echo 'Maven Task apps imported'"
 
   skipper-server:


### PR DESCRIPTION
This commit is the 1st step in the effort to update the default version of stream apps from 3.2.1 to 5.0.0.

* All references to `dataflow.spring.io/*-*-latest` are replaced w/ `dataflow.spring.io/*-*-(5-0-x|3-0-x)`
* All references to stream apps version `3.2.1` are replaced w/ `5.0.0` (unless it is a version diff or version upgrade test)
* All references to task apps version `2.0.2` are replaced w/ `3.0.0` (unless it is a version diff or version upgrade test)

> [!NOTE]
> @corneil we are still registering task apps version 2 and 3 in many of the scripts under `/src/` and I am pretty sure we should remove the 2.x ones but I wanted to understand the implications before we do. Will this break the ATs?  


> [!NOTE]
> The following PRs were merged to enable this change:
> * https://github.com/spring-cloud/spring-cloud-dataflow-ui/pull/2010
> * https://github.com/spring-io/dataflow.spring.io/pull/524