### PR TITLE
Update various dependencies patch versions

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -22,7 +22,8 @@
 		<docs.main>${project.artifactId}</docs.main>
 		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
 		<spring-boot.version>2.7.18</spring-boot.version>
-		<spring-framework.version>5.3.37</spring-framework.version>
+		<!-- Required by spring-cloud-skipper-docs/pom.xml for javadoc processing -->
+		<spring-framework.version>5.3.39</spring-framework.version>
 		<spring-cloud.version>2021.0.9</spring-cloud.version>
 		<spring-security.version>5.7.12</spring-security.version>
 		<spring-shell.version>2.1.15</spring-shell.version>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -21,24 +21,24 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
 		<spring-boot.version>2.7.18</spring-boot.version>
-		<spring-framework.version>5.3.37</spring-framework.version>
+		<spring-framework.version>5.3.39</spring-framework.version>
 		<spring-cloud.version>2021.0.9</spring-cloud.version>
 		<spring-security.version>5.7.12</spring-security.version>
 		<spring-shell.version>2.1.13</spring-shell.version>
 		<commons-text.version>1.10.0</commons-text.version>
 		<testcontainers.version>1.19.8</testcontainers.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
-		<tomcat.version>9.0.90</tomcat.version>
+		<tomcat.version>9.0.93</tomcat.version>
 		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
-		<netty.version>4.1.111.Final</netty.version>
-		<reactor-bom.version>2020.0.45</reactor-bom.version>
+		<netty.version>4.1.113.Final</netty.version>
+		<reactor-bom.version>2020.0.47</reactor-bom.version>
 		<rsocket.version>1.1.4</rsocket.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<jackson-bom.version>2.17.2</jackson-bom.version>
 		<json-smart.version>2.4.11</json-smart.version>
 		<nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
-		<snappy-java.version>1.1.10.5</snappy-java.version>
+		<snappy-java.version>1.1.10.6</snappy-java.version>
 		<commons-compress.version>1.26.1</commons-compress.version>
 		<commons-io.version>2.15.1</commons-io.version>
 		<postgresql.version>42.7.2</postgresql.version>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -18,7 +18,7 @@
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<spring-boot.version>2.7.18</spring-boot.version>
-		<spring-framework.version>5.3.37</spring-framework.version>
+		<spring-framework.version>5.3.39</spring-framework.version>
 		<spring-security.version>5.7.12</spring-security.version>
 		<spring-cloud-dataflow-ui.version>3.4.6-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<spring-cloud-dataflow-common.version>${dataflow.version}</spring-cloud-dataflow-common.version>
@@ -33,16 +33,16 @@
 		<codearte-props2yml.version>0.5</codearte-props2yml.version>
 		<jettison.version>1.5.4</jettison.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
-		<tomcat.version>9.0.90</tomcat.version>
+		<tomcat.version>9.0.93</tomcat.version>
 		<bouncycastle.version>1.78.1</bouncycastle.version>
 		<spring-kafka.version>2.9.13</spring-kafka.version>
-		<netty.version>4.1.111.Final</netty.version>
-		<reactor-bom.version>2020.0.45</reactor-bom.version>
+		<netty.version>4.1.113.Final</netty.version>
+		<reactor-bom.version>2020.0.47</reactor-bom.version>
 		<rsocket.version>1.1.4</rsocket.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<json-smart.version>2.4.11</json-smart.version>
 		<nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
-		<snappy-java.version>1.1.10.5</snappy-java.version>
+		<snappy-java.version>1.1.10.6</snappy-java.version>
 		<commons-compress.version>1.26.1</commons-compress.version>
 		<commons-io.version>2.15.1</commons-io.version>
 		<jackson-bom.version>2.17.2</jackson-bom.version>


### PR DESCRIPTION
Updates the following:
- Spring Framework to 5.3.39
- Tomcat to 9.0.93
- Netty to 4.1.113.Final
- Reactor to 2020.0.47
- Snappy Java to 1.1.10.6

> [!NOTE]
> I chose to keep these in a single commit as they are not CVE related. I will update the release notes accordingly