### PR TITLE
Use new Prometheus RSocket client

### DIFF
--- a/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
+++ b/spring-cloud-dataflow-build/spring-cloud-dataflow-build-dependencies/pom.xml
@@ -32,7 +32,7 @@
 		<commons-compress.version>1.26.2</commons-compress.version>
 		<!-- Specific version overrides to deal w/ CVEs -->
 		<nimbus-jose-jwt.version>9.39.3</nimbus-jose-jwt.version>
-		<prometheus-rsocket.version>2.0.0-M2</prometheus-rsocket.version>
+		<prometheus-rsocket.version>2.0.0-M4</prometheus-rsocket.version>
 		<java-cfenv.version>2.3.0</java-cfenv.version>
 		<spring-cloud-services-starter-config-client.version>3.5.4</spring-cloud-services-starter-config-client.version>
 		<kubernetes-fabric8-client.version>5.12.4</kubernetes-fabric8-client.version>

--- a/spring-cloud-dataflow-composed-task-runner/pom.xml
+++ b/spring-cloud-dataflow-composed-task-runner/pom.xml
@@ -102,7 +102,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>

--- a/spring-cloud-dataflow-server-core/pom.xml
+++ b/spring-cloud-dataflow-server-core/pom.xml
@@ -28,7 +28,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>

--- a/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-dependencies/pom.xml
+++ b/spring-cloud-dataflow-tasklauncher/spring-cloud-dataflow-tasklauncher-sink-dependencies/pom.xml
@@ -79,7 +79,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper/spring-cloud-skipper-server-core/pom.xml
@@ -40,7 +40,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer.prometheus</groupId>

--- a/src/carvel/config/values/values.yml
+++ b/src/carvel/config/values/values.yml
@@ -112,5 +112,5 @@ scdf:
         enabled: false
         image:
           repository: micrometermetrics/prometheus-rsocket-proxy
-          tag: 2.0.0-M2
+          tag: 2.0.0-M4
           digest: ""

--- a/src/carvel/docs/configuration-options.adoc
+++ b/src/carvel/docs/configuration-options.adoc
@@ -597,7 +597,7 @@ No
   Type:::
 String
    Default Value:::
-2.0.0-M2
+2.0.0-M4
 
 [[configuration-options-scdf.feature.monitoring.prometheusRsocketProxy.image.digest]]`scdf.feature.monitoring.prometheusRsocketProxy.image.digest`::
   Description:::

--- a/src/deploy/carvel/load-images.sh
+++ b/src/deploy/carvel/load-images.sh
@@ -67,7 +67,7 @@ else
     sh "$K8S/load-image.sh" "springcloud/spring-cloud-dataflow-server" "$DATAFLOW_VERSION" true
 fi
 if [ "$PROMETHEUS" = "true" ]; then
-    sh "$K8S/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy" "2.0.0-M2" false
+    sh "$K8S/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy" "2.0.0-M4" false
 fi
 if [ "$REGISTRY" = "" ]; then
     REGISTRY=springcloud

--- a/src/deploy/images/pull-prometheus-rsocket-proxy.sh
+++ b/src/deploy/images/pull-prometheus-rsocket-proxy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker pull "micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2"
+docker pull "micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4"

--- a/src/deploy/k8s/deploy-scdf.sh
+++ b/src/deploy/k8s/deploy-scdf.sh
@@ -171,7 +171,7 @@ if [ "$PROMETHEUS" = "true" ] || [ "$METRICS" = "prometheus" ]; then
     if [ "$K8S_DRIVER" != "tmc" ] && [ "$K8S_DRIVER" != "gke" ]; then
         sh "$SCDIR/load-image.sh" "springcloud/spring-cloud-dataflow-grafana-prometheus:$DATAFLOW_VERSION" false
         sh "$SCDIR/load-image.sh" "prom/prometheus:v2.37.8"
-        sh "$SCDIR/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2"
+        sh "$SCDIR/load-image.sh" "micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4"
     fi
     set +e
     kubectl create --namespace "$NS" serviceaccount prometheus-rsocket-proxy

--- a/src/docker-compose/docker-compose-prometheus.yml
+++ b/src/docker-compose/docker-compose-prometheus.yml
@@ -20,7 +20,7 @@ services:
       #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2
+    image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'

--- a/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-rsocket-proxy
       containers:
         - name: prometheus-rsocket-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2
+          image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4
           imagePullPolicy: IfNotPresent
           ports:
             - name: scrape

--- a/src/templates/docker-compose/docker-compose-prometheus.yml
+++ b/src/templates/docker-compose/docker-compose-prometheus.yml
@@ -22,7 +22,7 @@ services:
       #- SPRING_APPLICATION_JSON={"spring.jpa.properties.hibernate.generate_statistics":true}
 
   prometheus-rsocket-proxy:
-    image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2
+    image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'

--- a/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
+++ b/src/templates/kubernetes/prometheus-proxy/prometheus-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: prometheus-rsocket-proxy
       containers:
         - name: prometheus-rsocket-proxy
-          image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M2
+          image: micrometermetrics/prometheus-rsocket-proxy:2.0.0-M4
           imagePullPolicy: IfNotPresent
           ports:
             - name: scrape


### PR DESCRIPTION
Replaces the `micrometer.io:micrometer-registry-prometheus-simpleclient` with `micrometer.io:micrometer-registry-prometheus`.

Also updates the Prometheus RSocket version from `2.0.0-M3` to `2.0.0-M4`.

See #6068
See #6069