### PR TITLE
Provide for disabling security scan in ci-pr.yml and adding alternative repo

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -3,6 +3,10 @@ name: CI PRs
 on:
   pull_request:
 
+env:
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
+  TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,3 +21,24 @@ jobs:
       timeout-minutes: 75
       run: |
         ./mvnw -B -s .github/settings.xml -Pdocs clean install
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+      - name: 'Scanned'
+        shell: bash
+        run: echo "::info ::Scanned"
+  done:
+    runs-on: ubuntu-latest
+    needs: [ scan, build ]
+    steps:
+      - name: 'Done'
+        shell: bash
+        run: echo "::info ::Done"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       enableSecurityScan:
         type: boolean
-        default: false
+        default: true
         description: 'Enable security scan with Trivy'
   push:
     branches:
@@ -15,6 +15,8 @@ on:
 
 env:
   MAVEN_THREADS: '-T 1'
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
+  TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
 
 jobs:
   build:
@@ -193,7 +195,7 @@ jobs:
       GCR_JSON_KEY: ${{ secrets.GCR_JSON_KEY }}
   scan:
     runs-on: ubuntu-latest
-    if: ${{ inputs.enableSecurityScan != null && inputs.enableSecurityScan }}
+    if: ${{ inputs.enableSecurityScan == null || inputs.enableSecurityScan }}
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode


### PR DESCRIPTION
Added env to control the scan.
Added env to identify alternate repo.