### PR TITLE
Mark failing tests caused by main-3 migration as Boot3x

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
@@ -42,7 +42,8 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Adam J. Weigold
  * @author Corneil du Plessis
  */
-@Disabled("failing and need to be resolved.")
+//TODO: Boot3x followup
+@Disabled("TODO: Boot3x `org.springframework.web.client.HttpClientErrorException$BadRequest: 400 : [no body]` is thrown by REST Template")
 public class DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest {
 	@RegisterExtension
 	public final static S3SignedRedirectRequestServerResource s3SignedRedirectRequestServerResource =

--- a/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
+++ b/spring-cloud-dataflow-core-dsl/src/test/java/org/springframework/cloud/dataflow/core/dsl/TaskParserTests.java
@@ -696,7 +696,7 @@ class TaskParserTests {
 				+ "[0-1][1-2][2-3][3-4][fail:1-9][fail2:2-9][9-10][10-4]", spec);
 	}
 
-	@Disabled
+	@Disabled ("Transition out of flow is incorrect. Verify test or parser.")
 	@Test
 	void transitionToSplit() {
 		String spec = "aa 'foo'->:split && bb && split: <cc || dd> && ee";

--- a/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionServiceUtilsTests.java
+++ b/spring-cloud-dataflow-core/src/test/java/org/springframework/cloud/dataflow/core/StreamDefinitionServiceUtilsTests.java
@@ -39,10 +39,9 @@ class StreamDefinitionServiceUtilsTests {
 		reverseDslTest("time | log", 2);
 	}
 
-	@Disabled
 	@Test
 	void quotesInParams() {
-		reverseDslTest("foo --bar='payload.matches(''hello'')' | file", 2);
+		reverseDslTest("foo --bar='payload.matches(\'hello\')' | file", 2);
 	}
 
 	@Test
@@ -65,7 +64,7 @@ class StreamDefinitionServiceUtilsTests {
 		reverseDslTest("http | transform --expression='payload.replace(\"abc\", \"\")' | log", 3);
 	}
 
-	@Disabled
+	@Disabled("The result from the parser is stating that the escaped single ticks is 2, but the assert is requesting 4 ticks.   Verify the assert is correct.")
 	@Test
 	void xd24162() {
 		reverseDslTest("http | transform --expression='payload.replace(\"abc\", '''')' | log", 3);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/MetricsReplicationEnvironmentPostProcessorTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/config/MetricsReplicationEnvironmentPostProcessorTests.java
@@ -194,7 +194,8 @@ class MetricsReplicationEnvironmentPostProcessorTests {
 		}
 	}
 
-	@Disabled("Waiting on https://github.com/spring-cloud/spring-cloud-dataflow/issues/5675#issuecomment-1953867317")
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x Waiting on https://github.com/spring-cloud/spring-cloud-dataflow/issues/5675#issuecomment-1953867317")
 	@Test
 	void prometheusPropertiesReplication() {
 		try (ConfigurableApplicationContext ctx = applicationContext(

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractDatabaseTests.java
@@ -64,7 +64,8 @@ public abstract class AbstractDatabaseTests extends AbstractDataflowTests {
 
 	@Test
 	@DataflowMain
-	@Disabled("TODO: Enable once Java 21 images are supported")
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x  Enable once Java 21 images are supported")
 	public void latestSharedDbJdk21() {
 		log.info("Running testLatestSharedDb()");
 		// start defined database

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/AbstractSmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/AbstractSmokeTest.java
@@ -15,16 +15,13 @@
  */
 package org.springframework.cloud.dataflow.server.db.migration;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -121,9 +118,6 @@ public abstract class AbstractSmokeTest {
 				.allSatisfy((taskExecution) -> assertThat(taskExecution.getExecutionId()).isNotEqualTo(0L));
 	}
 
-	//TODO: Boot3x followup Due to some changes the SQL being tested for is not being outputted by SCDF logs
-	//Not sure if this is because dataflow should be in debug or the print was removed as a part of the migration.
-	@Disabled
 	@Test
 	void shouldListJobExecutionsUsingPerformantRowNumberQuery(
 			CapturedOutput output,
@@ -141,11 +135,6 @@ public abstract class AbstractSmokeTest {
 		// Get all executions and ensure the count and that the row number function was (or not) used
 		jobExecutions = taskJobService.listJobExecutionsWithStepCount(Pageable.ofSize(100));
 		assertThat(jobExecutions).hasSize(originalCount + 4);
-		String expectedSqlFragment = (this.supportsRowNumberFunction()) ?
-				"as STEP_COUNT, ROW_NUMBER() OVER (PARTITION" :
-				"as STEP_COUNT FROM BATCH_JOB_INSTANCE";
-		Awaitility.waitAtMost(Duration.ofSeconds(5))
-				.untilAsserted(() -> assertThat(output).contains(expectedSqlFragment));
 
 		// Verify that paging works as well
 		jobExecutions = taskJobService.listJobExecutionsWithStepCount(Pageable.ofSize(2).withPage(0));

--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2_11_5_SmokeTest.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/db/migration/DB2_11_5_SmokeTest.java
@@ -34,7 +34,8 @@ import org.springframework.cloud.dataflow.server.db.DB2_11_5_ContainerSupport;
 //at com.ibm.db2.jcc.am.ResultSet.getObject(ResultSet.java:2045)
 //at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
 //at org.springframework.cloud.task.repository.dao.JdbcTaskExecutionDao$TaskExecutionRowMapper.mapRow(JdbcTaskExecutionDao.java:621)
-@Disabled("TODO: DB2 Driver and LocalDateTime has a bug when the row has is null in the column")
+//TODO: Boot3x followup
+@Disabled("TODO: Boot3x DB2 Driver and LocalDateTime has a bug when the row has is null in the column")
 @EnabledIfEnvironmentVariable(named = "ENABLE_DB2", matches = "true", disabledReason = "Container is too big")
 @Tag("DB2")
 public class DB2_11_5_SmokeTest extends AbstractSmokeTest implements DB2_11_5_ContainerSupport {

--- a/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
+++ b/spring-cloud-dataflow-shell-core/src/test/java/org/springframework/cloud/dataflow/shell/command/TaskCommandTests.java
@@ -125,7 +125,7 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 	}
 
 	@Test
-	@Disabled
+	@Disabled("Shell is merging 2 properties into a single property.")
 	void taskLaunchCTRUsingAltCtrName() {
 		logger.info("Launching instance of task");
 		String taskName = generateUniqueStreamOrTaskName();
@@ -134,7 +134,6 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 		task().launchWithAlternateCTR(taskName, "timestamp");
 	}
 
-	@Disabled("Find why log is inaccessible")
 	@Test
 	void getLog() throws Exception{
 		logger.info("Retrieving task execution log");
@@ -152,7 +151,6 @@ class TaskCommandTests extends AbstractShellIntegrationTest {
 				.isEqualTo("Log could not be retrieved.  Verify that deployments are still available.");
 	}
 
-	@Disabled("Find why it won't start")
 	@Test
 	void getLogInvalidId() {
 		assertThatThrownBy(() -> taskWithErrors().getTaskExecutionLogInvalidId())

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Ilayaperumal Gopinathan
  * @author Corneil du Plessis
  */
-@Disabled
+
 class LocalConfigurationTests {
 
 	private ConfigurableApplicationContext context;
@@ -104,6 +104,8 @@ class LocalConfigurationTests {
 		}
 	}
 
+	//TODO: Boot3x followup
+	@Disabled("TODO: Boot3x DataflowServerConfiguration requires DataflowTaskExecutionQueryDao bean.  Doesn't seem like it is needed.")
 	@Test
 	void configWithTasksDisabled() {
 		SpringApplication app = new SpringApplication(LocalTestDataFlowServer.class);

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/dataflowapp/LocalTestDataFlowServer.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/dataflowapp/LocalTestDataFlowServer.java
@@ -22,10 +22,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration;
 import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
+import org.springframework.cloud.task.configuration.SimpleTaskAutoConfiguration;
 
 /**
  * Bootstrap class for the local Spring Cloud Data Flow Server.
@@ -42,7 +44,9 @@ import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfigurati
 		UserDetailsServiceAutoConfiguration.class,
 		LocalDeployerAutoConfiguration.class,
 		CloudFoundryDeployerAutoConfiguration.class,
-		KubernetesAutoConfiguration.class
+		KubernetesAutoConfiguration.class,
+		SimpleTaskAutoConfiguration.class,
+		DataFlowClientAutoConfiguration.class
 })
 @EnableDataFlowServer
 public class LocalTestDataFlowServer {

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/nodataflowapp/LocalTestNoDataFlowServer.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/nodataflowapp/LocalTestNoDataFlowServer.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.cloud.dataflow.rest.client.config.DataFlowClientAutoConfiguration;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
@@ -42,7 +43,8 @@ import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfigurati
 		UserDetailsServiceAutoConfiguration.class,
 		LocalDeployerAutoConfiguration.class,
 		CloudFoundryDeployerAutoConfiguration.class,
-		KubernetesAutoConfiguration.class
+		KubernetesAutoConfiguration.class,
+		DataFlowClientAutoConfiguration.class
 })
 @AutoConfigureTestDatabase
 public class LocalTestNoDataFlowServer {


### PR DESCRIPTION
The goal is to isolate `Disabled` to the test level and provide documentation as to why it is disabled.   And if possible resolve the problem that facilitated the need for `Disabled` 
* Re-Enable  tests that are now functioning or needed small repairs/tweaks
* ReEnable LocalConfigurationTests
* Remove ROW_COUNT test from AbstractSmokeTests. The ROW_COUNT test was to make sure that this filter was applied for specific database types that uses the aggregate views. In this case we no longer need to test for this as SCDF no longer uses views
* Make sure all Disabled Tests have a message even if they are not a main-3 Disabled tests