### PR TITLE
Disable Trivy by default

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,24 +17,3 @@ jobs:
       timeout-minutes: 75
       run: |
         ./mvnw -B -s .github/settings.xml -Pdocs clean install
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          ignore-unfixed: true
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-      - name: 'Scanned'
-        shell: bash
-        run: echo "::info ::Scanned"
-  done:
-    runs-on: ubuntu-latest
-    needs: [ scan, build ]
-    steps:
-      - name: 'Done'
-        shell: bash
-        run: echo "::info ::Done"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      enableSecurityScan:
+        type: boolean
+        default: false
+        description: 'Enable security scan with Trivy'
   push:
     branches:
       - '2.11.x'
@@ -188,6 +193,7 @@ jobs:
       GCR_JSON_KEY: ${{ secrets.GCR_JSON_KEY }}
   scan:
     runs-on: ubuntu-latest
+    if: ${{ inputs.enableSecurityScan != null && inputs.enableSecurityScan }}
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode


### PR DESCRIPTION
Adds an input flag `enableSecurityScan` that is false by default and will only include the scan job if set to true.