### PR TITLE
Update Task Thin Executions list function for parity with 2.11.x

### DIFF
--- a/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
+++ b/spring-cloud-dataflow-classic-docs/src/test/java/org/springframework/cloud/dataflow/server/rest/documentation/ApiDocumentation.java
@@ -222,7 +222,7 @@ class ApiDocumentation extends BaseDocumentation {
 						fieldWithPath("_links.tasks/thinexecutions.href").description("Link to the tasks/thinexecutions"),
 
 						fieldWithPath("_links.tasks/thinexecutions/name.href").description("Link to the tasks/thinexecutions/name"),
-						fieldWithPath("_links.tasks/thinexecutions/name.templated").description("Link to the tasks/thinexecutions/name is templated"),
+						fieldWithPath("_links.tasks/thinexecutions/name.templated").type(JsonFieldType.BOOLEAN).optional().description("Link to the tasks/thinexecutions/name is templated"),
 
 						fieldWithPath("_links.tasks/info/executions.href").description("Link to the tasks/info/executions"),
 						fieldWithPath("_links.tasks/info/executions.templated").type(JsonFieldType.BOOLEAN).optional().description("Link tasks/info is templated"),

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -63,7 +63,7 @@ public class TaskTemplate implements TaskOperations {
 
 	private static final String DEFINITION_RELATION = "tasks/definitions/definition";
 
-	private static final String VALIDATION_MIN_VERSION = "3.0.0";
+	private static final String VALIDATION_MIN_VERSION = "3.0.0-SNAPSHOT";
 
 	private static final String EXECUTIONS_RELATION = "tasks/executions";
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -142,7 +142,12 @@ public class TaskTemplate implements TaskOperations {
 		this.restTemplate = restTemplate;
 
 		String version = VersionUtils.getThreePartVersion(dataFlowServerVersion);
-		Assert.isTrue(VersionUtils.isDataFlowServerVersionGreaterThanOrEqualToRequiredVersion(version, VALIDATION_MIN_VERSION), () -> "Minimum Data Flow version required is " + VALIDATION_MIN_VERSION + " but got " + version);
+		if (StringUtils.hasText(version)) {
+			Assert.isTrue(
+					VersionUtils.isDataFlowServerVersionGreaterThanOrEqualToRequiredVersion(version,
+							VALIDATION_MIN_VERSION),
+					() -> "Minimum Data Flow version required is " + VALIDATION_MIN_VERSION + " but got " + version);
+		}
 
 		this.aboutLink = resources.getLink("about").get();
 

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -146,12 +146,6 @@ public class TaskTemplate implements TaskOperations {
 		if (VersionUtils.isDataFlowServerVersionGreaterThanOrEqualToRequiredVersion(version, VALIDATION_RELATION_VERSION)) {
 			Assert.notNull(resources.getLink(VALIDATION_REL), ()-> VALIDATION_REL + " relation is required");
 		}
-		if (VersionUtils.isDataFlowServerVersionGreaterThanOrEqualToRequiredVersion(version, EXECUTIONS_CURRENT_RELATION_VERSION)) {
-			Assert.isTrue(resources.getLink(EXECUTIONS_CURRENT_RELATION).isPresent(), ()-> EXECUTIONS_CURRENT_RELATION + " relation is required");
-			this.executionsCurrentLink = resources.getLink(EXECUTIONS_CURRENT_RELATION).get();
-		} else {
-			this.executionsCurrentLink = null;
-		}
 
 		this.aboutLink = resources.getLink("about").get();
 
@@ -159,22 +153,10 @@ public class TaskTemplate implements TaskOperations {
 		this.definitionLink = resources.getLink(DEFINITION_RELATION).get();
 		this.executionsLink = resources.getLink(EXECUTIONS_RELATION).get();
 		this.executionLink = resources.getLink(EXECUTION_RELATION).get();
-		if(resources.getLink(THIN_EXECUTIONS_RELATION).isPresent()) {
-			this.thinExecutionsLink = resources.getLink(THIN_EXECUTIONS_RELATION).get();
-		} else {
-			this.thinExecutionsLink = null;
-		}
-		if(resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).isPresent()) {
-			this.thinExecutionsByNameLink = resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).get();
-		} else {
-			this.thinExecutionsByNameLink = null;
-		}
-
-		if(resources.getLink(EXECUTION_LAUNCH_RELATION).isPresent()) {
-			this.executionLaunchLink = resources.getLink(EXECUTION_LAUNCH_RELATION).get();
-		} else {
-			this.executionLaunchLink = null;
-		}
+		this.executionsCurrentLink = resources.getLink(EXECUTIONS_CURRENT_RELATION).orElse(null);
+		this.thinExecutionsLink = resources.getLink(THIN_EXECUTIONS_RELATION).orElse(null);
+		this.thinExecutionsByNameLink = resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).orElse(null);
+		this.executionLaunchLink = resources.getLink(EXECUTION_LAUNCH_RELATION).orElse(null);
 		this.executionByNameLink = resources.getLink(EXECUTION_RELATION_BY_NAME).get();
 		if (resources.getLink(EXECUTIONS_INFO_RELATION).isPresent()) {
 			this.executionsInfoLink = resources.getLink(EXECUTIONS_INFO_RELATION).get();

--- a/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
+++ b/spring-cloud-dataflow-rest-client/src/main/java/org/springframework/cloud/dataflow/rest/client/TaskTemplate.java
@@ -134,7 +134,10 @@ public class TaskTemplate implements TaskOperations {
 			PLATFORM_LIST_RELATION,
 			RETRIEVE_LOG,
 			VALIDATION_REL,
-			EXECUTIONS_CURRENT_RELATION
+			EXECUTIONS_CURRENT_RELATION,
+			THIN_EXECUTIONS_RELATION,
+			THIN_EXECUTIONS_BY_NAME_RELATION,
+			EXECUTION_LAUNCH_RELATION
 		).forEach(relation -> {
 			Assert.isTrue(resources.getLink(relation).isPresent(), () -> relation + " relation is required");
 		});
@@ -148,19 +151,19 @@ public class TaskTemplate implements TaskOperations {
 							VALIDATION_MIN_VERSION),
 					() -> "Minimum Data Flow version required is " + VALIDATION_MIN_VERSION + " but got " + version);
 		}
-
+		this.executionsCurrentLink = resources.getLink(EXECUTIONS_CURRENT_RELATION).get();
 		this.aboutLink = resources.getLink("about").get();
 
 		this.definitionsLink = resources.getLink(DEFINITIONS_RELATION).get();
 		this.definitionLink = resources.getLink(DEFINITION_RELATION).get();
 		this.executionsLink = resources.getLink(EXECUTIONS_RELATION).get();
 		this.executionLink = resources.getLink(EXECUTION_RELATION).get();
-		this.executionsCurrentLink = resources.getLink(EXECUTIONS_CURRENT_RELATION).orElse(null);
-		this.thinExecutionsLink = resources.getLink(THIN_EXECUTIONS_RELATION).orElse(null);
-		this.thinExecutionsByNameLink = resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).orElse(null);
-		this.executionLaunchLink = resources.getLink(EXECUTION_LAUNCH_RELATION).orElse(null);
+
+		this.thinExecutionsLink = resources.getLink(THIN_EXECUTIONS_RELATION).get();
+		this.thinExecutionsByNameLink = resources.getLink(THIN_EXECUTIONS_BY_NAME_RELATION).get();
+		this.executionLaunchLink = resources.getLink(EXECUTION_LAUNCH_RELATION).get();
 		this.executionByNameLink = resources.getLink(EXECUTION_RELATION_BY_NAME).get();
-		this.executionsInfoLink = resources.getLink(EXECUTIONS_INFO_RELATION).orElse(null);
+		this.executionsInfoLink = resources.getLink(EXECUTIONS_INFO_RELATION).get();
 		this.validationLink = resources.getLink(VALIDATION_REL).get();
 		this.platformListLink = resources.getLink(PLATFORM_LIST_RELATION).get();
 		this.retrieveLogLink = resources.getLink(RETRIEVE_LOG).get();

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -48,20 +48,13 @@ class TaskTemplateTests {
 	}
 
 	@Test
-	void oldDataFlow() {
-		validateExecutionLinkNotPresent("1.6.0");
-	}
-
-	@Test
 	void minDataFlow() {
-		validateExecutionLinkPresent("1.7.0");
+		validateExecutionLinkPresent("3.0.0");
 	}
 
 	@Test
 	void futureDataFlow() {
-		validateExecutionLinkPresent("1.8.0");
-		validateExecutionLinkPresent("1.9.0");
-		validateExecutionLinkPresent("2.0.0");
+		validateExecutionLinkPresent("3.0.0");
 	}
 
 
@@ -69,12 +62,6 @@ class TaskTemplateTests {
 		TestResource testResource = new TestResource();
 		new TaskTemplate(this.restTemplate, testResource, dataFlowVersion);
 		assertThat(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK)).isTrue();
-	}
-
-	private void validateExecutionLinkNotPresent(String version) {
-		TestResource testResource = new TestResource();
-		new TaskTemplate(this.restTemplate, testResource, version);
-		assertThat(testResource.isLinkRequested(CURRENT_TASK_EXECUTION_LINK)).isFalse();
 	}
 
 	public static class TestResource extends RepresentationModel<TestResource> {

--- a/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
+++ b/spring-cloud-dataflow-rest-client/src/test/java/org/springframework/cloud/dataflow/rest/client/TaskTemplateTests.java
@@ -28,6 +28,7 @@ import org.springframework.hateoas.RepresentationModel;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -46,7 +47,11 @@ class TaskTemplateTests {
 	void setup() {
 		restTemplate = mock(RestTemplate.class);
 	}
-
+	@Test
+	void invalidVersion() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> validateExecutionLinkPresent("2.11.5"));
+	}
 	@Test
 	void minDataFlow() {
 		validateExecutionLinkPresent("3.0.0");

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskExecutionControllerTests.java
@@ -343,6 +343,12 @@ class TaskExecutionControllerTests {
 	}
 	@Test
 	void getThinExecutionsByName() throws Exception {
+		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", TASK_NAME_ORIG).accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].executionId", containsInAnyOrder(2, 1)))
+				.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].parentExecutionId", containsInAnyOrder(null, 1)))
+				.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList[*].taskExecutionStatus", containsInAnyOrder("RUNNING", "RUNNING")))
+				.andExpect(jsonPath("$._embedded.taskExecutionThinResourceList", hasSize(2)));
 		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", "nope").accept(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.page.totalElements", is(0)));
 		mockMvc.perform(get("/tasks/thinexecutions").queryParam("name", "none").accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
Updated task thin executions link handing and added extra test for parity with 2.11.x

See #6062