### PR TITLE
Remove deprecation annotation from StepExecutionHistory.java

### DIFF
--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -3072,9 +3072,6 @@ include::{snippets}/job-step-executions-documentation/step-progress/curl-request
 
 include::{snippets}/job-step-executions-documentation/step-progress/http-response.adoc[]
 
-NOTE: The following fields in the stepExecutionHistory are deprecated and will be removed in a future release: rollbackCount, readCount, writeCount, filterCount, readSkipCount, writeSkipCount, processSkipCount, durationPerRead.
-
-
 [[api-guide-resources-runtime-information-applications]]
 === Runtime Information about Applications
 

--- a/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
+++ b/spring-cloud-dataflow-rest-resource/src/main/java/org/springframework/cloud/dataflow/rest/job/StepExecutionHistory.java
@@ -23,7 +23,7 @@ import org.springframework.batch.core.StepExecution;
 
 /**
  * Stores the cumulative information for a specific {@link StepExecution}'s history.
- * }
+ *
  * @author Glenn Renfro
  */
 public class StepExecutionHistory {
@@ -84,7 +84,6 @@ public class StepExecutionHistory {
 
 	/**
 	 * Returns the number of {@link StepExecution}s are being used for history calculations.
-	 *
 	 * The id of an existing step execution for a specific job execution (required)
 	 * @return the number of {@link StepExecution}s.
 	 */
@@ -92,12 +91,10 @@ public class StepExecutionHistory {
 		return count;
 	}
 
-	@Deprecated
 	public CumulativeHistory getCommitCount() {
 		return commitCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getRollbackCount() {
 		return rollbackCount;
 	}
@@ -106,27 +103,22 @@ public class StepExecutionHistory {
 		return readCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getWriteCount() {
 		return writeCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getFilterCount() {
 		return filterCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getReadSkipCount() {
 		return readSkipCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getWriteSkipCount() {
 		return writeSkipCount;
 	}
 
-	@Deprecated
 	public CumulativeHistory getProcessSkipCount() {
 		return processSkipCount;
 	}
@@ -139,7 +131,6 @@ public class StepExecutionHistory {
 		return duration;
 	}
 
-	@Deprecated
 	public CumulativeHistory getDurationPerRead() {
 		return durationPerRead;
 	}


### PR DESCRIPTION
Update api-guide to remove deprecation notice

Also polish documents to remove errors.

The original intent was to remove these calls from the Rest request as it was not actively used.
But after discussions, we decided to retain this feature.

Resolves #6015