### PR TITLE
Remove the 'version: 3' to match the main docker compose file.

### DIFF
--- a/src/docker-compose/docker-compose-cf.yml
+++ b/src/docker-compose/docker-compose-cf.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   skipper-server:

--- a/src/docker-compose/docker-compose-debug-dataflow.yml
+++ b/src/docker-compose/docker-compose-debug-dataflow.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   dataflow-server:

--- a/src/docker-compose/docker-compose-debug-skipper.yml
+++ b/src/docker-compose/docker-compose-debug-skipper.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   skipper-server:

--- a/src/docker-compose/docker-compose-dood.yml
+++ b/src/docker-compose/docker-compose-dood.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Allows deploying docker (both Stream and Task) apps. The Docker-out-of-Docker (DooD) approach is used to allow Skipper
 # and DataFlow (running inside docker containers) to deploy stream and task docker apps in per-app docker containers.
 #

--- a/src/docker-compose/docker-compose-influxdb.yml
+++ b/src/docker-compose/docker-compose-influxdb.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Extends the default docker-compose.yml with Influx/Grafana monitoring configuration
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-influxdb.yml up
 services:

--- a/src/docker-compose/docker-compose-k8s.yml
+++ b/src/docker-compose/docker-compose-k8s.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   skipper-server:

--- a/src/docker-compose/docker-compose-kafka.yml
+++ b/src/docker-compose/docker-compose-kafka.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Configuration environment variables:
 # - DATAFLOW_VERSION and SKIPPER_VERSION specify what DataFlow and Skipper image versions to use.
 # - STREAM_APPS_URI and TASK_APPS_URI are used to specify what Stream and Task applications to pre-register.

--- a/src/docker-compose/docker-compose-mariadb.yml
+++ b/src/docker-compose/docker-compose-mariadb.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Configuration environment variables:
 # - DATAFLOW_VERSION and SKIPPER_VERSION specify what DataFlow and Skipper image versions to use.
 # - STREAM_APPS_URI and TASK_APPS_URI are used to specify what Stream and Task applications to pre-register.

--- a/src/docker-compose/docker-compose-mssql.yml
+++ b/src/docker-compose/docker-compose-mssql.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Reconfigures the default docker-compose.yml to replace MariaDB by Postgres
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-postgres.yml up
 services:

--- a/src/docker-compose/docker-compose-mysql.yml
+++ b/src/docker-compose/docker-compose-mysql.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Configuration environment variables:
 # - DATAFLOW_VERSION and SKIPPER_VERSION specify what DataFlow and Skipper image versions to use.
 # - STREAM_APPS_URI and TASK_APPS_URI are used to specify what Stream and Task applications to pre-register.

--- a/src/docker-compose/docker-compose-postgres.yml
+++ b/src/docker-compose/docker-compose-postgres.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Reconfigures the default docker-compose.yml to replace MariaDB by Postgres
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-postgres.yml up
 services:

--- a/src/docker-compose/docker-compose-rabbitmq.yml
+++ b/src/docker-compose/docker-compose-rabbitmq.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Reconfigures the default docker-compose.yml to replace Kafka/Zookeeper by RabbitMQ
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-rabbitmq.yml up
 services:

--- a/src/docker-compose/docker-compose-ssl.yml
+++ b/src/docker-compose/docker-compose-ssl.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Enables HTTPS for the SCDF and Skipper servers as well as all deployed stream and task applications.
 #
 # Before starting docker-compose you must alter the following URI variables to use the HTTPS instead of HTTP:

--- a/src/docker-compose/docker-compose-wavefront.yml
+++ b/src/docker-compose/docker-compose-wavefront.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Extends the default docker-compose.yml with Wavefront monitoring configuration
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-wavefront.yml up
 # Configuration:

--- a/src/docker-compose/docker-compose-zipkin.yml
+++ b/src/docker-compose/docker-compose-zipkin.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 # Extends the default docker-compose.yml with Zipkin Server distributed tracing configuration.
 # Usage: docker-compose -f ./docker-compose.yml -f ./docker-compose-zipkin.yml up
 


### PR DESCRIPTION
This avoids the warning:
> the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion