### PR TITLE
Enable MariadbSharedDbIT

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.dataflow.integration.test.db;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,7 @@ public abstract class AbstractDatabaseTests extends AbstractDataflowTests {
 
 	@Test
 	@DataflowMain
+	@Disabled("TODO: Enable once Java 21 images are supported")
 	public void latestSharedDbJdk21() {
 		log.info("Running testLatestSharedDb()");
 		// start defined database

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MariadbSharedDbIT.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/MariadbSharedDbIT.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.integration.test.db;
 
-import org.junit.jupiter.api.Disabled;
 import org.springframework.cloud.dataflow.integration.test.tags.DatabaseShared;
 import org.springframework.cloud.dataflow.integration.test.tags.Mariadb;
 import org.springframework.cloud.dataflow.integration.test.tags.TagNames;
@@ -25,8 +24,6 @@ import org.springframework.test.context.ActiveProfiles;
 /**
  * Database tests for {@code mariadb 10.3} using shared db.
  */
-@Disabled("TODO: Boot3x followup Enable once Spring Cloud Skipper has successfully built and pushed its bits to dockerhub")
-//TODO: Boot3x followup
 @Mariadb
 @DatabaseShared
 @ActiveProfiles({TagNames.PROFILE_DB_SHARED})


### PR DESCRIPTION
This commit re-enables the `MariadbSharedDbIT` and disables the Java 21 test variant as Java 21 container images are not yet supported.