### PR TITLE
Back port of Task Thin Execution List and List By Name

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -124,6 +124,7 @@ public class ApiDocumentation extends BaseDocumentation {
 				linkWithRel("tasks/platforms").description("Provides platform accounts for launching tasks.  The results can be filtered to show the platforms that support scheduling by adding a request parameter of 'schedulesEnabled=true"),
 				linkWithRel("tasks/logs").description("Retrieve the task application log"),
 				linkWithRel("tasks/thinexecutions").description("Returns thin Task executions"),
+				linkWithRel("tasks/thinexecutions/name").description("Returns all thin Task executions for a given Task name"),
 
 				linkWithRel("schema/versions").description("List of Spring Boot related schemas"),
 				linkWithRel("schema/targets").description("List of schema targets"),
@@ -233,6 +234,9 @@ public class ApiDocumentation extends BaseDocumentation {
 						fieldWithPath("_links.tasks/logs.templated").type(JsonFieldType.BOOLEAN).optional().description("Link tasks/logs is templated"),
 
 						fieldWithPath("_links.tasks/thinexecutions.href").description("Link to the tasks/thinexecutions"),
+
+						fieldWithPath("_links.tasks/thinexecutions/name.href").description("Link to the tasks/thinexecutions/name"),
+						fieldWithPath("_links.tasks/thinexecutions/name.templated").type(JsonFieldType.BOOLEAN).optional().description("Link to the tasks/thinexecutions/name is templated"),
 
 						fieldWithPath("_links.tasks/schedules.href").description("Link to the tasks/executions/schedules"),
 						fieldWithPath("_links.tasks/schedules/instances.href").description("Link to the tasks/schedules/instances"),

--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/TaskExecutionsDocumentation.java
@@ -315,6 +315,29 @@ public class TaskExecutionsDocumentation extends BaseDocumentation {
 	}
 
 	@Test
+	public void listTaskThinExecutionsByName() throws Exception {
+		this.mockMvc.perform(
+						get("/tasks/thinexecutions")
+								.param("name", "taskB")
+								.param("page", "0")
+								.param("size", "10")
+				)
+				.andExpect(status().isOk()).andDo(this.documentationHandler.document(
+						requestParameters(
+								parameterWithName("page")
+										.description("The zero-based page number (optional)"),
+								parameterWithName("size")
+										.description("The requested page size (optional)"),
+								parameterWithName("name")
+										.description("The name associated with the task execution")),
+						responseFields(
+								subsectionWithPath("_embedded.taskExecutionThinResourceList")
+										.description("Contains a collection of Task Executions/"),
+								subsectionWithPath("_links.self").description("Link to the task execution resource"),
+								subsectionWithPath("page").description("Pagination properties"))));
+	}
+
+	@Test
 	public void stopTask() throws Exception {
 		this.mockMvc.perform(
 						post("/tasks/executions")

--- a/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-dataflow-docs/src/main/asciidoc/api-guide.adoc
@@ -1862,6 +1862,8 @@ The following topics provide more details:
 * <<api-guide-resources-task-executions-stopping>>
 * <<api-guide-resources-task-executions-list>>
 * <<api-guide-resources-task-executions-list-by-name>>
+* <<api-guide-resources-task-thin-executions-list>>
+* <<api-guide-resources-task-thin-executions-list-by-name>>
 * <<api-guide-resources-task-executions-detail>>
 * <<api-guide-resources-task-executions-delete>>
 * <<api-guide-resources-task-executions-current-count>>
@@ -2066,7 +2068,132 @@ include::{snippets}/task-executions-documentation/list-task-executions-by-name/c
 
 include::{snippets}/task-executions-documentation/list-task-executions-by-name/http-response.adoc[]
 
+[[api-guide-resources-task-thin-executions-list]]
+==== List All Task Thin Executions
 
+The task executions endpoint lets you list all task executions with only top-level data.
+The following topics provide more details:
+
+* <<api-guide-resources-task-thin-executions-list-request-structure>>
+* <<api-guide-resources-task-thin-executions-list-request-parameters>>
+* <<api-guide-resources-task-thin-executions-list-example-request>>
+* <<api-guide-resources-task-thin-executions-list-response-structure>>
+
+[[api-guide-resources-task-thin-executions-list-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-request.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/query-parameters.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/curl-request.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-response.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-by-name]]
+==== List All Task Thin Executions With a Specified Task Name
+
+The task thin executions endpoint lets you list task executions with a specified task name.
+The following topics provide more details:
+
+* <<api-guide-resources-task-thin-executions-list-by-name-request-structure>>
+* <<api-guide-resources-task-thin-executions-list-by-name-request-parameters>>
+* <<api-guide-resources-task-thin-executions-list-by-name-example-request>>
+* <<api-guide-resources-task-thin-executions-list-by-name-response-structure>>
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/query-parameters.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/curl-request.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-by-name-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-response.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/request-parameters.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/curl-request.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions/http-response.adoc[]
+
+
+
+[[api-guide-resources-task-thin-executions-list-by-name]]
+==== List All Task Thin Executions With a Specified Task Name
+
+The task thin executions endpoint lets you list task executions with a specified task name.
+The following topics provide more details:
+
+* <<api-guide-resources-task-thin-executions-list-by-name-request-structure>>
+* <<api-guide-resources-task-thin-executions-list-by-name-request-parameters>>
+* <<api-guide-resources-task-thin-executions-list-by-name-example-request>>
+* <<api-guide-resources-task-thin-executions-list-by-name-response-structure>>
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-structure]]
+===== Request Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-request.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-by-name-request-parameters]]
+===== Request Parameters
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/request-parameters.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-by-name-example-request]]
+===== Example Request
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/curl-request.adoc[]
+
+[[api-guide-resources-task-thin-executions-list-by-name-response-structure]]
+===== Response Structure
+
+include::{snippets}/task-executions-documentation/list-task-thin-executions-by-name/http-response.adoc[]
 
 [[api-guide-resources-task-executions-detail]]
 ==== Task Execution Detail

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskOperations.java
@@ -124,6 +124,14 @@ public interface TaskOperations {
 	PagedModel<TaskExecutionResource> executionListByTaskName(String taskName);
 
 	/**
+	 * List task thin executions known to the system filtered by task name.
+	 *
+	 * @param taskName of the executions.
+	 * @return the list of thin task executions known to the system.
+	 */
+	PagedModel<TaskExecutionThinResource> thinExecutionListByTaskName(String taskName);
+
+	/**
 	 * Return the {@link TaskExecutionResource} for the id specified.
 	 *
 	 * @param id           identifier of the task execution

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -54,14 +54,12 @@ public class TaskTemplateTests {
 
 	@Test
 	public void testMinDataFlow() {
-		validateExecutionLinkPresent("1.7.0");
+		validateExecutionLinkPresent("2.10.0");
 	}
 
 	@Test
 	public void testFutureDataFlow() {
-		validateExecutionLinkPresent("1.8.0");
-		validateExecutionLinkPresent("1.9.0");
-		validateExecutionLinkPresent("2.0.0");
+		validateExecutionLinkPresent("2.11.6");
 	}
 
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/config/DataFlowControllerAutoConfiguration.java
@@ -300,8 +300,8 @@ public class DataFlowControllerAutoConfiguration {
 		}
 
 		@Bean
-		public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer aggregateTaskExplorer, TaskJobService taskJobService) {
-			return new TaskExecutionThinController(aggregateTaskExplorer, taskJobService);
+		public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer aggregateTaskExplorer, TaskDefinitionRepository taskDefinitionRepository, TaskJobService taskJobService) {
+			return new TaskExecutionThinController(aggregateTaskExplorer, taskDefinitionRepository, taskJobService);
 		}
 
 		@Bean

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/RootController.java
@@ -159,6 +159,7 @@ public class RootController {
 			root.add(linkTo(methodOn(TasksInfoController.class).getInfo(null, null, null)).withRel("tasks/info/executions"));
 			root.add(linkTo(methodOn(TaskLogsController.class).getLog(null, null, null)).withRel("tasks/logs"));
 			root.add(linkTo(methodOn(TaskExecutionThinController.class).listTasks(null, null)).withRel("tasks/thinexecutions"));
+			root.add(linkTo(methodOn(TaskExecutionThinController.class).retrieveTasksByName(null, null, null)).withRel("tasks/thinexecutions/name"));
 			if (featuresProperties.isSchedulesEnabled()) {
 				root.add(entityLinks.linkToCollectionResource(ScheduleInfoResource.class).withRel("tasks/schedules"));
 				String scheduleTemplated = entityLinks.linkToCollectionResource(ScheduleInfoResource.class).getHref()

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/repository/TaskDefinitionRepository.java
@@ -46,4 +46,5 @@ public interface TaskDefinitionRepository extends KeyValueRepository<TaskDefinit
 	 */
 	TaskDefinition findByTaskName(String name);
 
+	long countByTaskName(String taskName);
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/JobDependencies.java
@@ -244,8 +244,8 @@ public class JobDependencies {
 	}
 
 	@Bean
-	public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer aggregateTaskExplorer, TaskJobService taskJobService) {
-		return new TaskExecutionThinController(aggregateTaskExplorer, taskJobService);
+	public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer aggregateTaskExplorer, TaskDefinitionRepository taskDefinitionRepository, TaskJobService taskJobService) {
+		return new TaskExecutionThinController(aggregateTaskExplorer, taskDefinitionRepository, taskJobService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/configuration/TestDependencies.java
@@ -550,8 +550,8 @@ public class TestDependencies extends WebMvcConfigurationSupport {
 		);
 	}
 	@Bean
-	public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer explorer, TaskJobService taskJobService) {
-		return new TaskExecutionThinController(explorer, taskJobService);
+	public TaskExecutionThinController taskExecutionThinController(AggregateTaskExplorer explorer, TaskDefinitionRepository taskDefinitionRepository, TaskJobService taskJobService) {
+		return new TaskExecutionThinController(explorer, taskDefinitionRepository, taskJobService);
 	}
 
 	@Bean

--- a/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
+++ b/spring-cloud-dataflow-server-core/src/test/resources/root-controller-result.json
@@ -156,6 +156,10 @@
     "tasks/thinexecutions": {
       "href":"http://localhost/tasks/thinexecutions"
     },
+    "tasks/thinexecutions/name": {
+      "href":"http://localhost/tasks/thinexecutions/?name={name}",
+      "templated": true
+    },
     "jobs/executions": {
       "href": "http://localhost/jobs/executions"
     },


### PR DESCRIPTION
Updates api docs for tasks/thinexecutions/name and all HATEOAS links. Updates related tests for links. Improved link handling and tests in TaskTemplate.
Original PR #5994 
Issues #5991, #5973

Fixes #5995