### PR TITLE
The authorization header was not dropped by redirect strategy as expected.

### DIFF
--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest.java
@@ -42,8 +42,6 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Adam J. Weigold
  * @author Corneil du Plessis
  */
-//TODO: Boot3x followup
-@Disabled("TODO: Boot3x `org.springframework.web.client.HttpClientErrorException$BadRequest: 400 : [no body]` is thrown by REST Template")
 public class DropAuthorizationHeaderOnSignedS3RequestRedirectStrategyTest {
 	@RegisterExtension
 	public final static S3SignedRedirectRequestServerResource s3SignedRedirectRequestServerResource =

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class S3SignedRedirectRequestController {
-	private final static Logger logger = LoggerFactory.getLogger(S3SignedRedirectRequestController.class);
 
 	@RequestMapping("/service/token")
 	public ResponseEntity<Map<String, String>> getToken() {
@@ -57,7 +56,6 @@ public class S3SignedRedirectRequestController {
 	@RequestMapping("/v2/test/s3-redirect-image/blobs/signed_redirect_digest")
 	public ResponseEntity<Map<String, String>> getBlobRedirect(@RequestHeader("Authorization") String token) {
 		if (!"bearer my_token_999".equals(token.trim().toLowerCase())) {
-			logger.info("getBlobRedirect=BAD_REQUEST");
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		HttpHeaders redirectHeaders = new HttpHeaders();
@@ -68,15 +66,12 @@ public class S3SignedRedirectRequestController {
 				"&X-Amz-Expires=1200" +
 				"&X-Amz-SignedHeaders=host" +
 				"&X-Amz-Signature=test");
-		logger.info("getBlobRedirect:{}", redirectHeaders);
 		return new ResponseEntity<>(redirectHeaders, HttpStatus.TEMPORARY_REDIRECT);
 	}
 
 	@RequestMapping("/test/docker/registry/v2/blobs/test/data")
 	public ResponseEntity<Resource> getSignedBlob(@RequestHeader Map<String, String> headers) {
-		logger.info("getSignedBlob:{}", headers);
 		if (headers.containsKey("authorization")) {
-			logger.info("getSignedBlob=BAD_REQUEST");
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		return buildFromString("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }");

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.dataflow.container.registry.authorization.supp
 import java.util.Collections;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.dataflow.container.registry.ContainerRegistryProperties;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -36,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class S3SignedRedirectRequestController {
+	private final static Logger logger = LoggerFactory.getLogger(S3SignedRedirectRequestController.class);
 
 	@RequestMapping("/service/token")
 	public ResponseEntity<Map<String, String>> getToken() {
@@ -53,6 +57,7 @@ public class S3SignedRedirectRequestController {
 	@RequestMapping("/v2/test/s3-redirect-image/blobs/signed_redirect_digest")
 	public ResponseEntity<Map<String, String>> getBlobRedirect(@RequestHeader("Authorization") String token) {
 		if (!"bearer my_token_999".equals(token.trim().toLowerCase())) {
+			logger.info("getBlobRedirect=BAD_REQUEST");
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		HttpHeaders redirectHeaders = new HttpHeaders();
@@ -63,13 +68,15 @@ public class S3SignedRedirectRequestController {
 				"&X-Amz-Expires=1200" +
 				"&X-Amz-SignedHeaders=host" +
 				"&X-Amz-Signature=test");
-
+		logger.info("getBlobRedirect:{}", redirectHeaders);
 		return new ResponseEntity<>(redirectHeaders, HttpStatus.TEMPORARY_REDIRECT);
 	}
 
 	@RequestMapping("/test/docker/registry/v2/blobs/test/data")
 	public ResponseEntity<Resource> getSignedBlob(@RequestHeader Map<String, String> headers) {
-		if (!headers.containsKey("authorization")) {
+		logger.info("getSignedBlob:{}", headers);
+		if (headers.containsKey("authorization")) {
+			logger.info("getSignedBlob=BAD_REQUEST");
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		return buildFromString("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }");

--- a/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
+++ b/spring-cloud-dataflow-configuration-metadata/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author Adam J. Weigold
+ * @author Corneil du Plessis
  */
 @RestController
 public class S3SignedRedirectRequestController {
@@ -68,7 +69,7 @@ public class S3SignedRedirectRequestController {
 
 	@RequestMapping("/test/docker/registry/v2/blobs/test/data")
 	public ResponseEntity<Resource> getSignedBlob(@RequestHeader Map<String, String> headers) {
-		if (headers.containsKey("authorization")) {
+		if (!headers.containsKey("authorization")) {
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		return buildFromString("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }");

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerImageRestTemplateFactory.java
@@ -21,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -216,14 +217,11 @@ public class ContainerImageRestTemplateFactory {
 			routePlanner = new DefaultRoutePlanner(DefaultSchemePortResolver.INSTANCE);
 		}
 
-		DropAuthorizationHeaderRequestRedirectStrategy redirectStrategy = new DropAuthorizationHeaderRequestRedirectStrategy(
-				extra);
+		DropAuthorizationHeaderRequestRedirectStrategy redirectStrategy = new DropAuthorizationHeaderRequestRedirectStrategy(extra);
 		HttpComponentsClientHttpRequestFactory customRequestFactory = new HttpComponentsClientHttpRequestFactory(
 				clientBuilder.setRedirectStrategy(redirectStrategy)
-					.replaceExecInterceptor(ChainElement.REDIRECT.name(),
-							new SpecialRedirectExec(routePlanner, redirectStrategy))
-					// Azure redirects may contain double slashes and on default those are
-					// normilised
+					.replaceExecInterceptor(ChainElement.REDIRECT.name(), new SpecialRedirectExec(routePlanner, redirectStrategy))
+					// Azure redirects may contain double slashes and on default those are normalised
 					.setDefaultRequestConfig(RequestConfig.custom().build())
 					.build());
 
@@ -232,7 +230,7 @@ public class ContainerImageRestTemplateFactory {
 		// Therefore we extend the MappingJackson2HttpMessageConverter media-types to
 		// include application/octet-stream and text/plain.
 		MappingJackson2HttpMessageConverter octetSupportJsonConverter = new MappingJackson2HttpMessageConverter();
-		ArrayList<MediaType> mediaTypeList = new ArrayList(octetSupportJsonConverter.getSupportedMediaTypes());
+		List<MediaType> mediaTypeList = new ArrayList(octetSupportJsonConverter.getSupportedMediaTypes());
 		mediaTypeList.add(MediaType.APPLICATION_OCTET_STREAM);
 		mediaTypeList.add(MediaType.TEXT_PLAIN);
 		octetSupportJsonConverter.setSupportedMediaTypes(mediaTypeList);

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/ContainerRegistryService.java
@@ -31,7 +31,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -47,9 +46,9 @@ public class ContainerRegistryService {
 
 	private static final Logger logger = LoggerFactory.getLogger(ContainerRegistryService.class);
 
-	private static final List<String> SUPPORTED_MANIFEST_MEDIA_TYPES = Collections
-		.unmodifiableList(Arrays.asList(ContainerRegistryProperties.OCI_IMAGE_MANIFEST_MEDIA_TYPE,
-				ContainerRegistryProperties.DOCKER_IMAGE_MANIFEST_MEDIA_TYPE));
+	private static final List<String> SUPPORTED_MANIFEST_MEDIA_TYPES =
+			Collections.unmodifiableList(Arrays.asList(ContainerRegistryProperties.OCI_IMAGE_MANIFEST_MEDIA_TYPE,
+					ContainerRegistryProperties.DOCKER_IMAGE_MANIFEST_MEDIA_TYPE));
 
 	private static final String HTTPS_SCHEME = "https";
 
@@ -89,38 +88,35 @@ public class ContainerRegistryService {
 	}
 
 	/**
-	 * Get the tag information for the given container image identified by its repository
-	 * and registry. The registry information is expected to be set via container registry
-	 * configuration in SCDF.
+	 * Get the tag information for the given container image identified by its repository and registry.
+	 * The registry information is expected to be set via container registry configuration in SCDF.
 	 * @param registryName the container registry name
 	 * @param repositoryName the image repository name
 	 * @return the list of tags for the image
 	 */
 	public List<String> getTags(String registryName, String repositoryName) {
 		try {
-			ContainerRegistryConfiguration containerRegistryConfiguration = this.registryConfigurations
-				.get(registryName);
+			ContainerRegistryConfiguration containerRegistryConfiguration = this.registryConfigurations.get(registryName);
 			Map<String, String> properties = new HashMap<>();
 			properties.put(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_REPOSITORY_FIELD_KEY, repositoryName);
-			HttpHeaders httpHeaders = new HttpHeaders(
-					this.registryAuthorizerMap.get(containerRegistryConfiguration.getAuthorizationType())
-						.getAuthorizationHeaders(containerRegistryConfiguration, properties));
+			HttpHeaders httpHeaders = new HttpHeaders(this.registryAuthorizerMap.get(containerRegistryConfiguration.getAuthorizationType()).getAuthorizationHeaders(
+					containerRegistryConfiguration, properties));
 			httpHeaders.set(HttpHeaders.ACCEPT, "application/json");
 
 			UriComponents manifestUriComponents = UriComponentsBuilder.newInstance()
-				.scheme(HTTPS_SCHEME)
-				.host(containerRegistryConfiguration.getRegistryHost())
-				.path(TAGS_LIST_PATH)
-				.build()
-				.expand(repositoryName);
+					.scheme(HTTPS_SCHEME)
+					.host(containerRegistryConfiguration.getRegistryHost())
+					.path(TAGS_LIST_PATH)
+					.build().expand(repositoryName);
 
 			RestTemplate requestRestTemplate = this.containerImageRestTemplateFactory.getContainerRestTemplate(
 					containerRegistryConfiguration.isDisableSslVerification(),
-					containerRegistryConfiguration.isUseHttpProxy(), containerRegistryConfiguration.getExtra());
+					containerRegistryConfiguration.isUseHttpProxy(),
+					containerRegistryConfiguration.getExtra());
 
-			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(), HttpMethod.GET,
-					new HttpEntity<>(httpHeaders), Map.class);
-			return (List<String>) manifest.getBody().get(TAGS_FIELD);
+			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
+					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
+			return  (List<String>) manifest.getBody().get(TAGS_FIELD);
 		}
 		catch (Exception e) {
 			logger.error("Exception getting tag information for the {} from {}", repositoryName, registryName);
@@ -136,25 +132,28 @@ public class ContainerRegistryService {
 	public Map getRepositories(String registryName) {
 		try {
 			ContainerRegistryConfiguration containerRegistryConfiguration = this.registryConfigurations
-				.get(registryName);
+					.get(registryName);
 			Map<String, String> properties = new HashMap<>();
 			properties.put(DockerOAuth2RegistryAuthorizer.DOCKER_REGISTRY_REPOSITORY_FIELD_KEY, registryName);
 			HttpHeaders httpHeaders = new HttpHeaders(
 					this.registryAuthorizerMap.get(containerRegistryConfiguration.getAuthorizationType())
-						.getAuthorizationHeaders(containerRegistryConfiguration, properties));
+							.getAuthorizationHeaders(
+									containerRegistryConfiguration, properties));
 			httpHeaders.set(HttpHeaders.ACCEPT, "application/json");
 			UriComponents manifestUriComponents = UriComponentsBuilder.newInstance()
-				.scheme(HTTPS_SCHEME)
-				.host(containerRegistryConfiguration.getRegistryHost())
-				.path(CATALOG_LIST_PATH)
-				.build();
+					.scheme(HTTPS_SCHEME)
+					.host(containerRegistryConfiguration.getRegistryHost())
+					.path(CATALOG_LIST_PATH)
+					.build();
+
 
 			RestTemplate requestRestTemplate = this.containerImageRestTemplateFactory.getContainerRestTemplate(
 					containerRegistryConfiguration.isDisableSslVerification(),
-					containerRegistryConfiguration.isUseHttpProxy(), containerRegistryConfiguration.getExtra());
+					containerRegistryConfiguration.isUseHttpProxy(),
+					containerRegistryConfiguration.getExtra());
 
-			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(), HttpMethod.GET,
-					new HttpEntity<>(httpHeaders), Map.class);
+			ResponseEntity<Map> manifest = requestRestTemplate.exchange(manifestUriComponents.toUri(),
+					HttpMethod.GET, new HttpEntity<>(httpHeaders), Map.class);
 			return manifest.getBody();
 		}
 		catch (Exception e) {
@@ -207,20 +206,18 @@ public class ContainerRegistryService {
 		// Docker Registry HTTP V2 API pull manifest
 		ContainerImage containerImage = registryRequest.getContainerImage();
 		UriComponents manifestUriComponents = UriComponentsBuilder.newInstance()
-			.scheme(HTTPS_SCHEME)
-			.host(containerImage.getHostname())
-			.port(StringUtils.hasText(containerImage.getPort()) ? containerImage.getPort() : null)
-			.path(IMAGE_MANIFEST_REFERENCE_PATH)
-			.build()
-			.expand(containerImage.getRepository(), containerImage.getRepositoryReference());
+				.scheme(HTTPS_SCHEME)
+				.host(containerImage.getHostname())
+				.port(StringUtils.hasText(containerImage.getPort()) ? containerImage.getPort() : null)
+				.path(IMAGE_MANIFEST_REFERENCE_PATH)
+				.build().expand(containerImage.getRepository(), containerImage.getRepositoryReference());
 
-		ResponseEntity<T> manifest = registryRequest.getRestTemplate()
-			.exchange(manifestUriComponents.toUri(), HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
+		ResponseEntity<T> manifest = registryRequest.getRestTemplate().exchange(manifestUriComponents.toUri(),
+				HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
 		return manifest.getBody();
 	}
 
-	public <T> T getImageBlob(ContainerRegistryRequest registryRequest, String configDigest,
-			Class<T> responseClassType) {
+	public <T> T getImageBlob(ContainerRegistryRequest registryRequest, String configDigest, Class<T> responseClassType) {
 		ContainerImage containerImage = registryRequest.getContainerImage();
 		HttpHeaders httpHeaders = new HttpHeaders(registryRequest.getAuthHttpHeaders());
 
@@ -230,19 +227,11 @@ public class ContainerRegistryService {
 			.host(containerImage.getHostname())
 			.port(StringUtils.hasText(containerImage.getPort()) ? containerImage.getPort() : null)
 			.path(IMAGE_BLOB_DIGEST_PATH)
-			.build()
-			.expand(containerImage.getRepository(), configDigest);
-		try {
-			logger.info("getImageBlob:request:{},{}", blobUriComponents.toUri(), httpHeaders);
-			ResponseEntity<T> blob = registryRequest.getRestTemplate()
-				.exchange(blobUriComponents.toUri(), HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
+			.build().expand(containerImage.getRepository(), configDigest);
 
-			return blob.getStatusCode().is2xxSuccessful() ? blob.getBody() : null;
-		}
-		catch (RestClientException x) {
-			logger.error("getImageBlob:exception:" + x, x);
-			return null;
-		}
+		ResponseEntity<T> blob = registryRequest.getRestTemplate().exchange(blobUriComponents.toUri(),
+			HttpMethod.GET, new HttpEntity<>(httpHeaders), responseClassType);
+
+		return blob.getBody();
 	}
-
 }

--- a/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/SpecialRedirectExec.java
+++ b/spring-cloud-dataflow-container-registry/src/main/java/org/springframework/cloud/dataflow/container/registry/authorization/SpecialRedirectExec.java
@@ -1,0 +1,226 @@
+package org.springframework.cloud.dataflow.container.registry.authorization;
+
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+
+import org.apache.hc.client5.http.CircularRedirectException;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.RedirectException;
+import org.apache.hc.client5.http.auth.AuthExchange;
+import org.apache.hc.client5.http.classic.ExecChain;
+import org.apache.hc.client5.http.classic.ExecChainHandler;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.RedirectLocations;
+import org.apache.hc.client5.http.protocol.RedirectStrategy;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
+import org.apache.hc.client5.http.utils.URIUtils;
+import org.apache.hc.core5.annotation.Contract;
+import org.apache.hc.core5.annotation.Internal;
+import org.apache.hc.core5.annotation.ThreadingBehavior;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.util.Args;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Essential copy of RedirectExec to override the behaviour allowing the use of current request when creating a request builder.
+ *
+ * @author Corneil du Plessis
+ */
+@Contract(threading = ThreadingBehavior.STATELESS)
+@Internal
+public final class SpecialRedirectExec implements ExecChainHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SpecialRedirectExec.class);
+
+	private final RedirectStrategy redirectStrategy;
+	private final HttpRoutePlanner routePlanner;
+
+	public SpecialRedirectExec(
+		final HttpRoutePlanner routePlanner,
+		final RedirectStrategy redirectStrategy) {
+		super();
+		Args.notNull(routePlanner, "HTTP route planner");
+		Args.notNull(redirectStrategy, "HTTP redirect strategy");
+		this.routePlanner = routePlanner;
+		this.redirectStrategy = redirectStrategy;
+	}
+
+	@Override
+	public ClassicHttpResponse execute(
+		final ClassicHttpRequest request,
+		final ExecChain.Scope scope,
+		final ExecChain chain) throws IOException, HttpException {
+		Args.notNull(request, "HTTP request");
+		Args.notNull(scope, "Scope");
+
+		final HttpClientContext context = scope.clientContext;
+		RedirectLocations redirectLocations = context.getRedirectLocations();
+		if (redirectLocations == null) {
+			redirectLocations = new RedirectLocations();
+			context.setAttribute(HttpClientContext.REDIRECT_LOCATIONS, redirectLocations);
+		}
+		redirectLocations.clear();
+
+		final RequestConfig config = context.getRequestConfig();
+		final int maxRedirects = config.getMaxRedirects() > 0 ? config.getMaxRedirects() : 50;
+		ClassicHttpRequest originalRequest = scope.originalRequest;
+		ClassicHttpRequest currentRequest = request;
+		ExecChain.Scope currentScope = scope;
+		for (int redirectCount = 0;;) {
+			final String exchangeId = currentScope.exchangeId;
+			final ClassicHttpResponse response = chain.proceed(currentRequest, currentScope);
+			try {
+				if (config.isRedirectsEnabled() && this.redirectStrategy.isRedirected(request, response, context)) {
+					final HttpEntity requestEntity = request.getEntity();
+					if (requestEntity != null && !requestEntity.isRepeatable()) {
+						if (LOG.isDebugEnabled()) {
+							LOG.debug("{} cannot redirect non-repeatable request", exchangeId);
+						}
+						return response;
+					}
+					if (redirectCount >= maxRedirects) {
+						throw new RedirectException("Maximum redirects ("+ maxRedirects + ") exceeded");
+					}
+					redirectCount++;
+
+					final URI redirectUri = this.redirectStrategy.getLocationURI(currentRequest, response, context);
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("{} redirect requested to location '{}'", exchangeId, redirectUri);
+					}
+
+					final HttpHost newTarget = URIUtils.extractHost(redirectUri);
+					if (newTarget == null) {
+						throw new ProtocolException("Redirect URI does not specify a valid host name: " +
+							redirectUri);
+					}
+
+					if (!config.isCircularRedirectsAllowed()) {
+						if (redirectLocations.contains(redirectUri)) {
+							throw new CircularRedirectException("Circular redirect to '" + redirectUri + "'");
+						}
+					}
+					redirectLocations.add(redirectUri);
+
+					final int statusCode = response.getCode();
+					final ClassicRequestBuilder redirectBuilder;
+					switch (statusCode) {
+						case HttpStatus.SC_MOVED_PERMANENTLY:
+						case HttpStatus.SC_MOVED_TEMPORARILY:
+							if (Method.POST.isSame(request.getMethod())) {
+								redirectBuilder = ClassicRequestBuilder.get();
+							} else {
+								redirectBuilder = ClassicRequestBuilder.copy(currentRequest);
+							}
+							break;
+						case HttpStatus.SC_SEE_OTHER:
+							if (!Method.GET.isSame(request.getMethod()) && !Method.HEAD.isSame(request.getMethod())) {
+								redirectBuilder = ClassicRequestBuilder.get();
+							} else {
+								redirectBuilder = ClassicRequestBuilder.copy(currentRequest);
+							}
+							break;
+						default:
+							redirectBuilder = ClassicRequestBuilder.copy(currentRequest);
+					}
+					redirectBuilder.setUri(redirectUri);
+
+					final HttpRoute currentRoute = currentScope.route;
+					if (!Objects.equals(currentRoute.getTargetHost(), newTarget)) {
+						final HttpRoute newRoute = this.routePlanner.determineRoute(newTarget, context);
+						if (!Objects.equals(currentRoute, newRoute)) {
+							if (LOG.isDebugEnabled()) {
+								LOG.debug("{} new route required", exchangeId);
+							}
+							final AuthExchange targetAuthExchange = context.getAuthExchange(currentRoute.getTargetHost());
+							if (LOG.isDebugEnabled()) {
+								LOG.debug("{} resetting target auth state", exchangeId);
+							}
+							targetAuthExchange.reset();
+							if (currentRoute.getProxyHost() != null) {
+								final AuthExchange proxyAuthExchange = context.getAuthExchange(currentRoute.getProxyHost());
+								if (proxyAuthExchange.isConnectionBased()) {
+									if (LOG.isDebugEnabled()) {
+										LOG.debug("{} resetting proxy auth state", exchangeId);
+									}
+									proxyAuthExchange.reset();
+								}
+							}
+							currentScope = new ExecChain.Scope(
+								currentScope.exchangeId,
+								newRoute,
+								currentScope.originalRequest,
+								currentScope.execRuntime,
+								currentScope.clientContext);
+						}
+					}
+
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("{} redirecting to '{}' via {}", exchangeId, redirectUri, currentRoute);
+					}
+					originalRequest = redirectBuilder.build();
+					currentRequest = redirectBuilder.build();
+
+					EntityUtils.consume(response.getEntity());
+					response.close();
+				} else {
+					return response;
+				}
+			} catch (final RuntimeException | IOException ex) {
+				response.close();
+				throw ex;
+			} catch (final HttpException ex) {
+				// Protocol exception related to a direct.
+				// The underlying connection may still be salvaged.
+				try {
+					EntityUtils.consume(response.getEntity());
+				} catch (final IOException ioex) {
+					if (LOG.isDebugEnabled()) {
+						LOG.debug("{} I/O error while releasing connection", exchangeId, ioex);
+					}
+				} finally {
+					response.close();
+				}
+				throw ex;
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
+++ b/spring-cloud-dataflow-container-registry/src/test/java/org/springframework/cloud/dataflow/container/registry/authorization/support/S3SignedRedirectRequestController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author Adam J. Weigold
+ * @author Corneil du Plessis
  */
 @RestController
 public class S3SignedRedirectRequestController {
@@ -68,7 +69,7 @@ public class S3SignedRedirectRequestController {
 
 	@RequestMapping("/test/docker/registry/v2/blobs/test/data")
 	public ResponseEntity<Resource> getSignedBlob(@RequestHeader Map<String, String> headers) {
-		if (headers.containsKey("authorization")) {
+		if (!headers.containsKey("authorization")) {
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 		return buildFromString("{\"config\": {\"Labels\": {\"foo\": \"bar\"} } }");


### PR DESCRIPTION
Edit:
Discovered that `RedirectStrategy` was change from Apache HTTP Client 4 -> 5. The change meant header changes were not possible.
I copied to `RedirectExec` interceptor / chain handler and modified it to use the modified request instead of the original request to create a request builder.