### PR TITLE
Initialize useUserAccessToken to false.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.dataflow.core.DataFlowPropertyKeys;
+import org.springframework.util.Assert;
 
 /**
  * Properties used to define the behavior of the composed task runner.
@@ -44,7 +45,7 @@ public class ComposedTaskRunnerConfigurationProperties {
 	 * If true SCDF will set the dataflow-server-access-token for the composed
 	 * task runner to the user's token when launching composed tasks.
 	 */
-	private Boolean useUserAccessToken;
+	private Boolean useUserAccessToken = false;
 
 	public String getUri() {
 		return uri;
@@ -67,6 +68,7 @@ public class ComposedTaskRunnerConfigurationProperties {
 	}
 
 	public void setUseUserAccessToken(Boolean useUserAccessToken) {
+		Assert.notNull(useUserAccessToken, "'useUserAccessToken' cannot be null");
 		this.useUserAccessToken = useUserAccessToken;
 	}
 }

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationPropertiesTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/service/impl/ComposedTaskRunnerConfigurationPropertiesTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.dataflow.server.service.impl;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ComposedTaskRunnerConfigurationPropertiesTests {
 
@@ -43,7 +44,16 @@ public class ComposedTaskRunnerConfigurationPropertiesTests {
 	void useUserAccessTokenFromCTRPropNotSet() {
 		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
 			new ComposedTaskRunnerConfigurationProperties();
-		assertThat(composedTaskRunnerConfigurationProperties.isUseUserAccessToken()).as("Use user access token should be false").isNull();
+		assertThat(composedTaskRunnerConfigurationProperties.isUseUserAccessToken()).as("Use user access token should be false").isFalse();
+	}
+
+	@Test
+	void setUserAccessTokenFromCTRToNull() {
+		ComposedTaskRunnerConfigurationProperties composedTaskRunnerConfigurationProperties =
+			new ComposedTaskRunnerConfigurationProperties();
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> composedTaskRunnerConfigurationProperties.setUseUserAccessToken(null)).
+			withMessageContaining("'useUserAccessToken' cannot be null")
+		;
 	}
 
 	@Test


### PR DESCRIPTION
With the effort to remove deprecated methods from TaskConfigurationProperties with this [commit](https://github.com/spring-cloud/spring-cloud-dataflow/commit/b27f0c22094c20ad63fe7f4c7e0bc6d41ad7c79d), we introduced a NPE when DefaultTaskExecutionService.handleAccessToken tried to use useUserAccessToken. The original code would use TaskServiceUtils to return a false if it was null.

This behavior was a shim to maintain backwards compatibility which is no longer needed.
So the solution is to set the default for this field to false.   
