### PR TITLE
⚠️ Do not merge: Resolve Postgres IT test failure

### DIFF
--- a/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
+++ b/spring-cloud-dataflow-server/src/test/java/org/springframework/cloud/dataflow/integration/test/db/AbstractPostgresDatabaseTests.java
@@ -79,15 +79,15 @@ public abstract class AbstractPostgresDatabaseTests extends AbstractDatabaseTest
 	@SuppressWarnings("deprecation")
 	@Test
 	@DataflowMain
-	public void migration210211() throws URISyntaxException {
+	public void migration211_30() throws URISyntaxException {
 		log.info("Running testMigrationError()");
 		this.dataflowCluster.startSkipperDatabase(getDatabaseTag());
 		this.dataflowCluster.startDataflowDatabase(getDatabaseTag());
 
-		this.dataflowCluster.startSkipper(TagNames.SKIPPER_2_9);
+		this.dataflowCluster.startSkipper(TagNames.SKIPPER_2_11);
 		assertSkipperServerRunning(this.dataflowCluster);
 
-		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_2_10);
+		this.dataflowCluster.startDataflow(TagNames.DATAFLOW_2_11);
 		assertDataflowServerRunning(this.dataflowCluster);
 
 		ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
We are currently testing 2.10 to 2.11 migrations in the 3.x project

This is causing a failure in the IT test: migration210211

The resolution is to test it the 2.11 -> 3.0 migration.