### PR TITLE
Using TimeZone set in the JVM.

### DIFF
--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionResource.java
@@ -123,8 +123,8 @@ public class JobExecutionResource extends RepresentationModel<JobExecutionResour
 			this.name = "?";
 		}
 
-		// Duration is always in GMT
-		durationFormat.setTimeZone(TimeUtils.getDefaultTimeZone());
+		durationFormat.setTimeZone(TimeUtils.getJvmTimeZone());
+
 		// The others can be localized
 		timeFormat.setTimeZone(timeZone);
 		dateFormat.setTimeZone(timeZone);

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
@@ -132,8 +132,8 @@ public class JobExecutionThinResource extends RepresentationModel<JobExecutionTh
 			this.name = "?";
 		}
 
-		// Duration is always in GMT
 		durationFormat.setTimeZone(TimeUtils.getJvmTimeZone());
+
 		// The others can be localized
 		timeFormat.setTimeZone(timeZone);
 		dateFormat.setTimeZone(timeZone);

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/resource/JobExecutionThinResource.java
@@ -133,7 +133,7 @@ public class JobExecutionThinResource extends RepresentationModel<JobExecutionTh
 		}
 
 		// Duration is always in GMT
-		durationFormat.setTimeZone(TimeUtils.getDefaultTimeZone());
+		durationFormat.setTimeZone(TimeUtils.getJvmTimeZone());
 		// The others can be localized
 		timeFormat.setTimeZone(timeZone);
 		dateFormat.setTimeZone(timeZone);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionController.java
@@ -168,7 +168,7 @@ public class JobExecutionController {
 	 */
 	private static class Assembler extends RepresentationModelAssemblerSupport<TaskJobExecution, JobExecutionResource> {
 
-		private TimeZone timeZone = TimeUtils.getDefaultTimeZone();
+		private TimeZone timeZone = TimeUtils.getJvmTimeZone();
 
 		public Assembler() {
 			super(JobExecutionController.class, JobExecutionResource.class);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -198,7 +198,7 @@ public class JobExecutionThinController {
 	 */
 	private static class Assembler extends RepresentationModelAssemblerSupport<TaskJobExecution, JobExecutionThinResource> {
 
-		private TimeZone timeZone = TimeUtils.getDefaultTimeZone();
+		private TimeZone timeZone = TimeUtils.getJvmTimeZone();
 
 		public Assembler() {
 			super(JobExecutionThinController.class, JobExecutionThinResource.class);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobInstanceController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobInstanceController.java
@@ -126,7 +126,7 @@ public class JobInstanceController {
 	 */
 	private static class Assembler extends RepresentationModelAssemblerSupport<JobInstanceExecutions, JobInstanceResource> {
 
-		private TimeZone timeZone = TimeUtils.getDefaultTimeZone();
+		private TimeZone timeZone = TimeUtils.getJvmTimeZone();
 
 		public Assembler() {
 			super(JobInstanceController.class, JobInstanceResource.class);


### PR DESCRIPTION
Hello,

Change the TimeZone, which is always set to UTC in the time field of API responses, to the TimeZone set in the JVM.
In the code below, it is defined to use only the TimeZone set to UTC unconditionally.

For this reason, even if a separate TimeZone is set through JVM Arguments internally, the setting is not applied.
When used in countries that use a separate TimeZone, there is a time difference due to UTC, so I would like to modify this.

Thank you.