### PR TITLE
Remove Deprecated methods from TaskConfigurationProperties.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskCtrController.java
@@ -61,9 +61,7 @@ public class TaskCtrController {
 	public List<ConfigurationMetadataProperty> options() {
 		URI ctrUri = null;
 		try {
-			ctrUri = new URI(composedTaskRunnerConfigurationProperties.getUri() != null
-					? composedTaskRunnerConfigurationProperties.getUri()
-					: this.taskConfigurationProperties.getComposedTaskRunnerUri());
+			ctrUri = new URI(composedTaskRunnerConfigurationProperties.getUri());
 		} catch (Exception e) {
 			throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
 		}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultSchedulerService.java
@@ -224,11 +224,7 @@ public class DefaultSchedulerService implements SchedulerService {
 				appRegistration = new AppRegistration(
 						ComposedTaskRunnerConfigurationProperties.COMPOSED_TASK_RUNNER_NAME,
 						ApplicationType.task,
-						new URI(TaskServiceUtils.getComposedTaskLauncherUri(
-								this.taskConfigurationProperties,
-								this.composedTaskRunnerConfigurationProperties)
-						)
-				);
+						new URI(this.composedTaskRunnerConfigurationProperties.getUri()));
 			} catch (URISyntaxException e) {
 				throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
 			}
@@ -528,8 +524,7 @@ public class DefaultSchedulerService implements SchedulerService {
 		AppRegistration appRegistration = null;
 		if (TaskServiceUtils.isComposedTaskDefinition(taskDefinition.getDslText())) {
 			URI composedTaskUri = null;
-			String composedTaskLauncherUri = TaskServiceUtils.getComposedTaskLauncherUri(this.taskConfigurationProperties,
-					this.composedTaskRunnerConfigurationProperties);
+			String composedTaskLauncherUri = this.composedTaskRunnerConfigurationProperties.getUri();
 			try {
 				composedTaskUri = new URI(composedTaskLauncherUri);
 			} catch (URISyntaxException e) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionInfoService.java
@@ -198,8 +198,7 @@ public class DefaultTaskExecutionInfoService implements TaskExecutionInfoService
 			try {
 				appRegistration = new AppRegistration(ComposedTaskRunnerConfigurationProperties.COMPOSED_TASK_RUNNER_NAME,
 					ApplicationType.task,
-					new URI(TaskServiceUtils.getComposedTaskLauncherUri(this.taskConfigurationProperties,
-						this.composedTaskRunnerConfigurationProperties)));
+					new URI(this.composedTaskRunnerConfigurationProperties.getUri()));
 			} catch (URISyntaxException e) {
 				throw new IllegalStateException("Invalid Compose Task Runner Resource", e);
 			}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskExecutionService.java
@@ -583,7 +583,7 @@ public class DefaultTaskExecutionService implements TaskExecutionService {
 				break;
 			}
 		}
-		if (TaskServiceUtils.isUseUserAccessToken(this.taskConfigurationProperties, this.composedTaskRunnerConfigurationProperties)) {
+		if ( this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken()) {
 			useUserAccessToken = true;
 		}
 		if (!containsAccessToken && useUserAccessToken && oauth2TokenUtilsService != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskConfigurationProperties.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -76,21 +75,6 @@ public class TaskConfigurationProperties {
 
 	private boolean useJsonJobParameters = false;
 
-	@Deprecated
-	public String getComposedTaskRunnerUri() {
-		logDeprecationWarning("getUri");
-		return this.composedTaskRunnerConfigurationProperties.getUri();
-	}
-
-	@Deprecated
-	public void setComposedTaskRunnerUri(String composedTaskRunnerUri) {
-		logDeprecationWarning("setUri");
-
-		if (!StringUtils.hasText(this.composedTaskRunnerConfigurationProperties.getUri())) {
-			this.composedTaskRunnerConfigurationProperties.setUri(composedTaskRunnerUri);
-		}
-	}
-
 	public DeployerProperties getDeployerProperties() {
 		return deployerProperties;
 	}
@@ -105,23 +89,6 @@ public class TaskConfigurationProperties {
 
 	public void setAutoCreateTaskDefinitions(boolean autoCreateTaskDefinitions) {
 		this.autoCreateTaskDefinitions = autoCreateTaskDefinitions;
-	}
-
-	@Deprecated
-	public boolean isUseUserAccessToken() {
-		logDeprecationWarning();
-
-		return this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken() == null ? false :
-				this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
-	}
-
-	@Deprecated
-	public void setUseUserAccessToken(boolean useUserAccessToken) {
-		logDeprecationWarning();
-
-		if (this.composedTaskRunnerConfigurationProperties.isUseUserAccessToken() == null) {
-			this.composedTaskRunnerConfigurationProperties.setUseUserAccessToken(useUserAccessToken);
-		}
 	}
 
 	public static class DeployerProperties {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtils.java
@@ -380,27 +380,6 @@ public class TaskServiceUtils {
 		}
 	}
 
-	static String getComposedTaskLauncherUri(TaskConfigurationProperties taskConfigurationProperties,
-									  ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
-		if(composedTaskRunnerConfigurationProperties != null &&
-				StringUtils.hasText(composedTaskRunnerConfigurationProperties.getUri())) {
-			return composedTaskRunnerConfigurationProperties.getUri();
-		}
-
-		return taskConfigurationProperties.getComposedTaskRunnerUri();
-	}
-
-	static boolean isUseUserAccessToken(TaskConfigurationProperties taskConfigurationProperties,
-						ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties) {
-		if (composedTaskRunnerConfigurationProperties != null) {
-			if (composedTaskRunnerConfigurationProperties.isUseUserAccessToken() != null) {
-				return composedTaskRunnerConfigurationProperties.isUseUserAccessToken();
-			}
-		}
-
-		return taskConfigurationProperties.isUseUserAccessToken();
-	}
-
 	/**
 	 * Converts command lines args into a format acceptable for CTR.
 	 * <p>The input args are copied and entries that begin with {@code 'app.'}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationPropertiesTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationPropertiesTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.service.impl;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComposedTaskRunnerConfigurationPropertiesTests {
+
+	private static final String DEFAULT_URI = "https://testuri.something";
+
+	@Test
+	void useUserAccessTokenFromCTRPropsTrue() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+		composedTaskRunnerConfigurationProperties.setUseUserAccessToken(true);
+		assertThat(composedTaskRunnerConfigurationProperties.isUseUserAccessToken()).as("Use user access token should be true").isTrue();
+	}
+
+	@Test
+	void useUserAccessTokenFromCTRPropFalse() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+		composedTaskRunnerConfigurationProperties.setUseUserAccessToken(false);
+		assertThat(composedTaskRunnerConfigurationProperties.isUseUserAccessToken()).as("Use user access token should be false").isFalse();
+	}
+
+	@Test
+	void useUserAccessTokenFromCTRPropNotSet() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+		assertThat(composedTaskRunnerConfigurationProperties.isUseUserAccessToken()).as("Use user access token should be false").isNull();
+	}
+
+	@Test
+	void uriFromComposedTaskRunnerConfigurationProperties() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+		composedTaskRunnerConfigurationProperties.setUri(DEFAULT_URI);
+
+		assertThat(composedTaskRunnerConfigurationProperties.getUri()).as("DEFAULT_URI is not being returned from properties").isEqualTo(DEFAULT_URI);
+	}
+
+	@Test
+	void emptyUriFromComposedTaskRunnerConfigurationProperties() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+
+		assertThat(composedTaskRunnerConfigurationProperties.getUri()).as("URI should be empty").isNull();
+	}
+}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/TaskServiceUtilsTests.java
@@ -268,105 +268,10 @@ public class TaskServiceUtilsTests {
 	}
 
 	@Test
-	void composedTaskRunnerUriFromTaskProps() {
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
-				new ComposedTaskRunnerConfigurationProperties();
-		TaskConfigurationProperties taskConfigurationProperties = new TaskConfigurationProperties();
-		taskConfigurationProperties.setComposedTaskRunnerConfigurationProperties(composedTaskRunnerConfigurationProperties);
-		taskConfigurationProperties.setComposedTaskRunnerUri("docker://something");
-
-		String uri = TaskServiceUtils.getComposedTaskLauncherUri(taskConfigurationProperties,
-				composedTaskRunnerConfigurationProperties);
-
-		assertThat(uri).as("Invalid task runner URI string").isEqualTo("docker://something");
-	}
-
-	@Test
-	void composedTaskRunnerUriFromCTRProps() {
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
-				new ComposedTaskRunnerConfigurationProperties();
-		composedTaskRunnerConfigurationProperties.setUri("docker://something");
-
-		String uri = TaskServiceUtils.getComposedTaskLauncherUri(new TaskConfigurationProperties(),
-				composedTaskRunnerConfigurationProperties);
-
-		assertThat(uri).as("Invalid task runner URI string").isEqualTo("docker://something");
-	}
-
-	@Test
-	void composedTaskRunnerUriFromCTRPropsOverridesTaskProps() {
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
-				new ComposedTaskRunnerConfigurationProperties();
-		composedTaskRunnerConfigurationProperties.setUri("gcr.io://something");
-
-		TaskConfigurationProperties taskConfigurationProperties = new TaskConfigurationProperties();
-		taskConfigurationProperties.setComposedTaskRunnerConfigurationProperties(composedTaskRunnerConfigurationProperties);
-		taskConfigurationProperties.setComposedTaskRunnerUri("docker://something");
-
-		String uri = TaskServiceUtils.getComposedTaskLauncherUri(taskConfigurationProperties,
-				composedTaskRunnerConfigurationProperties);
-
-		assertThat(uri).as("Invalid task runner URI string").isEqualTo("gcr.io://something");
-	}
-
-	@Test
 	void imagePullSecretNullCTRProperties() {
 		Map<String, String> taskDeploymentProperties = new HashMap<>();
 		TaskServiceUtils.addImagePullSecretProperty(taskDeploymentProperties, null);
 		assertThat(taskDeploymentProperties.containsKey("deployer.composed-task-runner.kubernetes.imagePullSecret")).as("Task deployment properties should not contain imagePullSecret").isFalse();
-	}
-
-	@Test
-	void useUserAccessTokenFromCTRPropsEnabled() {
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
-				new ComposedTaskRunnerConfigurationProperties();
-		composedTaskRunnerConfigurationProperties.setUseUserAccessToken(true);
-
-		boolean result = TaskServiceUtils.isUseUserAccessToken(null, composedTaskRunnerConfigurationProperties);
-
-		assertThat(result).as("Use user access token should be true").isTrue();
-	}
-
-	@Test
-	void useUserAccessTokenFromCTRPropsDisabled() {
-		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
-				new ComposedTaskRunnerConfigurationProperties();
-		composedTaskRunnerConfigurationProperties.setUseUserAccessToken(false);
-
-		boolean result = TaskServiceUtils.isUseUserAccessToken(null, composedTaskRunnerConfigurationProperties);
-
-		assertThat(result).as("Use user access token should be false").isFalse();
-	}
-
-	@Test
-	void useUserAccessTokenFromNullCTRProps() {
-		TaskConfigurationProperties taskConfigurationProperties = new TaskConfigurationProperties();
-		taskConfigurationProperties.setComposedTaskRunnerConfigurationProperties(new ComposedTaskRunnerConfigurationProperties());
-
-		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
-
-		assertThat(result).as("Use user access token should be false").isFalse();
-	}
-
-	@Test
-	void useUserAccessTokenFromTaskProps() {
-		TaskConfigurationProperties taskConfigurationProperties = new TaskConfigurationProperties();
-		taskConfigurationProperties.setComposedTaskRunnerConfigurationProperties(new ComposedTaskRunnerConfigurationProperties());
-		taskConfigurationProperties.setUseUserAccessToken(true);
-
-		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
-
-		assertThat(result).as("Use user access token should be true").isTrue();
-	}
-
-	@Test
-	void useUserAccessTokenFromTaskPropsDefault() {
-		TaskConfigurationProperties taskConfigurationProperties = new TaskConfigurationProperties();
-		taskConfigurationProperties.setComposedTaskRunnerConfigurationProperties(new ComposedTaskRunnerConfigurationProperties());
-
-		boolean result = TaskServiceUtils.isUseUserAccessToken(taskConfigurationProperties, null);
-
-		assertThat(result).as("Use user access token should be false").isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
This will require updates in other classes to have them use ComposedTaskRunnerConfigurationProperties
 Remove the the utilities methods from TaskServiceUtils that would look at the Deprecated taskConfigurationProperties if the entry from ComposedTaskRunnerConfigurationProperties was empty.

resolves #5985