### PR TITLE
Remove unused spring.factories in the spring-cloud-dataflow-platform-kubernetes

### DIFF
--- a/spring-cloud-dataflow-platform-kubernetes/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-platform-kubernetes/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.cloud.dataflow.server.config.kubernetes.KubernetesTaskPlatformAutoConfiguration,\
-  org.springframework.cloud.dataflow.server.config.kubernetes.KubernetesSchedulerAutoConfiguration
-


### PR DESCRIPTION
These autoconfigurations have already been moved to the spring/org.springframework.autoconfigure.AutoConfiguration.imports file