### PR TITLE
Disable Trivy by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      enableSecurityScan:
+        type: boolean
+        default: false
+        description: 'Enable security scan with Trivy'
   push:
     branches:
       - 'main'
@@ -172,6 +177,7 @@ jobs:
     secrets: inherit
   scan:
     runs-on: ubuntu-latest
+    if: ${{ inputs.enableSecurityScan != null && inputs.enableSecurityScan }}
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode


### PR DESCRIPTION
Adds an input flag `enableSecurityScan` that is false by default and will only include the scan job if set to true.