### PR TITLE
Add task thin executions by name and fix missing docs.

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ jobs:
       shell: bash
       timeout-minutes: 75
       run: |
-        ./mvnw -B -s .github/settings.xml -Pdocs clean install --no-transfer-progress
+        ./mvnw -B -s .github/settings.xml -Pfull,docs clean install --no-transfer-progress
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ jobs:
       shell: bash
       timeout-minutes: 75
       run: |
-        ./mvnw -B -s .github/settings.xml -Pfull,docs clean install --no-transfer-progress
+        ./mvnw -B -s .github/settings.xml -Pdocs clean install --no-transfer-progress
   scan:
     runs-on: ubuntu-latest
     steps:

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -115,6 +115,7 @@ class ApiDocumentation extends BaseDocumentation {
 				linkWithRel("tasks/executions/external").description("Returns Task execution by external id"),
 				linkWithRel("tasks/executions/current").description("Provides the current count of running tasks"),
 				linkWithRel("tasks/thinexecutions").description("Returns thin Task executions"),
+				linkWithRel("tasks/thinexecutions/name").description("Returns thin Task executions for a given task name"),
 				linkWithRel("tasks/info/executions").description("Provides the task executions info"),
 				linkWithRel("tasks/schedules").description("Provides schedule information of tasks"),
 				linkWithRel("tasks/schedules/instances").description("Provides schedule information of a specific task	"),
@@ -122,7 +123,6 @@ class ApiDocumentation extends BaseDocumentation {
 				linkWithRel("tasks/executions/execution").description("Provides details for a specific task execution"),
 				linkWithRel("tasks/platforms").description("Provides platform accounts for launching tasks.  The results can be filtered to show the platforms that support scheduling by adding a request parameter of 'schedulesEnabled=true"),
 				linkWithRel("tasks/logs").description("Retrieve the task application log"),
-				linkWithRel("tasks/thinexecutions").description("Returns thin Task executions"),
 
 				linkWithRel("streams/definitions").description("Exposes the Streams resource"),
 				linkWithRel("streams/definitions/definition").description("Handle a specific Stream definition"),
@@ -221,13 +221,14 @@ class ApiDocumentation extends BaseDocumentation {
 
 						fieldWithPath("_links.tasks/thinexecutions.href").description("Link to the tasks/thinexecutions"),
 
+						fieldWithPath("_links.tasks/thinexecutions/name.href").description("Link to the tasks/thinexecutions/name"),
+						fieldWithPath("_links.tasks/thinexecutions/name.templated").description("Link to the tasks/thinexecutions/name is templated"),
+
 						fieldWithPath("_links.tasks/info/executions.href").description("Link to the tasks/info/executions"),
 						fieldWithPath("_links.tasks/info/executions.templated").type(JsonFieldType.BOOLEAN).optional().description("Link tasks/info is templated"),
 
 						fieldWithPath("_links.tasks/logs.href").description("Link to the tasks/logs"),
 						fieldWithPath("_links.tasks/logs.templated").type(JsonFieldType.BOOLEAN).optional().description("Link tasks/logs is templated"),
-
-						fieldWithPath("_links.tasks/thinexecutions.href").description("Link to the tasks/thinexecutions"),
 
 						fieldWithPath("_links.tasks/schedules.href").description("Link to the tasks/executions/schedules"),
 						fieldWithPath("_links.tasks/schedules/instances.href").description("Link to the tasks/schedules/instances"),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -312,9 +312,9 @@ class TaskExecutionsDocumentation extends BaseDocumentation {
 	}
 
 	@Test
-	void listTaskExecutionsByName() throws Exception {
+	void listTaskThinExecutionsByName() throws Exception {
 		this.mockMvc.perform(
-						get("/tasks/executions")
+						get("/tasks/thinexecutions")
 								.queryParam("name", "taskB")
 								.queryParam("page", "0")
 								.queryParam("size", "10")
@@ -328,10 +328,32 @@ class TaskExecutionsDocumentation extends BaseDocumentation {
 								parameterWithName("name")
 										.description("The name associated with the task execution")),
 						responseFields(
-								subsectionWithPath("_embedded.taskExecutionResourceList")
-										.description("Contains a collection of Task Executions/"),
+							subsectionWithPath("_embedded.taskExecutionThinResourceList")
+								.description("Contains a collection of thin Task Executions/"),
 								subsectionWithPath("_links.self").description("Link to the task execution resource"),
 								subsectionWithPath("page").description("Pagination properties"))));
+	}
+	@Test
+	void listTaskExecutionsByName() throws Exception {
+		this.mockMvc.perform(
+				get("/tasks/executions")
+					.queryParam("name", "taskB")
+					.queryParam("page", "0")
+					.queryParam("size", "10")
+			)
+			.andExpect(status().isOk()).andDo(this.documentationHandler.document(
+				queryParameters(
+					parameterWithName("page")
+						.description("The zero-based page number (optional)"),
+					parameterWithName("size")
+						.description("The requested page size (optional)"),
+					parameterWithName("name")
+						.description("The name associated with the task execution")),
+				responseFields(
+					subsectionWithPath("_embedded.taskExecutionResourceList")
+						.description("Contains a collection of Task Executions/"),
+					subsectionWithPath("_links.self").description("Link to the task execution resource"),
+					subsectionWithPath("page").description("Pagination properties"))));
 	}
 
 	@Test

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -2067,6 +2067,85 @@ include::{snippets}/task-executions-documentation/list-task-executions-by-name/c
 include::{snippets}/task-executions-documentation/list-task-executions-by-name/http-response.adoc[]
 
 
+[[api-guide-resources-task-thin-executions-list]]
+==== List All Task Thin Executions
+
+The task executions endpoint lets you list all task executions with only top-level data.
+The following topics provide more details:
+
+* <<api-guide-resources-task-thin-executions-list-request-structure>>
+* <<api-guide-resources-task-thin-executions-list-request-parameters>>
+* <<api-guide-resources-task-thin-executions-list-example-request>>
+* <<api-guide-resources-task-thin-executions-list-response-structure>>
+
+
+
+[[api-guide-resources-task-thin-executions-list-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/request-parameters.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/curl-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-response.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name]]
+==== List All Task Thin Executions With a Specified Task Name
+
+The task thin executions endpoint lets you list task executions with a specified task name.
+The following topics provide more details:
+
+* <<api-guide-resources-task-thin-executions-list-by-name-request-structure>>
+* <<api-guide-resources-task-thin-executions-list-by-name-request-parameters>>
+* <<api-guide-resources-task-thin-executions-list-by-name-example-request>>
+* <<api-guide-resources-task-thin-executions-list-by-name-response-structure>>
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/request-parameters.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/curl-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-response.adoc[]
 
 [[api-guide-resources-task-executions-detail]]
 ==== Task Execution Detail

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/configuration.adoc
@@ -661,6 +661,7 @@ spring:
             - DELETE /tasks/executions/*             => hasRole('ROLE_DESTROY')
 
             - GET    /tasks/thinexecutions           => hasRole('ROLE_VIEW')
+			- GET    /tasks/thinexecutions/*         => hasRole('ROLE_VIEW')
 
             # Task Schedules
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -114,6 +114,12 @@ public interface TaskOperations {
 	PagedModel<TaskExecutionThinResource> thinExecutionList();
 
 	/**
+	 * List task executions filtered by task name.
+	 * @return the page of task executions for the given task name.
+	 */
+	PagedModel<TaskExecutionThinResource> thinExecutionListByTaskName(String taskName);
+
+	/**
 	 * List task executions known to the system filtered by task name.
 	 *
 	 * @param taskName of the executions.

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -71,6 +71,8 @@ public class TaskTemplate implements TaskOperations {
 
 	private static final String THIN_EXECUTIONS_RELATION = "tasks/thinexecutions";
 
+	private static final String THIN_EXECUTIONS_BY_NAME_RELATION = "tasks/thinexecutions/name";
+
 	private static final String EXECUTIONS_CURRENT_RELATION = "tasks/executions/current";
 
 	private static final String EXECUTION_RELATION = "tasks/executions/execution";
@@ -96,6 +98,8 @@ public class TaskTemplate implements TaskOperations {
 	private final Link executionsLink;
 
 	private final Link thinExecutionsLink;
+
+	private final Link thinExecutionsByNameLink;
 
 	private final Link executionLink;
 
@@ -160,6 +164,12 @@ public class TaskTemplate implements TaskOperations {
 		} else {
 			this.thinExecutionsLink = null;
 		}
+		if(resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).isPresent()) {
+			this.thinExecutionsByNameLink = resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).get();
+		} else {
+			this.thinExecutionsByNameLink = null;
+		}
+
 		if(resources.getLink(EXECUTION_LAUNCH_RELATION).isPresent()) {
 			this.executionLaunchLink = resources.getLink(EXECUTION_LAUNCH_RELATION).get();
 		} else {
@@ -272,6 +282,15 @@ public class TaskTemplate implements TaskOperations {
 			return restTemplate.getForObject(thinExecutionsLink.getHref(), TaskExecutionThinResource.Page.class);
 		} else {
 			return restTemplate.getForObject(executionsLink.getHref(), TaskExecutionThinResource.Page.class);
+		}
+	}
+
+	@Override
+	public PagedModel<TaskExecutionThinResource> thinExecutionListByTaskName(String taskName) {
+		if(thinExecutionsByNameLink != null) {
+			return restTemplate.getForObject(thinExecutionsByNameLink.expand(taskName).getHref(), TaskExecutionThinResource.Page.class);
+		} else {
+			return restTemplate.getForObject(executionByNameLink.expand(taskName).getHref(), TaskExecutionThinResource.Page.class);
 		}
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -286,8 +286,8 @@ public class DataFlowControllerAutoConfiguration {
 		}
 
 		@Bean
-		public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer taskExplorer) {
-			return new TaskExecutionThinController(taskExplorer);
+		public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer taskExplorer, TaskDefinitionRepository taskDefinitionRepository) {
+			return new TaskExecutionThinController(taskExplorer, taskDefinitionRepository);
 		}
 
 		@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -155,6 +155,7 @@ public class RootController {
 			root.add(linkTo(methodOn(TasksInfoController.class).getInfo(null, null, null)).withRel("tasks/info/executions"));
 			root.add(linkTo(methodOn(TaskLogsController.class).getLog(null, null)).withRel("tasks/logs"));
 			root.add(linkTo(methodOn(TaskExecutionThinController.class).listTasks(null, null)).withRel("tasks/thinexecutions"));
+			root.add(linkTo(methodOn(TaskExecutionThinController.class).retrieveTasksByName(null,null, null)).withRel("tasks/thinexecutions/name"));
 
 			if (featuresProperties.isSchedulesEnabled()) {
 				root.add(entityLinks.linkToCollectionResource(ScheduleInfoResource.class).withRel("tasks/schedules"));

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionController.java
@@ -185,9 +185,11 @@ public class TaskExecutionController {
 			Pageable pageable,
 			PagedResourcesAssembler<TaskJobExecutionRel> assembler
 	) {
+		long tasks = this.taskDefinitionRepository.countByTaskName(taskName);
+		if(tasks == 0) {
+			throw new NoSuchTaskDefinitionException(taskName);
+		}
 		validatePageable(pageable);
-		this.taskDefinitionRepository.findById(taskName)
-				.orElseThrow(() -> new NoSuchTaskDefinitionException(taskName));
 		Page<TaskExecution> taskExecutions = this.explorer.findTaskExecutionsByName(taskName, pageable);
 		Page<TaskJobExecutionRel> result = getPageableRelationships(taskExecutions, pageable);
 		return assembler.toModel(result, this.taskAssembler);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionThinController.java
@@ -30,6 +30,7 @@ import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSuppor
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -57,6 +58,19 @@ public class TaskExecutionThinController {
 	@ResponseStatus(HttpStatus.OK)
 	public PagedModel<TaskExecutionThinResource> listTasks(Pageable pageable, PagedResourcesAssembler<ThinTaskExecution> pagedAssembler) {
 		Page<TaskExecution> page = explorer.findAll(pageable);
+		Page<ThinTaskExecution> thinTaskExecutions = new PageImpl<>(page.stream().map(ThinTaskExecution::new).toList(), pageable, page.getTotalElements());
+		explorer.populateCtrStatus(thinTaskExecutions.getContent());
+		return pagedAssembler.toModel(thinTaskExecutions, resourceAssembler);
+	}
+
+	@GetMapping(value = "", params = "name")
+	@ResponseStatus(HttpStatus.OK)
+	public PagedModel<TaskExecutionThinResource> retrieveTasksByName(
+		@RequestParam("name") String taskName,
+		Pageable pageable,
+		PagedResourcesAssembler<ThinTaskExecution> pagedAssembler
+	) {
+		Page<TaskExecution> page = this.explorer.findTaskExecutionsByName(taskName, pageable);
 		Page<ThinTaskExecution> thinTaskExecutions = new PageImpl<>(page.stream().map(ThinTaskExecution::new).toList(), pageable, page.getTotalElements());
 		explorer.populateCtrStatus(thinTaskExecutions.getContent());
 		return pagedAssembler.toModel(thinTaskExecutions, resourceAssembler);

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
@@ -46,4 +46,5 @@ public interface TaskDefinitionRepository extends KeyValueRepository<TaskDefinit
 	 */
 	TaskDefinition findByTaskName(String name);
 
+    long countByTaskName(String taskName);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/task/impl/DefaultDataFlowTaskExecutionQueryDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/task/impl/DefaultDataFlowTaskExecutionQueryDao.java
@@ -522,20 +522,19 @@ public class DefaultDataFlowTaskExecutionQueryDao implements DataflowTaskExecuti
 
 	@Override
 	public void populateCtrStatus(Collection<ThinTaskExecution> thinTaskExecutions) {
-		Map<Long, ThinTaskExecution> taskExecutionMap = thinTaskExecutions.stream()
+		if(!thinTaskExecutions.isEmpty()) {
+			Map<Long, ThinTaskExecution> taskExecutionMap = thinTaskExecutions.stream()
 				.collect(Collectors.toMap(ThinTaskExecution::getExecutionId, Function.identity()));
-		String ids = taskExecutionMap.keySet()
-				.stream()
-				.map(Object::toString)
-				.collect(Collectors.joining(","));
-		String sql = FIND_CTR_STATUS.replace(":taskExecutionIds", ids);
-		jdbcTemplate.query(sql, rs -> {
-			Long id = rs.getLong("TASK_EXECUTION_ID");
-			String ctrStatus = rs.getString("CTR_STATUS");
-			logger.debug("populateCtrStatus:{}={}", id, ctrStatus);
-			ThinTaskExecution execution = taskExecutionMap.get(id);
-			Assert.notNull(execution, "Expected TaskExecution for " + id + " from " + ids);
-			execution.setCtrTaskStatus(ctrStatus);
-		});
+			String ids = taskExecutionMap.keySet().stream().map(Object::toString).collect(Collectors.joining(","));
+			String sql = FIND_CTR_STATUS.replace(":taskExecutionIds", ids);
+			jdbcTemplate.query(sql, rs -> {
+				Long id = rs.getLong("TASK_EXECUTION_ID");
+				String ctrStatus = rs.getString("CTR_STATUS");
+				logger.debug("populateCtrStatus:{}={}", id, ctrStatus);
+				ThinTaskExecution execution = taskExecutionMap.get(id);
+				Assert.notNull(execution, "Expected TaskExecution for " + id + " from " + ids);
+				execution.setCtrTaskStatus(ctrStatus);
+			});
+		}
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
+++ b/spring-cloud-dataflow-server-core/src/main/resources/META-INF/dataflow-server-defaults.yml
@@ -241,6 +241,7 @@ spring:
             - GET    /tasks/info/*                   => hasRole('ROLE_VIEW')
 
             - GET    /tasks/thinexecutions           => hasRole('ROLE_VIEW')
+            - GET    /tasks/thinexecutions/*         => hasRole('ROLE_VIEW')
 
             # Task Schedules
 

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -270,8 +270,8 @@ public class JobDependencies {
 	}
 
 	@Bean
-	public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer dataflowTaskExplorer) {
-		return new TaskExecutionThinController(dataflowTaskExplorer);
+	public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer dataflowTaskExplorer, TaskDefinitionRepository taskDefinitionRepository) {
+		return new TaskExecutionThinController(dataflowTaskExplorer, taskDefinitionRepository);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -593,8 +593,8 @@ public class TestDependencies implements WebMvcConfigurer {
 	}
 
 	@Bean
-	public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer dataflowTaskExplorer) {
-		return new TaskExecutionThinController(dataflowTaskExplorer);
+	public TaskExecutionThinController taskExecutionThinController(DataflowTaskExplorer dataflowTaskExplorer, TaskDefinitionRepository taskDefinitionRepository) {
+		return new TaskExecutionThinController(dataflowTaskExplorer, taskDefinitionRepository);
 	}
 	@Bean
 	public TasksInfoController taskExecutionsInfoController(TaskExecutionService taskExecutionService) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -420,7 +420,7 @@ class TaskExecutionControllerTests {
 		mockMvc.perform(get("/tasks/definitions").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(print())
-			.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(1)));
+			.andExpect(jsonPath("$._embedded.taskDefinitionResourceList", hasSize(2)));
 	}
 	@Test
 	void getExecutionsByNameNotFound() throws Exception {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -342,6 +342,13 @@ class TaskExecutionControllerTests {
 			.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].taskExecutionStatus", containsInAnyOrder("RUNNING", "RUNNING","RUNNING","RUNNING")))
 			.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList", hasSize(4)));
 	}
+	@Test
+	void getThinExecutionsByName() throws Exception {
+		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", "nope").accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.page.totalElements", is(0)));
+	}
 
 	@Test
 	void getCurrentExecutions() throws Exception {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -204,6 +204,7 @@ class TaskExecutionControllerTests {
 			SAMPLE_CLEANSED_ARGUMENT_LIST.add("spring.datasource.password=******");
 
 			taskDefinitionRepository.save(new TaskDefinition(TASK_NAME_ORIG, "demo"));
+			taskDefinitionRepository.save(new TaskDefinition("nope", "demo"));
 			TaskExecution taskExecution1 =
 				taskExecutionDao.createTaskExecution(TASK_NAME_ORIG, LocalDateTime.now(), SAMPLE_ARGUMENT_LIST, "foobar");
 
@@ -324,7 +325,6 @@ class TaskExecutionControllerTests {
 	void getAllExecutions() throws Exception {
 		verifyTaskArgs(SAMPLE_CLEANSED_ARGUMENT_LIST, "$._embedded.taskExecutionResourceList[0].",
 				mockMvc.perform(get("/tasks/executions").accept(MediaType.APPLICATION_JSON))
-						.andDo(print())
 						.andExpect(status().isOk()))
 				.andExpect(jsonPath("$._embedded.taskExecutionResourceList[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
 				.andExpect(jsonPath("$._embedded.taskExecutionResourceList[*].parentExecutionId", containsInAnyOrder(null, null, null, 1)))
@@ -335,7 +335,6 @@ class TaskExecutionControllerTests {
 	@Test
 	void getAllThinExecutions() throws Exception {
 			mockMvc.perform(get("/tasks/thinexecutions").accept(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isOk())
 			.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].executionId", containsInAnyOrder(4, 3, 2, 1)))
 			.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].parentExecutionId", containsInAnyOrder(null, null, null, 1)))
@@ -345,9 +344,9 @@ class TaskExecutionControllerTests {
 	@Test
 	void getThinExecutionsByName() throws Exception {
 		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", "nope").accept(MediaType.APPLICATION_JSON))
-			.andDo(print())
-			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.page.totalElements", is(0)));
+		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", "none").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError());
 	}
 
 	@Test
@@ -388,7 +387,6 @@ class TaskExecutionControllerTests {
 		resultActions = mockMvc.perform(
 						get("/tasks/executions/" + resource.getExecutionId())
 								.accept(MediaType.APPLICATION_JSON))
-				.andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(content().json("{taskName: \"timestamp3\"}"));
 		response = resultActions.andReturn().getResponse().getContentAsString();

--- a/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
@@ -116,6 +116,10 @@
     "tasks/executions": {
       "href": "http://localhost/tasks/executions"
     },
+    "tasks/thinexecutions/name": {
+      "href": "http://localhost/tasks/thinexecutions?name={name}",
+      "templated": true
+    },
     "tasks/executions/external": {
       "href": "http://localhost/tasks/executions/external/{externalExecutionId}{?platform}",
       "templated": true

--- a/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
+++ b/spring-cloud-dataflow-shell-core/src/main/java/org/springframework/cloud/dataflow/shell/command/TaskCommands.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.rest.resource.LauncherResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskAppStatusResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskDefinitionResource;
 import org.springframework.cloud.dataflow.rest.resource.TaskExecutionResource;
+import org.springframework.cloud.dataflow.rest.resource.TaskExecutionThinResource;
 import org.springframework.cloud.dataflow.rest.util.DeploymentPropertiesUtils;
 import org.springframework.cloud.dataflow.shell.command.support.OpsType;
 import org.springframework.cloud.dataflow.shell.command.support.RoleType;
@@ -298,11 +299,11 @@ public class TaskCommands {
 	public Table executionListByName(
 			@ShellOption(value = {"", "--name"}, help = "the task name to be used as a filter", valueProvider = TaskNameValueProvider.class, defaultValue = ShellOption.NULL) String name) {
 
-		final PagedModel<TaskExecutionResource> tasks;
+		PagedModel<TaskExecutionThinResource> thinTasks = null;
 		if (name == null) {
-			tasks = taskOperations().executionList();
+			thinTasks = taskOperations().thinExecutionList();
 		} else {
-			tasks = taskOperations().executionListByTaskName(name);
+			thinTasks = taskOperations().thinExecutionListByTaskName(name);
 		}
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("taskName", "Task Name");
@@ -310,7 +311,7 @@ public class TaskCommands {
 		headers.put("startTime", "Start Time");
 		headers.put("endTime", "End Time");
 		headers.put("exitCode", "Exit Code");
-		final TableBuilder builder = new TableBuilder(new BeanListTableModel<>(tasks, headers));
+		TableBuilder builder = new TableBuilder(new BeanListTableModel<>(thinTasks, headers));
 		return DataFlowTables.applyStyle(builder).build();
 	}
 


### PR DESCRIPTION
Change TaskTemplate to use task/thinexecutions instead of task/executions.

 Add task thin executions by name.
 Update api-guide.adoc with links to generated documentation.
 Modify TaskCommands to use thin executions since it provides the data required.
 Removed duplicate entries from api docs.

 Fixes #5991
 Fixes #5973