### PR TITLE
[CI] Update jfrog cli to v3

### DIFF
--- a/.github/workflows/build-snapshot-worker.yml
+++ b/.github/workflows/build-snapshot-worker.yml
@@ -40,16 +40,15 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/cental-sync.yml
+++ b/.github/workflows/cental-sync.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: actions/checkout@v4
 
     # Setup jfrog cli
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
 
     # Extract build id from input

--- a/.github/workflows/central-release.yml
+++ b/.github/workflows/central-release.yml
@@ -16,11 +16,10 @@ jobs:
     # to get spec file in .github
     - uses: actions/checkout@v4
 
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
 
     # zoo extract and ensure
     - name: Extract Zoo Context Properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,15 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/milestone-worker.yml
+++ b/.github/workflows/milestone-worker.yml
@@ -32,16 +32,15 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-milestone-local \

--- a/.github/workflows/next-dev-version-worker.yml
+++ b/.github/workflows/next-dev-version-worker.yml
@@ -37,16 +37,15 @@ jobs:
       with:
         maven-version: 3.8.8
         maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Configure JFrog Cli
       run: |
         jfrog rt mvnc \
-          --server-id-resolve=repo.spring.io \
-          --server-id-deploy=repo.spring.io \
+          --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+          --server-id-deploy=${{ vars.JF_SERVER_ID }} \
           --repo-resolve-releases=libs-milestone \
           --repo-resolve-snapshots=libs-snapshot \
           --repo-deploy-releases=libs-release-local \

--- a/.github/workflows/promote-milestone.yml
+++ b/.github/workflows/promote-milestone.yml
@@ -26,11 +26,10 @@ jobs:
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_buildnumber
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildname
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildnumber
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Promote Build
       run: |
         jfrog rt build-promote $BUILD_ZOO_HANDLER_spring_cloud_deployer_buildname $BUILD_ZOO_HANDLER_spring_cloud_deployer_buildnumber libs-milestone-local

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -26,11 +26,10 @@ jobs:
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_ui_buildnumber
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildname
           BUILD_ZOO_HANDLER_spring_cloud_dataflow_buildnumber
-    - uses: jfrog/setup-jfrog-cli@v1
-      with:
-        version: 1.54.0
+    - uses: jfrog/setup-jfrog-cli@v3
       env:
-        JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+        JF_URL: 'https://repo.spring.io'
+        JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
     - name: Promote Build
       run: |
         jfrog rt build-promote $BUILD_ZOO_HANDLER_spring_cloud_deployer_buildname $BUILD_ZOO_HANDLER_spring_cloud_deployer_buildnumber libs-release-local

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,16 +30,15 @@ jobs:
         with:
           maven-version: 3.8.8
           maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-      - uses: jfrog/setup-jfrog-cli@v1
-        with:
-          version: 1.54.0
+      - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+          JF_URL: 'https://repo.spring.io'
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
       - name: Configure JFrog Cli
         run: |
           jfrog rt mvnc \
-            --server-id-resolve=repo.spring.io \
-            --server-id-deploy=repo.spring.io \
+            --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+            --server-id-deploy=${{ vars.JF_SERVER_ID }} \
             --repo-resolve-releases=libs-release-staging \
             --repo-resolve-snapshots=libs-snapshot \
             --repo-deploy-releases=libs-staging-local \

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -33,16 +33,15 @@ jobs:
         with:
           maven-version: 3.8.8
           maven-mirror: 'https://dlcdn.apache.org/maven/maven-3/'
-      - uses: jfrog/setup-jfrog-cli@v1
-        with:
-          version: 1.54.0
+      - uses: jfrog/setup-jfrog-cli@v3
         env:
-          JF_ARTIFACTORY_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+          JF_URL: 'https://repo.spring.io'
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
       - name: Configure JFrog Cli
         run: |
           jfrog rt mvnc \
-            --server-id-resolve=repo.spring.io \
-            --server-id-deploy=repo.spring.io \
+            --server-id-resolve=${{ vars.JF_SERVER_ID }} \
+            --server-id-deploy=${{ vars.JF_SERVER_ID }} \
             --repo-resolve-releases=libs-release-staging \
             --repo-resolve-snapshots=libs-snapshot \
             --repo-deploy-releases=libs-staging-local \


### PR DESCRIPTION
Update setup-jfrog-cli to use `JF_ENV_SPRING` instead of `JF_ARTIFACTORY_SPRING` 
Added `JF_URL`
Added reference to `${{ vars.JF_SERVER_ID }}` in place of `repo.spring.io`