### PR TITLE
Deprecate search field for taskName search in TaskDefinitionController

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskDefinitionsDocumentation.java
@@ -98,7 +98,7 @@ class TaskDefinitionsDocumentation extends BaseDocumentation {
 				.queryParam("page", "0")
 				.queryParam("size", "10")
 				.queryParam("sort", "taskName,ASC")
-				.queryParam("search", "")
+				.queryParam("taskName", "")
 				.queryParam("manifest", "true")
 			)
 			.andExpect(status().isOk())
@@ -106,7 +106,7 @@ class TaskDefinitionsDocumentation extends BaseDocumentation {
 				queryParameters(
 					parameterWithName("page").description("The zero-based page number (optional)"),
 					parameterWithName("size").description("The requested page size (optional)"),
-					parameterWithName("search").description("The search string performed on the name (optional)"),
+					parameterWithName("taskName").description("Search for a specific taskName (optional)"),
 					parameterWithName("sort").description("The sort on the list (optional)"),
 					parameterWithName("manifest").description("The flag to include the task manifest into the latest task execution (optional)")
 				),

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -1526,7 +1526,7 @@ The task definition endpoint lets you get all task definitions.
 The following topics provide more details:
 
 * <<api-guide-resources-stream-task-definitions-list-request-structure>>
-* <<api-guide-resources-stream-task-definitions-list-request-parameters>>
+* <<api-guide-resources-stream-task-definitions-list-query-parameters>>
 * <<api-guide-resources-stream-task-definitions-list-example-request>>
 * <<api-guide-resources-stream-task-definitions-list-response-structure>>
 
@@ -1539,10 +1539,10 @@ include::{snippets}/task-definitions-documentation/list-all-task-definitions/htt
 
 
 
-[[api-guide-resources-stream-task-definitions-list-request-parameters]]
-===== Request Parameters
+[[api-guide-resources-stream-task-definitions-list-query-parameters]]
+===== Query Parameters
 
-include::{snippets}/task-definitions-documentation/list-all-task-definitions/request-parameters.adoc[]
+include::{snippets}/task-definitions-documentation/list-all-task-definitions/query-parameters.adoc[]
 
 
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -160,7 +160,6 @@ public class TaskDefinitionController {
 	 * Return a page-able list of {@link TaskDefinitionResource} defined tasks.
 	 *
 	 * @param pageable    page-able collection of {@code TaskDefinitionResource}
-	 * @param search      optional findByTaskNameContains parameter (Deprecated: please use taskName instead)
 	 * @param taskName    optional findByTaskNameContains parameter
 	 * @param dslText     optional findByDslText parameter
 	 * @param description optional findByDescription parameter
@@ -172,7 +171,6 @@ public class TaskDefinitionController {
 	@ResponseStatus(HttpStatus.OK)
 	public PagedModel<? extends TaskDefinitionResource> list(
 			Pageable pageable,
-			@RequestParam(required = false) @Deprecated String search,
 			@RequestParam(required = false) String taskName,
 			@RequestParam(required = false) String description,
 			@RequestParam(required = false) boolean manifest,
@@ -181,14 +179,12 @@ public class TaskDefinitionController {
 	) {
 		final Page<TaskDefinition> taskDefinitions;
 
-		if (Stream.of(search, taskName, description, dslText).filter(Objects::nonNull).count() > 1L) {
-			throw new TaskQueryParamException(new String[]{"taskName (or search)", "description", "dslText"});
+		if (Stream.of(taskName, description, dslText).filter(Objects::nonNull).count() > 1L) {
+			throw new TaskQueryParamException(new String[]{"taskName", "description", "dslText"});
 		}
 
 		if (taskName != null) {
 			taskDefinitions = repository.findByTaskNameContains(taskName, pageable);
-		} else if (search != null) {
-			taskDefinitions = repository.findByTaskNameContains(search, pageable);
 		} else if (description != null) {
 			taskDefinitions = repository.findByDescriptionContains(description, pageable);
 		} else if (dslText != null) {

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -334,28 +334,28 @@ class TaskControllerTests {
 		assertThat(myTask2.getName()).isEqualTo("myTask-t2");
 	}
 
-	@ParameterizedTest
-	@ValueSource(strings = {"search", "taskName"})
-	void findTaskNameContainsSubstring(String taskNameRequestParamName) throws Exception {
+	@Test
+	void findTaskNameContainsSubstring() throws Exception {
+		final String TASK_NAME_REQUEST_PARAMETER = "taskName";
 		repository.save(new TaskDefinition("foo", "task"));
 		repository.save(new TaskDefinition("foz", "task"));
 		repository.save(new TaskDefinition("ooz", "task"));
 
-		mockMvc.perform(get("/tasks/definitions").param(taskNameRequestParamName, "f")
+		mockMvc.perform(get("/tasks/definitions").param(TASK_NAME_REQUEST_PARAMETER, "f")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList.*", hasSize(2)))
 
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].name", is("foo")))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[1].name", is("foz")));
 
-		mockMvc.perform(get("/tasks/definitions").param(taskNameRequestParamName, "oz")
+		mockMvc.perform(get("/tasks/definitions").param(TASK_NAME_REQUEST_PARAMETER, "oz")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList.*", hasSize(2)))
 
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[0].name", is("foz")))
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList[1].name", is("ooz")));
 
-		mockMvc.perform(get("/tasks/definitions").param(taskNameRequestParamName, "o")
+		mockMvc.perform(get("/tasks/definitions").param(TASK_NAME_REQUEST_PARAMETER, "o")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.taskDefinitionResourceList.*", hasSize(3)))
 
@@ -411,7 +411,7 @@ class TaskControllerTests {
 
 	@Test
 	void findByDslTextAndNameBadRequest() throws Exception {
-		mockMvc.perform(get("/tasks/definitions").param("dslText", "fo").param("search", "f")
+		mockMvc.perform(get("/tasks/definitions").param("dslText", "fo").param("taskName", "f")
 				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
 	}
 


### PR DESCRIPTION
resolves #5993

* Remove search as a parameter from the javadoc
* Fix docs such that queryParameter descriptions appear in reference docs.
* Rename Request Parameters header  to Query Parameters