### PR TITLE
Use Duration.toMillis instead of CronoUnit

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobStepExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/JobStepExecutionsDocumentation.java
@@ -20,7 +20,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.BatchStatus;
@@ -124,7 +123,6 @@ class JobStepExecutionsDocumentation extends BaseDocumentation {
 				));
 	}
 
-	@Disabled("TODO: Boot3x followup : Need to create DataflowSqlPagingQueryProvider so that dataflow can call generateJumpToItemQuery")
 	@Test
 	void stepProgress() throws Exception {
 		this.mockMvc.perform(

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.rest.job;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 import org.springframework.batch.core.StepExecution;
 
@@ -63,7 +62,7 @@ public class StepExecutionHistory {
 		}
 		LocalDateTime startTime = stepExecution.getStartTime();
 		LocalDateTime endTime = stepExecution.getEndTime();
-		long time = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
+		long time = Duration.between(startTime, endTime).toMillis();
 		duration.append(time);
 		if (stepExecution.getReadCount() > 0) {
 			durationPerRead.append(time / stepExecution.getReadCount());

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/job/support/StepExecutionProgressInfo.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.server.job.support;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
 import org.springframework.batch.core.StepExecution;
@@ -64,7 +63,7 @@ public class StepExecutionProgressInfo {
 		if (startTime == null) {
 			startTime = LocalDateTime.now();
 		}
-		duration = Duration.between(startTime, endTime).get(ChronoUnit.MILLIS);
+		duration = Duration.between(startTime, endTime).toMillis();
 		percentageComplete = calculatePercentageComplete();
 	}
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobStepExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/JobStepExecutionControllerTests.java
@@ -20,7 +20,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.JobExecution;
@@ -173,8 +172,6 @@ class JobStepExecutionControllerTests {
 				.andExpect(jsonPath("$._embedded.stepExecutionResourceList[2].stepExecution.id", is(6)));
 	}
 
-	//TODO: Boot3x followup
-	@Disabled("TODO: Boot3x followup Need to create DataflowSqlPagingQueryProvider so that dataflow can call generateJumpToItemQuery")
 	@Test
 	void singleGetStepExecutionProgress() throws Exception {
 		mockMvc.perform(get("/jobs/executions/1/steps/1/progress").accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
Duration using ChronoUnit only supports nanos and seconds on conversion. In this case use the toMillis() function