### PR TITLE
Fix tracing properties in docker compose

### DIFF
--- a/src/docker-compose/docker-compose-wavefront.yml
+++ b/src/docker-compose/docker-compose-wavefront.yml
@@ -7,22 +7,30 @@ version: '3'
 #  - WAVEFRONT_URI (optional) can be used to set the wavefront uri. Defaults to https://vmware.wavefront.com
 #  - WAVEFRONT_SOURCE (optional) can be used to set the wavefront source name. Defaults to scdf-docker-compose
 
+# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' available.
+# This means in order to disable the other tracer reporters we have to exclude their tracing
+# auto-configuration. In Boot 3.4 there is a specific enabled property
+# 'management.<product>.tracing.export.enabled' that simplifies this by not requiring the
+# auto-configuration exclusion. However, to support all version of Boot 3.0 - 3.4 we add
+# both sets of properties in env vars below.
+
 services:
   dataflow-server:
     environment:
+      - MANAGEMENT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - MANAGEMENT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - MANAGEMENT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
       - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_ENABLED=true
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_TRACING_ENABLED=true
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_TRACING_SAMPLING_PROBABILITY=1.0
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_WAVEFRONT_TRACING_EXPORT_ENABLED=true
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_AUTOCONFIGURE_EXCLUDE=org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration
       - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   skipper-server:
     environment:
+      - MANAGEMENT_WAVEFRONT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
+      - MANAGEMENT_WAVEFRONT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
+      - MANAGEMENT_WAVEFRONT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
       - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_ENABLED=true
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_APITOKEN=${WAVEFRONT_KEY:?WAVEFRONT_KEY is not set!}
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_URI=${WAVEFRONT_URI:-https://vmware.wavefront.com}
-      - MANAGEMENT_WAVEFRONT_METRICS_EXPORT_SOURCE=${WAVEFRONT_SOURCE:-scdf-docker-compose}
       - SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}

--- a/src/docker-compose/docker-compose-wavefront.yml
+++ b/src/docker-compose/docker-compose-wavefront.yml
@@ -7,11 +7,11 @@ version: '3'
 #  - WAVEFRONT_URI (optional) can be used to set the wavefront uri. Defaults to https://vmware.wavefront.com
 #  - WAVEFRONT_SOURCE (optional) can be used to set the wavefront source name. Defaults to scdf-docker-compose
 
-# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' available.
+# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' is available.
 # This means in order to disable the other tracer reporters we have to exclude their tracing
 # auto-configuration. In Boot 3.4 there is a specific enabled property
 # 'management.<product>.tracing.export.enabled' that simplifies this by not requiring the
-# auto-configuration exclusion. However, to support all version of Boot 3.0 - 3.4 we add
+# auto-configuration exclusion. However, to support all versions of Boot 3.0 - 3.4 we add
 # both sets of properties in env vars below.
 
 services:

--- a/src/docker-compose/docker-compose-zipkin.yml
+++ b/src/docker-compose/docker-compose-zipkin.yml
@@ -3,11 +3,11 @@ version: '3'
 # Extends the default docker-compose.yml with Zipkin Server distributed tracing configuration.
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-zipkin.yml up
 
-# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' available.
+# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' is available.
 # This means in order to disable the other tracer reporters we have to exclude their tracing
 # auto-configuration. In Boot 3.4 there is a specific enabled property
 # 'management.<product>.tracing.export.enabled' that simplifies this by not requiring the
-# auto-configuration exclusion. However, to support all version of Boot 3.0 - 3.4 we add
+# auto-configuration exclusion. However, to support all versions of Boot 3.0 - 3.4 we add
 # both sets of properties in env vars below.
 
 services:

--- a/src/docker-compose/docker-compose-zipkin.yml
+++ b/src/docker-compose/docker-compose-zipkin.yml
@@ -3,6 +3,13 @@ version: '3'
 # Extends the default docker-compose.yml with Zipkin Server distributed tracing configuration.
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-zipkin.yml up
 
+# NOTE: In Boot 3.0 - 3.3 only global tracing property 'management.tracing.enabled' available.
+# This means in order to disable the other tracer reporters we have to exclude their tracing
+# auto-configuration. In Boot 3.4 there is a specific enabled property
+# 'management.<product>.tracing.export.enabled' that simplifies this by not requiring the
+# auto-configuration exclusion. However, to support all version of Boot 3.0 - 3.4 we add
+# both sets of properties in env vars below.
+
 services:
 
   zipkin-server:
@@ -19,3 +26,4 @@ services:
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_TRACING_SAMPLING_PROBABILITY=1.0
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_ZIPKIN_TRACING_EXPORT_ENABLED=true
       - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_MANAGEMENT_ZIPKIN_TRACING_ENDPOINT=http://zipkin-server:9411/api/v2/spans
+      - SPRING_CLOUD_DATAFLOW_APPLICATIONPROPERTIES_STREAM_SPRING_AUTOCONFIGURE_EXCLUDE=org.springframework.boot.actuate.autoconfigure.tracing.wavefront.WavefrontTracingAutoConfiguration


### PR DESCRIPTION
This commit adds the global tracing property
'management.tracing.enabled' to the Zipkin and Wavefront docker compose files.

Also, the Wavefront docker compose file excludes the Zipkin tracing auto-configuration and the Zipkin docker compose file excludes the Wavefront tracing auto-configuration.