### PR TITLE
Fix containers name in docker compose files.

### DIFF
--- a/src/docker-compose/docker-compose-kafka.yml
+++ b/src/docker-compose/docker-compose-kafka.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Configuration environment variables:
 # - DATAFLOW_VERSION and SKIPPER_VERSION specify what DataFlow and Skipper image versions to use.
 # - STREAM_APPS_URI and TASK_APPS_URI are used to specify what Stream and Task applications to pre-register.
@@ -23,7 +21,7 @@ services:
 
   kafka-broker:
     image: confluentinc/cp-kafka:5.5.2
-    container_name: dataflow-kafka
+    container_name: kafka-broker
     expose:
       - "9092"
     environment:
@@ -41,7 +39,7 @@ services:
 
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.2
-    container_name: dataflow-kafka-zookeeper
+    container_name: zookeeper
     expose:
       - "2181"
     environment:

--- a/src/docker-compose/docker-compose-postgres.yml
+++ b/src/docker-compose/docker-compose-postgres.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Reconfigures the default docker-compose.yml to replace MariaDB by Postgres
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-postgres.yml up
 services:
@@ -7,7 +5,7 @@ services:
   postgres:
     image: postgres:14
     command: postgres -c 'max_connections=300'
-    container_name: dataflow-postgres
+    container_name: postgres
     restart: always
     environment:
       LANG: en_US.utf8


### PR DESCRIPTION
Rename the containers to match the host name in the properties. Otherwise it fails to connect to the containers from the applications. Remove the 'version: 3' to match the main docker compose file.

Signed-off-by: Alejandro Fabian Silva Grife <afsg77@gmail.com>