### PR TITLE
Allow users to disable task features in dataflow

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowServerConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.dataflow.server.config.features.FeaturesConfigu
 import org.springframework.cloud.dataflow.server.config.web.WebConfiguration;
 import org.springframework.cloud.dataflow.server.db.migration.DataFlowFlywayConfigurationCustomizer;
 import org.springframework.cloud.dataflow.server.support.AuthenticationSuccessEventListener;
-import org.springframework.cloud.dataflow.server.task.DataflowTaskConfiguration;
+import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorerConfiguration;
 import org.springframework.cloud.task.configuration.TaskProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -65,7 +65,7 @@ import org.springframework.web.filter.ForwardedHeaderFilter;
 		FeaturesConfiguration.class,
 		WebConfiguration.class,
 		H2ServerConfiguration.class,
-		DataflowTaskConfiguration.class,
+		DataflowTaskExplorerConfiguration.class,
 		DataFlowTaskConfiguration.class
 })
 @EnableConfigurationProperties({ BatchProperties.class, CommonApplicationProperties.class })

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/features/TaskConfiguration.java
@@ -60,7 +60,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskJobServ
 import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveService;
 import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
-import org.springframework.cloud.dataflow.server.task.DataflowTaskConfiguration;
+import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorerConfiguration;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExecutionQueryDao;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorer;
 import org.springframework.cloud.dataflow.server.task.TaskDefinitionReader;
@@ -103,7 +103,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @Import({
 		TaskConfiguration.TaskDeleteServiceConfig.class,
-		DataflowTaskConfiguration.class,
+		DataflowTaskExplorerConfiguration.class,
 		DataFlowTaskConfiguration.class
 })
 public class TaskConfiguration {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/task/DataflowTaskExplorerConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/task/DataflowTaskExplorerConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.dataflow.server.task;
 
 import javax.sql.DataSource;
 
+import org.springframework.cloud.dataflow.server.config.features.ConditionalOnTasksEnabled;
 import org.springframework.cloud.dataflow.server.task.impl.DefaultDataflowTaskExplorer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,11 +28,12 @@ import org.springframework.util.Assert;
  *
  * @author Corneil du Plessis
  */
+@ConditionalOnTasksEnabled
 @Configuration
-public class DataflowTaskConfiguration {
+public class DataflowTaskExplorerConfiguration {
 
 	@Bean
-	public DataflowTaskExplorer aggregateTaskExplorer(
+	public DataflowTaskExplorer dataflowTaskExplorer(
 			DataSource dataSource,
 			DataflowTaskExecutionQueryDao taskExecutionQueryDao,
 			TaskDefinitionReader taskDefinitionReader,

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -100,7 +100,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveSer
 import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
-import org.springframework.cloud.dataflow.server.task.DataflowTaskConfiguration;
+import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorerConfiguration;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExecutionQueryDao;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorer;
 import org.springframework.cloud.dataflow.server.task.impl.DefaultDataFlowTaskExecutionQueryDao;
@@ -139,7 +139,7 @@ import static org.mockito.Mockito.mock;
 @Configuration
 @EnableSpringDataWebSupport
 @Import({
-		DataflowTaskConfiguration.class,
+		DataflowTaskExplorerConfiguration.class,
 		DataFlowTaskConfiguration.class
 })
 @ImportAutoConfiguration({

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TaskServiceDependencies.java
@@ -80,7 +80,7 @@ import org.springframework.cloud.dataflow.server.service.impl.DefaultTaskSaveSer
 import org.springframework.cloud.dataflow.server.service.impl.TaskAppDeploymentRequestCreator;
 import org.springframework.cloud.dataflow.server.service.impl.TaskConfigurationProperties;
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
-import org.springframework.cloud.dataflow.server.task.DataflowTaskConfiguration;
+import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorerConfiguration;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExecutionQueryDao;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorer;
 import org.springframework.cloud.dataflow.server.task.impl.DefaultDataFlowTaskExecutionQueryDao;
@@ -125,7 +125,7 @@ import static org.mockito.Mockito.when;
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 @Import({
 		CompletionConfiguration.class,
-		DataflowTaskConfiguration.class,
+		DataflowTaskExplorerConfiguration.class,
 		DataFlowTaskConfiguration.class
 })
 @ImportAutoConfiguration({

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -146,7 +146,7 @@ import org.springframework.cloud.dataflow.server.service.impl.validation.Default
 import org.springframework.cloud.dataflow.server.service.impl.validation.DefaultTaskValidationService;
 import org.springframework.cloud.dataflow.server.stream.SkipperStreamDeployer;
 import org.springframework.cloud.dataflow.server.stream.StreamDeployer;
-import org.springframework.cloud.dataflow.server.task.DataflowTaskConfiguration;
+import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorerConfiguration;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExecutionQueryDao;
 import org.springframework.cloud.dataflow.server.task.DataflowTaskExplorer;
 import org.springframework.cloud.dataflow.server.task.impl.DefaultDataFlowTaskExecutionQueryDao;
@@ -204,7 +204,7 @@ import static org.mockito.Mockito.when;
 @EnableSpringDataWebSupport
 @Import({
 		CompletionConfiguration.class,
-		DataflowTaskConfiguration.class,
+		DataflowTaskExplorerConfiguration.class,
 		DataFlowTaskConfiguration.class,
 		ContainerRegistryAutoConfiguration.class,
 		TaskConfiguration.TaskJobServiceConfig.class

--- a/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
+++ b/spring-cloud-starter-dataflow-server/src/test/java/org/springframework/cloud/dataflow/server/single/LocalConfigurationTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.dataflow.server.single;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -104,8 +103,6 @@ class LocalConfigurationTests {
 		}
 	}
 
-	//TODO: Boot3x followup
-	@Disabled("TODO: Boot3x DataflowServerConfiguration requires DataflowTaskExecutionQueryDao bean.  Doesn't seem like it is needed.")
 	@Test
 	void configWithTasksDisabled() {
 		SpringApplication app = new SpringApplication(LocalTestDataFlowServer.class);


### PR DESCRIPTION
Currently if the user sets task-enabled to false SCDF will fail to start.

* Rename DataflowTaskConfiguration to DataflowTaskExplorerConfiguration so that it expresses its usage. 
* Rename aggregateTaskExplorer to dataflowTaskExplorer 
* Set the `ConditionalOnTasksEnabled` annotation so that the configuration won't fire if `task-enabled` is set to false. 
* Remove the `Disabled` annotation from the test so that we can verify that the `task-enabled` works properly.