### PR TITLE
Provide consistent method  to specify app version when launching schedules

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/tasks.adoc
@@ -288,6 +288,29 @@ NOTE: Properties configured by using this mechanism have lower precedence than t
 They are overridden if a property with the same key is specified at task launch time (for example, `app.trigger.prop2`
 overrides the common property).
 
+==== Launching tasks with a specific application version
+
+When launching a task you can specify the specific version of the application.
+If no version is specified Spring Cloud Data Flow will use the default version of the application.
+To specify a version of the application to be used at launch time use the deployer property `version.<app-name>`.
+For example:
+
+====
+[source,bash,subs=attributes]
+----
+task launch my-task --properties 'version.timestamp=3.0.0'
+----
+====
+
+Similarly, when scheduling a task you will use the same format of `version.<app-name>`.  For example:
+
+====
+[source,bash,subs=attributes]
+----
+task schedule create --name my-schedule --definitionName my-task --expression '*/1 * * * *' --properties 'version.timestamp=3.0.0'
+----
+====
+
 [[spring-cloud-dataflow-task-limit-concurrent-executions]]
 === Limit the number concurrent task launches
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -210,10 +210,11 @@ public class DefaultSchedulerService implements SchedulerService {
 
 		String taskAppName = taskDefinition.getRegisteredAppName();
 		String taskLabel = taskDefinition.getAppDefinition().getName();
-		if(!StringUtils.hasText(taskLabel)) {
-			taskLabel = taskAppName;
-		}
 		String version = taskDeploymentProperties.get("version." + taskLabel);
+		if (version == null) {
+			version = taskDeploymentProperties.get("version." + taskAppName);
+		}
+
 		TaskParser taskParser = new TaskParser(taskDefinition.getName(), taskDefinition.getDslText(), true, true);
 		TaskNode taskNode = taskParser.parse();
 		AppRegistration appRegistration;


### PR DESCRIPTION
Currently the user specifies version.<task-definition-name> to specify the app version for a schedule. This is inconsistent with stream where it should be version.<app-name>. This commit supports both versions..

This is a modified cherry-pick of this [commit](https://github.com/spring-cloud/spring-cloud-dataflow/commit/b3be82a247f3b0661cde94d867b7c6e12f10575e)