### PR TITLE
Remove metrics auto-config exclusions

### DIFF
--- a/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
+++ b/spring-cloud-dataflow-server/src/main/java/org/springframework/cloud/dataflow/server/single/DataFlowServerApplication.java
@@ -17,11 +17,7 @@
 package org.springframework.cloud.dataflow.server.single;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.actuate.autoconfigure.metrics.export.influx.InfluxMetricsExportAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.metrics.export.wavefront.WavefrontMetricsExportAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
-import org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
@@ -30,7 +26,6 @@ import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
-import org.springframework.cloud.task.configuration.observation.ObservationTaskAutoConfiguration;
 import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
 
 /**
@@ -40,17 +35,7 @@ import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
  */
-//TODO: Boot3x followup - remove the following exclusions once we have identified the proper way to handle metrics:
-// 		WavefrontMetricsExportAutoConfiguration.class,
-//		WavefrontAutoConfiguration.class,
-//		ObservationAutoConfiguration.class,
-//		InfluxMetricsExportAutoConfiguration.class,
 @SpringBootApplication(exclude = {
-		WavefrontMetricsExportAutoConfiguration.class,
-		WavefrontAutoConfiguration.class,
-		ObservationAutoConfiguration.class,
-		InfluxMetricsExportAutoConfiguration.class,
-		ObservationTaskAutoConfiguration.class,
 		SessionAutoConfiguration.class,
 		SimpleTaskAutoConfiguration.class,
 		ManagementWebSecurityAutoConfiguration.class,


### PR DESCRIPTION
This commit removes temporary auto-config exclusions that were in place to allow compiling against Boot 3.x prior to migrating to the newer Observation API.