### PR TITLE
Remove deprecations from AppRegistryController

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -223,7 +223,7 @@ public class AppRegistryController {
 	 * @param type module type
 	 * @param name module name
 	 * @param version module version
-	 * @param bootVersion module boot version or {@code null} to use the default.  Deprecated: bootVersion is no longer needed when registering an app.
+	 * @param bootVersion module boot version or {@code null} to use the default.  Deprecated: bootVersion parameter is ignored.
 	 * @param uri URI for the module artifact (e.g. {@literal maven://group:artifact:version})
 	 * @param metadataUri URI for the metadata artifact
 	 * @param force if {@code true}, overwrites a pre-existing registration

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/AppRegistryController.java
@@ -170,7 +170,6 @@ public class AppRegistryController {
 		return getInfo(type, name, version, exhaustive);
 	}
 
-	@Deprecated
 	@GetMapping("/{type}/{name}")
 	@ResponseStatus(HttpStatus.OK)
 	public DetailedAppRegistrationResource info(
@@ -224,7 +223,7 @@ public class AppRegistryController {
 	 * @param type module type
 	 * @param name module name
 	 * @param version module version
-	 * @param bootVersion module boot version or {@code null} to use the default
+	 * @param bootVersion module boot version or {@code null} to use the default.  Deprecated: bootVersion is no longer needed when registering an app.
 	 * @param uri URI for the module artifact (e.g. {@literal maven://group:artifact:version})
 	 * @param metadataUri URI for the metadata artifact
 	 * @param force if {@code true}, overwrites a pre-existing registration
@@ -235,7 +234,7 @@ public class AppRegistryController {
 			@PathVariable ApplicationType type,
 			@PathVariable String name,
 			@PathVariable String version,
-			@RequestParam(required = false) String bootVersion,
+			@RequestParam(required = false) @Deprecated String bootVersion,
 			@RequestParam String uri,
 			@RequestParam(name = "metadata-uri", required = false) String metadataUri,
 			@RequestParam(defaultValue = "false") boolean force) {
@@ -260,7 +259,6 @@ public class AppRegistryController {
 		}
 	}
 
-	@Deprecated
 	@PostMapping("/{type}/{name}")
 	@ResponseStatus(HttpStatus.CREATED)
 	public void register(
@@ -375,7 +373,6 @@ public class AppRegistryController {
 		return null;
 	}
 
-	@Deprecated
 	@DeleteMapping("/{type}/{name}")
 	@ResponseStatus(HttpStatus.OK)
 	public void unregister(@PathVariable ApplicationType type, @PathVariable String name) {

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -13,7 +13,7 @@ Announce New Feature Here
 Announce Next New Feature Here
 
 === Deprecations
-Announce new deprecations here
+* `bootVersion` query parameter for `POST` `/{type}/{name}/{version:.+}` has been deprecated.  This query parameter will be ignored when registering a new application.
 
 === Removals
 Deprecated methods, properties, and features that have been removed in this release.
@@ -35,7 +35,7 @@ VersionInfoProperties versionInfoProperties, SecurityStateBean securityStateBean
 ** countStepExecutionsForJobExecution
 ** stopAll
 ** getStepNamesForJob
-* The following deprecated `Converters` have been removed from SCDF: `AbstractDateTimeConverter`, `DateToStringConverter`, and `StringToDateConverter`.   : Use the converters provided by Spring Batch.
+* The following deprecated `Converters` have been removed from SCDF: `AbstractDateTimeConverter`, `DateToStringConverter`, and `StringToDateConverter`.  Use the converters provided by Spring Batch.
 
 
 === Breaking Changes


### PR DESCRIPTION
The original issue states to remove deprecated functions. However, this would remove some of SCDF's default behavior when registering applications. In that it can look the suffix of the URL to obtain the version. The original Issues for the PR that put in the deprecations just wanted to give the user the ability to override the version.

Also deprecated the use of bootVersion when registering an app.

Resolves #6011