### PR TITLE
Provide method for stopping Batch 5 Jobs upon user request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<module>spring-cloud-dataflow-shell</module>
 		<module>spring-cloud-dataflow-shell-core</module>
 		<module>spring-cloud-dataflow-completion</module>
-		<module>spring-cloud-skipper</module>
+<!--		<module>spring-cloud-skipper</module>-->
 		<module>spring-cloud-starter-dataflow-server</module>
 		<module>spring-cloud-starter-dataflow-ui</module>
 		<module>spring-cloud-dataflow-server</module>

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
@@ -225,9 +225,7 @@ public class SimpleJobService implements JobService, DisposableBean {
 		Collection<JobExecution> result = jobExecutionDao.getRunningJobExecutions();
 		for (JobExecution jobExecution : result) {
 			try {
-				jobExecution.getStepExecutions().forEach(StepExecution::setTerminateOnly);
-				jobExecution.setStatus( BatchStatus.STOPPING);
-				jobRepository.update(jobExecution);
+				stop(jobExecution.getId());
 			} catch (Exception e) {
 				throw new IllegalArgumentException("The following JobExecutionId was not found: " + jobExecution.getId(), e);
 			}
@@ -246,7 +244,7 @@ public class SimpleJobService implements JobService, DisposableBean {
 		// 'STOPPING'. It is assumed that
 		// the step implementation will check this status at chunk boundaries.
 		logger.info("Stopping job execution: " + jobExecution);
-
+		jobExecution.getStepExecutions().forEach(StepExecution::setTerminateOnly);
 		jobExecution.setStatus(BatchStatus.STOPPING);
 		jobRepository.update(jobExecution);
 		return jobExecution;

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
@@ -242,10 +242,12 @@ public class SimpleJobService implements JobService, DisposableBean {
 		if (!jobExecution.isRunning()) {
 			throw new JobExecutionNotRunningException("JobExecution is not running and therefore cannot be stopped");
 		}
-
+		// Indicate the execution should be stopped by setting it's status to
+		// 'STOPPING'. It is assumed that
+		// the step implementation will check this status at chunk boundaries.
 		logger.info("Stopping job execution: " + jobExecution);
 
-		jobExecution.setStatus(BatchStatus.STOPPED);
+		jobExecution.setStatus(BatchStatus.STOPPING);
 		jobRepository.update(jobExecution);
 		return jobExecution;
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
@@ -28,6 +28,8 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.launch.JobExecutionNotRunningException;
+import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import org.springframework.batch.core.BatchStatus;
@@ -192,6 +194,18 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 	@Test
 	void stoppingJobExecutionShouldLeaveJobExecutionWithStatusOfStopping() throws Exception {
 		JobExecution jobExecution = createJobExecution(BASE_JOB_INST_NAME,true);
+		assertJobHasStopped(jobExecution);
+	}
+
+	@Test
+	void stoppingAllJobExecutionsShouldLeaveJobExecutionsWithStatusOfStopping() throws Exception {
+		JobExecution jobExecutionOne = createJobExecution(BASE_JOB_INST_NAME,true);
+		JobExecution jobExecutionTwo = createJobExecution(BASE_JOB_INST_NAME+"_TWO",true);
+		assertJobHasStopped(jobExecutionOne);
+		assertJobHasStopped(jobExecutionTwo);
+	}
+
+	private void assertJobHasStopped(JobExecution jobExecution) throws NoSuchJobExecutionException, JobExecutionNotRunningException {
 		jobExecution = jobService.getJobExecution(jobExecution.getId());
 		assertThat(jobExecution.isRunning()).isTrue();
 		assertThat(jobExecution.getStatus()).isNotEqualTo(BatchStatus.STOPPING);

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
@@ -197,7 +197,7 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 		assertThat(jobExecution.getStatus()).isNotEqualTo(BatchStatus.STOPPING);
 		jobService.stop(jobExecution.getId());
 		jobExecution = jobService.getJobExecution(jobExecution.getId());
-		assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.STOPPED);
+		assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.STOPPING);
 	}
 
 	private void verifyJobInstance(long id, String name) throws Exception {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/batch/AbstractSimpleJobServiceTests.java
@@ -193,25 +193,25 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 
 	@Test
 	void stoppingJobExecutionShouldLeaveJobExecutionWithStatusOfStopping() throws Exception {
-		JobExecution jobExecution = createJobExecution(BASE_JOB_INST_NAME,true);
+		JobExecution jobExecution = createRunningJobExecution(BASE_JOB_INST_NAME);
+		jobService.stop(jobExecution.getId());
 		assertJobHasStopped(jobExecution);
 	}
 
 	@Test
 	void stoppingAllJobExecutionsShouldLeaveJobExecutionsWithStatusOfStopping() throws Exception {
-		JobExecution jobExecutionOne = createJobExecution(BASE_JOB_INST_NAME,true);
-		JobExecution jobExecutionTwo = createJobExecution(BASE_JOB_INST_NAME+"_TWO",true);
+		JobExecution jobExecutionOne = createRunningJobExecution(BASE_JOB_INST_NAME);
+		JobExecution jobExecutionTwo = createRunningJobExecution(BASE_JOB_INST_NAME+"_TWO");
+		jobService.stop(jobExecutionOne.getId());
 		assertJobHasStopped(jobExecutionOne);
+		jobService.stop(jobExecutionTwo.getId());
 		assertJobHasStopped(jobExecutionTwo);
 	}
 
 	private void assertJobHasStopped(JobExecution jobExecution) throws NoSuchJobExecutionException, JobExecutionNotRunningException {
 		jobExecution = jobService.getJobExecution(jobExecution.getId());
-		assertThat(jobExecution.isRunning()).isTrue();
-		assertThat(jobExecution.getStatus()).isNotEqualTo(BatchStatus.STOPPING);
-		jobService.stop(jobExecution.getId());
-		jobExecution = jobService.getJobExecution(jobExecution.getId());
 		assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.STOPPING);
+		assertThat(jobExecution.isRunning()).isTrue();
 	}
 
 	private void verifyJobInstance(long id, String name) throws Exception {
@@ -235,9 +235,13 @@ public abstract class AbstractSimpleJobServiceTests extends AbstractDaoTests {
 		return createJobExecution(name, BatchStatus.STARTING, false);
 	}
 
-	private JobExecution createJobExecution(String name, boolean isRunning)
+	private JobExecution createRunningJobExecution(String name)
 			throws Exception {
-		return createJobExecution(name, BatchStatus.STARTING, isRunning);
+		JobExecution jobExecution = createJobExecution(name, BatchStatus.STARTING, true);
+		jobExecution = jobService.getJobExecution(jobExecution.getId());
+		assertThat(jobExecution.isRunning()).isTrue();
+		assertThat(jobExecution.getStatus()).isNotEqualTo(BatchStatus.STOPPING);
+		return jobExecution;
 	}
 
 	private JobExecution createJobExecution(String name, BatchStatus batchStatus, boolean isRunning) throws Exception {


### PR DESCRIPTION
In the previous release of SCDF we used the JsrJobOperator to stop job executions. The 2 stages of stopping jobs is as follows:

1.  Sets the Batch Status of the job execution to STOPPING.  This signals to Spring Batch to stop execution at the next step. 
2. If the Job is a StepLocator it will go through each of the StoppableTasklets and stop them.

Since Dataflow never deals with a Job directly, it never executed the 2nd stage.  Meaning the Job is in the application that SCDF launched, not SCDF itself. So when using Batch 4.x it was just a quick check of the JobRegistry to retrieve the job, which was always empty since SCDF never deals with Jobs directly. But with Batch 5.x they loaded the Job Registry and attempted to retrieve the Job in a different way using the SimpleJobOperator. This caused a NPE when it tried to retrieve and determine if the Job was a StepLocator. In the updated solution, SCDF doesn't use the SimpleJobOperator since SCDF doesn't have access to the StepLocator for the Job, nor does it use the JobRegistry and even if it did, it would always be empty.

Resolves #5986