### PR TITLE
Update to Spring Boot 3.3.5 and cleanup deps

### DIFF
--- a/spring-cloud-dataflow-build/pom.xml
+++ b/spring-cloud-dataflow-build/pom.xml
@@ -20,9 +20,19 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<main.basedir>${basedir}</main.basedir>
 		<docs.main>${project.artifactId}</docs.main>
-		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
-		<spring-boot.version>3.3.4</spring-boot.version>
-		<spring-framework.version>6.1.13</spring-framework.version>
+		<!-- =========================================================================
+		Keep Spring Boot version in sync in the following locations:
+			- spring-cloud-dataflow-build property (here)
+			- spring-cloud-dataflow-build-dependencies parent version
+			- spring-cloud-dataflow-parent property
+		========================================================================== -->
+		<spring-boot.version>3.3.5</spring-boot.version>
+		<!-- =========================================================================
+		Keep dataflow version in sync with project.version in the following locations:
+			- spring-cloud-dataflow-build property (here)
+			- spring-cloud-dataflow-parent property
+			- spring-cloud-dataflow-dependencies-parent property
+		========================================================================== -->
 		<dataflow.version>3.0.0-SNAPSHOT</dataflow.version>
 		<docs.resources.dir>${project.build.directory}/build-docs</docs.resources.dir>
 		<refdocs.build.directory>${project.build.directory}/refdocs/</refdocs.build.directory>
@@ -32,18 +42,15 @@
 		<guides-project.version>${project.version}</guides-project.version>
 		<guides-update.phase>deploy</guides-update.phase>
 		<revision>${project.version}</revision>
-		<asciidoctorj.version>2.5.7</asciidoctorj.version>
-		<jruby-complete.version>9.2.7.0</jruby-complete.version>
-
 		<!-- Sonar -->
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
 		<sonar.language>java</sonar.language>
-
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
+		<asciidoctorj.version>2.5.7</asciidoctorj.version>
 		<!-- for backwards compatibility, use maven-checkstyle-plugin.version -->
 		<checkstyle.version>${maven-checkstyle-plugin.version}</checkstyle.version>
 		<puppycrawl-tools-checkstyle.version>8.29</puppycrawl-tools-checkstyle.version>
@@ -91,10 +98,6 @@
 		<maven-dependency-plugin-for-guides.phase>generate-resources</maven-dependency-plugin-for-guides.phase>
 		<groups />
 		<excludedGroups>slow,docker</excludedGroups>
-		<junit-jupiter.version>5.10.3</junit-jupiter.version>
-		<junit.version>4.13.1</junit.version>
-		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<javadoc-spring.version>6.1.3</javadoc-spring.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -13,49 +13,39 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-dependencies</artifactId>
-		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
-		<version>3.3.0</version>
+		<!-- =========================================================================
+		Keep Spring Boot version in sync in the following locations:
+			- spring-cloud-dataflow-build property
+			- spring-cloud-dataflow-build-dependencies parent version (here)
+			- spring-cloud-dataflow-parent property
+		========================================================================== -->
+		<version>3.3.5</version>
 		<relativePath/>
 	</parent>
 	<properties>
 		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- Keep spring boot version in sync between spring-cloud-dataflow-build and spring-boot-dependencies (parent and properties) -->
-		<spring-boot.version>3.3.0</spring-boot.version>
 		<spring-cloud.version>2023.0.3</spring-cloud.version>
 		<spring-shell.version>3.2.5</spring-shell.version>
 		<commons-io.version>2.16.1</commons-io.version>
 		<commons-text.version>1.12.0</commons-text.version>
+		<commons-compress.version>1.26.2</commons-compress.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
 		<nimbus-jose-jwt.version>9.39.3</nimbus-jose-jwt.version>
-		<snappy-java.version>1.1.10.5</snappy-java.version>
-		<commons-compress.version>1.26.2</commons-compress.version>
 		<prometheus-rsocket.version>2.0.0-M1</prometheus-rsocket.version>
 		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<spring-cloud-services-starter-config-client.version>3.5.4</spring-cloud-services-starter-config-client.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>
-		<junit-jupiter.version>5.10.3</junit-jupiter.version>
 		<junit.version>4.13.1</junit.version>
-		<json-path.version>2.9.0</json-path.version>
-		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<javadoc-spring.version>6.1.3</javadoc-spring.version>
+		<guava.version>32.1.3-jre</guava.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<!-- Override Nimbus version from Spring Security -->
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
 				<version>${nimbus-jose-jwt.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.xerial.snappy</groupId>
-				<artifactId>snappy-java</artifactId>
-				<version>${snappy-java.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>${commons-compress.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.fabric8</groupId>
@@ -77,6 +67,16 @@
 				<version>${spring-shell.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>${guava.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
@@ -132,11 +132,6 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-api</artifactId>
-				<version>${junit-jupiter.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-dependencies-parent/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-dependencies-parent/pom.xml
@@ -37,7 +37,12 @@
 	<properties>
 		<maven.compiler.release>17</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- NOTE: this needs to be updated and kept in sync w/ the project.version -->
+		<!-- =========================================================================
+		Keep dataflow version in sync with project.version in the following locations:
+			- spring-cloud-dataflow-build property
+			- spring-cloud-dataflow-parent property
+			- spring-cloud-dataflow-dependencies-parent property (here)
+		========================================================================== -->
 		<dataflow.version>3.0.0-SNAPSHOT</dataflow.version>
 	</properties>
 	<profiles>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -13,12 +13,26 @@
 	<properties>
 		<!-- NOTE: this needs to be updated and kept in sync w/ the project.version -->
 		<git-commit-id-plugin.version>4.9.9</git-commit-id-plugin.version>
-		<dataflow.version>3.0.0-SNAPSHOT</dataflow.version>
 		<java.version>17</java.version>
 		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<maven-surefire-report-plugin.version>3.5.0</maven-surefire-report-plugin.version>
-		<spring-boot.version>3.3.4</spring-boot.version>
+		<!-- =========================================================================
+		Keep Spring Boot version in sync in the following locations:
+			- spring-cloud-dataflow-build property
+			- spring-cloud-dataflow-build-dependencies parent version
+			- spring-cloud-dataflow-parent property (here)
+		========================================================================== -->
+		<spring-boot.version>3.3.5</spring-boot.version>
+		<!-- =========================================================================
+		Keep dataflow version in sync with project.version in the following locations:
+			- spring-cloud-dataflow-build property
+			- spring-cloud-dataflow-parent property (here)
+			- spring-cloud-dataflow-dependencies-parent property
+		========================================================================== -->
+		<dataflow.version>3.0.0-SNAPSHOT</dataflow.version>
+		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
+		<javadoc-spring.version>6.1.14</javadoc-spring.version>
 		<spring-cloud-dataflow-ui.version>3.4.3-SNAPSHOT</spring-cloud-dataflow-ui.version>
 		<spring-cloud-dataflow-common.version>${dataflow.version}</spring-cloud-dataflow-common.version>
 		<spring-cloud-skipper.version>${dataflow.version}</spring-cloud-skipper.version>
@@ -32,9 +46,8 @@
 		<codearte-props2yml.version>0.5</codearte-props2yml.version>
 		<jettison.version>1.5.4</jettison.version>
 		<nimbus-jose-jwt.version>9.39.3</nimbus-jose-jwt.version>
-		<snappy-java.version>1.1.10.5</snappy-java.version>
+		<snappy-java.version>1.1.10.7</snappy-java.version>
 		<commons-compress.version>1.26.2</commons-compress.version>
-
 		<json-unit.version>2.11.1</json-unit.version>
 		<findbugs.version>3.0.2</findbugs.version>
 		<joda-time.version>2.12.7</joda-time.version>
@@ -46,54 +59,35 @@
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
 		<springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 		<guava.version>32.1.3-jre</guava.version>
-		<json-path.version>2.9.0</json-path.version>
-		<junit-jupiter.version>5.10.3</junit-jupiter.version>
-		<junit.version>4.13.1</junit.version>
-		<!--Specific Spring framework javadoc version for attach-javadocs plugin-->
-		<javadoc-spring.version>6.1.3</javadoc-spring.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>${guava.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.h2database</groupId>
-				<artifactId>h2</artifactId>
-				<version>2.2.222</version>
-			</dependency>
+			<!-- Override Nimbus version from Spring Security -->
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
 				<version>${nimbus-jose-jwt.version}</version>
 			</dependency>
+			<!-- =========================================================================
+			Override Snappy from Spring Kafka (kafka-clients)
+				 NOTE: Kafka is only used in tasklauncher / single step batch job apps
+				 which descend from this pom therefore this treatment is not required
+				 in spring-cloud-dataflow-dependencies.
+            ========================================================================== -->
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
 				<version>${snappy-java.version}</version>
 			</dependency>
+			<!-- Override commons compress from testcontainers -->
 			<dependency>
-				<groupId>com.jayway.jsonpath</groupId>
-				<artifactId>json-path</artifactId>
-				<version>${json-path.version}</version>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>${commons-compress.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>com.squareup.okhttp3</groupId>
-				<artifactId>okhttp</artifactId>
-				<version>4.11.0</version>
-			</dependency>
-			<dependency>
-				<groupId>com.squareup.okio</groupId>
-				<artifactId>okio</artifactId>
-				<version>3.4.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.codehaus.jettison</groupId>
-				<artifactId>jettison</artifactId>
-				<version>${jettison.version}</version>
-			</dependency>
+			<!-- ================================================== -->
+			<!-- Override dependencies should go above this comment -->
+			<!-- ================================================== -->
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
@@ -141,11 +135,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-single-step-batch-job</artifactId>
 				<version>${spring-cloud-task.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>${commons-compress.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -208,6 +197,11 @@
 				<version>${findbugs.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>${guava.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
 				<version>${joda-time.version}</version>
@@ -216,6 +210,11 @@
 				<groupId>com.amazonaws</groupId>
 				<artifactId>aws-java-sdk-ecr</artifactId>
 				<version>${aws-java-sdk-ecr.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.jettison</groupId>
+				<artifactId>jettison</artifactId>
+				<version>${jettison.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springdoc</groupId>

--- a/spring-cloud-dataflow-parent/pom.xml
+++ b/spring-cloud-dataflow-parent/pom.xml
@@ -59,6 +59,12 @@
 		<spring-cloud-dataflow-apps-metadata-plugin.version>1.0.14</spring-cloud-dataflow-apps-metadata-plugin.version>
 		<springdoc-openapi.version>2.6.0</springdoc-openapi.version>
 		<guava.version>32.1.3-jre</guava.version>
+		<!-- database driver versions -->
+		<oracle-ojdbc8.version>21.9.0.0</oracle-ojdbc8.version>
+		<db2-jcc.version>11.5.9.0</db2-jcc.version>
+		<!-- questionable testing libs -->
+		<org-json.version>20240303</org-json.version>
+		<littleproxy.version>1.1.2</littleproxy.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-dataflow-rest-resource/pom.xml
+++ b/spring-cloud-dataflow-rest-resource/pom.xml
@@ -68,7 +68,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jettison</groupId>

--- a/spring-cloud-dataflow-server/pom.xml
+++ b/spring-cloud-dataflow-server/pom.xml
@@ -42,39 +42,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcprov-jdk15on</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcpkix-jdk15on</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcutil-jdk15on</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.pivotal.spring.cloud</groupId>
 			<artifactId>spring-cloud-services-starter-config-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.76</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.75</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcutil-jdk18on</artifactId>
-			<version>1.75</version>
 		</dependency>
 		<dependency>
 			<groupId>io.fabric8</groupId>

--- a/spring-cloud-dataflow-shell-core/pom.xml
+++ b/spring-cloud-dataflow-shell-core/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20230227</version>
+			<version>${org-json.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.littleshoot</groupId>
 			<artifactId>littleproxy</artifactId>
-			<version>1.1.2</version>
+			<version>${littleproxy.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -39,7 +39,6 @@
 
 		<jmockit.version>1.24</jmockit.version>
 
-		<commons-compress.version>1.26.1</commons-compress.version>
 		<asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
 		<asciidoctorj.pdf.version>2.3.7</asciidoctorj.pdf.version>
 		<asciidoctorj.version>2.5.7</asciidoctorj.version>
@@ -201,11 +200,6 @@
 				<groupId>org.jmockit</groupId>
 				<artifactId>jmockit</artifactId>
 				<version>${jmockit.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>${commons-compress.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -114,7 +114,6 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>[3.1.2,)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -244,7 +243,6 @@
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-suite</artifactId>
-			<version>1.11.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-skipper/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/pom.xml
@@ -19,21 +19,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcprov-jdk18on</artifactId>
-				<version>1.76</version>
-			</dependency>
-			<dependency>
-				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcpkix-jdk18on</artifactId>
-				<version>1.75</version>
-			</dependency>
-			<dependency>
-				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcutil-jdk18on</artifactId>
-				<version>1.75</version>
-			</dependency>
-			<dependency>
 				<groupId>org.mariadb.jdbc</groupId>
 				<artifactId>mariadb-java-client</artifactId>
 				<version>[3.1.2,)</version>
@@ -69,42 +54,15 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcprov-jdk15on</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcpkix-jdk15on</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcutil-jdk15on</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.pivotal.spring.cloud</groupId>
 			<artifactId>spring-cloud-services-starter-config-client</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk18on</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk18on</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcutil-jdk18on</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-test</artifactId>

--- a/spring-cloud-skipper/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server/pom.xml
@@ -16,15 +16,6 @@
 	<properties>
 		<maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.mariadb.jdbc</groupId>
-				<artifactId>mariadb-java-client</artifactId>
-				<version>[3.1.2,)</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -113,16 +104,15 @@
 		<dependency>
 			<groupId>com.ibm.db2</groupId>
 			<artifactId>jcc</artifactId>
-			<version>11.5.9.0</version>
+			<version>${db2-jcc.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc8</artifactId>
-			<version>21.9.0.0</version>
+			<version>${oracle-ojdbc8.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>

--- a/spring-cloud-skipper/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-common-persistence</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
+			<version>${dataflow.version}</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This commit does the following:
- Removes versions on dependencies that are already managed by boot
- Pulls version numbers into the root pom.xml
- Removes some unused properties and dependencies

> [!IMPORTANT]
> The goal of this PR is to update the versions and remove any unnecessary cruft (dep mgmt, versions, etc..). However, once we get this done I plan on reducing the parentage down to a single one rather than the 2 we have now. If we don't do it now, we never will. 

> [!NOTE]
> I have painstakenly run dep tree on each of the libs in question to ensure there is only a single version and that version is the latest w/o CVEs. For example:
> ```
> DEP="org.apache.commons:commons-compress"
> ./mvnw dependency:tree -Dincludes="$DEP" | grep -E "$DEP"
> ```
> Yields
> ```
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:test
> [INFO]    \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]          \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]    \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]          \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]       \- org.apache.commons:commons-compress:jar:1.26.2:compile
> [INFO]             \- org.apache.commons:commons-compress:jar:1.26.2:test
> [INFO]                \- org.apache.commons:commons-compress:jar:1.26.2:compile
> ```
> And
> ```
>  DEP="com.google.guava:guava"
> ./mvnw dependency:tree -Dincludes="$DEP" | grep -E "$DEP"
> ```
> Yields
> ```
> [INFO]    \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]       \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]             \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]    \- com.google.guava:guava:jar:32.1.3-jre:test
> [INFO]       \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]       \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> [INFO]          \- com.google.guava:guava:jar:32.1.3-jre:compile
> ```
> So on and so forth...