### PR TITLE
[CI] Update jfrog cli to v3

### DIFF
--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -25,11 +25,10 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
@@ -44,8 +43,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \
@@ -122,11 +121,10 @@ jobs:
         with:
           maven-version: 3.8.8
           maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-      - uses: jfrog/setup-jfrog-cli@v1
-        with:
-          version: 1.46.4
+      - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+          JF_URL: 'https://repo.spring.io'
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
       - name: Login dockerhub
         uses: docker/login-action@v3
         with:
@@ -135,8 +133,8 @@ jobs:
       - name: Configure JFrog Cli
         run: |
           jfrog rt mvnc \
-            --server-id-resolve=repo.spring.io \
-            --server-id-deploy=repo.spring.io \
+            --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+            --server-id-deploy=${{ vars.JF_SERVER_ID }} \
             --repo-resolve-releases=libs-milestone \
             --repo-resolve-snapshots=libs-snapshot \
             --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/cental-sync.yml
+++ b/.github/workflows/cental-sync.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: actions/checkout@v4
 
     # Setup jfrog cli
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # Extract build id from input
     - name: Extract Build Id

--- a/.github/workflows/central-release.yml
+++ b/.github/workflows/central-release.yml
@@ -17,11 +17,10 @@ jobs:
     - uses: actions/checkout@v4
 
     # Setup jfrog cli
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     # zoo extract and ensure
     - name: Extract Zoo Context Properties
       uses: jvalkeal/build-zoo-handler@v0.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,10 @@ jobs:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
 #     jfrog cli
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Login dockerhub
       uses: docker/login-action@v3
       with:
@@ -58,8 +57,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \
@@ -134,11 +133,10 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Login dockerhub
       uses: docker/login-action@v3
       with:
@@ -147,8 +145,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -24,11 +24,10 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
@@ -40,8 +39,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-milestone-local \

--- a/.github/workflows/next-dev-version-worker.yml
+++ b/.github/workflows/next-dev-version-worker.yml
@@ -24,11 +24,10 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # cache maven .m2
     - uses: actions/cache@v3
@@ -42,8 +41,8 @@ jobs:
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/promote-milestone.yml
+++ b/.github/workflows/promote-milestone.yml
@@ -14,11 +14,10 @@ jobs:
     steps:
     # need repo to push release branch and a tag
     - uses: actions/checkout@v4
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     # zoo extract and ensure
     - name: Extract Zoo Context Properties
       uses: jvalkeal/build-zoo-handler@v0.0.4

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -14,11 +14,10 @@ jobs:
     steps:
     # need repo to push release branch and a tag
     - uses: actions/checkout@v4
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.46.4
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     # zoo extract and ensure
     - name: Extract Zoo Context Properties
       uses: jvalkeal/build-zoo-handler@v0.0.4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,11 +20,10 @@ jobs:
         with:
           maven-version: 3.8.8
           maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-      - uses: jfrog/setup-jfrog-cli@v1
-        with:
-          version: 1.46.4
+      - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+          JF_URL: 'https://repo.spring.io'
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -36,8 +35,8 @@ jobs:
       - name: Configure JFrog Cli
         run: |
           jfrog rt mvnc \
-            --server-id-resolve=repo.spring.io \
-            --server-id-deploy=repo.spring.io \
+            --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+            --server-id-deploy=${{ vars.JF_SERVER_ID }} \
             --repo-resolve-releases=libs-release-staging \
             --repo-resolve-snapshots=libs-snapshot \
             --repo-deploy-releases=libs-staging-local \

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -24,11 +24,10 @@ jobs:
         with:
           maven-version: 3.8.8
           maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-      - uses: jfrog/setup-jfrog-cli@v1
-        with:
-          version: 1.46.4
+      - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+          JF_URL: 'https://repo.spring.io'
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -40,8 +39,8 @@ jobs:
       - name: Configure JFrog Cli
         run: |
           jfrog rt mvnc \
-            --server-id-resolve=repo.spring.io \
-            --server-id-deploy=repo.spring.io \
+            --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+            --server-id-deploy=${{ vars.JF_SERVER_ID }} \
             --repo-resolve-releases=libs-release-staging \
             --repo-resolve-snapshots=libs-snapshot \
             --repo-deploy-releases=libs-staging-local \


### PR DESCRIPTION
Update setup-jfrog-cli to use `JF_ENV_SPRING` instead of `JF_ARTIFACTORY_SPRING` 
Added `JF_URL`
Added reference to `${{ vars.JF_SERVER_ID }}` in place of `repo.spring.io`


**NOTE**: The branch was labeled with -main but was actually branched from 2.11.x