### PR TITLE
Fix rest documentation for changes to spring-rest-docs in skipper

### DIFF
--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -28,7 +28,6 @@
 		<spring-cloud-deployer.version>3.0.0-SNAPSHOT</spring-cloud-deployer.version>
 
 		<zeroturnaround.version>1.17</zeroturnaround.version>
-		<spring-restdocs.version>3.0.1</spring-restdocs.version>
 		<java-semver.version>0.10.2</java-semver.version>
 
 		<equalverifier.version>3.15.8</equalverifier.version>
@@ -181,16 +180,6 @@
 				<groupId>com.github.zafarkhaja</groupId>
 				<artifactId>java-semver</artifactId>
 				<version>${java-semver.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.restdocs</groupId>
-				<artifactId>spring-restdocs-mockmvc</artifactId>
-				<version>${spring-restdocs.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.restdocs</groupId>
-				<artifactId>spring-restdocs-core</artifactId>
-				<version>${spring-restdocs.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>nl.jqno.equalsverifier</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-docs/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-docs/pom.xml
@@ -47,6 +47,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
+			<artifactId>spring-restdocs-mockmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-core</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/spring-cloud-skipper/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -158,6 +158,10 @@ A `GET` request returns a paginated list for all the Spring Cloud Skipper platfo
 
 include::{snippets}/deployers-documentation/get-all-deployers/http-request.adoc[]
 
+===== Request parameters
+
+include::{snippets}/deployers-documentation/get-all-deployers/query-parameters.adoc[]
+
 ===== Example request
 
 include::{snippets}/deployers-documentation/get-all-deployers/curl-request.adoc[]
@@ -183,6 +187,10 @@ A `GET` request will return a paginated list for all Spring Cloud Skipper packag
 ===== Request structure
 
 include::{snippets}/package-metadata-documentation/get-all-package-metadata/http-request.adoc[]
+
+===== Path parameters
+
+include::{snippets}/package-metadata-documentation/get-all-package-metadata/query-parameters.adoc[]
 
 ===== Example request
 
@@ -227,6 +235,11 @@ A `GET` request returns the details of a package using the `id` of the package.
 
 include::{snippets}/package-metadata-documentation/get-package-metadata-details/http-request.adoc[]
 
+===== Path parameters
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-details/path-parameters.adoc[]
+
+
 ===== Example request
 
 include::{snippets}/package-metadata-documentation/get-package-metadata-details/curl-request.adoc[]
@@ -248,6 +261,10 @@ A `GET` request returns a list of all the Spring Cloud Skipper package metadata 
 getPackageMetadataSearchFindByName
 include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name/http-request.adoc[]
 
+===== Request parameters
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name/query-parameters.adoc[]
+
 ===== Example request
 
 include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name/curl-request.adoc[]
@@ -267,7 +284,11 @@ A `GET` request returns a list for all Spring Cloud Skipper package metadata by 
 
 ===== Request structure
 
-include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name-containing-ignore-case//http-request.adoc[]
+include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name-containing-ignore-case/http-request.adoc[]
+
+===== Request parameters
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-search-find-by-name-containing-ignore-case/query-parameters.adoc[]
 
 ===== Example request
 
@@ -337,6 +358,10 @@ The `install` link can install a package identified by its ID into the target pl
 ===== Request structure
 
 include::{snippets}/install-documentation/install-package-with-id/http-request.adoc[]
+
+===== Path parameters
+
+include::{snippets}/install-documentation/install-package-with-id/path-parameters.adoc[]
 
 ===== Example request
 
@@ -458,6 +483,10 @@ given release name.
 
 include::{snippets}/list-documentation/list-releases-by-release-name/http-request.adoc[]
 
+====== Path parameters
+
+include::{snippets}/list-documentation/list-releases-by-release-name/path-parameters.adoc[]
+
 ====== Example request
 
 include::{snippets}/list-documentation/list-releases-by-release-name/curl-request.adoc[]
@@ -481,6 +510,10 @@ The `status` REST endpoint provides the status for the last known release versio
 
 include::{snippets}/status-documentation/get-status-of-release/http-request.adoc[]
 
+====== Path parameters
+
+include::{snippets}/status-documentation/get-status-of-release/path-parameters.adoc[]
+
 ====== Example request
 
 include::{snippets}/status-documentation/get-status-of-release/curl-request.adoc[]
@@ -500,6 +533,10 @@ The `status` REST endpoint can provide the status for a specific release version
 ====== Request structure
 
 include::{snippets}/status-documentation/get-status-of-release-for-version/http-request.adoc[]
+
+====== Path parameters
+
+include::{snippets}/status-documentation/get-status-of-release-for-version/path-parameters.adoc[]
 
 ====== Example request
 
@@ -554,6 +591,10 @@ This part of the api is deprecated, please use
 
 include::{snippets}/rollback-documentation/rollback-release/http-request.adoc[]
 
+====== Path parameters
+
+include::{snippets}/rollback-documentation/rollback-release/path-parameters.adoc[]
+
 ====== Example request
 
 include::{snippets}/rollback-documentation/rollback-release/curl-request.adoc[]
@@ -598,6 +639,10 @@ The `manifest` REST endpoint returns the manifest for the last known release ver
 
 include::{snippets}/manifest-documentation/get-manifest-of-release/http-request.adoc[]
 
+====== Path parameters
+
+include::{snippets}/manifest-documentation/get-manifest-of-release/path-parameters.adoc[]
+
 ====== Example request
 
 include::{snippets}/manifest-documentation/get-manifest-of-release/curl-request.adoc[]
@@ -613,6 +658,10 @@ The `manifest` REST endpoint can return the manifest for a specific release vers
 ====== Request structure
 
 include::{snippets}/manifest-documentation/get-manifest-of-release-for-version/http-request.adoc[]
+
+====== Path parameters
+
+include::{snippets}/manifest-documentation/get-manifest-of-release-for-version/path-parameters.adoc[]
 
 ====== Example request
 
@@ -635,6 +684,10 @@ The delete operation does not uninstall the uploaded packages corresponding to t
 
 include::{snippets}/delete-documentation/delete-release-default/http-request.adoc[]
 
+====== Path Parameters
+
+include::{snippets}/delete-documentation/delete-release-default/path-parameters.adoc[]
+
 ====== Example request
 
 include::{snippets}/delete-documentation/delete-release-default/curl-request.adoc[]
@@ -654,6 +707,10 @@ You can use a DELETE request to delete an existing release and uninstall the pac
 ====== Request structure
 
 include::{snippets}/delete-documentation/delete-release/http-request.adoc[]
+
+====== Path Parameters
+
+include::{snippets}/delete-documentation/delete-release-default/path-parameters.adoc[]
 
 ====== Example request
 

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -32,8 +32,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -44,12 +45,16 @@ class DeleteDocumentation extends BaseDocumentation {
 	@Test
 	void deleteRelease() throws Exception {
 		Release release = createTestRelease("test", StatusCode.DELETED);
+
 		when(this.skipperStateMachineService.deleteRelease(any(String.class), any(DeleteProperties.class))).thenReturn(release);
 		this.mockMvc.perform(
 				delete("/api/release/{releaseName}/package", release.getName())
 						.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(
+								parameterWithName("releaseName").description("The name of the release to be deleted")
+						),
 						responseFields(
 								subsectionWithPath("links").ignored(),
 								fieldWithPath("name").description("Name of the release"),
@@ -117,6 +122,7 @@ class DeleteDocumentation extends BaseDocumentation {
 						.accept(MediaType.APPLICATION_JSON).contentType(contentType))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("Name of the release to be deleted")),
 						responseFields(
 								subsectionWithPath("links").ignored(),
 								fieldWithPath("name").description("Name of the release"),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -26,8 +26,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -43,6 +44,7 @@ class HistoryDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				get("/api/releases/search/findByNameIgnoreCaseContainingOrderByNameAscVersionDesc?name={name}", "test")).andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						queryParameters(parameterWithName("name").description("Name of release")),
 						responseFields(
 								subsectionWithPath("_links").ignored(),
 								subsectionWithPath("_embedded.releases[]._links").ignored(),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -33,8 +33,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -143,6 +144,7 @@ class InstallDocumentation extends BaseDocumentation {
 				.contentType(contentType)
 				.content(convertObjectToJson(installProperties2))).andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("packageMetaDataId").description("Id of package to install")),
 						responseFields(
 								subsectionWithPath("links").ignored(),
 								fieldWithPath("name").description("Name of the release"),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -30,8 +30,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -115,6 +116,7 @@ class ListDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(
 				get("/api/release/list/{releaseName}", release.getName())).andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("Name of the releases to list")),
 						responseFields(
 								subsectionWithPath("_embedded.releases[]._links").ignored(),
 								fieldWithPath("_embedded.releases[].name").description("Name of the release"),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
@@ -28,8 +28,9 @@ import org.springframework.http.MediaType;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseBody;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Ilayaperumal Gopinathan
  * @author Corneil du Plessis
@@ -48,6 +49,7 @@ class LogsDocumentation extends BaseDocumentation {
 						.contentType(contentType))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("The name of the release to show logs")),
 						responseBody()));
 	}
 
@@ -61,6 +63,10 @@ class LogsDocumentation extends BaseDocumentation {
 						release.getName(), "myapp"))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(
+							parameterWithName("releaseName").description("The name of the release to show logs"),
+							parameterWithName("appName").description("The name of the app to show logs")
+						),
 						responseBody()));
 	}
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
@@ -26,8 +26,9 @@ import org.springframework.http.MediaType;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseBody;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -47,6 +48,7 @@ class ManifestDocumentation extends BaseDocumentation {
 						.contentType(contentType))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("The name of the release")),
 						responseBody()));
 	}
 
@@ -61,6 +63,10 @@ class ManifestDocumentation extends BaseDocumentation {
 						release.getName(), release.getVersion()))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(
+							parameterWithName("releaseName").description("The name of the release"),
+							parameterWithName("releaseVersion").description("The version of the release")
+						),
 						responseBody()));
 	}
 }

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -153,7 +153,7 @@ class PackageMetadataDocumentation extends BaseDocumentation {
 		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
 		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
-				get("/api/packageMetadata/search/findByName?name=log"))
+				get("/api/packageMetadata/search/findByName").queryParam("name", "log"))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						queryParameters(parameterWithName("name").description("The name of the Package")),
@@ -197,7 +197,7 @@ class PackageMetadataDocumentation extends BaseDocumentation {
 		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
 		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
-				get("/api/packageMetadata/search/findByNameContainingIgnoreCase?name=LO"))
+				get("/api/packageMetadata/search/findByNameContainingIgnoreCase").queryParam("name","LO"))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						queryParameters(parameterWithName("name").description("The name of the Package")),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
@@ -23,8 +23,9 @@ import org.springframework.test.context.ActiveProfiles;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Corneil du Plessis
@@ -62,9 +63,10 @@ class RepositoriesDocumentation extends BaseDocumentation {
 	void getSingleRepository() throws Exception {
 
 		this.mockMvc.perform(
-				get("/api/repositories/search/findByName?name={name}", "local"))
+				get("/api/repositories/search/findByName").queryParam("name", "local"))
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						queryParameters(parameterWithName("name").description("Name of the Repository")),
 						responseFields(
 								fieldWithPath("name").description("Name of the Repository"),
 								fieldWithPath("url").description("URL of the Repository"),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -33,8 +33,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -47,9 +48,11 @@ class RollbackDocumentation extends BaseDocumentation {
 		Release release = createTestRelease();
 		when(this.skipperStateMachineService.rollbackRelease(any(RollbackRequest.class))).thenReturn(release);
 		MvcResult result = this.mockMvc.perform(
-				post("/api/release/rollback/{releaseName}/{releaseVersion}",
-						release.getName(), release.getVersion())).andExpect(status().isCreated())
+				post("/api/release/rollback/{releaseName}/{releaseVersion}", release.getName(), release.getVersion())
+				).andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("The name of the release to rollback"),
+								parameterWithName("releaseVersion").description("The release version to rollback")),
 						responseFields(
 								subsectionWithPath("_links").ignored(),
 								fieldWithPath("name").description("Name of the release"),

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
@@ -27,8 +27,9 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 /**
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
@@ -41,8 +42,11 @@ class StatusDocumentation extends BaseDocumentation {
 		Release release = createTestRelease();
 		when(this.releaseService.status(release.getName())).thenReturn(release.getInfo());
 		this.mockMvc.perform(
-				get("/api/release/status/{releaseName}", release.getName())).andExpect(status().isOk())
+					get("/api/release/status/{releaseName}", release.getName())
+				)
+				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(parameterWithName("releaseName").description("The name of the release")),
 						responseFields(
 								subsectionWithPath("_links").ignored(),
 								fieldWithPath("status.statusCode").description(
@@ -62,10 +66,14 @@ class StatusDocumentation extends BaseDocumentation {
 		Release release = createTestRelease();
 		when(this.releaseService.status(release.getName(), release.getVersion())).thenReturn(release.getInfo());
 		this.mockMvc.perform(
-				get("/api/release/status/{releaseName}/{releaseVersion}",
-						release.getName(), release.getVersion()))
+					get("/api/release/status/{releaseName}/{releaseVersion}", release.getName(), release.getVersion())
+				)
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						pathParameters(
+							parameterWithName("releaseName").description("The name of the release"),
+							parameterWithName("releaseVersion").description("The version of the release")
+						),
 						responseFields(
 								subsectionWithPath("_links").ignored(),
 								fieldWithPath("status.statusCode").description(

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,11 @@
+`*{{path}}*`
+|===
+|Parameter - Description
+
+{{#parameters}}
+|{{#tableCellContent}}`*{{name}}*` {{#optional}} [small]#_(optional)_#{{/optional}}{{^optional}} [small]#*(required)*#{{/optional}}{{/tableCellContent}}
+
+{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
@@ -1,0 +1,9 @@
+|===
+|Parameter - Description
+{{#parameters}}
+|{{#tableCellContent}}`*{{name}}*` {{#optional}} [small]#_(optional)_#{{/optional}}{{^optional}} [small]#*(required)*#{{/optional}}{{/tableCellContent}}
+
+{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===


### PR DESCRIPTION
Added query-parameters and path-parameters where applicable.

Added snippet template to query-parameters and updated template for path-parameters to improve readability.

Fixes #6008


*NOTE* :notebook:  I have noticed there are some of the Spring Data Rest endpoints that are not in the api-guide.adoc[] Do you believe this is an oversight or deliberate choice?