### PR TITLE
Enable tests that were disabled because of TaskRepository issue

### DIFF
--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/ShellCommandsTests.java
@@ -57,7 +57,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
 class ShellCommandsTests extends AbstractShellIntegrationTest {
 
 	@AfterEach
@@ -77,6 +76,8 @@ class ShellCommandsTests extends AbstractShellIntegrationTest {
 		assertAppExists("timestamp", ApplicationType.task);
 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x Throws exception stating: No static resource No static resource apps/task/timestamp")
 	@Test
 	void multiFileCommandOrderPreserved() {
 		String commandFiles = toAbsolutePaths(

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/TestConfig.java
@@ -21,8 +21,10 @@ import java.util.List;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration;
 import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
 import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
@@ -30,6 +32,7 @@ import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Dependency;
 import org.springframework.cloud.skipper.domain.VersionInfo;
+import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -45,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @author Mark Pollack
  * @author Chris Bono
  */
-@SpringBootApplication(exclude = {DataFlowClientAutoConfiguration.class})
+@SpringBootApplication(exclude = {DataFlowClientAutoConfiguration.class, SimpleTaskAutoConfiguration.class})
 @EnableDataFlowServer
 @Configuration
 public class TestConfig {
@@ -122,6 +125,12 @@ public class TestConfig {
 		when(skipperClient.info()).thenReturn(about);
 		when(skipperClient.listDeployers()).thenReturn(new ArrayList<>());
 		return skipperClient;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean({ActuatorOperations.class})
+	ActuatorOperations actuatorOperations() {
+		return mock(ActuatorOperations.class);
 	}
 
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommandsTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/AppRegistryCommandsTests.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -41,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
 class AppRegistryCommandsTests extends AbstractShellIntegrationTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(AppRegistryCommandsTests.class);
@@ -70,9 +68,9 @@ class AppRegistryCommandsTests extends AbstractShellIntegrationTest {
 		}
 	}
 
-	private AppRegistration registerTimestampTask(String name, String timestampArtifactVersion, String bootVersionOption, boolean force) {
-		String commandTemplate = "app register --type task --name %s %s %s --uri maven://org.springframework.cloud.task.app:task-timestamp:%s";
-		String command = String.format(commandTemplate, name, bootVersionOption, (force ? "--force" : ""), timestampArtifactVersion);
+	private AppRegistration registerTimestampTask(String name, String timestampArtifactVersion, boolean force) {
+		String commandTemplate = "app register --type task --name %s %s --uri maven://org.springframework.cloud.task.app:task-timestamp:%s";
+		String command = String.format(commandTemplate, name, (force ? "--force" : ""), timestampArtifactVersion);
 		logger.info("COMMAND -> {}", command);
 		Object result = this.commandRunner.executeCommand(command);
 		logger.info("RESULT <- {}", result);
@@ -82,39 +80,13 @@ class AppRegistryCommandsTests extends AbstractShellIntegrationTest {
 		return registration;
 	}
 
-	private AppRegistration registerTimeSource(String name, String timeSourceArtifactVersion,  boolean force) {
-		String commandTemplate = "app register --type source --name %s %s --uri maven://org.springframework.cloud.stream.app:time-source-kafka:%s";
-		String command = String.format(commandTemplate, name, (force ? "--force" : ""), timeSourceArtifactVersion);
-		logger.info("COMMAND -> {}", command);
-		Object result = this.commandRunner.executeCommand(command);
-		logger.info("RESULT <- {}", result);
-		assertThat(registry.appExist(name, ApplicationType.source, timeSourceArtifactVersion)).isTrue();
-		AppRegistration registration = registry.find(name, ApplicationType.source, timeSourceArtifactVersion);
-		registeredApps.add(registration);
-		return registration;
-	}
-
 	@Nested
 	class AppRegisterTests {
 		@Test
 		void taskAppNoBootVersion() {
-			AppRegistration registration = registerTimestampTask("timestamp1", "3.2.0", "", false);
+			AppRegistration registration = registerTimestampTask("timestamp1", "3.2.0",  false);
 			assertThat(registration.getVersion()).isEqualTo("3.2.0");
 		}
 
-		@Test
-		void taskAppBootVersion() {
-			AppRegistration registration = registerTimestampTask("timestamp3", "5.0.0", "--bootVersion 3", false);
-			assertThat(registration.getVersion()).isEqualTo("5.0.0");
-		}
-
-		@Test
-		void taskAppBootVersion2updateTo3() {
-			AppRegistration registration = registerTimestampTask("timestamp2to3", "3.2.0", "-b 2", false);
-			assertThat(registration.getVersion()).isEqualTo("3.2.0");
-			// The 'force=true' signals to udpate the existing 'timestamp2to3' app
-			registration = registerTimestampTask("timestamp2to3", "5.0.0", "-b 3", true);
-			assertThat(registration.getVersion()).isEqualTo("5.0.0");
-		}
 	}
 }

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/JobCommandTests.java
@@ -56,7 +56,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
 class JobCommandTests extends AbstractShellIntegrationTest {
 
 	private final static String BASE_JOB_NAME = "myJob";
@@ -129,17 +128,17 @@ class JobCommandTests extends AbstractShellIntegrationTest {
 	void jobExecutionList() {
 		logger.info("Retrieve Job Execution List Test");
 		Table table = getTable(job().jobExecutionList());
-		verifyColumnNumber(table, 7);
+		verifyColumnNumber(table, 6);
 		checkCell(table, 0, 0, "ID ");
 		checkCell(table, 0, 1, "Task ID");
 		checkCell(table, 0, 2, "Job Name ");
 		checkCell(table, 0, 3, "Start Time ");
 		checkCell(table, 0, 4, "Step Execution Count ");
 		checkCell(table, 0, 5, "Definition Status ");
-		checkCell(table, 0, 6, "Schema Target");
-
  	 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x SCDF /jobs/thinexecutions endpoint fails to respond.")
 	@Test
 	void jobExecutionListByName() {
 		logger.info("Retrieve Job Execution List By Name Test");
@@ -176,7 +175,6 @@ class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, rowNumber++, 0, "Exit Status ");
 		checkCell(table, rowNumber++, 0, "Exit Message ");
 		checkCell(table, rowNumber++, 0, "Definition Status ");
-		checkCell(table, rowNumber++, 0, "Schema Target ");
 		checkCell(table, rowNumber++, 0, "Job Parameters ");
 		int paramRowOne = rowNumber;
 
@@ -204,7 +202,7 @@ class JobCommandTests extends AbstractShellIntegrationTest {
 		logger.info("Retrieve Job Instance Detail by Id");
 
 		Table table = getTable(job().instanceDisplay(jobInstances.get(0).getInstanceId()));
-		verifyColumnNumber(table, 6);
+		verifyColumnNumber(table, 5);
 		checkCell(table, 0, 0, "Name ");
 		checkCell(table, 0, 1, "Execution ID ");
 		checkCell(table, 0, 2, "Step Execution Count ");
@@ -233,6 +231,8 @@ class JobCommandTests extends AbstractShellIntegrationTest {
 		checkCell(table, 0, 5, "Status ");
 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x https://github.com/spring-cloud/spring-cloud-dataflow/pull/5964 should resolve this.  Validate with this test")
 	@Test
 	void jobStepExecutionProgress() {
 		logger.info("Retrieve Job Step Execution Progress Test");
@@ -249,6 +249,8 @@ class JobCommandTests extends AbstractShellIntegrationTest {
 
 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x https://github.com/spring-cloud/spring-cloud-dataflow/pull/5964 should resolve this.  Validate with this test")
 	@Test
 	void stepExecutionView() {
 		logger.info("Retrieve Job Execution Detail by Id");

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/StreamCommandTests.java
@@ -51,7 +51,6 @@ import static org.mockito.Mockito.when;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
 class StreamCommandTests extends AbstractShellIntegrationTest {
 
 	private static final String APPS_URI = "META-INF/test-stream-apps.properties";
@@ -91,6 +90,8 @@ class StreamCommandTests extends AbstractShellIntegrationTest {
 		stream().update(streamName, "version.log=5.0.0","Update request has been sent for the stream");
 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x Failing stating that long:sing:3.2.1 isn't registered.")
 	@Test
 	void streamUpdatePropFileForTickTock() throws InterruptedException {
 		String streamName = generateUniqueStreamOrTaskName();

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.dataflow.shell.command;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import javax.sql.DataSource;
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
+
 class TaskCommandTests extends AbstractShellIntegrationTest {
 
 	private static final String APPS_URI = "META-INF/test-task-apps.properties";
@@ -65,9 +65,9 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 
 	private static final long TASK_EXECUTION_ID = 10000;
 
-	private static final Date startTime = new Date();
+	private static final LocalDateTime startTime = LocalDateTime.now();
 
-	private static final Date endTime = new Date(startTime.getTime() + 5000);
+	private static final LocalDateTime endTime = LocalDateTime.now().plusSeconds(5);
 
 	private static final String EXTERNAL_EXECUTION_ID = "WOW22";
 
@@ -251,7 +251,7 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 		logger.info("Retrieve Task Execution List Test");
 		Object result = task().taskExecutionList();
 		Table table = (Table) result;
-		assertThat(table.getModel().getColumnCount()).isEqualTo(6);
+		assertThat(table.getModel().getColumnCount()).isEqualTo(5);
 		verifyTableValue(table, 0, 0, "Task Name");
 		verifyTableValue(table, 0, 1, "ID");
 		verifyTableValue(table, 0, 2, "Start Time");
@@ -281,7 +281,7 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 		task().create("mytask", "timestamp");
 		Object result = task().taskExecutionListByName("mytask");
 		Table table = (Table) result;
-		assertThat(table.getModel().getColumnCount()).isEqualTo(6);
+		assertThat(table.getModel().getColumnCount()).isEqualTo(5);
 
 		verifyTableValue(table,0, 0, "Task Name");
 		verifyTableValue(table,0, 1, "ID");
@@ -314,8 +314,7 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 		verifyTableValue(table, 10, 0, "Exit Code ");
 		verifyTableValue(table, 11, 0, "Exit Message ");
 		verifyTableValue(table, 12, 0, "Error Message ");
-		verifyTableValue(table, 13, 0, "Schema Target ");
-		verifyTableValue(table, 14, 0, "External Execution Id ");
+		verifyTableValue(table, 13, 0, "External Execution Id ");
 
 		verifyTableValue(table, 1, 1, TASK_EXECUTION_ID);
 		verifyTableValue(table, 3, 1, TASK_NAME);
@@ -324,8 +323,7 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 		verifyTableValue(table, 10, 1, EXIT_CODE);
 		verifyTableValue(table, 11, 1, EXIT_MESSAGE);
 		verifyTableValue(table, 12, 1, ERROR_MESSAGE);
-		verifyTableValue(table, 13, 1, BOOT3_SCHEMA);
-		verifyTableValue(table, 14, 1, EXTERNAL_EXECUTION_ID);
+		verifyTableValue(table, 13, 1, EXTERNAL_EXECUTION_ID);
 	}
 
 	@Test

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandsTest.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskScheduleCommandsTest.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.dataflow.shell.command;
 import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.dataflow.shell.AbstractShellIntegrationTest;
@@ -30,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Chris Bono
  * @author Corneil du Plessis
  */
-@Disabled("taskRepository not found")
 class TaskScheduleCommandsTest extends AbstractShellIntegrationTest {
 
 	@BeforeAll


### PR DESCRIPTION
Tests suites were disabled with the following message `"taskRepository not found"`.
This message was incorrect.   They were failing because multiple taskRepository beans were declared.
By excluding SimpleTaskAutoConfiguration from the @SpringBootApplication the issue no longer occured in these tests.

Another issue arose where 2 RestTemplates were declared and only one was required for actuatorOperations.  Since this is not needed for these tests, this was mocked out.

Once past this, individual tests were able to run.   I resolved issues for failed tests or Disabled those that were either waiting for another PR to be merged or needed more investigation.