### PR TITLE
Remove deprecated DockerComposeRule.waitingForService method

### DIFF
--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker-junit5/src/main/java/org/springframework/cloud/dataflow/common/test/docker/junit5/DockerComposeManager.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker-junit5/src/main/java/org/springframework/cloud/dataflow/common/test/docker/junit5/DockerComposeManager.java
@@ -98,7 +98,7 @@ public class DockerComposeManager {
 			Builder<?> builder = DockerComposeRule.builder();
 			builder.files(DockerComposeFiles.from(locations.toArray(new String[0])));
 			for (String service : services) {
-				builder.waitingForService(service, toHaveAllPortsOpen());
+				builder.waitingForService(service, toHaveAllPortsOpen(), DockerComposeRule.DEFAULT_TIMEOUT);
 			}
 			builder.saveLogsTo("build/test-docker-logs/" + log + classKey + "-" + methodKey);
 			DockerComposeRule rule = builder.build();
@@ -132,7 +132,7 @@ public class DockerComposeManager {
 			Builder<?> builder = DockerComposeRule.builder();
 			builder.files(DockerComposeFiles.from(locations.toArray(new String[0])));
 			for (String service : services) {
-				builder.waitingForService(service, toHaveAllPortsOpen());
+				builder.waitingForService(service, toHaveAllPortsOpen(), DockerComposeRule.DEFAULT_TIMEOUT);
 			}
 			builder.saveLogsTo("build/test-docker-logs/" + log + classKey + "-" + methodKey);
 			DockerComposeRule rule = builder.build();

--- a/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/DockerComposeRule.java
+++ b/spring-cloud-dataflow-common/spring-cloud-dataflow-common-test-docker/src/main/java/org/springframework/cloud/dataflow/common/test/docker/compose/DockerComposeRule.java
@@ -236,11 +236,6 @@ public class DockerComposeRule {
 			return self();
 		}
 
-		@Deprecated
-		public T waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
-			return waitingForService(serviceName, healthCheck, DEFAULT_TIMEOUT);
-		}
-
 		public T waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout) {
 			ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(serviceName, healthCheck);
 			return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -36,6 +36,7 @@ VersionInfoProperties versionInfoProperties, SecurityStateBean securityStateBean
 ** stopAll
 ** getStepNamesForJob
 * The following deprecated `Converters` have been removed from SCDF: `AbstractDateTimeConverter`, `DateToStringConverter`, and `StringToDateConverter`.  Use the converters provided by Spring Batch.
+* `DockerComposeRule.waitingForService(String serviceName, HealthCheck<Container> healthCheck)` has been replaced by `DockerComposeRule.waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout)`.
 
 
 === Breaking Changes


### PR DESCRIPTION
Replace the usage of this deprecated method with the waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout) method.

resolves issue #6013

Signed-off-by: Glenn Renfro <grenfro@vmware.com>